### PR TITLE
Fix/poolswap restriction

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -943,7 +943,13 @@ Res ApplyPoolSwapTx(CCustomCSView &mnview, const CCoinsViewCache &coins, const C
         return Res::Err("%s: can't find the poolpair!", base);
     }
 
+    /// @attention Consensus breaking, if liquidity trade was deployed!!!
     CPoolPair pp = poolPair->second;
+    const auto srcReserve = pp.idTokenA == poolSwapMsg.idTokenFrom ? pp.reserveA : pp.reserveB;
+    if (poolSwapMsg.amountFrom > srcReserve) {
+        return Res::Err("%s: %s", base, "Tradeble amount > than reserved in the pool");
+    }
+
     const auto res = pp.Swap({poolSwapMsg.idTokenFrom, poolSwapMsg.amountFrom}, poolSwapMsg.maxPrice, [&] (const CTokenAmount &tokenAmount) {
         auto resPP = mnview.SetPoolPair(poolPair->first, pp);
         if (!resPP.ok) {

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -161,6 +161,19 @@ class PoolPairTest (DefiTestFramework):
         self.nodes[0].updatepoolpair({"pool": "GS", "status": True})
         self.nodes[0].generate(1)
 
+        # 6.1 Try to swap more than reserved
+        print (self.nodes[0].listpoolpairs())
+        try:
+            self.nodes[0].poolswap({
+                "from": accountGN0,
+                "tokenFrom": symbolSILVER,
+                "amountFrom": 1001, # 1000 reservedB!
+                "to": accountSN1,
+                "tokenTo": symbolGOLD,
+            }, [])
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("than reserved in the pool" in errorString)
 
         self.nodes[0].poolswap({
             "from": accountGN0,


### PR DESCRIPTION
Restrict initial swappable amount in tx to the pool reserved funds.

**Consensus breaking, if liquidity trade was deployed before!!!**

