### PR TITLE
RPC clearmempool

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -529,6 +529,35 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
     return MempoolToJSON(::mempool, fVerbose);
 }
 
+static UniValue clearmempool(const JSONRPCRequest& request)
+{
+    RPCHelpMan("clearmempool",
+       "\nClears the memory pool and returns a list of the removed transactions.\n",
+       {},
+       RPCResult{
+           "[                     (json array of string)\n"
+           "  \"hash\"              (string) The transaction hash\n"
+           "  ,...\n"
+           "]\n"
+       },
+       RPCExamples{
+           HelpExampleCli("clearmempool", "")
+           + HelpExampleRpc("clearmempool", "")
+       }
+    ).Check(request);
+
+    std::vector<uint256> vtxid;
+    mempool.queryHashes(vtxid);
+
+    UniValue removed(UniValue::VARR);
+    for (const uint256& hash : vtxid)
+        removed.push_back(hash.ToString());
+
+    mempool.clear();
+
+    return removed;
+}
+
 static UniValue getmempoolancestors(const JSONRPCRequest& request)
 {
             RPCHelpMan{"getmempoolancestors",
@@ -2263,6 +2292,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getmempooldescendants",  &getmempooldescendants,  {"txid","verbose"} },
     { "blockchain",         "getmempoolentry",        &getmempoolentry,        {"txid"} },
     { "blockchain",         "getmempoolinfo",         &getmempoolinfo,         {} },
+    { "blockchain",         "clearmempool",           &clearmempool,           {} },
     { "blockchain",         "getrawmempool",          &getrawmempool,          {"verbose"} },
     { "blockchain",         "gettxout",               &gettxout,               {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        {} },


### PR DESCRIPTION
Add clearmempool RPC call, useful in testing when rolling back blocks to retry a transaction without old transaction creating problems.