### PR TITLE
Prevent transactions in blocks from going below balance.

### DIFF
--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -6,6 +6,8 @@
 #include <masternodes/accounts.h>
 #include <key_io.h>
 
+#include <limits>
+
 /// @attention make sure that it does not overlap with those in masternodes.cpp/tokens.cpp/undos.cpp/accounts.cpp !!!
 const unsigned char CAccountsHistoryView::ByAccountHistoryKey::prefix = 'h'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
 
@@ -32,7 +34,8 @@ Res CAccountsHistoryView::SetAccountHistory(const CScript & owner, uint32_t heig
 }
 
 bool CAccountsHistoryView::TrackAffectedAccounts(CStorageKV const & before, MapKV const & diff, uint32_t height, uint32_t txn, const uint256 & txid, unsigned char category) {
-    if (!gArgs.GetBoolArg("-acindex", false))
+    // txn set to max if called from CreateNewBlock to check account balances, do not track here.
+    if (!gArgs.GetBoolArg("-acindex", false) || txn == std::numeric_limits<uint32_t>::max())
         return false;
 
     std::map<CScript, TAmounts> balancesDiff;

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -113,7 +113,7 @@ bool HasAuth(CTransaction const & tx, CKeyID const & auth);
 bool HasAuth(CTransaction const & tx, CCoinsViewCache const & coins, CScript const & auth);
 bool HasCollateralAuth(CTransaction const & tx, CCoinsViewCache const & coins, uint256 const & collateralTx);
 
-Res ApplyCustomTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, const Consensus::Params& consensusParams, uint32_t height, uint32_t txn, bool isCheck = true);
+Res ApplyCustomTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, const Consensus::Params& consensusParams, uint32_t height, uint32_t txn, bool isCheck = true, bool skipAuth = false);
 //! Deep check (and write)
 Res ApplyCreateMasternodeTx(CCustomCSView & mnview, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
 Res ApplyResignMasternodeTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata);
@@ -121,7 +121,7 @@ Res ApplyResignMasternodeTx(CCustomCSView & mnview, CCoinsViewCache const & coin
 Res ApplyCreateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 Res ApplyUpdateTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 Res ApplyUpdateTokenAnyTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
-Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyMintTokenTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams, bool skipAuth = false);
 
 Res ApplyCreatePoolPairTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 Res ApplyUpdatePoolPairTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
@@ -130,7 +130,7 @@ Res ApplyAddPoolLiquidityTx(CCustomCSView & mnview, CCoinsViewCache const & coin
 Res ApplyRemovePoolLiquidityTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 
 Res ApplyUtxosToAccountTx(CCustomCSView & mnview, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
-Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
+Res ApplyAccountToUtxosTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams, bool skipAuth = false);
 Res ApplyAccountToAccountTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 Res ApplyAnyAccountsToAccountsTx(CCustomCSView & mnview, CCoinsViewCache const & coins, CTransaction const & tx, uint32_t height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -557,17 +557,17 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             }
 
             std::vector<unsigned char> metadata;
-            CustomTxType txType = GuessCustomTxType(sortedEntries[i]->GetTx(), metadata);
+            CustomTxType txType = GuessCustomTxType(tx, metadata);
 
             // Only check custom TXs
             if (txType != CustomTxType::None) {
-                auto res = ApplyCustomTx(view, ::ChainstateActive().CoinsTip(), sortedEntries[i]->GetTx(), chainparams.GetConsensus(), nHeight, std::numeric_limits<uint32_t>::max(), false, true);
+                auto res = ApplyCustomTx(view, ::ChainstateActive().CoinsTip(), tx, chainparams.GetConsensus(), nHeight, std::numeric_limits<uint32_t>::max(), false, true);
 
                 // Not okay invalidate, undo and skip
                 if (!res.ok && NotAllowedToFail(txType)) {
                     customTxPassed = false;
 
-                    LogPrintf("%s: Failed %s TX %s: %s\n", __func__, ToString(txType), sortedEntries[i]->GetTx().GetHash().GetHex(), res.msg);
+                    LogPrintf("%s: Failed %s TX %s: %s\n", __func__, ToString(txType), tx.GetHash().GetHex(), res.msg);
 
                     break;
                 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -180,7 +180,7 @@ private:
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, int nHeight) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1835,7 +1835,6 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return Res::ErrDbg("bad-cb-wrong-tokens", "coinbase should pay only Defi coins");
 
     if (height >= consensus.AMKHeight) {
-        LogPrintf("ApplyGeneralCoinbaseTx() post AMK logic\n");
         // check classic UTXO foundation share:
         if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1 != 0) {
             CAmount foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;

--- a/test/functional/feature_account_mining.py
+++ b/test/functional/feature_account_mining.py
@@ -16,7 +16,7 @@ class AccountMiningTest(DefiTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        node.generate(101)
+        node.generate(110)
 
         # Get addresses and set up account
         account = node.getnewaddress()
@@ -28,8 +28,10 @@ class AccountMiningTest(DefiTestFramework):
         assert_equal(node.getaccount(account)[0], "10.00000000@DFI")
 
         # Send double the amount we have in account
-        node.accounttoutxos(account, {destination: "10@0"})
-        node.accounttoutxos(account, {destination: "10@0"})
+        node.accounttoutxos(account, {destination: "10@DFI"})
+        node.accounttoutxos(account, {destination: "2@DFI"})
+        node.accounttoutxos(account, {destination: "2@DFI"})
+        node.accounttoutxos(account, {destination: "2@DFI"})
 
         # Store block height
         blockcount = node.getblockcount()

--- a/test/functional/feature_account_mining.py
+++ b/test/functional/feature_account_mining.py
@@ -16,7 +16,7 @@ class AccountMiningTest(DefiTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        node.generate(110)
+        node.generate(120)
 
         # Get addresses and set up account
         account = node.getnewaddress()
@@ -28,10 +28,8 @@ class AccountMiningTest(DefiTestFramework):
         assert_equal(node.getaccount(account)[0], "10.00000000@DFI")
 
         # Send double the amount we have in account
-        node.accounttoutxos(account, {destination: "10@DFI"})
-        node.accounttoutxos(account, {destination: "2@DFI"})
-        node.accounttoutxos(account, {destination: "2@DFI"})
-        node.accounttoutxos(account, {destination: "2@DFI"})
+        for _ in range(100):
+            node.accounttoutxos(account, {destination: "2@DFI"})
 
         # Store block height
         blockcount = node.getblockcount()

--- a/test/functional/feature_account_mining.py
+++ b/test/functional/feature_account_mining.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test account mining behaviour"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import assert_equal
+
+class AccountMiningTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [['-txnotokens=0', '-amkheight=50']]
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.generate(101)
+
+        # Get addresses and set up account
+        account = node.getnewaddress()
+        destination = node.getnewaddress()
+        node.utxostoaccount({account: "10@0"})
+        node.generate(1)
+
+        # Check we have expected balance
+        assert_equal(node.getaccount(account)[0], "10.00000000@DFI")
+
+        # Send double the amount we have in account
+        node.accounttoutxos(account, {destination: "10@0"})
+        node.accounttoutxos(account, {destination: "10@0"})
+
+        # Store block height
+        blockcount = node.getblockcount()
+
+        # Generate a block
+        node.generate(1)
+
+        # Check the blockchain has extended as expected
+        assert_equal(node.getblockcount(), blockcount + 1)
+
+        # Account should now be empty
+        assert_equal(node.getaccount(account), [])
+
+if __name__ == '__main__':
+    AccountMiningTest().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -229,6 +229,7 @@ BASE_SCRIPTS = [
     'p2p_permissions.py',
     'feature_blocksdir.py',
     'feature_config_args.py',
+    'feature_account_mining.py',
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -49,6 +49,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "validation -> wallet/wallet -> validation"
     "policy/fees -> txmempool -> validation -> wallet/wallet -> policy/fees"
     "policy/fees -> txmempool -> validation -> wallet/wallet -> util/fees -> policy/fees"
+    "chainparams -> masternodes/mn_checks -> txmempool -> chainparams"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
Tracks changes to account when including transactions in a blocks, this prevents an account trying to spend more than it has which is an invalid state and would be rejected. After block creation some transactions left in the mempool may then be invalid due to our bespoke account layer, we iterate over the mempool and remove any transactions that fail CheckTxInputs. 