### PR TITLE
Check index not null before creating JSON output entry

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -3232,6 +3232,10 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
             }
             pwtx->GetAmounts(listReceived, listSent, nFee, filter);
             const auto index = LookupBlockIndex(pwtx->hashBlock);
+            // Check we have index before progressing, wallet might be reindexing.
+            if (!index) {
+                continue;
+            }
             for (auto it = listSent.begin(); limit != 0 && it != listSent.end(); ++it) {
                 if (!IsValidDestination(it->destination) || (IsValidDestination(destination) && destination != it->destination)) {
                     continue;


### PR DESCRIPTION
If a wallet with transactions calls listaccounthistory during a reindex it can trigger a segmentation fault. When the wallet transaction block hash is used to loop up the block index during reindex, the returned blockindex can be nullptr, when this is accessed later to build a JSON result we trigger the segmentation fault. The fix here is to continue to the next wallet TX, only wallet TXs which belong to a valid block in the block index will be displayed.