### PR TITLE
Use auto auth for minttokens with collateral address

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -413,15 +413,19 @@ static std::vector<CTxIn> GetAuthInputsSmart(CWallet* const pwallet, int32_t txV
     if (needFounderAuth && result.empty()) {
         auto anyFounder = AmIFounder(pwallet);
         if (!anyFounder) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Need foundation member authorization");
-        }
-        auto authInput = GetAnyFoundationAuthInput(pwallet);
-        if (authInput) {
-            if (std::find(result.begin(), result.end(), *authInput) == result.end())
-                result.push_back(authInput.get());
-        }
-        else {
-            notFoundYet.insert(anyFounder.get());
+            // Called from minttokens if auth not empty here which can use collateralAddress
+            if (auths.empty()) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Need foundation member authorization");
+            }
+        } else {
+            auto authInput = GetAnyFoundationAuthInput(pwallet);
+            if (authInput) {
+                if (std::find(result.begin(), result.end(), *authInput) == result.end())
+                    result.push_back(authInput.get());
+            }
+            else {
+                notFoundYet.insert(anyFounder.get());
+            }
         }
     }
 


### PR DESCRIPTION
On a DAT when minttokens is used do not fail on `Need foundation member authorization` as auto auth may be able to create an auth using the collateral address.