### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -147,3 +147,9 @@ jobs:
         asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
         asset_content_type: application/gzip
+
+    - name: Generate SHA256 checksum
+        run: |
+            sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
+            sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip
+            sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz

--- a/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
+++ b/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
@@ -51,6 +51,8 @@ RUN ./configure --prefix=`pwd`/depends/${TARGET} \
     --enable-reduce-exports \
     LDFLAGS="-static-libstdc++"
 
+ARG BUILD_VERSION=
+
 RUN make
 RUN mkdir /app && make prefix=/ DESTDIR=/app install && cp /work/README.md /app/.
 

--- a/contrib/dockerfiles/x86_64-apple-darwin11.dockerfile
+++ b/contrib/dockerfiles/x86_64-apple-darwin11.dockerfile
@@ -48,6 +48,8 @@ RUN ./autogen.sh
 # XREF: #make-configure
 RUN ./configure --prefix=`pwd`/depends/${TARGET}
 
+ARG BUILD_VERSION=
+
 RUN make
 RUN mkdir /app && make prefix=/ DESTDIR=/app install && cp /work/README.md /app/.
 

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -49,6 +49,8 @@ RUN ./autogen.sh
 # XREF: #make-configure
 RUN ./configure --prefix=`pwd`/depends/${TARGET}
 
+ARG BUILD_VERSION=
+
 RUN make
 RUN mkdir /app && make prefix=/ DESTDIR=/app install && cp /work/README.md /app/.
 

--- a/contrib/dockerfiles/x86_64-w64-mingw32.dockerfile
+++ b/contrib/dockerfiles/x86_64-w64-mingw32.dockerfile
@@ -51,6 +51,8 @@ RUN ./autogen.sh
 # XREF: #make-configure
 RUN CONFIG_SITE=`pwd`/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
 
+ARG BUILD_VERSION=
+
 RUN make
 RUN mkdir /app && make prefix=/ DESTDIR=/app install && cp /work/README.md /app/.
 

--- a/make.sh
+++ b/make.sh
@@ -164,7 +164,7 @@ docker_build() {
         echo "> building: ${img}"
         local docker_file="${dockerfiles_dir}/${target}.dockerfile"
         echo "> docker build: ${img}"
-        docker build -f "${docker_file}" -t "${img}" "${docker_context}"
+        docker build --build-arg BUILD_VERSION=v${IMAGE_VERSION} -f "${docker_file}" -t "${img}" "${docker_context}"
     done
 }
 

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -43,6 +43,8 @@ if [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""
 elif [ -n "$SUFFIX" ]; then
     NEWINFO="#define BUILD_SUFFIX $SUFFIX"
+elif [ -n "$BUILD_VERSION" ]; then
+    NEWINFO="#define BUILD_DESC \"$BUILD_VERSION\""
 else
     NEWINFO="// No build information available"
 fi


### PR DESCRIPTION
- We use build in docker but it's not checkout the source code that prevent `genbuild.sh` to get proper version. The patch expose the version to docker and consume it in build process.

- Generate checksums in release builds