### PR TITLE
Search all addresses for specified address

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -3138,7 +3138,6 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
     // start block for asc order
     const auto startBlock = maxBlockHeight - depth;
 
-    CScript owner;
     isminefilter filter = ISMINE_ALL_USED;
 
     std::set<uint256> txs;
@@ -3200,7 +3199,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         }
 
         return true;
-    }, { account, startBlock, std::numeric_limits<uint32_t>::max() });
+    }, { CScript(), startBlock, std::numeric_limits<uint32_t>::max() });
 
     if (shouldSearchInWallet) {
 
@@ -3209,8 +3208,8 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         std::list<COutputEntry> listReceived;
 
         CTxDestination destination;
-        if (!owner.empty()) {
-            ExtractDestination(owner, destination);
+        if (!account.empty()) {
+            ExtractDestination(account, destination);
         }
 
         LOCK(pwallet->cs_wallet);
@@ -3275,7 +3274,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
             }
 
             return true;
-        }, { account, startBlock, std::numeric_limits<uint32_t>::max() });
+        }, { CScript(), startBlock, {std::numeric_limits<uint32_t>::max()} });
     }
 
     UniValue slice(UniValue::VARR);

--- a/test/functional/rpc_listaccounthistory.py
+++ b/test/functional/rpc_listaccounthistory.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test listaccounthistory RPC."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+
+class TokensRPCListAccountHistory(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [
+        ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50'],
+        ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50']]
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+        num_tokens = len(self.nodes[0].listtokens())
+
+        # collateral address
+        collateral_a = self.nodes[0].getnewaddress("", "legacy")
+
+        # Create token
+        self.nodes[0].createtoken({
+            "symbol": "GOLD",
+            "name": "gold",
+            "collateralAddress": collateral_a
+        })
+        self.nodes[0].generate(1)
+
+        # Make sure there's an extra token
+        assert_equal(len(self.nodes[0].listtokens()), num_tokens + 1)
+
+        # Get token ID
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "GOLD"):
+                token_a = idx
+
+        # Mint some tokens
+        self.nodes[0].minttokens(["300@" + token_a])
+        self.nodes[0].generate(1)
+
+        # Get node 0 results
+        results = self.nodes[0].listaccounthistory(collateral_a)
+
+        # Expect two sends, two receives and one mint tokens
+        assert_equal(len(results), 5)
+
+        # All TXs should be for collateral_a and contain a MintTokens TX
+        found = False
+        for txs in results:
+            assert_equal(txs['owner'], collateral_a)
+            if txs['type'] == 'MintToken':
+                found = True
+        assert_equal(found, True)
+
+        # Get node 1 results
+        results = self.nodes[1].listaccounthistory(collateral_a)
+
+        # Expect one mint token TX
+        assert_equal(len(results), 1)
+
+        # Check owner is collateral_a and type MintTokens
+        assert_equal(results[0]['owner'], collateral_a)
+        assert_equal(results[0]['type'], 'MintToken')
+
+if __name__ == '__main__':
+    TokensRPCListAccountHistory().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -220,6 +220,7 @@ BASE_SCRIPTS = [
     'wallet_coinbase_category.py',
     'feature_filelock.py',
     'p2p_unrequested_blocks.py',
+    'rpc_listaccounthistory.py',
     'feature_includeconf.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',


### PR DESCRIPTION
This is a quick solution for the issue discovered where no results were returned for an address from account or reward history, instead we now iterate over every entry and filter for what we require. Also owner was used by mistake when searching wallet for a specified address, account should have been used instead.