### PR TITLE
Fix liquidity pool API parameter bug and help message

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -1710,8 +1710,13 @@ UniValue addpoolliquidity(const JSONRPCRequest& request) {
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
     CTxDestination ownerDest;
-    if (!request.params[2].get_array().empty()) {
-        rawTx.vin = GetAuthInputs(pwallet, ownerDest, request.params[2].get_array());
+    UniValue txInputs = request.params[2];
+    if (txInputs.isNull())
+    {
+        txInputs.setArray();
+    }
+    if (!txInputs.get_array().empty()) {
+        rawTx.vin = GetAuthInputs(pwallet, ownerDest, txInputs.get_array());
     } else {
         for (const auto& kv : msg.from) {
             if (!ExtractDestination(kv.first, ownerDest)) {
@@ -1747,25 +1752,25 @@ UniValue removepoolliquidity(const JSONRPCRequest& request) {
                HelpRequiringPassphrase(pwallet) + "\n",
                {
                        {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address which has tokens"},
-                       {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Token amount"},
+                       {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Liquidity amount@Liquidity pool symbol"},
                        {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
+                            "A json array of json objects",
+                            {
                                 {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
+                                    {
+                                        {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                                        {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                                    },
                                 },
-                        },
+                            },
                        },
                },
                RPCResult{
                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
                },
                RPCExamples{
-                       HelpExampleCli("removepoolliquidity", "from_address amount []")
-                       + HelpExampleRpc("removepoolliquidity", "from_address amount []")
+                       HelpExampleCli("removepoolliquidity", "from_address 1.0@LpSymbol")
+                       + HelpExampleRpc("removepoolliquidity", "from_address 1.0@LpSymbol")
                },
     }.Check(request);
 
@@ -1804,7 +1809,13 @@ UniValue removepoolliquidity(const JSONRPCRequest& request) {
     if (!ExtractDestination(msg.from, ownerDest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner destination");
     }
-    rawTx.vin = GetAuthInputs(pwallet, ownerDest, request.params[2].get_array());
+
+    UniValue txInputs = request.params[2];
+    if (txInputs.isNull())
+    {
+        txInputs.setArray();
+    }
+    rawTx.vin = GetAuthInputs(pwallet, ownerDest, txInputs.get_array());
 
     // fund
     rawTx = fund(rawTx, request, pwallet);
@@ -2267,6 +2278,12 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
+    UniValue txInputs = request.params[1];
+    if (txInputs.isNull())
+    {
+        txInputs.setArray();
+    }
+
     for(std::set<CScript>::iterator it = Params().GetConsensus().foundationMembers.begin(); it != Params().GetConsensus().foundationMembers.end() && rawTx.vin.size() == 0; it++)
     {
         if(IsMine(*pwallet, *it) == ISMINE_SPENDABLE)
@@ -2276,7 +2293,7 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid destination");
             }
             try {
-                rawTx.vin = GetAuthInputs(pwallet, destination, request.params[1].get_array());
+                rawTx.vin = GetAuthInputs(pwallet, destination, txInputs.get_array());
             }
             catch (const UniValue& objError) {}
         }
@@ -2569,7 +2586,13 @@ UniValue poolswap(const JSONRPCRequest& request) {
     if (!ExtractDestination(poolSwapMsg.from, ownerDest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner destination");
     }
-    rawTx.vin = GetAuthInputs(pwallet, ownerDest, request.params[1].get_array());
+
+    UniValue txInputs = request.params[1];
+    if (txInputs.isNull())
+    {
+        txInputs.setArray();
+    }
+    rawTx.vin = GetAuthInputs(pwallet, ownerDest, txInputs.get_array());
 
     // fund
     rawTx = fund(rawTx, request, pwallet);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -189,8 +189,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "minttokens", 1, "inputs"},
     { "utxostoaccount", 0, "amounts" },
     { "utxostoaccount", 1, "inputs" },
+    { "addpoolliquidity", 0, "from" },
     { "addpoolliquidity", 2, "inputs" },
-    { "removepoolliquidity", 1, "amount" },
     { "removepoolliquidity", 2, "inputs" },
 
     { "listpoolpairs", 0, "pagination" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -195,7 +195,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     { "listpoolpairs", 0, "pagination" },
     { "listpoolpairs", 1, "verbose" },
-    { "getpoolpair", 0, "key" },
     { "getpoolpair", 1, "verbose" },
 
     { "listaccounts", 0, "pagination" },


### PR DESCRIPTION
1. Make liquidity pool API empty parameter "[]" optional.
2. Fix `addpoolliquidity` and `removepoolliquidity` cannot run from defi-cli problem, `addpoolliquidity` the first parameter need to convert to json object, `removepoolliquidity` the second parameter no need to convert.
3. Update the API help messages.