### PR TITLE
Using ubuntu16.04 to build linux distribute

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-16.04]
     env:
       BUILD_VERSION: latest # Computed
     

--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=x86_64-pc-linux-gnu
 
 # -----------
-FROM ubuntu:18.04 as builder-base
+FROM ubuntu:16.04 as builder-base
 ARG TARGET
 LABEL org.defichain.name="defichain-builder-base"
 LABEL org.defichain.arch=${TARGET}
@@ -10,6 +10,8 @@ RUN apt update && apt dist-upgrade -y
 
 # Setup Defichain build dependencies. Refer to depends/README.md and doc/build-unix.md
 # from the source root for info on the builder setup
+
+RUN apt-get install -y apt-transport-https
 
 RUN apt install -y software-properties-common build-essential libtool autotools-dev automake \
 pkg-config bsdmainutils python3 libssl-dev libevent-dev libboost-system-dev \
@@ -52,7 +54,7 @@ RUN mkdir /app && make prefix=/ DESTDIR=/app install && cp /work/README.md /app/
 
 # -----------
 ### Actual image that contains defi binaries
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 ARG TARGET
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}


### PR DESCRIPTION
Using ubuntu16.04 to build linux distribute, so it can be run on ubuntu16.04, ubuntu18.04 and ubuntu20.04. After test, this solution works and the modification in the work flow is very little.