### PR TITLE
Refactored "AMK heights" validation

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -138,28 +138,22 @@ Res ApplyCustomTx(CCustomCSView & base_mnview, CCoinsViewCache const & coins, CT
                 res = ApplyResignMasternodeTx(mnview, coins, tx, height, metadata);
                 break;
             case CustomTxType::CreateToken:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyCreateTokenTx(mnview, coins, tx, height, metadata);
+                res = ApplyCreateTokenTx(mnview, coins, tx, height, metadata, consensusParams);
                 break;
             case CustomTxType::UpdateToken:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyUpdateTokenTx(mnview, coins, tx, height, metadata);
+                res = ApplyUpdateTokenTx(mnview, coins, tx, height, metadata, consensusParams);
                 break;
             case CustomTxType::MintToken:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyMintTokenTx(mnview, coins, tx, metadata);
+                res = ApplyMintTokenTx(mnview, coins, tx, height, metadata, consensusParams);
                 break;
             case CustomTxType::UtxosToAccount:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyUtxosToAccountTx(mnview, tx, metadata);
+                res = ApplyUtxosToAccountTx(mnview, tx, height, metadata, consensusParams);
                 break;
             case CustomTxType::AccountToUtxos:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyAccountToUtxosTx(mnview, coins, tx, metadata);
+                res = ApplyAccountToUtxosTx(mnview, coins, tx, height, metadata, consensusParams);
                 break;
             case CustomTxType::AccountToAccount:
-                if(height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height"); }
-                res = ApplyAccountToAccountTx(mnview, coins, tx, metadata);
+                res = ApplyAccountToAccountTx(mnview, coins, tx, height, metadata, consensusParams);
                 break;
             default:
                 return Res::Ok(); // not "custom" tx
@@ -257,8 +251,10 @@ Res ApplyResignMasternodeTx(CCustomCSView & mnview, CCoinsViewCache const & coin
     return Res::Ok(base);
 }
 
-Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata)
+Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     const std::string base{"Token creation"};
     // Check quick conditions first
     if (tx.vout.size() < 2 ||
@@ -301,8 +297,10 @@ Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CT
     return Res::Ok(base);
 }
 
-Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata)
+Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     const std::string base{"Token update"};
 
     uint256 tokenTx;
@@ -335,8 +333,10 @@ Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CT
     return Res::Ok(base);
 }
 
-Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata)
+Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     const std::string base{"Token minting"};
 
     CBalances minted;
@@ -376,8 +376,10 @@ Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTra
 }
 
 
-Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, std::vector<unsigned char> const & metadata)
+Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     // deserialize
     CUtxosToAccountMessage msg;
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
@@ -406,8 +408,10 @@ Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, std::
     return Res::Ok(base);
 }
 
-Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata)
+Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     // deserialize
     CAccountToUtxosMessage msg;
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
@@ -446,8 +450,10 @@ Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins,
     return Res::Ok(base);
 }
 
-Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata)
+Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
+    if((int)height < consensusParams.AMKHeight) { return Res::Err("Token tx before AMK height (block %d)", consensusParams.AMKHeight); }
+
     // deserialize
     CAccountToAccountMessage msg;
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
@@ -475,7 +481,7 @@ Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coin
     return Res::Ok(base);
 }
 
-ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const & tx, int height, uint256 const & prevStakeModifier, std::vector<unsigned char> const & metadata)
+ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const & tx, int height, uint256 const & prevStakeModifier, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
 {
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
     CAnchorFinalizationMessage finMsg;
@@ -497,7 +503,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
     }
 
     // check reward sum
-    if (height >= Params().GetConsensus().AMKHeight) {
+    if (height >= consensusParams.AMKHeight) {
         auto const cbValues = tx.GetValuesOut();
         if (cbValues.size() != 1 || cbValues.begin()->first != DCT_ID{0})
             return Res::ErrDbg("bad-ar-wrong-tokens", "anchor reward should be payed only in Defi coins");
@@ -509,7 +515,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         }
     }
     else { // pre-AMK logic
-        auto anchorReward = GetAnchorSubsidy(finMsg.anchorHeight, finMsg.prevAnchorHeight, Params().GetConsensus());
+        auto anchorReward = GetAnchorSubsidy(finMsg.anchorHeight, finMsg.prevAnchorHeight, consensusParams);
         if (tx.GetValueOut() > anchorReward) {
             return Res::ErrDbg("bad-ar-amount", "anchor pays too much (actual=%d vs limit=%d)",
                                tx.GetValueOut(), anchorReward);
@@ -529,7 +535,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         return Res::ErrDbg("bad-ar-nextteam", "anchor wrong next team");
     }
     mnview.SetTeam(finMsg.nextTeam);
-    if (height >= Params().GetConsensus().AMKHeight) {
+    if (height >= consensusParams.AMKHeight) {
         mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     }
     else {

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -81,15 +81,15 @@ Res ApplyCustomTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransa
 Res ApplyCreateMasternodeTx(CCustomCSView & mnview, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
 Res ApplyResignMasternodeTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
 
-Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
-Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
-Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata);
+Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 
-Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, std::vector<unsigned char> const & metadata);
-Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata);
-Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, std::vector<unsigned char> const & metadata);
+Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 
-ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const & tx, int height, uint256 const & prevStakeModifier, std::vector<unsigned char> const & metadata);
+ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const & tx, int height, uint256 const & prevStakeModifier, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 
 bool IsMempooledCustomTxCreate(const CTxMemPool& pool, const uint256 & txid);
 

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -582,10 +582,6 @@ UniValue createtoken(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, true);
     if (request.params[0].isNull()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
@@ -606,10 +602,10 @@ UniValue createtoken(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "collateralAddress (" + collateralAddress + ") does not refer to any valid address");
     }
 
-    int height{0};
+    int targetHeight;
     {
         LOCK(cs_main);
-        height = ::ChainActive().Tip()->height + 1;
+        targetHeight = ::ChainActive().Height() + 1;
     }
 
     CToken token;
@@ -628,7 +624,7 @@ UniValue createtoken(const JSONRPCRequest& request) {
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
 
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
 
     if(metaObj["isDAT"].getBool())
@@ -653,7 +649,7 @@ UniValue createtoken(const JSONRPCRequest& request) {
     else
         rawTx.vin = GetInputs(txInputs.get_array());
 
-    rawTx.vout.push_back(CTxOut(GetTokenCreationFee(height), scriptMeta));
+    rawTx.vout.push_back(CTxOut(GetTokenCreationFee(targetHeight), scriptMeta));
     rawTx.vout.push_back(CTxOut(GetTokenCollateralAmount(), GetScriptForDestination(collateralDest)));
 
     rawTx = fund(rawTx, request, pwallet);
@@ -662,8 +658,8 @@ UniValue createtoken(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyCreateTokenTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), height,
-                                      ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, token}));
+        const auto res = ApplyCreateTokenTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), targetHeight,
+                                      ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, token}), Params().GetConsensus());
         if (!res.ok) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "Execution test failed:\n" + res.msg);
         }
@@ -714,10 +710,6 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, true);
     if (request.params[0].isNull()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
@@ -735,6 +727,7 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     std::string const tokenStr = trim_ws(metaObj["token"].getValStr());
     CTxDestination ownerDest;
     uint256 creationTx{};
+    int targetHeight;
     {
         LOCK(cs_main);
         DCT_ID id;
@@ -748,9 +741,10 @@ UniValue updatetoken(const JSONRPCRequest& request) {
         LOCK(pwallet->cs_wallet);
         auto tokenImpl = static_cast<CTokenImplementation const& >(*token);
         creationTx = tokenImpl.creationTx;
+        targetHeight = ::ChainActive().Height() + 1;
     }
 
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
 
     for(std::set<CScript>::iterator it = Params().GetConsensus().foundationMembers.begin(); it != Params().GetConsensus().foundationMembers.end() && rawTx.vin.size() == 0; it++)
@@ -785,8 +779,8 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyUpdateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), CTransaction(rawTx), ::ChainActive().Tip()->height + 1,
-                                      ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, creationTx, metaObj["isDAT"].getBool()}));
+        const auto res = ApplyUpdateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), CTransaction(rawTx), targetHeight,
+                                      ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, creationTx, metaObj["isDAT"].getBool()}), Params().GetConsensus());
         if (!res.ok) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "Execution test failed:\n" + res.msg);
         }
@@ -956,10 +950,6 @@ UniValue minttokens(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     const CBalances minted = DecodeAmounts(pwallet->chain(), request.params[0], "");
     UniValue txInputs = request.params[1];
     if (txInputs.isNull())
@@ -967,7 +957,13 @@ UniValue minttokens(const JSONRPCRequest& request) {
         txInputs.setArray();
     }
 
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    int targetHeight;
+    {
+        LOCK(cs_main);
+        targetHeight = ::ChainActive().Height() + 1;
+    }
+
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
 
     // auth
@@ -1017,8 +1013,8 @@ UniValue minttokens(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyMintTokenTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx),
-                                                 ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, minted }));
+        const auto res = ApplyMintTokenTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), targetHeight,
+                                                 ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, minted }), Params().GetConsensus());
         if (!res.ok) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "Execution test failed:\n" + res.msg);
         }
@@ -1279,10 +1275,6 @@ UniValue utxostoaccount(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, false);
 
     // decode recipients
@@ -1304,7 +1296,13 @@ UniValue utxostoaccount(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "zero amounts");
     }
 
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    int targetHeight;
+    {
+        LOCK(cs_main);
+        targetHeight = ::ChainActive().Height() + 1;
+    }
+
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
 
     for (const auto& kv : toBurn.balances) {
@@ -1322,8 +1320,8 @@ UniValue utxostoaccount(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyUtxosToAccountTx(mnview_dummy, CTransaction(rawTx),
-                                               ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}));
+        const auto res = ApplyUtxosToAccountTx(mnview_dummy, CTransaction(rawTx), targetHeight,
+                                               ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}), Params().GetConsensus());
         if (!res.ok) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "Execution test failed:\n" + res.msg);
         }
@@ -1374,10 +1372,6 @@ UniValue accounttoaccount(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ, UniValue::VARR}, false);
 
     // decode sender and recipients
@@ -1395,7 +1389,13 @@ UniValue accounttoaccount(const JSONRPCRequest& request) {
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
 
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    int targetHeight;
+    {
+        LOCK(cs_main);
+        targetHeight = ::ChainActive().Height() + 1;
+    }
+
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
 
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
@@ -1418,8 +1418,8 @@ UniValue accounttoaccount(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyAccountToAccountTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx),
-                                               ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}));
+        const auto res = ApplyAccountToAccountTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), targetHeight,
+                                               ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}), Params().GetConsensus());
         if (!res.ok) {
             if (res.code == CustomTxErrCodes::NotEnoughBalance) {
                 throw JSONRPCError(RPC_INVALID_REQUEST,
@@ -1476,10 +1476,6 @@ UniValue accounttoutxos(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (::ChainActive().Tip()->height < Params().GetConsensus().AMKHeight) {
-        throw JSONRPCError(RPC_TRANSACTION_REJECTED, "No tokenization transaction before block height " + std::to_string(Params().GetConsensus().AMKHeight));
-    }
-
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ, UniValue::VARR}, false);
 
     // decode sender and recipients
@@ -1498,8 +1494,14 @@ UniValue accounttoutxos(const JSONRPCRequest& request) {
         scriptMeta << OP_RETURN << dummyMetadata;
     }
 
+    int targetHeight;
+    {
+        LOCK(cs_main);
+        targetHeight = ::ChainActive().Height() + 1;
+    }
+
     // auth
-    const auto txVersion = GetTransactionVersion(::ChainActive().Height());
+    const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
     
     CTxDestination ownerDest;
@@ -1543,8 +1545,8 @@ UniValue accounttoutxos(const JSONRPCRequest& request) {
     {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // don't write into actual DB
-        const auto res = ApplyAccountToUtxosTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx),
-                                                 ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}));
+        const auto res = ApplyAccountToUtxosTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), targetHeight,
+                                                 ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}), Params().GetConsensus());
         if (!res.ok) {
             if (res.code == CustomTxErrCodes::NotEnoughBalance) {
                 throw JSONRPCError(RPC_INVALID_REQUEST,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2214,7 +2214,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                 if (!fJustCheck) {
                     LogPrintf("ConnectBlock(): connecting finalization tx: %s block: %d\n", tx.GetHash().GetHex(), block.height);
                 }
-                ResVal<uint256> res = ApplyAnchorRewardTx(mnview, tx, pindex->nHeight, pindex->pprev ? pindex->pprev->stakeModifier : uint256(), metadata);
+                ResVal<uint256> res = ApplyAnchorRewardTx(mnview, tx, pindex->nHeight, pindex->pprev ? pindex->pprev->stakeModifier : uint256(), metadata, chainparams.GetConsensus());
                 if (!res.ok) {
                     return state.Invalid(ValidationInvalidReason::CONSENSUS,
                                          error("ConnectBlock(): %s", res.msg),


### PR DESCRIPTION
- all `if (height < AMK)` clauses moved from "outer Apply switch" and from RPCs into inner Apply*s. It is less readable than "outer switch", but it is a "single point of validation" now.
- all heights in RPCs adjusted to "current height+1"
- all accesses to chainstate (I mean those `*.Tip()->height" or ".Height()` in tx versions etc) SHOULD be protected by cs_main lock!

After acceptance we can promote those changes into Stage#4 for the rest txs/rpcs. To minimize conflicts - we have not touched Stage#4 yet.