### PR TITLE
Added token collateral address for RPC

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -923,8 +923,12 @@ UniValue tokenToJSON(DCT_ID const& id, CTokenImplementation const& token, bool v
         tokenObj.pushKV("creationHeight", token.creationHeight);
         tokenObj.pushKV("destructionTx", token.destructionTx.ToString());
         tokenObj.pushKV("destructionHeight", token.destructionHeight);
-        /// @todo tokens: collateral address/script
-//      tokenObj.pushKV("collateralAddress", token.destructionHeight);
+        if (!token.IsPoolShare()) {
+            const Coin& authCoin = ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(token.creationTx, 1)); // always n=1 output
+            tokenObj.pushKV("collateralAddress", ScriptToString(authCoin.out.scriptPubKey));
+        } else {
+            tokenObj.pushKV("collateralAddress", "undefined");
+        }
     }
     UniValue ret(UniValue::VOBJ);
     ret.pushKV(id.ToString(), tokenObj);

--- a/test/functional/feature_tokens_minting.py
+++ b/test/functional/feature_tokens_minting.py
@@ -84,6 +84,9 @@ class TokensMintingTest (DefiTestFramework):
         assert_equal(self.nodes[0].gettoken(symbolGold)[idGold]['minted'], 300)
         assert_equal(self.nodes[0].gettoken(symbolSilver)[idSilver]['minted'], 3000)
 
+        assert_equal(self.nodes[0].gettoken(symbolGold)[idGold]['collateralAddress'], collateralGold)
+        assert_equal(self.nodes[0].gettoken(symbolSilver)[idSilver]['collateralAddress'], collateralSilver)
+
         try:
             self.nodes[0].accounttoutxos(collateralGold, { self.nodes[0].getnewaddress("", "legacy"): "100@" + symbolGold, alienMintAddr: "200@" + symbolGold}, [])
             self.nodes[0].accounttoutxos(collateralSilver, { self.nodes[0].getnewaddress("", "legacy"): "1000@" + symbolSilver, alienMintAddr: "2000@" + symbolSilver}, [])


### PR DESCRIPTION
Added info about collateral address (token owner) in RPC listtokens/gettoken. Returns "undefined" for LPS tokens.