### PR TITLE
Auth auto transactions

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -5,11 +5,12 @@
 #include <consensus/tx_verify.h>
 
 #include <consensus/consensus.h>
+#include <consensus/validation.h>
+#include <chainparams.h>
 #include <masternodes/masternodes.h>
 #include <masternodes/mn_checks.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
-#include <consensus/validation.h>
 
 // TODO remove the following dependencies
 #include <chain.h>
@@ -161,7 +162,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const CCustomCSView * mnview, int nSpendHeight, CAmount& txfee)
+bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const CCustomCSView * mnview, int nSpendHeight, CAmount& txfee, const CChainParams& chainparams)
 {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
@@ -220,7 +221,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     const auto txType = GuessCustomTxType(tx, dummy);
 
     if (NotAllowedToFail(txType)) {
-        auto res = ApplyCustomTx(const_cast<CCustomCSView&>(*mnview), inputs, tx, Params(), nSpendHeight, 0, true); // note for 'isCheck == true' here; 'zero' for txn is dummy value
+        auto res = ApplyCustomTx(const_cast<CCustomCSView&>(*mnview), inputs, tx, chainparams.GetConsensus(), nSpendHeight, 0, true); // note for 'isCheck == true' here; 'zero' for txn is dummy value
         if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {
             return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-customtx", res.msg);
         }

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class CBlockIndex;
+class CChainParams;
 class CCoinsViewCache;
 class CCustomCSView;
 class CTransaction;
@@ -25,7 +26,7 @@ namespace Consensus {
  * @param[out] txfee Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
-bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const CCustomCSView * mnview, int nSpendHeight, CAmount& txfee);
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const CCustomCSView * mnview, int nSpendHeight, CAmount& txfee, const CChainParams& chainparams);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -91,8 +91,7 @@ bool HasAuth(CTransaction const & tx, CCoinsViewCache const & coins, CScript con
 {
     for (auto input : tx.vin) {
         const Coin& coin = coins.AccessCoin(input.prevout);
-        assert(!coin.IsSpent());
-        if (coin.out.scriptPubKey == auth)
+        if (!coin.IsSpent() && coin.out.scriptPubKey == auth)
             return true;
     }
     return false;
@@ -108,8 +107,7 @@ bool HasFoundationAuth(CTransaction const & tx, CCoinsViewCache const & coins, C
 {
     for (auto input : tx.vin) {
         const Coin& coin = coins.AccessCoin(input.prevout);
-        assert(!coin.IsSpent());
-        if (consensusParams.foundationMembers.find(coin.out.scriptPubKey) != consensusParams.foundationMembers.end())
+        if (!coin.IsSpent() && consensusParams.foundationMembers.find(coin.out.scriptPubKey) != consensusParams.foundationMembers.end())
             return true;
     }
     return false;

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -226,7 +226,7 @@ sign(CMutableTransaction& mtx, CWallet* const pwallet, CTransactionRef optAuthTx
             if (!optAuthTx->vout[i].scriptPubKey.IsUnspendable()) {
                 UniValue prevout(UniValue::VOBJ);
                 prevout.pushKV("txid", optAuthTx->GetHash().GetHex());
-                prevout.pushKV("vout", i);
+                prevout.pushKV("vout", (uint64_t)i);
                 prevout.pushKV("scriptPubKey", optAuthTx->vout[i].scriptPubKey.GetHex());
                 //prevout.pushKV("redeemScript", );
                 //prevout.pushKV("witnessScript", );

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -371,14 +371,11 @@ CTransactionRef CreateAuthTx(CWallet* const pwallet, std::set<CScript> const & a
 }
 
 static boost::optional<CTxIn> GetAnyFoundationAuthInput(CWallet* const pwallet) {
-    CScript anyFounder;
     for (auto const & founderScript : Params().GetConsensus().foundationMembers) {
         if (IsMine(*pwallet, founderScript) == ISMINE_SPENDABLE) {
             CTxDestination destination;
             if (ExtractDestination(founderScript, destination)) {
-                anyFounder = founderScript;
-                auto auth = GetAuthInputOnly(pwallet, destination);
-                if (auth) {
+                if (auto auth = GetAuthInputOnly(pwallet, destination)) {
                     return auth;
                 }
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1881,7 +1881,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
+void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn, const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(g_cs_orphans);
@@ -1939,7 +1939,7 @@ void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_se
             EraseOrphanTx(orphanHash);
             done = true;
         }
-        mempool.xcheck(&::ChainstateActive().CoinsTip(), pcustomcsview.get());
+        mempool.xcheck(&::ChainstateActive().CoinsTip(), pcustomcsview.get(), chainparams);
     }
 }
 
@@ -2714,7 +2714,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         if (!AlreadyHave(inv) &&
             AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
-            mempool.xcheck(&::ChainstateActive().CoinsTip(), pcustomcsview.get());
+            mempool.xcheck(&::ChainstateActive().CoinsTip(), pcustomcsview.get(), chainparams);
             RelayTransaction(tx.GetHash(), *connman);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 auto it_by_prev = mapOrphanTransactionsByPrev.find(COutPoint(inv.hash, i));
@@ -2733,7 +2733,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 mempool.size(), mempool.DynamicMemoryUsage() / 1000);
 
             // Recursively process any orphan transactions that depended on this one
-            ProcessOrphanTx(connman, pfrom->orphan_work_set, lRemovedTxn);
+            ProcessOrphanTx(connman, pfrom->orphan_work_set, lRemovedTxn, chainparams);
         }
         else if (fMissingInputs)
         {
@@ -3478,7 +3478,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     if (!pfrom->orphan_work_set.empty()) {
         std::list<CTransactionRef> removed_txn;
         LOCK2(cs_main, g_cs_orphans);
-        ProcessOrphanTx(connman, pfrom->orphan_work_set, removed_txn);
+        ProcessOrphanTx(connman, pfrom->orphan_work_set, removed_txn, chainparams);
         for (const CTransactionRef& removedTx : removed_txn) {
             AddToCompactExtraTransactions(removedTx);
         }

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, false);
         BOOST_CHECK(!res.ok);
-        BOOST_CHECK(res.msg.find("negative amount") != std::string::npos);
+        BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
         BOOST_CHECK_EQUAL(mnview.GetBalance(owner, DFI), dfi100);
         BOOST_CHECK_EQUAL(mnview.GetBalance(CScript(0xA), DFI), CTokenAmount{});
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, false);
         BOOST_CHECK(!res.ok);
-        BOOST_CHECK(res.msg.find("negative amount") != std::string::npos);
+        BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
         BOOST_CHECK_EQUAL(mnview.GetBalance(owner, DFI), dfi100);
         BOOST_CHECK_EQUAL(mnview.GetBalance(CScript(0xA), DFI), CTokenAmount{});

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -600,16 +600,16 @@ void CTxMemPool::clear()
     _clear();
 }
 
-static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, const CCustomCSView * mnview, const int64_t spendheight)
+static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, const CCustomCSView * mnview, const int64_t spendheight, const CChainParams& chainparams)
 {
     CValidationState state;
     CAmount txfee = 0;
-    bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, mnview, spendheight, txfee);
+    bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, mnview, spendheight, txfee, chainparams);
     assert(fCheckResult);
     UpdateCoins(tx, mempoolDuplicate, std::numeric_limits<int>::max());
 }
 
-void CTxMemPool::xcheck(const CCoinsViewCache *pcoins, const CCustomCSView * mnview) const
+void CTxMemPool::xcheck(const CCoinsViewCache *pcoins, const CCustomCSView * mnview, const CChainParams& chainparams) const
 {
     LOCK(cs);
     if (nCheckFrequency == 0)
@@ -697,7 +697,7 @@ void CTxMemPool::xcheck(const CCoinsViewCache *pcoins, const CCustomCSView * mnv
         if (fDependsWait)
             waitingOnDependants.push_back(&(*it));
         else {
-            CheckInputsAndUpdateCoins(tx, mempoolDuplicate, mnview, spendheight);
+            CheckInputsAndUpdateCoins(tx, mempoolDuplicate, mnview, spendheight, chainparams);
         }
     }
     unsigned int stepsSinceLastRemove = 0;
@@ -709,7 +709,7 @@ void CTxMemPool::xcheck(const CCoinsViewCache *pcoins, const CCustomCSView * mnv
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            CheckInputsAndUpdateCoins(entry->GetTx(), mempoolDuplicate, mnview, spendheight);
+            CheckInputsAndUpdateCoins(entry->GetTx(), mempoolDuplicate, mnview, spendheight, chainparams);
             stepsSinceLastRemove = 0;
         }
     }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -30,6 +30,7 @@
 #include <boost/signals2/signal.hpp>
 
 class CBlockIndex;
+class CChainParams;
 class CCustomCSView;
 extern CCriticalSection cs_main;
 
@@ -561,7 +562,7 @@ public:
      * all inputs are in the mapNextTx array). If sanity-checking is turned off,
      * check does nothing.
      */
-    void xcheck(const CCoinsViewCache *pcoins, const CCustomCSView *mnview) const;
+    void xcheck(const CCoinsViewCache *pcoins, const CCustomCSView *mnview, const CChainParams& chainparams) const;
     void setSanityCheck(double dFrequency = 1.0) { LOCK(cs); nCheckFrequency = static_cast<uint32_t>(dFrequency * 4294967295.0); }
 
     // addUnchecked must updated state for all ancestors of a given transaction,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -602,7 +602,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         view.GetBestBlock();
 
         CAmount nFees = 0;
-        if (!Consensus::CheckTxInputs(tx, state, view, pcustomcsview.get(), GetSpendHeight(view), nFees)) {
+        if (!Consensus::CheckTxInputs(tx, state, view, pcustomcsview.get(), GetSpendHeight(view), nFees, chainparams)) {
             return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
         }
 
@@ -2116,7 +2116,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (!tx.IsCoinBase())
         {
             CAmount txfee = 0;
-            if (!Consensus::CheckTxInputs(tx, state, view, &mnview, pindex->nHeight, txfee)) {
+            if (!Consensus::CheckTxInputs(tx, state, view, &mnview, pindex->nHeight, txfee, chainparams)) {
                 if (!IsBlockReason(state.GetReason())) {
                     // CheckTxInputs may return MISSING_INPUTS or
                     // PREMATURE_SPEND but we can't return that, as it's not
@@ -2957,7 +2957,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
         // any disconnected transactions back to the mempool.
         UpdateMempoolForReorg(disconnectpool, true);
     }
-    mempool.xcheck(&CoinsTip(), pcustomcsview.get());
+    mempool.xcheck(&CoinsTip(), pcustomcsview.get(), chainparams);
 
     // Callbacks/notifications for a new best chain.
     if (fInvalidFound)

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -49,6 +49,8 @@ public:
     CTxDestination matchDestination;
     //! Token's filter. Match token's ids if set
     std::set<DCT_ID> m_tokenFilter;
+    //! Possible non-wallet inputs (that are not in the wallet nor mempool yet - result of prev pending tx)
+    std::map<COutPoint, CTxOut> m_linkedCoins;
 
     CCoinControl()
     {

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -33,6 +33,13 @@ public:
         m_input_bytes = input_bytes;
     }
 
+    CInputCoin(COutPoint const & outp, CTxOut txout)
+        : outpoint(outp)
+        , txout(txout)
+        , effective_value(txout.nValue)
+    {
+    }
+
     COutPoint outpoint;
     CTxOut txout;
     CAmount effective_value;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1411,6 +1411,6 @@ public:
 // Use DummySignatureCreator, which inserts 71 byte signatures everywhere.
 // NOTE: this requires that all inputs must be in mapWallet (eg the tx should
 // be IsAllFromMe).
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, bool use_max_sig = false) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
+int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, bool use_max_sig = false, std::map<COutPoint, CTxOut> const & linkedCoins = {}) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet);
 int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, bool use_max_sig = false);
 #endif // DEFI_WALLET_WALLET_H

--- a/test/functional/feature_accounts_n_utxos.py
+++ b/test/functional/feature_accounts_n_utxos.py
@@ -54,7 +54,7 @@ class AccountsAndUTXOsTest (DefiTestFramework):
             self.nodes[0].accounttoaccount(self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@" + symbolGOLD}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        assert("not enough balance" in errorString)
 
         # missing from (account exist, but no tokens)
         try:
@@ -77,12 +77,12 @@ class AccountsAndUTXOsTest (DefiTestFramework):
             errorString = e.error['message']
         assert("JSON value is not a string as expected" in errorString)
 
-        # missing (account exists, but does not belong)
+        # missing (account exists, but does not belong) -
         try:
             self.nodes[0].accounttoaccount(accountSilver, {accountGold: "100@" + symbolSILVER}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        assert("Incorrect auth" in errorString)
 
         # transfer
         self.nodes[0].accounttoaccount(accountGold, {toGold: "100@" + symbolGOLD}, [])
@@ -104,12 +104,12 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(accountSilver, {}, True)[idSilver], self.nodes[1].getaccount(accountSilver, {}, True)[idSilver])
         assert_equal(self.nodes[0].getaccount(toSilver, {}, True)[idSilver], self.nodes[1].getaccount(toSilver, {}, True)[idSilver])
 
-        # missing (account exists, there are tokens, but not token 0)
-        try:
-            self.nodes[0].accounttoaccount(toSilver, {accountGold: "100@" + symbolSILVER}, [])
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        # missing (account exists, there are tokens, but not token 0) - autofunded now!
+        # try:
+        #     self.nodes[0].accounttoaccount(toSilver, {accountGold: "100@" + symbolSILVER}, [])
+        # except JSONRPCException as e:
+        #     errorString = e.error['message']
+        # assert("Can't find any UTXO" in errorString)
 
         # utxostoaccount
         #========================
@@ -143,10 +143,10 @@ class AccountsAndUTXOsTest (DefiTestFramework):
         #========================
         # missing from (account)
         try:
-            self.nodes[0].accounttoutxos(self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@" + symbolGOLD}, [])
+            self.nodes[0].accounttoutxos(self.nodes[0].getnewaddress("", "legacy"), {toGold: "100@DFI"}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        assert("not enough balance" in errorString)
 
         # missing amount
         try:
@@ -167,14 +167,14 @@ class AccountsAndUTXOsTest (DefiTestFramework):
             self.nodes[0].accounttoutxos(accountSilver, {accountGold: "100@" + symbolSILVER}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        assert("Incorrect auth" in errorString)
 
         # missing (account exists, there are tokens, but not token 0)
         try:
-            self.nodes[0].accounttoutxos(toSilver, {accountGold: "100@" + symbolSILVER}, [])
+            self.nodes[0].accounttoutxos(toSilver, {accountGold: "100@DFI"}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Can't find any UTXO" in errorString)
+        assert("not enough balance" in errorString)
 
         # transfer
         try:

--- a/test/functional/feature_autoauth.py
+++ b/test/functional/feature_autoauth.py
@@ -40,7 +40,7 @@ class TokensAutoAuthTest (DefiTestFramework):
         self.step()
 
 
-        ##### Masternodes auth:
+        #==== Masternodes auth:
         # RPC 'resignmasternode'
         mnCollateral = n0.getnewaddress("", "legacy")
         mnId = n0.createmasternode(mnCollateral)
@@ -61,7 +61,7 @@ class TokensAutoAuthTest (DefiTestFramework):
         assert_equal(len(n0.getrawmempool()), 0)
 
 
-        ##### Tokens auth:
+        #==== Tokens auth:
         # RPC 'createtoken'
         collateralGold = self.nodes[0].getnewaddress("", "legacy")
         try:
@@ -128,7 +128,7 @@ class TokensAutoAuthTest (DefiTestFramework):
         assert_equal(n0.getaccount(collateralSilver, {}, True)['2'], 5000)
 
 
-        ##### Liquidity Pools auth:
+        #==== Liquidity Pools auth:
         # RPC 'createpoolpair'
         poolOwner = n0.getnewaddress("", "legacy")
         try:
@@ -255,7 +255,7 @@ class TokensAutoAuthTest (DefiTestFramework):
         assert_equal(len(n0.getrawmempool()), 0)
 
 
-        ##### Transfer auths:
+        #==== Transfer auths:
         # RPC 'accounttoaccount'
         try:
             n0.accounttoaccount(poolShare, {swapped: "1@GS"}, [ n0.listunspent()[0] ])
@@ -289,7 +289,6 @@ class TokensAutoAuthTest (DefiTestFramework):
         assert_equal(len(n0.getrawmempool()), 2)
         self.step()
         assert_equal(len(n0.getrawmempool()), 0)
-        # print ("n0.listunspent()", n0.listunspent(addresses = [swapped] ))
         assert_equal(n0.listunspent(addresses = [swapped] )[0]['amount'], Decimal('0.2'))
 
 

--- a/test/functional/feature_autoauth.py
+++ b/test/functional/feature_autoauth.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test autoauth
+
+- verify creation and funding of special "chained" add-on auth tx for every custom tx that needs authtorization utxos
+"""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal
+from decimal import Decimal
+
+class TokensAutoAuthTest (DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50'],
+                           ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50']]
+
+    def step(self, node = None, blocks = 1):
+        if node is None:
+            node = self.nodes[1]
+        self.sync_mempools()
+        node.generate(blocks)
+        self.sync_blocks()
+
+    def run_test(self):
+        n0 = self.nodes[0]
+        n1 = self.nodes[1]
+
+        self.step(blocks=102) # for 2 matured utxos
+
+        # initial funds:
+        funds0 = n0.getnewaddress("", "legacy")
+        n1.sendmany("", { funds0 : 50} )
+        self.step()
+
+
+        ##### Masternodes auth:
+        # RPC 'resignmasternode'
+        mnCollateral = n0.getnewaddress("", "legacy")
+        mnId = n0.createmasternode(mnCollateral)
+        self.step()
+        assert_equal(len(n0.listmasternodes()), 9)
+        assert_equal(len(n0.getrawmempool()), 0)
+        try:
+            n0.resignmasternode(mnId, [ n0.listunspent()[0] ])
+            assert (False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from masternode owner" in errorString)
+
+        n0.resignmasternode(mnId)
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(n0.listmasternodes()[mnId]['state'], 'PRE_RESIGNED')
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        ##### Tokens auth:
+        # RPC 'createtoken'
+        collateralGold = self.nodes[0].getnewaddress("", "legacy")
+        try:
+            n0.createtoken({
+                "symbol": "GOLD",
+                "name": "shiny gold",
+                "isDAT": True,
+                "collateralAddress": collateralGold
+            }, [ n0.listunspent()[0] ])
+            assert (False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx not from foundation member" in errorString)
+        n0.createtoken({
+            "symbol": "GOLD",
+            "name": "shiny gold",
+            "isDAT": True,
+            "collateralAddress": collateralGold
+        })
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.listtokens()), 2)
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        # RPC 'updatetoken'
+        try:
+            n0.updatetoken("GOLD", {"isDAT": False}, [ n0.listunspent()[0] ])
+            assert (False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from token owner" in errorString)
+        n0.updatetoken(
+            "GOLD", {"isDAT": False}
+            )
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(n0.listtokens()['1']["isDAT"], False)
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        # RPC 'minttoken'
+        # create one more token (for multiple mint and latter LP)
+        collateralSilver = self.nodes[0].getnewaddress("", "legacy")
+        n0.createtoken({
+            "symbol": "SILVER",
+            "name": "just silver",
+            "isDAT": True,
+            "collateralAddress": collateralSilver
+        })
+        self.step()
+        assert_equal(len(n0.listtokens()), 3)
+
+        try:
+            n0.minttokens(["1000@GOLD#1", "1000@SILVER"], [ n0.listunspent()[0] ])
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from token owner" in errorString)
+        n0.minttokens(["1000@GOLD#1", "5000@SILVER"])
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        assert_equal(n0.getaccount(collateralGold,   {}, True)['1'], 1000)
+        assert_equal(n0.getaccount(collateralSilver, {}, True)['2'], 5000)
+
+
+        ##### Liquidity Pools auth:
+        # RPC 'createpoolpair'
+        poolOwner = n0.getnewaddress("", "legacy")
+        try:
+            n0.createpoolpair({
+                "tokenA": "GOLD#1",
+                "tokenB": "SILVER",
+                "comission": 0.001,
+                "status": True,
+                "ownerAddress": poolOwner,
+                "pairSymbol": "GS"
+            }, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx not from foundation member" in errorString)
+        n0.createpoolpair({
+            "tokenA": "GOLD#1",
+            "tokenB": "SILVER",
+            "comission": 0.001,
+            "status": True,
+            "ownerAddress": poolOwner,
+            "pairSymbol": "GS"
+        })
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        # RPC 'addpoolliquidity'
+        poolShare = n0.getnewaddress("", "legacy")
+        try:
+            n0.addpoolliquidity({
+                collateralGold: "100@GOLD#1", collateralSilver: "500@SILVER"
+            }, poolShare, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from account owner" in errorString)
+        n0.addpoolliquidity({
+            collateralGold: "100@GOLD#1", collateralSilver: "500@SILVER"
+        }, poolShare)
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        assert(n0.getaccount(poolShare, {}, True)['3'] > 200) # 223....
+
+
+        # RPC 'poolswap'
+        swapped = n0.getnewaddress("", "legacy")
+        try:
+            n0.poolswap({
+                "from": collateralGold,
+                "tokenFrom": "GOLD#1",
+                "amountFrom": 10,
+                "to": swapped,
+                "tokenTo": "SILVER"
+            }, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            # print (errorString)
+        assert("tx must have at least one input from account owner" in errorString)
+        n0.poolswap({
+            "from": collateralGold,
+            "tokenFrom": "GOLD#1",
+            "amountFrom": 10,
+            "to": swapped,
+            "tokenTo": "SILVER"
+        })
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        assert(n0.getaccount(swapped, {}, True)['2'] > 45)
+
+
+        # RPC 'removepoolliquidity'
+        try:
+            n0.removepoolliquidity(
+                poolShare, "200@GS", [ n0.listunspent()[0] ]
+            )
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from account owner" in errorString)
+        n0.removepoolliquidity(poolShare, "200@GS")
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        assert_equal(len(n0.getaccount(poolShare, {}, True)), 3) # so gold and silver appears
+
+
+        # RPC 'updatepoolpair'
+        try:
+            self.nodes[0].updatepoolpair({
+                "pool": "GS",
+                "status": False
+            }, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx not from foundation member" in errorString)
+        self.nodes[0].updatepoolpair({
+            "pool": "GS",
+            "status": False
+        })
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        # RPC 'setgov'
+        try:
+            n0.setgov({ "LP_DAILY_DFI_REWARD": 35.5 }, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx not from foundation member" in errorString)
+
+        n0.setgov({ "LP_DAILY_DFI_REWARD": 35.5 })
+        n0.setgov({ "LP_SPLITS": { "3": 1 } })
+
+        assert_equal(len(n0.getrawmempool()), 4)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+
+
+        ##### Transfer auths:
+        # RPC 'accounttoaccount'
+        try:
+            n0.accounttoaccount(poolShare, {swapped: "1@GS"}, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from account owner" in errorString)
+        n0.accounttoaccount(poolShare, {swapped: "10@GS"})
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        assert_equal(n0.getaccount(swapped, {}, True)['3'], 10)
+
+        # turn on the pool to get some DFI rewards on LP accounts
+        n0.updatepoolpair({
+            "pool": "GS",
+            "status": True
+        })
+        self.step()
+        print("swapped", n0.getaccount(swapped, {}, True))
+        print("poolShare", n0.getaccount(poolShare, {}, True))
+
+        # RPC 'accounttoutxos'
+        try:
+            self.nodes[0].accounttoutxos(swapped, {swapped: "0.2"}, [ n0.listunspent()[0] ])
+            assert(False)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("tx must have at least one input from account owner" in errorString)
+        n0.accounttoutxos(swapped, {swapped: "0.2"})
+        assert_equal(len(n0.getrawmempool()), 2)
+        self.step()
+        assert_equal(len(n0.getrawmempool()), 0)
+        # print ("n0.listunspent()", n0.listunspent(addresses = [swapped] ))
+        assert_equal(n0.listunspent(addresses = [swapped] )[0]['amount'], Decimal('0.2'))
+
+
+if __name__ == '__main__':
+    TokensAutoAuthTest ().main ()

--- a/test/functional/feature_poolpair.py
+++ b/test/functional/feature_poolpair.py
@@ -137,7 +137,7 @@ class PoolPairTest (DefiTestFramework):
         }, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Incorrect Authorization" in errorString)
+        assert("Need foundation member authorization" in errorString)
 
         # 9 Checking pool existence
         p0 = self.nodes[0].getpoolpair("PTGOLD")

--- a/test/functional/feature_poolpair_liquidity.py
+++ b/test/functional/feature_poolpair_liquidity.py
@@ -224,7 +224,7 @@ class PoolLiquidityTest (DefiTestFramework):
             self.nodes[0].removepoolliquidity(poolOwner, "10@GS", [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Amount 0 is less" in errorString)
+        assert("amount 0 is less" in errorString)
 
 
         resAmountA = make_rounded_decimal(25 * poolReserveA / poolLiquidity)

--- a/test/functional/feature_tokens_dat.py
+++ b/test/functional/feature_tokens_dat.py
@@ -104,7 +104,7 @@ class TokensBasicTest (DefiTestFramework):
             self.nodes[2].updatetoken("GOLD#128", {"isDAT": True}, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Incorrect Authorization" in errorString)
+        assert("Need foundation member authorization" in errorString)
 
         # 4.1 Trying to set smth else
         try:

--- a/test/functional/rpc_mn_basic.py
+++ b/test/functional/rpc_mn_basic.py
@@ -39,7 +39,6 @@ class MasternodesRpcBasicTest (DefiTestFramework):
             )
         except JSONRPCException as e:
             errorString = e.error['message']
-            print (errorString)
         assert("Insufficient funds" in errorString)
 
         # Create node0
@@ -82,11 +81,13 @@ class MasternodesRpcBasicTest (DefiTestFramework):
         # RESIGNING:
         #========================
         # Fail to resign: Have no money on ownerauth address
-        try:
-            self.nodes[0].resignmasternode(idnode0)
-        except JSONRPCException as e:
-            errorString = e.error['message']
-        assert("Can't find any UTXO's" in errorString)
+
+        # Deprecated due to auth automation
+        # try:
+        #     self.nodes[0].resignmasternode(idnode0)
+        # except JSONRPCException as e:
+        #     errorString = e.error['message']
+        # assert("Can't find any UTXO's" in errorString)
 
         # Funding auth address and successful resign
         fundingTx = self.nodes[0].sendtoaddress(collateral0, 1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -119,6 +119,7 @@ BASE_SCRIPTS = [
     'feature_anchors.py',
     'feature_anchor_rewards.py',
     'feature_anchorauths_pruning.py',
+    'feature_autoauth.py',
     'feature_criminals.py',
     'feature_setgov.py',
     'interface_zmq.py',


### PR DESCRIPTION
The whole of RPC's authorization mechanics were refactored. 
The main feature: all of the RPCs can create intermediate optional auth tx in the case when some "auth utxos" were missed in the regular authorization process.
This should greatly improve UX. Nothing was broken. Almost all changes touched only internal wallet/coin selector logic.

How it works:
The auth process starts as usual. But if there is no particular "auth utxo" - it is tracked and then, optional tx will be created with minimal (dust) amounts as auth txouts (and with the proper change of course). This tx will be auto funded (as usual) and signed (not sent yet!). Then, all of its txouts will be added into txins of "main" transaction - creating a kind of "chain".
Then, the "main" tx will be auto funded (as usual), with respect to locked/used coins in intermediate auth tx. Then, regular "apply*" checks will be processed. And only in the case of success, both of txs will be sent to mempool.
If some bad things happen, temporarily locked coins (by auth tx) will be unlocked by a special scoped autoobject.

This solution does not send the change back to auth address cause in the common cases this is not a "panacea": any users' activity between custom txs can (and will) grub auth utxos by standard funding process. So, sending the change back to auth addresses is almost useless.
Note that the whole spendable txouts (and the change too) of intermediate optional tx used as the next tx inputs. It was made for simplicity (of coins tracking/selecting) and for the ability to extend such a solution with additional intermediate txs in the future.

The tests in the separate commit addressed every custom tx where auth utxos used.