### PR TITLE
Improve overall node memory usage

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -166,6 +166,7 @@ DEFI_CORE_H = \
   masternodes/masternodes.h \
   masternodes/mn_checks.h \
   masternodes/res.h \
+  masternodes/rewardhistoryold.h \
   masternodes/tokens.h \
   masternodes/poolpairs.h \
   masternodes/undo.h \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1579,10 +1579,10 @@ bool AppInitMain(InitInterfaces& interfaces)
                 });
 
                 pcriminals.reset();
-                pcriminals = MakeUnique<CCriminalsView>(GetDataDir() / "criminals", nMinDbCache << 20, false, fReset || fReindexChainState);
+                pcriminals = MakeUnique<CCriminalsView>(GetDataDir() / "criminals", nDefaultDbCache << 20, false, fReset || fReindexChainState);
 
                 pcustomcsDB.reset();
-                pcustomcsDB = MakeUnique<CStorageLevelDB>(GetDataDir() / "enhancedcs", nMinDbCache << 20, false, fReset || fReindexChainState);
+                pcustomcsDB = MakeUnique<CStorageLevelDB>(GetDataDir() / "enhancedcs", nDefaultDbCache << 20, false, fReset || fReindexChainState);
                 pcustomcsview.reset();
                 pcustomcsview = MakeUnique<CCustomCSView>(*pcustomcsDB.get());
                 if (!fReset && gArgs.GetBoolArg("-acindex", false)) {
@@ -1613,7 +1613,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                 panchorAwaitingConfirms = MakeUnique<CAnchorAwaitingConfirms>();
                 panchors.reset();
                 /// @todo research best way of spv+anchors loading/update/regeneration
-                panchors = MakeUnique<CAnchorIndex>(nMinDbCache << 20, false, gArgs.GetBoolArg("-spv", false) && gArgs.GetBoolArg("-spv_resync", false) /*fReset || fReindexChainState*/);
+                panchors = MakeUnique<CAnchorIndex>(nDefaultDbCache << 20, false, gArgs.GetBoolArg("-spv", false) && gArgs.GetBoolArg("-spv_resync", false) /*fReset || fReindexChainState*/);
                 // load anchors after spv due to spv (and spv height) not set before (no last height yet)
 
                 if (gArgs.GetBoolArg("-spv", false)) {

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -4,13 +4,15 @@
 
 #include <masternodes/accountshistory.h>
 #include <masternodes/accounts.h>
+#include <masternodes/masternodes.h>
+#include <masternodes/rewardhistoryold.h>
 #include <key_io.h>
 
 #include <limits>
 
 /// @attention make sure that it does not overlap with those in masternodes.cpp/tokens.cpp/undos.cpp/accounts.cpp !!!
 const unsigned char CAccountsHistoryView::ByAccountHistoryKey::prefix = 'h'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
-const unsigned char CRewardsHistoryView::ByRewardHistoryKey::prefix = 'R'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
+const unsigned char CRewardsHistoryView::ByRewardHistoryKey::prefix = 'H'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
 
 void CAccountsHistoryView::ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start) const
 {
@@ -32,4 +34,34 @@ Res CRewardsHistoryView::SetRewardHistory(const RewardHistoryKey& key, const Rew
 {
     WriteBy<ByRewardHistoryKey>(key, value);
     return Res::Ok();
+}
+
+bool shouldMigrateOldRewardHistory(CCustomCSView & view)
+{
+    auto it = view.GetRaw().NewIterator();
+    try {
+        auto prefix = oldRewardHistoryPrefix;
+        auto oldKey = std::make_pair(prefix, oldRewardHistoryKey{});
+        it->Seek(DbTypeToBytes(oldKey));
+        if (it->Valid() && BytesToDbType(it->Key(), oldKey) && oldKey.first == prefix) {
+            return true;
+        }
+        prefix = CRewardsHistoryView::ByRewardHistoryKey::prefix;
+        auto newKey = std::make_pair(prefix, RewardHistoryKey{});
+        it->Seek(DbTypeToBytes(newKey));
+        if (it->Valid() && BytesToDbType(it->Key(), newKey) && newKey.first == prefix) {
+            return false;
+        }
+        bool hasOldAccountHistory = false;
+        view.ForEachAccountHistory([&](AccountHistoryKey const & key, CLazySerialize<AccountHistoryValue>) {
+            if (key.txn == std::numeric_limits<uint32_t>::max()) {
+                hasOldAccountHistory = true;
+                return false;
+            }
+            return true;
+        }, { {}, 0, std::numeric_limits<uint32_t>::max() });
+        return hasOldAccountHistory;
+    } catch(...) {
+        return true;
+    }
 }

--- a/src/masternodes/accountshistory.h
+++ b/src/masternodes/accountshistory.h
@@ -5,9 +5,8 @@
 #ifndef DEFI_MASTERNODES_ACCOUNTSHISTORY_H
 #define DEFI_MASTERNODES_ACCOUNTSHISTORY_H
 
-#include <flushablestorage.h>
-#include <masternodes/res.h>
 #include <amount.h>
+#include <flushablestorage.h>
 #include <script/script.h>
 #include <uint256.h>
 
@@ -56,7 +55,7 @@ struct AccountHistoryValue {
 struct RewardHistoryKey {
     CScript owner;
     uint32_t blockHeight;
-    DCT_ID poolID; // for order in block
+    uint8_t category;
 
     ADD_SERIALIZE_METHODS;
 
@@ -73,22 +72,11 @@ struct RewardHistoryKey {
             READWRITE(WrapBigEndian(blockHeight_));
         }
 
-        READWRITE(VARINT(poolID.v));
-    }
-};
-
-struct RewardHistoryValue {
-    unsigned char category;
-    TAmounts diff;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(category);
-        READWRITE(diff);
     }
 };
+
+using RewardHistoryValue = std::map<DCT_ID, TAmounts>;
 
 class CAccountsHistoryView : public virtual CStorageView
 {
@@ -109,5 +97,8 @@ public:
     // tags
     struct ByRewardHistoryKey { static const unsigned char prefix; };
 };
+
+class CCustomCSView;
+bool shouldMigrateOldRewardHistory(CCustomCSView & view);
 
 #endif //DEFI_MASTERNODES_ACCOUNTSHISTORY_H

--- a/src/masternodes/criminals.h
+++ b/src/masternodes/criminals.h
@@ -62,7 +62,7 @@ class CCriminalsView
 {
 public:
     CCriminalsView(const fs::path& dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false)
-        : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe, true)) // direct!
+        : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe))
     {}
 
 };

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -23,7 +23,6 @@
 #include <map>
 #include <set>
 #include <stdint.h>
-#include <tuple>
 
 #include <boost/optional.hpp>
 
@@ -238,7 +237,7 @@ class CRewardsHistoryStorage : public CCustomCSView
 {
     bool acindex;
     const uint32_t height;
-    std::map<CScript, std::tuple<DCT_ID, uint8_t, TAmounts>> diffs;
+    std::map<std::pair<CScript, uint8_t>, std::map<DCT_ID, TAmounts>> diffs;
 public:
     CRewardsHistoryStorage(CCustomCSView & storage, uint32_t height);
     Res AddBalance(CScript const & owner, DCT_ID poolID, uint8_t type, CTokenAmount amount);

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -214,8 +214,6 @@ public:
 
     bool CanSpend(const uint256 & txId, int height) const;
 
-    bool Flush() { return DB().Flush(); }
-
     CStorageKV& GetRaw() {
         return DB();
     }

--- a/src/masternodes/rewardhistoryold.h
+++ b/src/masternodes/rewardhistoryold.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 DeFi Blockchain Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFI_MASTERNODES_REWARDHISTORYOLD_H
+#define DEFI_MASTERNODES_REWARDHISTORYOLD_H
+
+#include <amount.h>
+#include <flushablestorage.h>
+#include <script/script.h>
+
+// key before migration
+const uint8_t oldRewardHistoryPrefix = 'R';
+
+struct oldRewardHistoryKey {
+    CScript owner;
+    uint32_t blockHeight;
+    DCT_ID poolID;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(owner);
+
+        if (ser_action.ForRead()) {
+            READWRITE(WrapBigEndian(blockHeight));
+            blockHeight = ~blockHeight;
+        } else {
+            uint32_t blockHeight_ = ~blockHeight;
+            READWRITE(WrapBigEndian(blockHeight_));
+        }
+
+        READWRITE(VARINT(poolID.v));
+    }
+};
+
+#endif //DEFI_MASTERNODES_REWARDHISTORYOLD_H

--- a/src/test/double_sign.cpp
+++ b/src/test/double_sign.cpp
@@ -83,6 +83,7 @@ BOOST_AUTO_TEST_CASE(check_doublesign)
     /// @todo newbase
     pcriminals->WriteMintedBlockHeader(masternodeID, mintedBlocks, criminalsBlockHeaders[0].GetHash(), criminalsBlockHeaders[0], false);
     pcriminals->WriteMintedBlockHeader(masternodeID, mintedBlocks, criminalsBlockHeaders[1].GetHash(), criminalsBlockHeaders[1], false);
+    pcriminals->Flush();
     CKeyID dummy;
     BOOST_CHECK(IsDoubleSigned(criminalsBlockHeaders[0], criminalsBlockHeaders[1], dummy));
 

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <interfaces/chain.h>
 #include <key_io.h>
+#include <masternodes/accountshistory.h>
 #include <masternodes/masternodes.h>
 #include <rpc/rawtransaction_util.h>
 #include <test/setup_common.h>
@@ -330,6 +331,33 @@ BOOST_AUTO_TEST_CASE(for_each_order)
             return true;
         }, TestBackward{ (uint32_t) -1 });
     }
+}
+
+BOOST_AUTO_TEST_CASE(AccountHistoryDescOrderTest)
+{
+    CCustomCSView view(*pcustomcsview);
+
+    view.SetAccountHistory({ {}, 5021, 0 }, {});
+    view.SetAccountHistory({ {}, 5022, 1 }, {});
+    view.SetAccountHistory({ {}, 5023, 2 }, {});
+    view.SetAccountHistory({ {}, 5024, 3 }, {});
+    view.SetAccountHistory({ {}, 5025, 4 }, {});
+    view.SetAccountHistory({ {}, 5026, 5 }, {});
+
+    uint32_t startBlock = 5021; // exclude
+    uint32_t maxBlockHeight = 5025;
+    auto blockCount = maxBlockHeight;
+
+    view.ForEachAccountHistory([&](AccountHistoryKey const & key, AccountHistoryValue) {
+        if (startBlock > key.blockHeight || key.blockHeight > maxBlockHeight) {
+            return true;
+        }
+
+        BOOST_CHECK_EQUAL(blockCount, key.blockHeight);
+        --blockCount;
+
+        return true;
+    }, { {}, maxBlockHeight, std::numeric_limits<uint32_t>::max() });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2591,6 +2591,7 @@ bool CChainState::DisconnectTip(CValidationState& state, const CChainParams& cha
         for (auto const & cr : disconnectedCriminals) {
             pcriminals->AddCriminalProof(cr.first, cr.second.blockHeader, cr.second.conflictBlockHeader);
         }
+        pcriminals->Flush();
     }
     LogPrint(BCLog::BENCH, "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * MILLI);
     // Write the chain state to disk, if necessary.
@@ -3847,9 +3848,9 @@ bool BlockManager::AcceptBlockHeader(const CBlockHeader& block, CValidationState
             if (it) {
             	auto const & nodeId = *it;
 
-	        std::map <uint256, CBlockHeader> blockHeaders{};
-        	pcriminals->FetchMintedHeaders(nodeId, block.mintedBlocks, blockHeaders, fIsFakeNet);
-        	if (blockHeaders.find(hash) == blockHeaders.end()) {
+                std::map <uint256, CBlockHeader> blockHeaders{};
+                pcriminals->FetchMintedHeaders(nodeId, block.mintedBlocks, blockHeaders, fIsFakeNet);
+                if (blockHeaders.find(hash) == blockHeaders.end()) {
             	    pcriminals->WriteMintedBlockHeader(nodeId, block.mintedBlocks, hash, block, fIsFakeNet);
             	}
 
@@ -3862,6 +3863,7 @@ bool BlockManager::AcceptBlockHeader(const CBlockHeader& block, CValidationState
                         }
                     }
                 }
+                pcriminals->Flush();
             }
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2835,7 +2835,6 @@ CBlockIndex* CChainState::FindMostWorkChain() {
         // Find the best candidate header.
         {
             auto filtered = FilterAnchorSatisfying(setBlockIndexCandidates);
-            LogPrintf("FindMostWorkChain: setBlockIndexCandidates: %i, filtered: %i\n", setBlockIndexCandidates.size(), filtered.size());
 
             std::set<CBlockIndex*, CBlockIndexWorkComparator>::reverse_iterator it = filtered.rbegin();
             if (it == filtered.rend())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2432,22 +2432,25 @@ bool CChainState::FlushStateToDisk(
                 UnlinkPrunedFiles(setFilesToPrune);
             nLastWrite = nNow;
         }
+        bool fMemoryCacheLarge = fDoFullFlush || (mode == FlushStateMode::PERIODIC && pcustomcsview->SizeEstimate() > (nDefaultDbCache << 16));
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
-        if (fDoFullFlush && !CoinsTip().GetBestBlock().IsNull()) {
+        if (fMemoryCacheLarge && !CoinsTip().GetBestBlock().IsNull()) {
+            // Flush view first to estimate size on disk later
+            if (!pcustomcsview->Flush()) {
+                return AbortNode(state, "Failed to write db batch");
+            }
             // Typical Coin structures on disk are around 48 bytes in size.
             // Pushing a new one to the database can cause it to be written
             // twice (once in the log, and once in the tables). This is already
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
-            /// @todo check free space for pcustomcsview flushing
-            if (!CheckDiskSpace(GetDataDir(), 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
+            if (!CheckDiskSpace(GetDataDir(), 48 * 2 * 2 * CoinsTip().GetCacheSize() + pcustomcsDB->SizeEstimate())) {
                 return AbortNode(state, "Disk space is too low!", _("Error: Disk space is too low!").translated, CClientUIInterface::MSG_NOPREFIX);
             }
             // Flush the chainstate (which may refer to block index entries).
-            /// @todo may be integrate pcustomcsview into ChainState?
-            /// @attention it is critical to flush 'pcustomcsview', then 'pcustomcsDB'!!!
-            if (!CoinsTip().Flush() || !pcustomcsview->Flush() || !pcustomcsDB->Flush())
-                return AbortNode(state, "Failed to write to coin or masternodes database");
+            if (!CoinsTip().Flush() || !pcustomcsDB->Flush()) {
+                return AbortNode(state, "Failed to write to coin or masternode db to disk");
+            }
             nLastFlush = nNow;
             full_flush_completed = true;
         }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -45,6 +45,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "masternodes/anchors -> masternodes/masternodes -> masternodes/anchors"
     "masternodes/anchors -> masternodes/masternodes -> masternodes/mn_checks -> masternodes/anchors"
     "masternodes/anchors -> masternodes/masternodes -> net_processing -> masternodes/anchors"
+    "masternodes/accountshistory -> masternodes/masternodes -> masternodes/accountshistory"
     "net_processing -> validation -> net_processing"
     "validation -> wallet/wallet -> validation"
     "policy/fees -> txmempool -> validation -> wallet/wallet -> policy/fees"


### PR DESCRIPTION
The high memory usage when `-acindex` is enabled is caused by `FlushStateToDisk` do actually flush when cache is going to end, (custom cache is not taken in calculation), periodic (DATABASE_FLUSH_INTERVAL is 24 hours) or when mode is ALWAYS (when node is going to shutting down). The patch aims to increase custom cache size as well as Flush occasionally when `CFlushableStorageKV` is going near maximum cache size, till now `changed` map going to be a couple of GiB, which can result in killing the daemon by the OS. New account rewards are introduced to reduce records in db and to increase performance when it's iterate. Limit in `listaccounthistory` is better exposed and proved by unit test. In result full resync should not take more than ~600 MB to operate, without performance loose.