### PR TITLE
Reduce getcustomtx length, rename JSON height and time keys

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -3802,6 +3802,69 @@ UniValue sendtokenstoaddress(const JSONRPCRequest& request) {
 
 }
 
+static bool GetCustomTXInfo(const int nHeight, const CTransactionRef tx, CustomTxType& guess, Res& res, UniValue& txResults)
+{
+    std::vector<unsigned char> metadata;
+    guess = GuessCustomTxType(*tx, metadata);
+    CCustomCSView mnview_dummy(*pcustomcsview);
+
+    switch (guess)
+    {
+        case CustomTxType::CreateMasternode:
+            res = ApplyCreateMasternodeTx(mnview_dummy, *tx, nHeight, metadata, &txResults);
+            break;
+        case CustomTxType::ResignMasternode:
+            res = ApplyResignMasternodeTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, true, &txResults);
+            break;
+        case CustomTxType::CreateToken:
+            res = ApplyCreateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::UpdateToken:
+            res = ApplyUpdateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::UpdateTokenAny:
+            res = ApplyUpdateTokenAnyTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::MintToken:
+            res = ApplyMintTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::CreatePoolPair:
+            res = ApplyCreatePoolPairTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::UpdatePoolPair:
+            res = ApplyUpdatePoolPairTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::PoolSwap:
+            res = ApplyPoolSwapTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::AddPoolLiquidity:
+            res = ApplyAddPoolLiquidityTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::RemovePoolLiquidity:
+            res = ApplyRemovePoolLiquidityTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::UtxosToAccount:
+            res = ApplyUtxosToAccountTx(mnview_dummy, *tx, nHeight, metadata, Params().GetConsensus(), &txResults);
+            break;
+        case CustomTxType::AccountToUtxos:
+            res = ApplyAccountToUtxosTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::AccountToAccount:
+            res = ApplyAccountToAccountTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::SetGovVariable:
+            res = ApplySetGovernanceTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        case CustomTxType::AnyAccountsToAccounts:
+            res = ApplyAnyAccountsToAccountsTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
+            break;
+        default:
+            return false;
+    }
+
+    return true;
+}
+
 static UniValue getcustomtx(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -3914,63 +3977,10 @@ static UniValue getcustomtx(const JSONRPCRequest& request)
             return "Coinbase transaction. Not a custom transaction.";
         }
 
-        std::vector<unsigned char> metadata;
-        guess = GuessCustomTxType(*tx, metadata);
-        CCustomCSView mnview_dummy(*pcustomcsview);
-
-        switch (guess)
-        {
-            case CustomTxType::CreateMasternode:
-                res = ApplyCreateMasternodeTx(mnview_dummy, *tx, nHeight, metadata, &txResults);
-                break;
-            case CustomTxType::ResignMasternode:
-                res = ApplyResignMasternodeTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, true, &txResults);
-                break;
-            case CustomTxType::CreateToken:
-                res = ApplyCreateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::UpdateToken:
-                res = ApplyUpdateTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::UpdateTokenAny:
-                res = ApplyUpdateTokenAnyTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::MintToken:
-                res = ApplyMintTokenTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::CreatePoolPair:
-                res = ApplyCreatePoolPairTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::UpdatePoolPair:
-                res = ApplyUpdatePoolPairTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::PoolSwap:
-                res = ApplyPoolSwapTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::AddPoolLiquidity:
-                res = ApplyAddPoolLiquidityTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::RemovePoolLiquidity:
-                res = ApplyRemovePoolLiquidityTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::UtxosToAccount:
-                res = ApplyUtxosToAccountTx(mnview_dummy, *tx, nHeight, metadata, Params().GetConsensus(), &txResults);
-                break;
-            case CustomTxType::AccountToUtxos:
-                res = ApplyAccountToUtxosTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::AccountToAccount:
-                res = ApplyAccountToAccountTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::SetGovVariable:
-                res = ApplySetGovernanceTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            case CustomTxType::AnyAccountsToAccounts:
-                res = ApplyAnyAccountsToAccountsTx(mnview_dummy, ::ChainstateActive().CoinsTip(), *tx, nHeight, metadata, Params().GetConsensus(), true, &txResults);
-                break;
-            default:
-                return "Not a custom transaction";
+        if (!GetCustomTXInfo(nHeight, tx, guess, res, txResults)) {
+            return "Not a custom transaction";
         }
+
     } else {
         // Should not really get here without prior failure.
         return "Could not find matching transaction.";
@@ -3997,8 +4007,8 @@ static UniValue getcustomtx(const JSONRPCRequest& request)
 
         result.pushKV("blockhash", hashBlock.GetHex());
         if (blockindex) {
-            result.pushKV("block height", blockindex->nHeight);
-            result.pushKV("blocktime", blockindex->GetBlockTime());
+            result.pushKV("blockHeight", blockindex->nHeight);
+            result.pushKV("blockTime", blockindex->GetBlockTime());
             result.pushKV("confirmations", 1 + ::ChainActive().Height() - blockindex->nHeight);
         } else {
             result.pushKV("confirmations", 0);

--- a/test/functional/rpc_getcustomtx.py
+++ b/test/functional/rpc_getcustomtx.py
@@ -51,7 +51,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['mintable'], True)
         assert_equal(result['results']['tradeable'], True)
         assert_equal(result['results']['finalized'], False)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -82,7 +82,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "MintToken")
         assert_equal(result['valid'], True)
         assert_equal(result['results'][str(token_a)], Decimal("300.00000000"))
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -91,7 +91,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "MintToken")
         assert_equal(result['valid'], True)
         assert_equal(result['results'][str(token_a)], Decimal("300.00000000"))
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -108,7 +108,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "MintToken")
         assert_equal(result['valid'], True)
         assert_equal(result['results'][str(token_a)], Decimal("300.00000000"))
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -135,7 +135,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['name'], "silver")
         assert_equal(result['results']['mintable'], False)
         assert_equal(result['results']['tradeable'], False)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -157,7 +157,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "CreateMasternode")
         assert_equal(result['valid'], True)
         assert_equal(result['results']['masternodeoperator'], collateral)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -177,7 +177,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "ResignMasternode")
         assert_equal(result['valid'], True)
         assert_equal(result['results']['id'], mn_txid)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -241,7 +241,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['mineable'], False)
         assert_equal(result['results']['tradeable'], True)
         assert_equal(result['results']['finalized'], True)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -262,7 +262,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['from'], address_b_scriptpubkey)
         assert_equal([*result['results']['to']][0], address_a_scriptpubkey)
         assert_equal(list(result['results']['to'].values())[0], "100.00000000@" + token_b)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -285,7 +285,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results'][token_a], Decimal("100.00000000"))
         assert_equal(result['results'][token_b], Decimal("100.00000000"))
         assert_equal(result['results']['shareaddress'], pool_share_scriptpubkey)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -314,7 +314,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['toAddress'], address_b_scriptpubkey)
         assert_equal(result['results']['toToken'], token_b)
         assert_equal(result['results']['maxPrice'], Decimal("2.00000000"))
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -332,7 +332,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['valid'], True)
         assert_equal(result['results']['from'], pool_share_scriptpubkey)
         assert_equal(result['results']['amount'], "25.00000000@1")
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -356,7 +356,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['commission'], Decimal("0.10000000"))
         assert_equal(result['results']['status'], False)
         assert_equal(result['results']['ownerAddress'], owner_scriptpubkey)
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -373,7 +373,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['type'], "UtxosToAccount")
         assert_equal(result['valid'], True)
         assert_equal(result['results'][address_a_scriptpubkey], "1.00000000@0")
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -392,7 +392,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['results']['from'], address_a_scriptpubkey)
         assert_equal(list(result['results']['to'].keys())[0], address_b_scriptpubkey)
         assert_equal(list(result['results']['to'].values())[0], "1.00000000@0")
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -415,7 +415,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(list(result['results']['from'].values())[0], "1.00000000@0")
         assert_equal(list(result['results']['to'].keys())[0], address_b_scriptpubkey)
         assert_equal(list(result['results']['to'].values())[0], "1.00000000@0")
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 
@@ -433,7 +433,7 @@ class TokensRPCGetCustomTX(DefiTestFramework):
         assert_equal(result['valid'], True)
         assert_equal(list(result['results'].keys())[0], "LP_DAILY_DFI_REWARD")
         assert_equal(list(result['results'].values())[0], Decimal("35.00000000"))
-        assert_equal(result['block height'], blockheight)
+        assert_equal(result['blockHeight'], blockheight)
         assert_equal(result['blockhash'], blockhash)
         assert_equal(result['confirmations'], 1)
 


### PR DESCRIPTION
Couple of updates requested by @ShengguangXiao on the getcustomtx PR to rename two JSON result keys and reduce the length of the getcustomtx function by moving out the switch statement.