### PR TITLE
Reverted testnet message start string

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -307,10 +307,10 @@ public:
         consensus.spv.subsidyIncreaseValue = 5 * COIN;
         consensus.spv.minConfirmations = 1;
 
-        pchMessageStart[0] = 0x0a;
+        pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
-        pchMessageStart[3] = 0x0c;
+        pchMessageStart[3] = 0x07;
         nDefaultPort = 18555;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 30;
@@ -429,10 +429,10 @@ public:
         consensus.spv.subsidyIncreaseValue = 5 * COIN;
         consensus.spv.minConfirmations = 1;
 
-        pchMessageStart[0] = 0x0a;
+        pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
-        pchMessageStart[3] = 0x0c;
+        pchMessageStart[3] = 0x07;
         nDefaultPort = 20555; /// @note devnet matter
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 30;


### PR DESCRIPTION
### Purpose of the PR

Testnet magic numbers were changed without a fallback mechanism, this PR reverts them back to the original values to maintain compatibility with the previous testnet magic values.