### PR TITLE
Fix updatetoken first parameter is string but need to input as json problem

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -179,7 +179,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listmasternodes", 1, "verbose" },
     { "createtoken", 0, "metadata" },
     { "createtoken", 1, "inputs"},
-    { "updatetoken", 0, "token"},
     { "updatetoken", 1, "metadata"},
     { "updatetoken", 2, "inputs"},
     { "listtokens", 0, "pagination" },


### PR DESCRIPTION
Fix updatetoken first parameter is string but need to input as json problem, for example, now the first parameter is token symbol, need to input like this

```
defi-cli updatetoken '"DGT#133"' "{\"mintable\":false}"
```

After change, can input like this, without the string quote in single quotes

```
defi-cli updatetoken "DGT#133" "{\"mintable\":false}"
```

or without quote

```
defi-cli updatetoken DGT#133 "{\"mintable\":false}"
```