### PR TITLE
Implemented utxo check

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -445,6 +445,15 @@ Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins,
     if (msg.balances != *minted.val) {
         return Res::Err("%s: amount of minted tokens in UTXOs and metadata do not match: (%s) != (%s)", base, minted.val->ToString(), msg.balances.ToString());
     }
+
+    // block for non-DFI transactions
+    for (auto const & kv : minted.balances) {
+        DCT_ID tokenId = kv.first;
+        if(tokenId == DCT_ID{0}) {
+            return Res::Err("AccountToUtxos only available for DFI transactions");
+        }
+    }
+
     // transfer
     const auto res = mnview.SubBalances(msg.from, msg.balances);
     if (!res.ok) {

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -447,7 +447,7 @@ Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins,
     }
 
     // block for non-DFI transactions
-    for (auto const & kv : minted.balances) {
+    for (auto const & kv : msg.balances.balances) {
         const DCT_ID& tokenId = kv.first;
         if (tokenId != DCT_ID{0}) {
             return Res::Err("AccountToUtxos only available for DFI transactions");

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -448,8 +448,8 @@ Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins,
 
     // block for non-DFI transactions
     for (auto const & kv : minted.balances) {
-        DCT_ID tokenId = kv.first;
-        if(tokenId != DCT_ID{0}) {
+        const DCT_ID& tokenId = kv.first;
+        if (tokenId != DCT_ID{0}) {
             return Res::Err("AccountToUtxos only available for DFI transactions");
         }
     }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -449,7 +449,7 @@ Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins,
     // block for non-DFI transactions
     for (auto const & kv : minted.balances) {
         DCT_ID tokenId = kv.first;
-        if(tokenId == DCT_ID{0}) {
+        if(tokenId != DCT_ID{0}) {
             return Res::Err("AccountToUtxos only available for DFI transactions");
         }
     }


### PR DESCRIPTION
This introduces a restriction to AccountToUTXO to prevent non-DFI tokens from being transformed into UTXOs