### PR TITLE
Reject all custom transactions that fail from block creation

### DIFF
--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -35,7 +35,7 @@ Res CAccountsHistoryView::SetAccountHistory(const CScript & owner, uint32_t heig
 
 bool CAccountsHistoryView::TrackAffectedAccounts(CStorageKV const & before, MapKV const & diff, uint32_t height, uint32_t txn, const uint256 & txid, unsigned char category) {
     // txn set to max if called from CreateNewBlock to check account balances, do not track here.
-    if (!gArgs.GetBoolArg("-acindex", false) || txn == std::numeric_limits<uint32_t>::max())
+    if (!gArgs.GetBoolArg("-acindex", false))
         return false;
 
     std::map<CScript, TAmounts> balancesDiff;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -561,7 +561,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
             // Only check custom TXs
             if (txType != CustomTxType::None) {
-                auto res = ApplyCustomTx(view, ::ChainstateActive().CoinsTip(), tx, chainparams.GetConsensus(), nHeight, std::numeric_limits<uint32_t>::max(), false, true);
+                auto res = ApplyCustomTx(view, ::ChainstateActive().CoinsTip(), tx, chainparams.GetConsensus(), nHeight, 0, false, true);
 
                 // Not okay invalidate, undo and skip
                 if (!res.ok) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -564,7 +564,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
                 auto res = ApplyCustomTx(view, ::ChainstateActive().CoinsTip(), tx, chainparams.GetConsensus(), nHeight, std::numeric_limits<uint32_t>::max(), false, true);
 
                 // Not okay invalidate, undo and skip
-                if (!res.ok && NotAllowedToFail(txType)) {
+                if (!res.ok) {
                     customTxPassed = false;
 
                     LogPrintf("%s: Failed %s TX %s: %s\n", __func__, ToString(txType), tx.GetHash().GetHex(), res.msg);

--- a/test/functional/feature_account_mining.py
+++ b/test/functional/feature_account_mining.py
@@ -40,8 +40,35 @@ class AccountMiningTest(DefiTestFramework):
         # Check the blockchain has extended as expected
         assert_equal(node.getblockcount(), blockcount + 1)
 
+        # Generate 10 more blocks
+        node.generate(10)
+
+        # Check the blockchain has extended as expected
+        assert_equal(node.getblockcount(), blockcount + 11)
+
         # Account should now be empty
         assert_equal(node.getaccount(account), [])
+
+        # Update block height
+        blockcount = node.getblockcount()
+
+        # Send more UTXOs to account
+        node.utxostoaccount({account: "1@0"})
+        node.generate(1)
+
+        # Update block height
+        blockcount = node.getblockcount()
+
+        # Test mixture of account TXs
+        for _ in range(10):
+            node.accounttoaccount(account, {destination: "1@DFI"})
+            node.accounttoutxos(account, {destination: "1@DFI"})
+
+        # Generate 1 more blocks
+        node.generate(1)
+
+        # Check the blockchain has extended as expected
+        assert_equal(node.getblockcount(), blockcount + 1)
 
 if __name__ == '__main__':
     AccountMiningTest().main ()


### PR DESCRIPTION
Reject any custom transaction from block creation that fails. This prevents transactions that are not `NotAllowedToFail` types taking an account balance to zero in a block that also contains a `NotAllowedToFail` transaction that tries to transfer from that account. We can end up with a situation where the account can be zeroed and a `NotAllowedToFail` transaction tries to run afterwards resulting in an invalid block.