### PR TITLE
Fix CI build fail

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -314,7 +314,7 @@ git_version() {
     fi
 
     echo "> version: ${IMAGE_VERSION}"
-    echo "::set-env name=BUILD_VERSION::${IMAGE_VERSION}" # GitHub Actions
+    echo "BUILD_VERSION::${IMAGE_VERSION}" >> $GITHUB_ENV # GitHub Actions
 }
 
 pkg_install_deps() {

--- a/make.sh
+++ b/make.sh
@@ -314,7 +314,7 @@ git_version() {
     fi
 
     echo "> version: ${IMAGE_VERSION}"
-    echo "BUILD_VERSION::${IMAGE_VERSION}" >> $GITHUB_ENV # GitHub Actions
+    echo "BUILD_VERSION=${IMAGE_VERSION}" >> $GITHUB_ENV # GitHub Actions
 }
 
 pkg_install_deps() {


### PR DESCRIPTION
Fix CI build fail, using environment file instead of environment variable according to github's guide.
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files