### PR TITLE
Pass updated coinview copy to RPC check function

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -3600,7 +3600,7 @@ UniValue sendtokenstoaddress(const JSONRPCRequest& request) {
         CCoinsViewCache coinview(&::ChainstateActive().CoinsTip());
         if (optAuthTx)
             AddCoins(coinview, *optAuthTx, targetHeight);
-        const auto res = ApplyAnyAccountsToAccountsTx(mnview_dummy, g_chainstate->CoinsTip(), CTransaction(rawTx), targetHeight,
+        const auto res = ApplyAnyAccountsToAccountsTx(mnview_dummy, coinview, CTransaction(rawTx), targetHeight,
                                                ToByteVector(CDataStream{SER_NETWORK, PROTOCOL_VERSION, msg}), Params().GetConsensus());
         if (!res.ok) {
             if (res.code == CustomTxErrCodes::NotEnoughBalance) {


### PR DESCRIPTION
Coinview is copied and auto auth UTXOs added to it. The call to check the RPC transaction was not being passed this updated coin view so could not authorise the transaction.