### PR TITLE
Added testpoolswap rpc method and python rpc test

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -234,6 +234,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "updatepoolpair", 1, "inputs" },
     { "poolswap", 0, "metadata" },
     { "poolswap", 1, "inputs" },
+    { "testpoolswap", 0, "metadata"},
     { "listpoolshares", 0, "pagination" },
     { "listpoolshares", 1, "verbose" },
 

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -161,6 +161,24 @@ class PoolPairTest (DefiTestFramework):
         self.nodes[0].updatepoolpair({"pool": "GS", "status": True})
         self.nodes[0].generate(1)
 
+        testPoolSwapRes =  self.nodes[0].testpoolswap({
+            "from": accountGN0,
+            "tokenFrom": symbolSILVER,
+            "amountFrom": 10,
+            "to": accountSN1,
+            "tokenTo": symbolGOLD,
+        })
+
+        # this acc will be
+        goldCheckPS = self.nodes[2].getaccount(accountSN1, {}, True)[idGold]
+        print("goldCheckPS:", goldCheckPS)
+        print("testPoolSwapRes:", testPoolSwapRes)
+
+        testPoolSwapRes = str(testPoolSwapRes).split("@", 2)
+
+        psTestAmount = testPoolSwapRes[0]
+        psTestTokenId = testPoolSwapRes[1]
+        assert_equal(psTestTokenId, idGold)
 
         self.nodes[0].poolswap({
             "from": accountGN0,
@@ -194,6 +212,7 @@ class PoolPairTest (DefiTestFramework):
         assert(goldCheckN0 == 700)
         assert(str(silverCheckN0) == "490.49990000") # TODO: calculate "true" values with trading fee!
         assert(list_pool['1']['reserveA'] + goldCheckN1 == 300)
+        assert(Decimal(goldCheckPS) + Decimal(psTestAmount) == Decimal(goldCheckN1))
         assert(str(silverCheckN1) == "500.50000000")
         assert(list_pool['1']['reserveB'] == 1009) #1010 - 1 (commission)
 


### PR DESCRIPTION
Added RPC method testpoolswap:
```
testpoolswap ( {"from":"str","tokenFrom":"str","amountFrom":n,"to":"str","tokenTo":"str","maxPrice":n} )

Tests a poolswap transaction with given metadata and returns poolswap result.

Arguments:
1. metadata                   (json object)
     {
       "from": "str",         (string, required) Address of the owner of tokenA.
       "tokenFrom": "str",    (string, required) One of the keys may be specified (id/symbol)
       "amountFrom": n,       (numeric, required) tokenFrom coins amount
       "to": "str",           (string, required) Address of the owner of tokenB.
       "tokenTo": "str",      (string, required) One of the keys may be specified (id/symbol)
       "maxPrice": n,         (numeric) Maximum acceptable price
     }

Result:
"amount@tokenId"    (string) The string with amount result of poolswap in format AMOUNT@TOKENID.
```
Throws RPC exception if input params were not valid.