### PR TITLE
Non unique token symbols

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -274,6 +274,10 @@ Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CT
     if (token.symbol.size() == 0 || IsDigit(token.symbol[0])) {
         return Res::Err("token symbol '%s' should be non-empty and starts with a letter", token.symbol);
     }
+    if (token.symbol.find('#') != std::string::npos) {
+        return Res::Err("%s: token symbol must not contain '#'", base);
+    }
+
     token.name = trim_ws(token.name).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
 
     token.creationTx = tx.GetHash();

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -41,6 +41,16 @@ boost::optional<std::pair<DCT_ID, std::unique_ptr<CToken> > > CTokensView::GetTo
 {
     DCT_ID id;
     auto varint = WrapVarInt(id.v);
+
+    const unsigned char ID_SPLITTER = '#';
+    size_t pos = symbol.rfind(ID_SPLITTER);
+
+    if (pos != std::string::npos) {
+        std::string token_id = symbol.substr(pos+1);
+        std::string token_name = symbol.substr(0, pos);
+        id.v = (uint32_t) std::stoul(token_id);
+        return { std::make_pair(id, std::move(GetToken(id)))};
+    }
     if (ReadBy<Symbol, std::string>(symbol, varint)) {
 //        assert(id >= DCT_ID_START);// ? not needed anymore?
         return { std::make_pair(id, std::move(GetToken(id)))};
@@ -118,9 +128,6 @@ Res CTokensView::CreateDFIToken()
 
 Res CTokensView::CreateToken(const CTokensView::CTokenImpl & token)
 {
-    if (GetToken(token.symbol)) {
-        return Res::Err("token '%s' already exists!", token.symbol);
-    }
     // this should not happen, but for sure
     if (GetTokenByCreationTx(token.creationTx)) {
         return Res::Err("token with creation tx %s already exists!", token.creationTx.ToString());
@@ -136,6 +143,9 @@ Res CTokensView::CreateToken(const CTokensView::CTokenImpl & token)
         if(id == DCT_ID_START) {
             LogPrintf("Critical fault: trying to create DCT_ID same as DCT_ID_START for Foundation owner\n");
             assert (false);
+        }
+        if (GetToken(token.symbol)) {
+            return Res::Err("token '%s' already exists!", token.symbol);
         }
     }
     else
@@ -175,7 +185,23 @@ Res CTokensView::UpdateToken(const uint256 &tokenTx)
         return Res::Err("token with creationTx %s does not exist!", tokenTx.ToString());
     }
     CTokenImpl & tokenImpl = pair->second;
-    tokenImpl.flags ^= (uint8_t)CToken::TokenFlags::isDAT;
+
+    if (!tokenImpl.IsDAT()) {
+        bool similarToken = false;
+        ForEachToken([&](DCT_ID const& id, CToken const& token) {
+                         if (token.symbol == tokenImpl.symbol && token.IsDAT()) {
+                             similarToken = true;
+                             return false;
+                         } else {
+                             return true;
+                         }
+                     }, DCT_ID{0});
+        if (similarToken) {
+            return Res::Err("Token already exists!");
+        }
+    }
+
+    tokenImpl.flags ^= (uint8_t)CToken::TokenFlags::DAT; // very strange logic. WHY only 'DAT' and WHY only triggering?
 
     WriteBy<ID>(WrapVarInt(pair->first.v), tokenImpl);
     return Res::Ok();

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -191,7 +191,7 @@ Res CTokensView::UpdateToken(const uint256 &tokenTx)
         WriteBy<Symbol>(symbolKey, WrapVarInt(pair->first.v));
     }
 
-    tokenImpl.flags ^= (uint8_t)CToken::TokenFlags::DAT; // very strange logic. WHY only 'DAT' and WHY only triggering?
+    tokenImpl.flags ^= (uint8_t)CToken::TokenFlags::isDAT;
 
     WriteBy<ID>(WrapVarInt(pair->first.v), tokenImpl);
     return Res::Ok();

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(tokens)
         BOOST_REQUIRE(token->symbol == "DCT1");
     }
     {   // search by symbol
-        auto pair = pcustomcsview->GetToken("DCT1");
+        auto pair = pcustomcsview->GetToken("DCT1#128");
         BOOST_REQUIRE(pair);
         BOOST_REQUIRE(pair->first == DCT_ID{128});
         BOOST_REQUIRE(pair->second);
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(tokens)
         BOOST_REQUIRE(token->symbol == "DCT2");
     }
     {   // search by symbol
-        auto pair = pcustomcsview->GetToken("DCT2");
+        auto pair = pcustomcsview->GetToken("DCT2#129");
         BOOST_REQUIRE(pair);
         BOOST_REQUIRE(pair->first == DCT_ID{129});
         BOOST_REQUIRE(pair->second);

--- a/test/functional/feature_accounts_n_utxos.py
+++ b/test/functional/feature_accounts_n_utxos.py
@@ -32,8 +32,11 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         # Stop node #2 for future revert
         self.stop_node(2)
 
-        idGold = list(self.nodes[0].gettoken("GOLD").keys())[0]
-        idSilver = list(self.nodes[0].gettoken("SILVER").keys())[0]
+        symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
+        symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+
+        idGold = list(self.nodes[0].gettoken(symbolGOLD).keys())[0]
+        idSilver = list(self.nodes[0].gettoken(symbolSILVER).keys())[0]
         accountGold = self.nodes[0].get_genesis_keys().ownerAuthAddress
         accountSilver = self.nodes[1].get_genesis_keys().ownerAuthAddress
         initialGold = self.nodes[0].getaccount(accountGold, {}, True)[idGold]
@@ -48,14 +51,14 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         #========================
         # missing from (account)
         try:
-            self.nodes[0].accounttoaccount([], self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@GOLD"})
+            self.nodes[0].accounttoaccount([], self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@" + symbolGOLD})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
 
         # missing from (account exist, but no tokens)
         try:
-            self.nodes[0].accounttoaccount([], accountGold, {toGold: "100@SILVER"})
+            self.nodes[0].accounttoaccount([], accountGold, {toGold: "100@" + symbolSILVER})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("not enough balance" in errorString)
@@ -69,20 +72,20 @@ class AccountsAndUTXOsTest (DefiTestFramework):
 
         #invalid UTXOs
         try:
-            self.nodes[0].accounttoaccount([{"": 0}], accountGold, {toGold: "100@GOLD"})
+            self.nodes[0].accounttoaccount([{"": 0}], accountGold, {toGold: "100@" + symbolGOLD})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("JSON value is not a string as expected" in errorString)
 
         # missing (account exists, but does not belong)
         try:
-            self.nodes[0].accounttoaccount([], accountSilver, {accountGold: "100@SILVER"})
+            self.nodes[0].accounttoaccount([], accountSilver, {accountGold: "100@" + symbolSILVER})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
 
         # transfer
-        self.nodes[0].accounttoaccount([], accountGold, {toGold: "100@GOLD"})
+        self.nodes[0].accounttoaccount([], accountGold, {toGold: "100@" + symbolGOLD})
         self.nodes[0].generate(1)
 
         assert_equal(self.nodes[0].getaccount(accountGold, {}, True)[idGold], initialGold - 100)
@@ -92,7 +95,7 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(toGold, {}, True)[idGold], self.nodes[1].getaccount(toGold, {}, True)[idGold])
 
         # transfer between nodes
-        self.nodes[1].accounttoaccount([], accountSilver, {toSilver: "100@SILVER"})
+        self.nodes[1].accounttoaccount([], accountSilver, {toSilver: "100@" + symbolSILVER})
         self.nodes[1].generate(1)
 
         assert_equal(self.nodes[1].getaccount(accountSilver, {}, True)[idSilver], initialSilver - 100)
@@ -103,7 +106,7 @@ class AccountsAndUTXOsTest (DefiTestFramework):
 
         # missing (account exists, there are tokens, but not token 0)
         try:
-            self.nodes[0].accounttoaccount([], toSilver, {accountGold: "100@SILVER"})
+            self.nodes[0].accounttoaccount([], toSilver, {accountGold: "100@" + symbolSILVER})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
@@ -111,7 +114,7 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         # utxostoaccount
         #========================
         try:
-            self.nodes[0].utxostoaccount([], {toGold: "100@GOLD"})
+            self.nodes[0].utxostoaccount([], {toGold: "100@" + symbolGOLD})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Insufficient funds" in errorString)
@@ -140,7 +143,7 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         #========================
         # missing from (account)
         try:
-            self.nodes[0].accounttoutxos([], self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@GOLD"})
+            self.nodes[0].accounttoutxos([], self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@" + symbolGOLD})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
@@ -154,27 +157,27 @@ class AccountsAndUTXOsTest (DefiTestFramework):
 
         #invalid UTXOs
         try:
-            self.nodes[0].accounttoutxos([{"": 0}], accountGold, {accountGold: "100@GOLD"})
+            self.nodes[0].accounttoutxos([{"": 0}], accountGold, {accountGold: "100@" + symbolGOLD})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("JSON value is not a string as expected" in errorString)
 
         # missing (account exists, but does not belong)
         try:
-            self.nodes[0].accounttoutxos([], accountSilver, {accountGold: "100@SILVER"})
+            self.nodes[0].accounttoutxos([], accountSilver, {accountGold: "100@" + symbolSILVER})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
 
         # missing (account exists, there are tokens, but not token 0)
         try:
-            self.nodes[0].accounttoutxos([], toSilver, {accountGold: "100@SILVER"})
+            self.nodes[0].accounttoutxos([], toSilver, {accountGold: "100@" + symbolSILVER})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO" in errorString)
 
         # transfer
-        self.nodes[0].accounttoutxos([], accountGold, {accountGold: "100@GOLD"})
+        self.nodes[0].accounttoutxos([], accountGold, {accountGold: "100@" + symbolGOLD})
         self.nodes[0].generate(1)
 
         assert_equal(self.nodes[0].getaccount(accountGold, {}, True)[idGold], initialGold - 200)

--- a/test/functional/feature_tokens_basic.py
+++ b/test/functional/feature_tokens_basic.py
@@ -48,8 +48,20 @@ class TokensBasicTest (DefiTestFramework):
             errorString = e.error['message']
         assert("Insufficient funds" in errorString)
 
-        print ("Create token 'GOLD' (128)...")
         self.nodes[0].generate(1)
+
+        # Fail to create:
+        try:
+            self.nodes[0].createtoken([], {
+                "symbol": "GOLD#1",
+                "name": "shiny gold",
+                "collateralAddress": collateral0
+            })
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("token symbol must not contain '#'" in errorString)
+
+        print ("Create token 'GOLD' (128)...")
         createTokenTx = self.nodes[0].createtoken([], {
             "symbol": "GOLD",
             "name": "shiny gold",

--- a/test/functional/feature_tokens_basic.py
+++ b/test/functional/feature_tokens_basic.py
@@ -50,7 +50,7 @@ class TokensBasicTest (DefiTestFramework):
 
         self.nodes[0].generate(1)
 
-        # Fail to create:
+        # Fail to create: use # in symbol
         try:
             self.nodes[0].createtoken([], {
                 "symbol": "GOLD#1",
@@ -114,6 +114,18 @@ class TokensBasicTest (DefiTestFramework):
             errorString = e.error['message']
         assert("collateral-locked," in errorString)
 
+        # Create new GOLD token
+        newGoldTx = self.nodes[0].createtoken([], {
+            "symbol": "GOLD",
+            "name": "shiny gold",
+            "collateralAddress": collateral0
+        })
+        self.nodes[0].generate(1)
+
+        # Get token by SYMBOL#ID
+        t129 = self.nodes[0].gettoken("GOLD#129")
+        assert_equal(t129['129']['symbol'], "GOLD")
+        assert_equal(self.nodes[0].gettoken("GOLD"), t129)
 
         # RESIGNING:
         #========================
@@ -129,13 +141,13 @@ class TokensBasicTest (DefiTestFramework):
         self.nodes[0].generate(1)
 
         print ("Destroy token...")
-        destroyTx = self.nodes[0].destroytoken([], "GOLD")
+        destroyTx = self.nodes[0].destroytoken([], "GOLD#128")
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].listtokens()['128']['destructionTx'], destroyTx)
 
         # Try to mint destroyed token ('minting' is not the task of current test, but let's check it here)
         try:
-            self.nodes[0].minttokens([], "100@GOLD")
+            self.nodes[0].minttokens([], "100@GOLD#128")
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("already destroyed" in errorString)
@@ -161,7 +173,7 @@ class TokensBasicTest (DefiTestFramework):
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_blocks(self.nodes[0:2])
 
-        assert_equal(sorted(self.nodes[0].getrawmempool()), sorted([fundingTx, destroyTx]))
+        assert_equal(sorted(self.nodes[0].getrawmempool()), sorted([fundingTx, destroyTx, newGoldTx]))
         assert_equal(self.nodes[0].listtokens()['128']['destructionHeight'], -1)
         assert_equal(self.nodes[0].listtokens()['128']['destructionTx'], '0000000000000000000000000000000000000000000000000000000000000000')
 
@@ -172,7 +184,7 @@ class TokensBasicTest (DefiTestFramework):
         connect_nodes_bi(self.nodes, 0, 2)
         self.sync_blocks(self.nodes[0:3])
         assert_equal(len(self.nodes[0].listtokens()), 1)
-        assert_equal(sorted(self.nodes[0].getrawmempool()), sorted([createTokenTx, fundingTx, destroyTx]))
+        assert_equal(sorted(self.nodes[0].getrawmempool()), sorted([createTokenTx, fundingTx, destroyTx, newGoldTx]))
 
 if __name__ == '__main__':
     TokensBasicTest ().main ()

--- a/test/functional/feature_tokens_basic.py
+++ b/test/functional/feature_tokens_basic.py
@@ -101,8 +101,15 @@ class TokensBasicTest (DefiTestFramework):
         assert_equal(self.nodes[0].gettoken("DFI"), t0)
         t128 = self.nodes[0].gettoken(128)
         assert_equal(t128['128']['symbol'], "GOLD")
-        assert_equal(self.nodes[0].gettoken("GOLD"), t128)
+        assert_equal(self.nodes[0].gettoken("GOLD#128"), t128)
         assert_equal(self.nodes[0].gettoken(createTokenTx), t128)
+
+        # Token not found, because not DAT
+        try:
+            self.nodes[0].gettoken("GOLD")
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("Token not found" in errorString)
 
         # Stop node #1 for future revert
         self.stop_node(1)
@@ -125,13 +132,13 @@ class TokensBasicTest (DefiTestFramework):
         # Get token by SYMBOL#ID
         t129 = self.nodes[0].gettoken("GOLD#129")
         assert_equal(t129['129']['symbol'], "GOLD")
-        assert_equal(self.nodes[0].gettoken("GOLD"), t129)
+        assert_equal(self.nodes[0].gettoken("GOLD#129"), t129)
 
         # RESIGNING:
         #========================
         # Try to resign w/o auth (no money on auth/collateral address)
         try:
-            self.nodes[0].destroytoken([], "GOLD")
+            self.nodes[0].destroytoken([], "GOLD#128")
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Can't find any UTXO's" in errorString)

--- a/test/functional/feature_tokens_dat.py
+++ b/test/functional/feature_tokens_dat.py
@@ -94,19 +94,22 @@ class TokensBasicTest (DefiTestFramework):
 
         # 4 Trying to make it DAT not from Foundation
         try:
-            self.nodes[2].updatetoken([], {"token": "GOLD", "isDAT": True})
+            self.nodes[2].updatetoken([], {"token": "GOLD#128", "isDAT": True})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Incorrect Authorization" in errorString)
 
         # 5 Making token isDAT from Foundation
-        self.nodes[0].updatetoken([], {"token": "GOLD", "isDAT": True})
+        self.nodes[0].updatetoken([], {"token": "GOLD#128", "isDAT": True})
 
         self.nodes[0].generate(1)
         # Checks
         tokens = self.nodes[0].listtokens()
         assert_equal(len(tokens), 3)
         assert_equal(tokens['128']["isDAT"], True)
+
+        # Get token
+        assert_equal(self.nodes[0].gettoken("GOLD")['128']["isDAT"], True)
 
         # 6 Checking after sync
         self.sync_blocks([self.nodes[0], self.nodes[2]])
@@ -123,6 +126,13 @@ class TokensBasicTest (DefiTestFramework):
         tokens = self.nodes[0].listtokens()
         assert_equal(len(tokens), 3)
         assert_equal(tokens['128']["isDAT"], False)
+
+        # Fail get token
+        try:
+            self.nodes[0].gettoken("GOLD")
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("Token not found" in errorString)
 
         self.nodes[0].generate(1)
 

--- a/test/functional/feature_tokens_dat.py
+++ b/test/functional/feature_tokens_dat.py
@@ -141,6 +141,41 @@ class TokensBasicTest (DefiTestFramework):
         assert_equal(tokens['2']["isDAT"], True)
         assert_equal(tokens['2']["symbol"], "TEST")
 
+        # 9 Fail to create: there can be only one DAT token
+        try:
+            self.nodes[0].createtoken([], {
+                "symbol": "TEST",
+                "name": "TEST token",
+                "isDAT": True,
+                "collateralAddress": collateral0
+            })
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("already exists" in errorString)
+
+        # 10 Fail to update
+        self.nodes[0].createtoken([], {
+            "symbol": "TEST",
+            "name": "TEST token copy",
+            "isDAT": False,
+            "collateralAddress": collateral0
+        })
+
+        self.nodes[0].generate(1)
+
+        tokens = self.nodes[0].listtokens()
+        assert_equal(len(tokens), 5)
+        assert_equal(tokens['129']["symbol"], "TEST")
+        assert_equal(tokens['129']["name"], "TEST token copy")
+        assert_equal(tokens['129']["isDAT"], False)
+
+        try:
+            self.nodes[0].updatetoken([], {"token": "TEST#129", "isDAT": True})
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("already exists" in errorString)
+
+
         # REVERTING:
         #========================
         print ("Reverting...")

--- a/test/functional/feature_tokens_minting.py
+++ b/test/functional/feature_tokens_minting.py
@@ -46,8 +46,15 @@ class TokensMintingTest (DefiTestFramework):
         tokens = self.nodes[0].listtokens()
         assert_equal(len(tokens), 3)
 
-        idGold = int(list(self.nodes[0].gettoken("GOLD").keys())[0])
-        idSilver = int(list(self.nodes[0].gettoken("SILVER").keys())[0])
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "GOLD"):
+                idGold = idx
+            if (token["symbol"] == "SILVER"):
+                idSilver = idx
+
+        symbolGold = "GOLD#" + idGold
+        symbolSilver = "SILVER#" + idSilver
 
         self.sync_blocks()
 
@@ -63,13 +70,13 @@ class TokensMintingTest (DefiTestFramework):
         # print(self.nodes[0].listunspent())
 
         alienMintAddr = self.nodes[1].getnewaddress("", "legacy")
-        self.nodes[0].minttokens([], "300@GOLD")
-        self.nodes[0].minttokens([], "3000@SILVER")
+        self.nodes[0].minttokens([], "300@" + symbolGold)
+        self.nodes[0].minttokens([], "3000@" + symbolSilver)
         self.nodes[0].generate(1)
         self.sync_blocks()
 
-        self.nodes[0].accounttoutxos([], collateralGold, { self.nodes[0].getnewaddress("", "legacy"): "100@GOLD", alienMintAddr: "200@GOLD"})
-        self.nodes[0].accounttoutxos([], collateralSilver, { self.nodes[0].getnewaddress("", "legacy"): "1000@SILVER", alienMintAddr: "2000@SILVER"})
+        self.nodes[0].accounttoutxos([], collateralGold, { self.nodes[0].getnewaddress("", "legacy"): "100@" + symbolGold, alienMintAddr: "200@" + symbolGold})
+        self.nodes[0].accounttoutxos([], collateralSilver, { self.nodes[0].getnewaddress("", "legacy"): "1000@" + symbolSilver, alienMintAddr: "2000@" + symbolSilver})
         self.nodes[0].generate(1)
         self.sync_blocks()
 
@@ -78,10 +85,10 @@ class TokensMintingTest (DefiTestFramework):
         assert_equal(self.nodes[0].getbalances(True)['mine']['trusted'][str(idSilver)], 1000)
         assert_equal(self.nodes[1].getbalances(True)['mine']['trusted'][str(idSilver)], 2000)
 
-        print ("Check 'sendmany' for tokens:")
+        print ("Check 'sendmany' for tokens")
         alienSendAddr = self.nodes[1].getnewaddress("", "legacy")
         # check sending of different tokens on same address
-        self.nodes[0].sendmany("", { alienSendAddr : [ str(10) + "@GOLD", str(20) + "@SILVER"] })
+        self.nodes[0].sendmany("", { alienSendAddr : [ str(10) + "@" + symbolGold, str(20) + "@" + symbolSilver] })
         self.nodes[0].generate(1)
         self.sync_blocks()
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -154,13 +154,13 @@ class InvalidMessagesTest(DefiTestFramework):
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
 
-        def swap_magic_bytes():
+        async def swap_magic_bytes():
             conn._on_data = lambda: None  # Need to ignore all incoming messages from now, since they come with "invalid" magic bytes
             conn.magic_bytes = b'\x00\x11\x22\x32'
 
         # Call .result() to block until the atomic swap is complete, otherwise
         # we might run into races later on
-        asyncio.run_coroutine_threadsafe(asyncio.coroutine(swap_magic_bytes)(), NetworkThread.network_event_loop).result()
+        asyncio.run_coroutine_threadsafe(swap_magic_bytes(), NetworkThread.network_event_loop).result()
 
         with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: INVALID MESSAGESTART ping']):
             conn.send_message(messages.msg_ping(nonce=0xff))

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -314,6 +314,12 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
                 assert_equal(chain_info["blocks"], 200)
                 assert_equal(chain_info["initialblockdownload"], False)
 
+    def get_id_token(self, symbol):
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == symbol):
+                return str(idx)
+
     def setup_tokens(self):
         # creates two tokens: GOLD for node#0 and SILVER for node1. Mint by 1000 for them
         assert(self.setup_clean_chain == True)
@@ -341,8 +347,11 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
         tokens = self.nodes[0].listtokens()
         assert_equal(len(tokens), 3)
 
-        self.nodes[0].minttokens([], "1000@GOLD")
-        self.nodes[1].minttokens([], "2000@SILVER")
+        symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
+        symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+
+        self.nodes[0].minttokens([], "1000@" + symbolGOLD)
+        self.nodes[1].minttokens([], "2000@" + symbolSILVER)
         self.sync_mempools()
         self.nodes[0].generate(1)
 


### PR DESCRIPTION
Allowed collisions for token symbols & getters/setters update
1. Allowed token name to be non-unique, except within DATs.
2. Getters and Setters for token symbols are prefixed with token ID, as such: AMOUNT@SYMBOL#ID, e.g. 23.88@DUSD#76
3. Aliases, without ID prefixes, are supported for DAT.