### PR TITLE
Accept both old and new magic values

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -311,10 +311,11 @@ public:
         consensus.spv.subsidyIncreaseValue = 5 * COIN;
         consensus.spv.minConfirmations = 1;
 
-        pchMessageStart[0] = 0x0a;
-        pchMessageStart[1] = 0x11;
-        pchMessageStart[2] = 0x09;
-        pchMessageStart[3] = 0x0c;
+        pchMessageStartPostAMK[0] = pchMessageStart[0] = 0x0a;
+        pchMessageStartPostAMK[1] = pchMessageStart[1] = 0x11;
+        pchMessageStartPostAMK[2] = pchMessageStart[2] = 0x09;
+        pchMessageStartPostAMK[3] = pchMessageStart[3] = 0x0c;
+        
         nDefaultPort = 18555;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 30;
@@ -433,10 +434,10 @@ public:
         consensus.spv.subsidyIncreaseValue = 5 * COIN;
         consensus.spv.minConfirmations = 1;
 
-        pchMessageStart[0] = 0x0a;
-        pchMessageStart[1] = 0x11;
-        pchMessageStart[2] = 0x09;
-        pchMessageStart[3] = 0x0c;
+        pchMessageStartPostAMK[0] = pchMessageStart[0] = 0x0a;
+        pchMessageStartPostAMK[1] = pchMessageStart[1] = 0x11;
+        pchMessageStartPostAMK[2] = pchMessageStart[2] = 0x09;
+        pchMessageStartPostAMK[3] = pchMessageStart[3] = 0x0c;
         nDefaultPort = 20555; /// @note devnet matter
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 30;
@@ -560,10 +561,10 @@ public:
         consensus.spv.subsidyIncreaseValue = 5 * COIN;
         consensus.spv.minConfirmations = 1;
 
-        pchMessageStart[0] = 0xfa;
-        pchMessageStart[1] = 0xbf;
-        pchMessageStart[2] = 0xb5;
-        pchMessageStart[3] = 0xda;
+        pchMessageStartPostAMK[0] = pchMessageStart[0] = 0xfa;
+        pchMessageStartPostAMK[1] = pchMessageStart[1] = 0xbf;
+        pchMessageStartPostAMK[2] = pchMessageStart[2] = 0xb5;
+        pchMessageStartPostAMK[3] = pchMessageStart[3] = 0xda;
         nDefaultPort = 19555;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 0;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -166,11 +166,15 @@ public:
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
          * a large 32-bit integer with any alignment.
-         */
-        pchMessageStart[0] = 0xe2;
-        pchMessageStart[1] = 0xaa;
-        pchMessageStart[2] = 0xc1;
-        pchMessageStart[3] = 0xe1;
+         */        
+        pchMessageStart[0] = 0xf9;
+        pchMessageStart[1] = 0xbe;	        
+        pchMessageStart[2] = 0xb4;	        
+        pchMessageStart[3] = 0xd9;
+        pchMessageStartPostAMK[0] = 0xe2;
+        pchMessageStartPostAMK[1] = 0xaa;
+        pchMessageStartPostAMK[2] = 0xc1;
+        pchMessageStartPostAMK[3] = 0xe1;
         nDefaultPort = 8555;
         nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 240;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -60,6 +60,7 @@ public:
 
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
+    const CMessageHeader::MessageStartChars& MessageStartPostAMK() const { return pchMessageStartPostAMK; }
     int GetDefaultPort() const { return nDefaultPort; }
 
     const CBlock& GenesisBlock() const { return genesis; }
@@ -91,6 +92,7 @@ protected:
 
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
+    CMessageHeader::MessageStartChars pchMessageStartPostAMK;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;
     uint64_t m_assumed_blockchain_size;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3511,7 +3511,8 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
 
     msg.SetVersion(pfrom->GetRecvVersion());
     // Scan for message start
-    if (memcmp(msg.hdr.pchMessageStart, chainparams.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
+    if (memcmp(msg.hdr.pchMessageStart, chainparams.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0 &&
+        memcmp(msg.hdr.pchMessageStart, chainparams.MessageStartPostAMK(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
         LogPrint(BCLog::NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()), pfrom->GetId());
         pfrom->fDisconnect = true;
         return false;
@@ -3519,7 +3520,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
 
     // Read header
     CMessageHeader& hdr = msg.hdr;
-    if (!hdr.IsValid(chainparams.MessageStart()))
+    if (!hdr.IsValid(chainparams.MessageStart()) && !hdr.IsValid(chainparams.MessageStartPostAMK()))
     {
         LogPrint(BCLog::NET, "PROCESSMESSAGE: ERRORS IN HEADER %s peer=%d\n", SanitizeString(hdr.GetCommand()), pfrom->GetId());
         return fMoreWork;


### PR DESCRIPTION
This PR makes the magic header changes more robust by allowing nodes to accept both old and new magic headers