### PR TITLE
Do not force boost filesystem no deprecated

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -11,7 +11,6 @@
 #include <ext/stdio_filebuf.h>
 #endif
 
-#define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 


### PR DESCRIPTION
Forcing BOOST_FILESYSTEM_NO_DEPRECATED makes no sense in source. It can added to configure by CCFLAGS.
Fix build with Boost > 1.74 