### PR TITLE
Validate signature on block index load instead of minter public key

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -15,7 +15,6 @@
 #include <uint256.h>
 
 #include <vector>
-#include <boost/optional.hpp>
 
 /**
  * Maximum amount of time that a block timestamp is allowed to exceed the
@@ -188,7 +187,6 @@ public:
     uint64_t mintedBlocks;
     uint256 stakeModifier; // hash modifier for proof-of-stake
     std::vector<unsigned char> sig;
-    CKeyID minter; // memory only
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -220,7 +218,6 @@ public:
         height         = 0;
         mintedBlocks   = 0;
         sig            = {};
-        minter         = CKeyID();
     }
 
     CBlockIndex()
@@ -240,7 +237,6 @@ public:
         mintedBlocks   = block.mintedBlocks;
         stakeModifier  = block.stakeModifier;
         sig            = block.sig;
-        block.ExtractMinterKey(minter);
     }
 
     FlatFilePos GetBlockPos() const {
@@ -277,7 +273,15 @@ public:
         return block;
     }
 
-    uint256 GetBlockHash() const
+    CKeyID minterKey() const
+    {
+        CKeyID key;
+        if (!GetBlockHeader().ExtractMinterKey(key) && pprev)
+            throw std::runtime_error("Wrong minter public key, data is corrupt");
+        return key;
+    }
+
+    const uint256& GetBlockHash() const
     {
         return *phashBlock;
     }

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -201,6 +201,8 @@ public:
 
     //! Derive BIP32 child pubkey.
     bool Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;
+
+    static bool TryRecoverSigCompat(const std::vector<unsigned char>& vchSig, std::vector<unsigned char>* sig = nullptr);
 };
 
 struct CExtPubKey {

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -135,9 +135,6 @@ BOOST_AUTO_TEST_CASE(math_liquidity_and_trade)
         res = pool.Swap(CTokenAmount{pool.idTokenB, 2}, PoolPrice{std::numeric_limits<CAmount>::max(), 0}, FAIL_onSwap);
         BOOST_CHECK(!res.ok && res.msg == "Lack of liquidity.");
 
-        res = pool.AddLiquidity(3037000500+1, 1, {}, FAIL_onMint);
-        BOOST_CHECK(!res.ok && res.msg == "Exceeds max ratio slippage protection of 3%");
-
         // thats all, we can't place anything here until removing. trading disabled due to reserveB < SLOPE_SWAP_RATE
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -280,13 +280,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->mintedBlocks = diskindex.mintedBlocks;
                 pindexNew->sig = diskindex.sig;
                 if (pindexNew->nHeight && !skipSigCheck) {
-                    CPubKey recoveredPubKey{};
-                    if (!recoveredPubKey.RecoverCompact(pindexNew->GetBlockHeader().GetHashToSign(), pindexNew->sig)) {
+                    if (!CPubKey::TryRecoverSigCompat(pindexNew->sig)) {
                         return error("%s: The block index #%d (%s) wasn't saved on disk correctly. Index content: %s", __func__, pindexNew->nHeight, pindexNew->GetBlockHash().ToString(), pindexNew->ToString());
                     }
-                    pindexNew->minter = recoveredPubKey.GetID();
-                } else {
-                    pindexNew->minter = CKeyID();
                 }
 //                if (pindexNew->nHeight > 0 && pindexNew->stakeModifier != pos::ComputeStakeModifier(pindexNew->pprev->stakeModifier, pindexNew->minter)) { // TODO: SS disable check stake modifier
 //                    return error("%s: The block index #%d (%s) wasn't saved on disk correctly. Stake modifier is incorrect (%s != %s). Index content: %s",

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1679,7 +1679,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     view.SetBestBlock(pindex->pprev->GetBlockHash());
 
     if (!fIsFakeNet) {
-        mnview.DecrementMintedBy(pindex->minter);
+        mnview.DecrementMintedBy(pindex->minterKey());
     }
     mnview.SetLastHeight(pindex->pprev->nHeight);
 
@@ -1944,7 +1944,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // We are forced not to check this due to the block wasn't signed yet if called by TestBlockValidity()
     if (!fJustCheck && !fIsFakeNet) {
         // Check only that mintedBlocks counter is correct (MN existence and activation was partially checked before in CheckBlock()->ContextualCheckProofOfStake(), but not in the case of fJustCheck)
-        auto nodeId = mnview.GetMasternodeIdByOperator(pindex->minter);
+        auto nodeId = mnview.GetMasternodeIdByOperator(pindex->minterKey());
         assert(nodeId);
         auto const & node = *mnview.GetMasternode(*nodeId);
         if (node.mintedBlocks + 1 != block.mintedBlocks)
@@ -2314,7 +2314,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     }
 
     if (!fIsFakeNet) {
-        mnview.IncrementMintedBy(pindex->minter); // pindex->minter was extracted before
+        mnview.IncrementMintedBy(pindex->minterKey());
     }
     mnview.SetLastHeight(pindex->nHeight);
 


### PR DESCRIPTION
Starting time down from 1 min to 1 sec, extracting minter public key is pretty slow for reason: hash to sign should be calculated on the fly, that slowdown whole validation process. Instead signature can be safe and fast checked that it's valid.