### PR TITLE
Change source code and website to defichain

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -587,8 +587,8 @@ void SetupServerArgs()
 
 std::string LicenseInfo()
 {
-    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
-    const std::string URL_WEBSITE = "<https://bitcoincore.org>";
+    const std::string URL_SOURCE_CODE = "<https://github.com/DeFiCh/ain>";
+    const std::string URL_WEBSITE = "<https://defichain.com>";
 
     return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
            "\n" +


### PR DESCRIPTION
When run defie —version, it is still displaying bitcoin information, now change to defichain website and github repo