### PR TITLE
Keep owned account history split from the rest ones

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -417,6 +417,7 @@ void SetupServerArgs()
 #endif
     gArgs.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-acindex", strprintf("Maintain a full account history index, tracking all accounts balances changes. Used by the listaccounthistory and accounthistorycount rpc calls (default: %u)", false), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-acindex-mineonly", strprintf("Maintain a mine only account history index, tracking mine accounts balances changes. Used by the listaccounthistory and accounthistorycount rpc calls (default: %u)", false), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blockfilterindex=<type>",
                  strprintf("Maintain an index of compact filters by block (default: %s, values: %s).", DEFAULT_BLOCKFILTERINDEX, ListBlockFilterTypes()) +
                  " If <type> is not supplied or if <type> = 1, indexes for all known types are enabled.",
@@ -1502,6 +1503,11 @@ bool AppInitMain(InitInterfaces& interfaces)
     LogPrintf("* Using %.1f MiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
 
+    if (gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX) && gArgs.GetBoolArg("-acindex-mineonly", DEFAULT_ACINDEX_MINEONLY)) {
+        LogPrintf("Warning -acindex and -acindex-mineonly are set, -acindex will be used\n");
+        gArgs.ForceSetArg("-acindex-mineonly", "0");
+    }
+
     bool fLoaded = false;
     while (!fLoaded && !ShutdownRequested()) {
         bool fReset = fReindex;
@@ -1586,7 +1592,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                 pcustomcsDB = MakeUnique<CStorageLevelDB>(GetDataDir() / "enhancedcs", nDefaultDbCache << 20, false, fReset || fReindexChainState);
                 pcustomcsview.reset();
                 pcustomcsview = MakeUnique<CCustomCSView>(*pcustomcsDB.get());
-                if (!fReset && gArgs.GetBoolArg("-acindex", false)) {
+                if (!fReset && (gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX) || gArgs.GetBoolArg("-acindex-mineonly", DEFAULT_ACINDEX_MINEONLY))) {
                     if (shouldMigrateOldRewardHistory(*pcustomcsview)) {
                         strLoadError = _("Account history needs rebuild").translated;
                         break;

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -11,28 +11,52 @@
 #include <limits>
 
 /// @attention make sure that it does not overlap with those in masternodes.cpp/tokens.cpp/undos.cpp/accounts.cpp !!!
-const unsigned char CAccountsHistoryView::ByAccountHistoryKey::prefix = 'h'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
-const unsigned char CRewardsHistoryView::ByRewardHistoryKey::prefix = 'H'; // don't intersects with CMintedHeadersView::MintedHeaders::prefix due to different DB
+const unsigned char CAccountsHistoryView::ByMineAccountHistoryKey::prefix = 'm';
+const unsigned char CAccountsHistoryView::ByAllAccountHistoryKey::prefix = 'h';
+const unsigned char CRewardsHistoryView::ByMineRewardHistoryKey::prefix = 'Q';
+const unsigned char CRewardsHistoryView::ByAllRewardHistoryKey::prefix = 'W';
 
-void CAccountsHistoryView::ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start) const
+void CAccountsHistoryView::ForEachMineAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start) const
 {
-    ForEach<ByAccountHistoryKey, AccountHistoryKey, AccountHistoryValue>(callback, start);
+    ForEach<ByMineAccountHistoryKey, AccountHistoryKey, AccountHistoryValue>(callback, start);
 }
 
-Res CAccountsHistoryView::SetAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
+Res CAccountsHistoryView::SetMineAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
 {
-    WriteBy<ByAccountHistoryKey>(key, value);
+    WriteBy<ByMineAccountHistoryKey>(key, value);
     return Res::Ok();
 }
 
-void CRewardsHistoryView::ForEachRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start) const
+void CAccountsHistoryView::ForEachAllAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start) const
 {
-    ForEach<ByRewardHistoryKey, RewardHistoryKey, RewardHistoryValue>(callback, start);
+    ForEach<ByAllAccountHistoryKey, AccountHistoryKey, AccountHistoryValue>(callback, start);
 }
 
-Res CRewardsHistoryView::SetRewardHistory(const RewardHistoryKey& key, const RewardHistoryValue& value)
+Res CAccountsHistoryView::SetAllAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
 {
-    WriteBy<ByRewardHistoryKey>(key, value);
+    WriteBy<ByAllAccountHistoryKey>(key, value);
+    return Res::Ok();
+}
+
+void CRewardsHistoryView::ForEachMineRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start) const
+{
+    ForEach<ByMineRewardHistoryKey, RewardHistoryKey, RewardHistoryValue>(callback, start);
+}
+
+Res CRewardsHistoryView::SetMineRewardHistory(const RewardHistoryKey& key, const RewardHistoryValue& value)
+{
+    WriteBy<ByMineRewardHistoryKey>(key, value);
+    return Res::Ok();
+}
+
+void CRewardsHistoryView::ForEachAllRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start) const
+{
+    ForEach<ByAllRewardHistoryKey, RewardHistoryKey, RewardHistoryValue>(callback, start);
+}
+
+Res CRewardsHistoryView::SetAllRewardHistory(const RewardHistoryKey& key, const RewardHistoryValue& value)
+{
+    WriteBy<ByAllRewardHistoryKey>(key, value);
     return Res::Ok();
 }
 
@@ -46,14 +70,20 @@ bool shouldMigrateOldRewardHistory(CCustomCSView & view)
         if (it->Valid() && BytesToDbType(it->Key(), oldKey) && oldKey.first == prefix) {
             return true;
         }
-        prefix = CRewardsHistoryView::ByRewardHistoryKey::prefix;
+        prefix = CRewardsHistoryView::ByMineRewardHistoryKey::prefix;
         auto newKey = std::make_pair(prefix, RewardHistoryKey{});
         it->Seek(DbTypeToBytes(newKey));
         if (it->Valid() && BytesToDbType(it->Key(), newKey) && newKey.first == prefix) {
             return false;
         }
+        prefix = CRewardsHistoryView::ByAllRewardHistoryKey::prefix;
+        newKey = std::make_pair(prefix, RewardHistoryKey{});
+        it->Seek(DbTypeToBytes(newKey));
+        if (it->Valid() && BytesToDbType(it->Key(), newKey) && newKey.first == prefix) {
+            return false;
+        }
         bool hasOldAccountHistory = false;
-        view.ForEachAccountHistory([&](AccountHistoryKey const & key, CLazySerialize<AccountHistoryValue>) {
+        view.ForEachAllAccountHistory([&](AccountHistoryKey const & key, CLazySerialize<AccountHistoryValue>) {
             if (key.txn == std::numeric_limits<uint32_t>::max()) {
                 hasOldAccountHistory = true;
                 return false;

--- a/src/masternodes/accountshistory.h
+++ b/src/masternodes/accountshistory.h
@@ -81,22 +81,31 @@ using RewardHistoryValue = std::map<DCT_ID, TAmounts>;
 class CAccountsHistoryView : public virtual CStorageView
 {
 public:
-    Res SetAccountHistory(AccountHistoryKey const & key, AccountHistoryValue const & value);
-    void ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start = {}) const;
+    Res SetMineAccountHistory(AccountHistoryKey const & key, AccountHistoryValue const & value);
+    Res SetAllAccountHistory(AccountHistoryKey const & key, AccountHistoryValue const & value);
+    void ForEachMineAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start = {}) const;
+    void ForEachAllAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start = {}) const;
 
     // tags
-    struct ByAccountHistoryKey { static const unsigned char prefix; };
+    struct ByMineAccountHistoryKey { static const unsigned char prefix; };
+    struct ByAllAccountHistoryKey { static const unsigned char prefix; };
 };
 
 class CRewardsHistoryView : public virtual CStorageView
 {
 public:
-    Res SetRewardHistory(RewardHistoryKey const & key, RewardHistoryValue const & value);
-    void ForEachRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start = {}) const;
+    Res SetMineRewardHistory(RewardHistoryKey const & key, RewardHistoryValue const & value);
+    Res SetAllRewardHistory(RewardHistoryKey const & key, RewardHistoryValue const & value);
+    void ForEachMineRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start = {}) const;
+    void ForEachAllRewardHistory(std::function<bool(RewardHistoryKey const &, CLazySerialize<RewardHistoryValue>)> callback, RewardHistoryKey const & start = {}) const;
 
     // tags
-    struct ByRewardHistoryKey { static const unsigned char prefix; };
+    struct ByMineRewardHistoryKey { static const unsigned char prefix; };
+    struct ByAllRewardHistoryKey { static const unsigned char prefix; };
 };
+
+static constexpr bool DEFAULT_ACINDEX = false;
+static constexpr bool DEFAULT_ACINDEX_MINEONLY = true;
 
 class CCustomCSView;
 bool shouldMigrateOldRewardHistory(CCustomCSView & view);

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -17,6 +17,7 @@
 #include <masternodes/poolpairs.h>
 #include <masternodes/gv.h>
 #include <uint256.h>
+#include <wallet/ismine.h>
 
 #include <functional>
 #include <iostream>
@@ -220,7 +221,7 @@ public:
 
 class CAccountsHistoryStorage : public CCustomCSView
 {
-    bool acindex;
+    int acindex;
     const uint32_t height;
     const uint32_t txn;
     const uint256 txid;
@@ -235,7 +236,7 @@ public:
 
 class CRewardsHistoryStorage : public CCustomCSView
 {
-    bool acindex;
+    int acindex;
     const uint32_t height;
     std::map<std::pair<CScript, uint8_t>, std::map<DCT_ID, TAmounts>> diffs;
 public:
@@ -243,6 +244,9 @@ public:
     Res AddBalance(CScript const & owner, DCT_ID poolID, uint8_t type, CTokenAmount amount);
     bool Flush();
 };
+
+class CWallet;
+isminetype IsMineCached(CWallet const & wallet, CScript const & script);
 
 /** Global DB and view that holds enhanced chainstate data (should be protected by cs_main) */
 extern std::unique_ptr<CStorageLevelDB> pcustomcsDB;

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(RewardMigrationTests)
         // Nothing to migrate
         BOOST_CHECK(!shouldMigrateOldRewardHistory(view));
 
-        view.SetRewardHistory(RewardHistoryKey{}, RewardHistoryValue{});
+        view.SetAllRewardHistory(RewardHistoryKey{}, RewardHistoryValue{});
 
         // we have new prefix and key, should not migrate
         BOOST_CHECK(!shouldMigrateOldRewardHistory(view));
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(RewardMigrationTests)
         // Nothing to migrate
         BOOST_CHECK(!shouldMigrateOldRewardHistory(view));
 
-        view.SetAccountHistory({ {}, 0, std::numeric_limits<uint32_t>::max() }, {});
+        view.SetAllAccountHistory({ {}, 0, std::numeric_limits<uint32_t>::max() }, {});
 
         // we have old accounthistory, should migrate
         BOOST_CHECK(shouldMigrateOldRewardHistory(view));
@@ -377,18 +377,18 @@ BOOST_AUTO_TEST_CASE(AccountHistoryDescOrderTest)
 {
     CCustomCSView view(*pcustomcsview);
 
-    view.SetAccountHistory({ {}, 5021, 0 }, {});
-    view.SetAccountHistory({ {}, 5022, 1 }, {});
-    view.SetAccountHistory({ {}, 5023, 2 }, {});
-    view.SetAccountHistory({ {}, 5024, 3 }, {});
-    view.SetAccountHistory({ {}, 5025, 4 }, {});
-    view.SetAccountHistory({ {}, 5026, 5 }, {});
+    view.SetAllAccountHistory({ {}, 5021, 0 }, {});
+    view.SetAllAccountHistory({ {}, 5022, 1 }, {});
+    view.SetAllAccountHistory({ {}, 5023, 2 }, {});
+    view.SetAllAccountHistory({ {}, 5024, 3 }, {});
+    view.SetAllAccountHistory({ {}, 5025, 4 }, {});
+    view.SetAllAccountHistory({ {}, 5026, 5 }, {});
 
     uint32_t startBlock = 5021; // exclude
     uint32_t maxBlockHeight = 5025;
     auto blockCount = maxBlockHeight;
 
-    view.ForEachAccountHistory([&](AccountHistoryKey const & key, AccountHistoryValue) {
+    view.ForEachAllAccountHistory([&](AccountHistoryKey const & key, AccountHistoryValue) {
         if (startBlock > key.blockHeight || key.blockHeight > maxBlockHeight) {
             return true;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2432,7 +2432,8 @@ bool CChainState::FlushStateToDisk(
                 UnlinkPrunedFiles(setFilesToPrune);
             nLastWrite = nNow;
         }
-        bool fMemoryCacheLarge = fDoFullFlush || (mode == FlushStateMode::PERIODIC && pcustomcsview->SizeEstimate() > (nDefaultDbCache << 16));
+        static const size_t memoryCacheSizeMax = gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX) ? (nDefaultDbCache << 16) : (nDefaultDbCache << 10);
+        bool fMemoryCacheLarge = fDoFullFlush || (mode == FlushStateMode::PERIODIC && pcustomcsview->SizeEstimate() > memoryCacheSizeMax);
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fMemoryCacheLarge && !CoinsTip().GetBestBlock().IsNull()) {
             // Flush view first to estimate size on disk later

--- a/test/functional/rpc_listaccounthistory.py
+++ b/test/functional/rpc_listaccounthistory.py
@@ -50,6 +50,7 @@ class TokensRPCListAccountHistory(DefiTestFramework):
 
         # Expect two sends, two receives and one mint tokens
         assert_equal(len(results), 5)
+        assert_equal(self.nodes[0].accounthistorycount(collateral_a), 5)
 
         # All TXs should be for collateral_a and contain a MintTokens TX
         found = False
@@ -64,6 +65,7 @@ class TokensRPCListAccountHistory(DefiTestFramework):
 
         # Expect one mint token TX
         assert_equal(len(results), 1)
+        assert_equal(self.nodes[1].accounthistorycount(collateral_a), 1)
 
         # Check owner is collateral_a and type MintTokens
         assert_equal(results[0]['owner'], collateral_a)


### PR DESCRIPTION
It introduces a new cli parameter `-acindex-mineonly` enabled by default, if `-acindex` is specified a warning message inform the user that full index will be used instead of mine only. In both operating modes mine history is stored separate for faster access. Now `listaccounthistory` is instant for mine, it still takes a bit more time when we search in the rest index table.