### PR TITLE
Fix call getgov API from defi-cli always fail

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -238,7 +238,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     { "setgov", 0, "variables" },
     { "setgov", 1, "inputs" },
-    { "getgov", 0, "name" },
 };
 // clang-format on
 


### PR DESCRIPTION
Fix call getgov API from defi-cli always fail