### PR TITLE
Remove use of PRECISION in reward calculations

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,6 +117,7 @@ public:
         consensus.AMKHeight = 356500;
         consensus.BayfrontHeight = 405000;
         consensus.BayfrontMarinaHeight = 465150;
+        consensus.BayfrontGardensHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -277,6 +278,7 @@ public:
         consensus.AMKHeight = 150;
         consensus.BayfrontHeight = 3000;
         consensus.BayfrontMarinaHeight = 90470;
+        consensus.BayfrontGardensHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -414,6 +416,7 @@ public:
         consensus.AMKHeight = 150;
         consensus.BayfrontHeight = 250;
         consensus.BayfrontMarinaHeight = 0;
+        consensus.BayfrontGardensHeight = 0;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -546,6 +549,7 @@ public:
         consensus.AMKHeight = 10000000;
         consensus.BayfrontHeight = 10000000;
         consensus.BayfrontMarinaHeight = 0;
+        consensus.BayfrontGardensHeight = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -704,6 +708,17 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
         int64_t height = gArgs.GetArg("-bayfrontheight", consensus.BayfrontHeight);
         if (height < -1 || height >= std::numeric_limits<int>::max()) {
             throw std::runtime_error(strprintf("Activation height %ld for Bayfront is out of valid range. Use -1 to disable bayfront features.", height));
+        } else if (height == -1) {
+            LogPrintf("Bayfront disabled for testing\n");
+            height = std::numeric_limits<int>::max();
+        }
+        consensus.BayfrontHeight = static_cast<int>(height);
+    }
+
+    if (gArgs.IsArgSet("-bayfrontgardensheight")) {
+        int64_t height = gArgs.GetArg("-bayfrontgardensheight", consensus.BayfrontGardensHeight);
+        if (height < -1 || height >= std::numeric_limits<int>::max()) {
+            throw std::runtime_error(strprintf("Activation height %ld for Bayfront is out of valid range. Use -1 to disable bayfront gardens features.", height));
         } else if (height == -1) {
             LogPrintf("Bayfront disabled for testing\n");
             height = std::numeric_limits<int>::max();

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,6 +75,7 @@ struct Params {
     /** What exactly? Changes to mint DAT, new updatetokens? */
     int BayfrontHeight;
     int BayfrontMarinaHeight;
+    int BayfrontGardensHeight;
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -465,6 +465,7 @@ void SetupServerArgs()
     gArgs.AddArg("-spv_rescan", "Block height to rescan from (default: 0 = off)", ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     gArgs.AddArg("-amkheight", "AMK fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontheight", "Bayfront fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-bayfrontgardensheight", "Bayfront Gardens fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -258,7 +258,7 @@ public:
     }
 
     /// @attention it throws (at least for debug), cause errors are critical!
-    CAmount DistributeRewards(CAmount yieldFarming, std::function<CTokenAmount(CScript const & owner, DCT_ID tokenID)> onGetBalance, std::function<Res(CScript const & to, CTokenAmount amount)> onTransfer) {
+    CAmount DistributeRewards(CAmount yieldFarming, std::function<CTokenAmount(CScript const & owner, DCT_ID tokenID)> onGetBalance, std::function<Res(CScript const & to, CTokenAmount amount)> onTransfer, bool newRewardCalc = false) {
 
         uint32_t const PRECISION = 10000; // (== 100%) just searching the way to avoid arith256 inflating
         CAmount totalDistributed = 0;
@@ -285,18 +285,27 @@ public:
 
                 // distribute trading fees
                 if (pool.swapEvent) {
-                    CAmount feeA = pool.blockCommissionA * liqWeight / PRECISION;       // liquidity / pool.totalLiquidity;
+                    CAmount feeA = pool.blockCommissionA * liquidity / pool.totalLiquidity;
+                    if (!newRewardCalc) {
+                        feeA = pool.blockCommissionA * liqWeight / PRECISION;
+                    }
                     distributedFeeA += feeA;
                     onTransfer(provider, {pool.idTokenA, feeA}); //can throw
 
-                    CAmount feeB = pool.blockCommissionB * liqWeight / PRECISION;       // liquidity / pool.totalLiquidity;
+                    CAmount feeB = pool.blockCommissionB * liquidity / pool.totalLiquidity;
+                    if (!newRewardCalc) {
+                        feeB = pool.blockCommissionB * liqWeight / PRECISION;
+                    }
                     distributedFeeB += feeB;
                     onTransfer(provider, {pool.idTokenB, feeB}); //can throw
                 }
 
                 // distribute yield farming
                 if (poolReward) {
-                    CAmount providerReward = poolReward * liqWeight / PRECISION;        //liquidity / pool.totalLiquidity;
+                    CAmount providerReward = poolReward * liquidity / pool.totalLiquidity;
+                    if (!newRewardCalc) {
+                        providerReward = poolReward * liqWeight / PRECISION;
+                    }
                     if (providerReward) {
                         onTransfer(provider, {DCT_ID{0}, providerReward}); //can throw
                         totalDistributed += providerReward;

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -270,7 +270,8 @@ public:
             CAmount distributedFeeA = 0;
             CAmount distributedFeeB = 0;
 
-            if (!pool.swapEvent && (poolReward == 0 || pool.totalLiquidity == 0)) {
+            
+            if (pool.totalLiquidity == 0 || (!pool.swapEvent && poolReward == 0)) {
                 return true; // no events, skip to the next pool
             }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2289,7 +2289,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!res.ok)
                         throw std::runtime_error(strprintf("Pool rewards: can't update balance of %s: %s, Block %ld (%s)", to.GetHex(), res.msg, block.height, block.GetHash().ToString()));
                     return res;
-                }
+                },
+                pindex->nHeight >= chainparams.GetConsensus().BayfrontGardensHeight // Toggle new reward calc behaviour
             );
 
             auto res = cache.SubCommunityBalance(CommunityAccountType::IncentiveFunding, distributed);


### PR DESCRIPTION
Remove use of PRECISION used in calculating pool rewards due to potential loss of rewards. It does not give the ability to create rewards at the lower values, currently the minimum possible payout is reward / 10,000. The PRECISION value always has the potential to lose rewards when the total pool liquidity is more than user liquidity times PRECISION.