### PR TITLE
Updated 'updatetoken' RPC

### DIFF
--- a/src/masternodes/tokens.h
+++ b/src/masternodes/tokens.h
@@ -29,6 +29,7 @@ public:
         Tradeable = 0x02,
         DAT = 0x04,
         LPS = 0x08, // Liquidity Pool Share
+        Finalized = 0x10, // locked forever
         Default = TokenFlags::Mintable | TokenFlags::Tradeable
     };
 
@@ -48,21 +49,38 @@ public:
     {}
     virtual ~CToken() = default;
 
-    bool IsMintable() const
+    inline bool IsMintable() const
     {
         return flags & (uint8_t)TokenFlags::Mintable;
     }
-    bool IsTradeable() const
+    inline bool IsTradeable() const
     {
         return flags & (uint8_t)TokenFlags::Tradeable;
     }
-    bool IsDAT() const
+    inline bool IsDAT() const
     {
         return flags & (uint8_t)TokenFlags::DAT;
     }
-    bool IsPoolShare() const
+    inline bool IsPoolShare() const
     {
         return flags & (uint8_t)TokenFlags::LPS;
+    }
+    inline bool IsFinalized() const
+    {
+        return flags & (uint8_t)TokenFlags::Finalized;
+    }
+    inline Res IsValidSymbol() const
+    {
+        if (symbol.size() == 0 || IsDigit(symbol[0])) {
+            return Res::Err("token symbol should be non-empty and starts with a letter");
+        }
+        if (symbol.find('#') != std::string::npos) {
+            return Res::Err("token symbol should not contain '#'");
+        }
+        return Res::Ok();
+    }
+    inline std::string CreateSymbolKey(DCT_ID const & id) const {
+        return symbol + (IsDAT() ? "" : "#" + std::to_string(id.v));
     }
 
     ADD_SERIALIZE_METHODS;

--- a/test/functional/feature_tokens_basic.py
+++ b/test/functional/feature_tokens_basic.py
@@ -60,7 +60,7 @@ class TokensBasicTest (DefiTestFramework):
             }, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("token symbol must not contain '#'" in errorString)
+        assert("token symbol should not contain '#'" in errorString)
 
         print ("Create token 'GOLD' (128)...")
         createTokenTx = self.nodes[0].createtoken({

--- a/test/functional/feature_tokens_dat.py
+++ b/test/functional/feature_tokens_dat.py
@@ -131,6 +131,40 @@ class TokensBasicTest (DefiTestFramework):
         assert_equal(len(tokens), 3)
         assert_equal(tokens['128']["isDAT"], False)
 
+        # changing token's symbol:
+        self.nodes[0].updatetoken("GOLD#128", {"symbol":"gold"})
+        self.nodes[0].generate(1)
+        token = self.nodes[0].gettoken('128')
+        assert_equal(token['128']["symbol"], "gold")
+        assert_equal(token['128']["symbolKey"], "gold#128")
+        assert_equal(token['128']["isDAT"], False)
+        assert_equal(self.nodes[0].gettoken('gold#128'), token)
+
+        # changing token's symbol AND DAT at once:
+        self.nodes[0].updatetoken("128", {"symbol":"goldy", "isDAT":True})
+        self.nodes[0].generate(1)
+        token = self.nodes[0].gettoken('128')
+        assert_equal(token['128']["symbol"], "goldy")
+        assert_equal(token['128']["symbolKey"], "goldy")
+        assert_equal(token['128']["isDAT"], True)
+        assert_equal(self.nodes[0].gettoken('goldy'), token) # can do it w/o '#'' cause it should be DAT
+
+        # changing other properties:
+        self.nodes[0].updatetoken("128", {"name":"new name", "tradeable": False, "mintable": False, "finalize": True})
+        self.nodes[0].generate(1)
+        token = self.nodes[0].gettoken('128')
+        assert_equal(token['128']["name"], "new name")
+        assert_equal(token['128']["mintable"], False)
+        assert_equal(token['128']["tradeable"], False)
+        assert_equal(token['128']["finalized"], True)
+
+        # try to change finalized token:
+        try:
+            self.nodes[0].updatetoken("128", {"tradable": True})
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("can't alter 'Finalized' tokens" in errorString)
+
         # Fail get token
         try:
             self.nodes[0].gettoken("GOLD")


### PR DESCRIPTION
- make token's "symbol" changeable with respect to DAT and "symbol#id" format
- add "finalized" flag to tokens and ability to lock changes forever (this is not separate RPC but 'updatetoken' itself, just additional token's flag)
- tests for all of that
- remove unused parameter in 'listtokens'/'gettoken' - just more verbose and clear logic on getters - new "symbolKey" field in json output
