### PR TITLE
Add ability to transfer token owner

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,6 +116,7 @@ public:
         consensus.BIP66Height = 0; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.AMKHeight = 356500;
         consensus.BayfrontHeight = 405000;
+        consensus.CQHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -275,6 +276,7 @@ public:
         consensus.BIP66Height = 0; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.AMKHeight = 150;
         consensus.BayfrontHeight = 3000;
+        consensus.CQHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -411,6 +413,7 @@ public:
         consensus.BIP66Height = 0;
         consensus.AMKHeight = 150;
         consensus.BayfrontHeight = 250;
+        consensus.CQHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -542,6 +545,7 @@ public:
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in functional tests)
         consensus.AMKHeight = 10000000;
         consensus.BayfrontHeight = 10000000;
+        consensus.CQHeight = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -705,6 +709,17 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             height = std::numeric_limits<int>::max();
         }
         consensus.BayfrontHeight = static_cast<int>(height);
+    }
+
+    if (gArgs.IsArgSet("-cqheight")) {
+        int64_t height = gArgs.GetArg("-cqheight", consensus.CQHeight);
+        if (height < -1 || height >= std::numeric_limits<int>::max()) {
+            throw std::runtime_error(strprintf("Activation height %ld for CQ is out of valid range. Use -1 to disable cq features.", height));
+        } else if (height == -1) {
+            LogPrintf("CQ disabled for testing\n");
+            height = std::numeric_limits<int>::max();
+        }
+        consensus.CQHeight = static_cast<int>(height);
     }
 
     if (!args.IsArgSet("-vbparams")) return;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -74,6 +74,8 @@ struct Params {
     int AMKHeight;
     /** What exactly? Changes to mint DAT, new updatetokens? */
     int BayfrontHeight;
+    /** Placeholder for third fork. Add ability to change token owner. */
+    int CQHeight;
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -465,6 +465,7 @@ void SetupServerArgs()
     gArgs.AddArg("-spv_rescan", "Block height to rescan from (default: 0 = off)", ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     gArgs.AddArg("-amkheight", "AMK fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontheight", "Bayfront fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-cqheight", "CQ fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -182,7 +182,7 @@ bool CTokensView::RevertCreateToken(const uint256 & txid)
     return true;
 }
 
-Res CTokensView::UpdateToken(const uint256 &tokenTx, CToken & newToken, bool isPreBayfront)
+Res CTokensView::UpdateToken(const uint256 &tokenTx, CToken & newToken, bool isPreBayfront, const uint256* newOwnerTX)
 {
     auto pair = GetTokenByCreationTx(tokenTx);
     if (!pair) {
@@ -230,6 +230,13 @@ Res CTokensView::UpdateToken(const uint256 &tokenTx, CToken & newToken, bool isP
 
     if (!oldToken.IsFinalized() && newToken.IsFinalized()) // IsFinalized() itself was checked upthere (with Err)
         oldToken.flags |= (uint8_t)CToken::TokenFlags::Finalized;
+
+    // Change the owner if newOwnerTX is not nullptr
+    if (newOwnerTX) {
+        EraseBy<CreationTx>(oldToken.creationTx);
+        oldToken.creationTx = *newOwnerTX;
+        WriteBy<CreationTx>(oldToken.creationTx, WrapVarInt(id.v));
+    }
 
     WriteBy<ID>(WrapVarInt(id.v), oldToken);
     return Res::Ok();

--- a/src/masternodes/tokens.h
+++ b/src/masternodes/tokens.h
@@ -17,6 +17,13 @@ class CTransaction;
 
 std::string trim_ws(std::string const & str);
 
+enum class TokenUpdateFlags : uint8_t
+{
+    None = 0,
+    NewOwner = 0x01 // Notify ApplyUpdateTokenAnyTx to change owner
+    // Future flags
+};
+
 class CToken
 {
 public:
@@ -146,7 +153,7 @@ public:
     Res CreateDFIToken();
     ResVal<DCT_ID> CreateToken(CTokenImpl const & token, bool isPreBayfront);
     bool RevertCreateToken(uint256 const & txid);   /// @deprecated used only by tests. rewrite tests
-    Res UpdateToken(uint256 const & tokenTx, CToken & newToken, bool isPreBayfront);
+    Res UpdateToken(uint256 const & tokenTx, CToken & newToken, bool isPreBayfront, const uint256* newOwner = nullptr);
 
     Res BayfrontFlagsCleanup();
     Res AddMintedTokens(uint256 const & tokenTx, CAmount const & amount);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1283,6 +1283,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "segwit", consensusParams.SegwitHeight);
     BuriedForkDescPushBack(softforks, "amk", consensusParams.AMKHeight);
     BuriedForkDescPushBack(softforks, "bayfront", consensusParams.BayfrontHeight);
+    BuriedForkDescPushBack(softforks, "cq", consensusParams.CQHeight);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 

--- a/test/functional/feature_tokens_owner.py
+++ b/test/functional/feature_tokens_owner.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test token ownership transfer RPC."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+
+class TokensOwnerTest (DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-cqheight=120']]
+
+    def run_test(self):
+        assert_equal(len(self.nodes[0].listtokens()), 1) # only one token == DFI
+
+        self.nodes[0].generate(101)
+
+        # CREATION:
+        #========================
+        original_owner = self.nodes[0].getnewaddress("", "legacy")
+        new_owner = self.nodes[0].getnewaddress("", "legacy")
+
+        print ("Create token 'GOLD' (128)...")
+        createTokenTx = self.nodes[0].createtoken({
+            "symbol": "GOLD",
+            "name": "shiny gold",
+            "collateralAddress": original_owner
+        }, [])
+
+        self.nodes[0].generate(1)
+
+        # Make sure owner as expected
+        t128 = self.nodes[0].gettoken(createTokenTx) # Gets ID from <CreationTx> and then by <ID> record
+        assert_equal(t128['128']['collateralAddress'], original_owner)
+        assert_equal(t128['128']["name"], "shiny gold")
+        assert_equal(t128['128']["creationTx"], createTokenTx)
+
+        # Fund original_owner address
+        self.nodes[0].sendtoaddress(original_owner, 1)
+        self.nodes[0].sendtoaddress(original_owner, 1)
+        self.nodes[0].generate(1)
+
+        # Try and change owner pre-CQ
+        self.nodes[0].updatetoken("128", {"collateralAddress": new_owner}, [])
+        self.nodes[0].generate(1)
+
+        # Make sure owner has not changed
+        t128 = self.nodes[0].gettoken(128)
+        assert_equal(t128['128']['collateralAddress'], original_owner)
+
+        # Move past CQ hard fork
+        self.nodes[0].generate(120 - self.nodes[0].getblockcount())
+
+        # Update owner post-CQ
+        updateTokenTx = self.nodes[0].updatetoken("128", {"collateralAddress": new_owner}, [])
+        self.nodes[0].generate(1)
+
+        # Make sure owner records have changed
+        t128 = self.nodes[0].gettoken(updateTokenTx) # Gets ID from <CreationTx> and then by <ID> record
+        assert_equal(t128['128']['collateralAddress'], new_owner)
+        assert_equal(t128['128']["creationTx"], updateTokenTx)
+
+        # Fund original_owner address
+        self.nodes[0].sendtoaddress(new_owner, 1)
+        self.nodes[0].sendtoaddress(new_owner, 1)
+        self.nodes[0].generate(1)
+
+        # Mint tokens using new owner
+        self.nodes[0].minttokens(["100000@128"])
+        self.nodes[0].generate(1)
+
+        # Check tokens minted using new_owner
+        t128 = self.nodes[0].gettoken(128)
+        assert_equal(t128['128']['minted'], 100000.00000000)
+
+        # Change name using new owner
+        self.nodes[0].updatetoken("128", {"name": "glossy gold"}, [])
+        self.nodes[0].generate(1)
+
+        # Make sure name has udated
+        t128 = self.nodes[0].gettoken(128)
+        assert_equal(t128['128']['name'], "glossy gold")
+
+        assert_equal(len(self.nodes[0].listtokens()), 2) # only two tokens == DFI, GOLD
+
+if __name__ == '__main__':
+    TokensOwnerTest ().main ()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -131,6 +131,7 @@ class BlockchainTest(DefiTestFramework):
             'segwit': {'type': 'buried', 'active': True, 'height': 0},
             'amk': {'type': 'buried', 'active': False, 'height': 10000000},
             'bayfront': {'type': 'buried', 'active': False, 'height': 10000000},
+            'cq': {'type': 'buried', 'active': False, 'height': 10000000},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -136,6 +136,7 @@ BASE_SCRIPTS = [
     'feature_tokens_basic.py',
     'feature_tokens_minting.py',
     'feature_tokens_dat.py',
+    'feature_tokens_owner.py',
     'feature_accounts_n_utxos.py',
     'feature_token_fork.py',
     'interface_rest.py',


### PR DESCRIPTION
This PR adds a placeholder variable for the next hard fork as the new feature added in this PR requires a consensus change. Hard fork placeholder is CQHeight, ability to set fork height on regtest added, fork height set to max int on all chains except for regtest due to getblockchaininfo test.

enum TokenUpdateFlags added for use as addition to update token metadata to signal change of owner, CToken is serialised into metadata but contains no owner information as owner is derived from the collateralTx output, hence the requirement for an additional flag. TokenUpdateFlags uses uint8_t with bit 1 set as new owner flag, other bits available for future use.

updatetoken RPC call updated to take optional collateralAddress as new owner. Update of owner on tokens owned by foundationMembers as defined in chainparams is not allowed. After CQHeight TokenUpdateFlags added to meta data in updatetoken RPC call and only after that height does ApplyUpdateTokenAnyTx read TokenUpdateFlags from the meta data.

If metadata read in ApplyUpdateTokenAnyTx signals new owner, token is not founders token and the update TX has a new vout[1] collateral output with the correct amount then the creationTx is set to the update TX hash in UpdateToken. UpdateToken first deletes the old <CreationTx> record before creating a new one and then updates the <ID> record.

Python test has been added to test transfer of owner and ability to change asset and mint tokens after ownership transfer.

