### PR TITLE
Fix anchor API parameter bugs

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -291,7 +291,6 @@ void CAnchorIndex::ForEachAnchorByBtcHeight(std::function<bool(const CAnchorInde
     KList const & list = anchors.get<AnchorRec::ByBtcHeight>();
     for (auto it = list.rbegin(); it != list.rend(); ++it)
         if (!callback(*it)) break;
-
 }
 
 const CAnchorIndex::AnchorRec * CAnchorIndex::GetActiveAnchor() const

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -212,7 +212,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     { "spv_sendrawtx", 0, "rawtx" },
     { "spv_createanchor", 0, "inputs" },
-    { "spv_createanchor", 1, "rewardAddress" },
     { "spv_createanchor", 2, "send" },
     { "spv_createanchor", 3, "feerate" },
     { "spv_createanchortemplate", 0, "rewardAddress" },

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -188,10 +188,13 @@ UniValue spv_createanchor(const JSONRPCRequest& request)
     {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, arguments 1 and 2 must be non-null");
     }
-
+    
+    const UniValue inputs = request.params[0].get_array();
+    if (inputs.empty())
+    {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Transaction input cannot be empty");
+    }
     std::vector<spv::TxInputData> inputsData;
-    UniValue inputs(UniValue::VARR);
-    inputs = request.params[0].get_array();
     for (size_t idx = 0; idx < inputs.size(); ++idx)
     {
         UniValue const & input = inputs[idx].get_obj();
@@ -655,11 +658,11 @@ UniValue spv_listanchorrewards(const JSONRPCRequest& request)
     CWallet* const pwallet = GetWallet(request);
 
     RPCHelpMan{"spv_listanchorrewards",
-               "\nList anchor confirms (if any)\n",
+               "\nList anchor rewards (if any)\n",
                {
                },
                RPCResult{
-                       "\"array\"                  Returns array of anchor confirms\n"
+                       "\"array\"                  Returns array of anchor rewards\n"
                },
                RPCExamples{
                        HelpExampleCli("spv_listanchorrewards", "")


### PR DESCRIPTION
1. Fix anchor API parameter convert bug
2. Add an extra parameter checking for `spv_createanchor`
3. Fix help message is wrong problem.