### PR TITLE
Add custom rewards to pool pairs

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -118,6 +118,7 @@ public:
         consensus.BayfrontHeight = 405000;
         consensus.BayfrontMarinaHeight = 465150;
         consensus.BayfrontGardensHeight = 488300;
+        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -279,6 +280,7 @@ public:
         consensus.BayfrontHeight = 3000;
         consensus.BayfrontMarinaHeight = 90470;
         consensus.BayfrontGardensHeight = 101342;
+        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -417,6 +419,7 @@ public:
         consensus.BayfrontHeight = 250;
         consensus.BayfrontMarinaHeight = 0;
         consensus.BayfrontGardensHeight = 0;
+        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -550,6 +553,7 @@ public:
         consensus.BayfrontHeight = 10000000;
         consensus.BayfrontMarinaHeight = 10000000;
         consensus.BayfrontGardensHeight = 10000000;
+        consensus.ClarkeQuayHeight = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -724,6 +728,17 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             height = std::numeric_limits<int>::max();
         }
         consensus.BayfrontGardensHeight = static_cast<int>(height);
+    }
+
+    if (gArgs.IsArgSet("-clarkequayheight")) {
+        int64_t height = gArgs.GetArg("-clarkequayheight", consensus.ClarkeQuayHeight);
+        if (height < -1 || height >= std::numeric_limits<int>::max()) {
+            throw std::runtime_error(strprintf("Activation height %ld for ClarkeQuay is out of valid range. Use -1 to disable clarkequay features.", height));
+        } else if (height == -1) {
+            LogPrintf("CQ disabled for testing\n");
+            height = std::numeric_limits<int>::max();
+        }
+        consensus.ClarkeQuayHeight = static_cast<int>(height);
     }
 
     if (!args.IsArgSet("-vbparams")) return;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -118,7 +118,7 @@ public:
         consensus.BayfrontHeight = 405000;
         consensus.BayfrontMarinaHeight = 465150;
         consensus.BayfrontGardensHeight = 488300;
-        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
+        consensus.ClarkeQuayHeight = 595738;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -280,7 +280,7 @@ public:
         consensus.BayfrontHeight = 3000;
         consensus.BayfrontMarinaHeight = 90470;
         consensus.BayfrontGardensHeight = 101342;
-        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
+        consensus.ClarkeQuayHeight = 155000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -417,9 +417,9 @@ public:
         consensus.BIP66Height = 0;
         consensus.AMKHeight = 150;
         consensus.BayfrontHeight = 250;
-        consensus.BayfrontMarinaHeight = 0;
-        consensus.BayfrontGardensHeight = 0;
-        consensus.ClarkeQuayHeight = std::numeric_limits<int>::max();
+        consensus.BayfrontMarinaHeight = 300;
+        consensus.BayfrontGardensHeight = 300;
+        consensus.ClarkeQuayHeight = 500;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -76,6 +76,8 @@ struct Params {
     int BayfrontHeight;
     int BayfrontMarinaHeight;
     int BayfrontGardensHeight;
+    /** Third major fork. */
+    int ClarkeQuayHeight;
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -468,6 +468,7 @@ void SetupServerArgs()
     gArgs.AddArg("-amkheight", "AMK fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontheight", "Bayfront fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontgardensheight", "Bayfront Gardens fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-clarkequayheight", "ClarkeQuay fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -1815,6 +1815,31 @@ UniValue poolToJSON(DCT_ID const& id, CPoolPair const& pool, CToken const& token
 
         poolObj.pushKV("rewardPct", ValueFromAmount(pool.rewardPct));
 
+        auto rewards = pcustomcsview->GetPoolCustomReward(id);
+        if (rewards && !rewards->balances.empty()) {
+            for (auto it = rewards->balances.cbegin(), next_it = it; it != rewards->balances.cend(); it = next_it) {
+                ++next_it;
+
+                // Get token balance
+                const auto balance = pcustomcsview->GetBalance(pool.ownerAddress, it->first).nValue;
+
+                // Make there's enough to pay reward otherwise remove it
+                if (balance < it->second) {
+                    rewards->balances.erase(it);
+                }
+            }
+
+            if (!rewards->balances.empty()) {
+                UniValue rewardArr(UniValue::VARR);
+
+                for (const auto& reward : rewards->balances) {
+                    rewardArr.push_back(CTokenAmount{reward.first, reward.second}.ToString());
+                }
+
+                poolObj.pushKV("customRewards", rewardArr);
+            }
+        }
+
         poolObj.pushKV("creationTx", pool.creationTx.GetHex());
         poolObj.pushKV("creationHeight", (uint64_t) pool.creationHeight);
     }
@@ -2500,6 +2525,8 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
                             "Pool Status: True is Active, False is Restricted"},
                             {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
                             "Address of the pool owner."},
+                            {"customReward", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                            "Token reward to be paid on each block, multiple can be specified."},
                             {"pairSymbol", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
                              "Pair symbol (unique), no longer than " +
                              std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
@@ -2524,14 +2551,16 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
                                                           "\"tokenB\":\"MyToken2\","
                                                           "\"commission\":\"0.001\","
                                                           "\"status\":\"True\","
-                                                          "\"ownerAddress\":\"Address\""
+                                                          "\"ownerAddress\":\"Address\","
+                                                          "\"customReward\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
                                                           "}' '[{\"txid\":\"id\",\"vout\":0}]'")
                        + HelpExampleRpc("createpoolpair", "'{\"tokenA\":\"MyToken1\","
                                                           "\"tokenB\":\"MyToken2\","
                                                           "\"commission\":\"0.001\","
                                                           "\"status\":\"True\","
-                                                          "\"ownerAddress\":\"Address\""
-                                                            "}' '[{\"txid\":\"id\",\"vout\":0}]'")
+                                                          "\"ownerAddress\":\"Address\","
+                                                          "\"customReward\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
+                                                          "}' '[{\"txid\":\"id\",\"vout\":0}]'")
                },
     }.Check(request);
 
@@ -2546,6 +2575,7 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     std::string tokenA, tokenB, pairSymbol;
     CAmount commission = 0; // !!!
     CScript ownerAddress;
+    CBalances rewards;
     bool status = true; // default Active
     UniValue metadataObj = request.params[0].get_obj();
     if (!metadataObj["tokenA"].isNull()) {
@@ -2565,6 +2595,9 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     }
     if (!metadataObj["pairSymbol"].isNull()) {
         pairSymbol = metadataObj["pairSymbol"].getValStr();
+    }
+    if (!metadataObj["customReward"].isNull()) {
+        rewards = DecodeAmounts(pwallet->chain(), metadataObj["customReward"], "");
     }
 
     int targetHeight;
@@ -2593,6 +2626,10 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
     metadata << static_cast<unsigned char>(CustomTxType::CreatePoolPair)
              << poolPairMsg << pairSymbol;
+
+    if (targetHeight >= Params().GetConsensus().ClarkeQuayHeight) {
+        metadata << rewards;
+    }
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -2648,7 +2685,7 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
                            {"status", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Pool Status new property (bool)"},
                            {"commission", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Pool commission, up to 10^-8"},
                            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address of the pool owner."},
-
+                           {"customReward", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Token reward to be paid on each block, multiple can be specified."},
                        },
                    },
                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
@@ -2668,10 +2705,12 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
                },
                RPCExamples{
                        HelpExampleCli("updatepoolpair", "'{\"pool\":\"POOL\",\"status\":true,"
-                                                     "\"commission\":0.01,\"ownerAddress\":\"Address\"}' "
+                                                     "\"commission\":0.01,\"ownerAddress\":\"Address\","
+                                                     "\"customReward\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
                                                      "'[{\"txid\":\"id\",\"vout\":0}]'")
                        + HelpExampleRpc("updatepoolpair", "'{\"pool\":\"POOL\",\"status\":true,"
-                                                       "\"commission\":0.01,\"ownerAddress\":\"Address\"}' "
+                                                       "\"commission\":0.01,\"ownerAddress\":\"Address\","
+                                                       "\"customReward\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
                                                        "'[{\"txid\":\"id\",\"vout\":0}]'")
                },
     }.Check(request);
@@ -2688,6 +2727,7 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     bool status = true;
     CAmount commission = -1;
     CScript ownerAddress;
+    CBalances rewards;
     UniValue const & metaObj = request.params[0].get_obj();
     UniValue const & txInputs = request.params[1];
 
@@ -2718,6 +2758,9 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     if (!metaObj["ownerAddress"].isNull()) {
         ownerAddress = DecodeScript(metaObj["ownerAddress"].getValStr());
     }
+    if (!metaObj["customReward"].isNull()) {
+        rewards = DecodeAmounts(pwallet->chain(), metaObj["customReward"], "");
+    }
 
     const auto txVersion = GetTransactionVersion(targetHeight);
     CMutableTransaction rawTx(txVersion);
@@ -2729,6 +2772,10 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
     metadata << static_cast<unsigned char>(CustomTxType::UpdatePoolPair)
              << poolId << status << commission << ownerAddress;
+
+    if (targetHeight >= Params().GetConsensus().ClarkeQuayHeight) {
+        metadata << rewards;
+    }
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -10,6 +10,7 @@
 const unsigned char CPoolPairView::ByID          ::prefix = 'i';
 const unsigned char CPoolPairView::ByPair        ::prefix = 'j';
 const unsigned char CPoolPairView::ByShare       ::prefix = 'k';
+const unsigned char CPoolPairView::Reward        ::prefix = 'I';
 
 Res CPoolPairView::SetPoolPair(DCT_ID const & poolId, CPoolPair const & pool)
 {
@@ -96,6 +97,36 @@ boost::optional<std::pair<DCT_ID, CPoolPair> > CPoolPairView::GetPoolPair(const 
             return { std::make_pair(poolId, std::move(*poolPair)) };
     }
     return {};
+}
+
+Res CPoolPairView::SetPoolCustomReward(const DCT_ID &poolId, CBalances& rewards)
+{
+    DCT_ID poolID = poolId;
+    if (!GetPoolPair(poolID))
+    {
+        return Res::Err("Error %s: poolID %s does not exist", __func__, poolID.ToString());
+    }
+
+    // Get existing rewards, can be called from update pool pair.
+    auto currentRewards = ReadBy<Reward, CBalances>(WrapVarInt(poolID.v));
+    if (currentRewards) {
+        for (const auto& item : currentRewards->balances) {
+
+            // If current token is not included in update, add it to rewards so it remains unchanged
+            if (rewards.balances.find(item.first) == rewards.balances.end()) {
+                rewards.Add(CTokenAmount{item.first, item.second});
+            }
+        }
+    }
+
+    WriteBy<Reward>(WrapVarInt(poolID.v), rewards);
+    return Res::Ok();
+}
+
+boost::optional<CBalances> CPoolPairView::GetPoolCustomReward(const DCT_ID &poolId)
+{
+    DCT_ID poolID = poolId;
+    return ReadBy<Reward, CBalances>(WrapVarInt(poolID.v));
 }
 
 Res CPoolPair::Swap(CTokenAmount in, PoolPrice const & maxPrice, std::function<Res (const CTokenAmount &tokenAmount)> onTransfer, bool postBayfrontGardens) {

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -107,18 +107,6 @@ Res CPoolPairView::SetPoolCustomReward(const DCT_ID &poolId, CBalances& rewards)
         return Res::Err("Error %s: poolID %s does not exist", __func__, poolID.ToString());
     }
 
-    // Get existing rewards, can be called from update pool pair.
-    auto currentRewards = ReadBy<Reward, CBalances>(WrapVarInt(poolID.v));
-    if (currentRewards) {
-        for (const auto& item : currentRewards->balances) {
-
-            // If current token is not included in update, add it to rewards so it remains unchanged
-            if (rewards.balances.find(item.first) == rewards.balances.end()) {
-                rewards.Add(CTokenAmount{item.first, item.second});
-            }
-        }
-    }
-
     WriteBy<Reward>(WrapVarInt(poolID.v), rewards);
     return Res::Ok();
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1312,6 +1312,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "segwit", consensusParams.SegwitHeight);
     BuriedForkDescPushBack(softforks, "amk", consensusParams.AMKHeight);
     BuriedForkDescPushBack(softforks, "bayfront", consensusParams.BayfrontHeight);
+    BuriedForkDescPushBack(softforks, "clarkequay", consensusParams.ClarkeQuayHeight);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(math_rewards)
             [&cache] (CScript const & owner, DCT_ID tokenID) {
                 return cache.GetBalance(owner, tokenID);
             },
-            [&cache] (CScript const & to, DCT_ID poolID, uint8_t type, CTokenAmount amount) {
+            [&cache] (CScript const & to, CScript const & from, DCT_ID poolID, uint8_t type, CTokenAmount amount) {
                 return cache.AddBalance(to, amount);
             }
         );

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2321,7 +2321,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
             auto res = cache.SubCommunityBalance(CommunityAccountType::IncentiveFunding, distributed);
             if (!res.ok)
-                throw std::runtime_error(strprintf("Pool rewards: can't update community balance: %s. Block %ld (%s)", res.msg, block.height, block.GetHash().ToString()));
+                LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, block.height, block.GetHash().ToString());
         }
         // Remove `Finalized` and/or `LPS` flags _possibly_set_ by bytecoded (cheated) txs before bayfront fork
         if (pindex->nHeight == chainparams.GetConsensus().BayfrontHeight - 1) { // call at block _before_ fork

--- a/test/functional/feature_custom_poolreward.py
+++ b/test/functional/feature_custom_poolreward.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test custom pool reward."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+
+class TokensCustomPoolReward(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50', '-clarkequayheight=50'],
+                           ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50', '-clarkequayheight=50']]
+
+    def run_test(self):
+        self.nodes[0].generate(102)
+        num_tokens = len(self.nodes[0].listtokens())
+
+        # collateral addresses
+        collateral_a = self.nodes[0].getnewaddress("", "legacy")
+        collateral_b = self.nodes[0].getnewaddress("", "legacy")
+
+        # Create token
+        self.nodes[0].createtoken({
+            "symbol": "GOLD",
+            "name": "gold",
+            "collateralAddress": collateral_a
+        })
+        self.nodes[0].generate(1)
+
+        # Create token
+        self.nodes[0].createtoken({
+            "symbol": "SILVER",
+            "name": "silver",
+            "collateralAddress": collateral_b
+        })
+        self.nodes[0].generate(1)
+
+        # Get token ID
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "GOLD"):
+                token_a = idx
+            if (token["symbol"] == "SILVER"):
+                token_b = idx
+
+        # Make sure there's an extra token
+        assert_equal(len(self.nodes[0].listtokens()), num_tokens + 2)
+
+        # Mint some tokens
+        self.nodes[0].minttokens(["100000@" + token_a])
+        self.nodes[0].minttokens(["100000@" + token_b])
+        self.nodes[0].generate(1)
+
+        # Create pool pair
+        pool_collateral = self.nodes[0].getnewaddress("", "legacy")
+        poolpair_tx = self.nodes[0].createpoolpair({
+            "tokenA": "GOLD#" + token_a,
+            "tokenB": "SILVER#" + token_b,
+            "commission": 0.001,
+            "status": True,
+            "ownerAddress": pool_collateral,
+            "pairSymbol": "SILVGOLD",
+            "customReward": ["1@" + token_a, "1@" + token_b]
+        })
+        self.nodes[0].generate(1)
+
+        # Check that customReards shows up in getcustomtx
+        result = self.nodes[0].getcustomtx(poolpair_tx)
+        assert_equal(result['results']['customRewards'], ["1.00000000@" + token_a, "1.00000000@" + token_b])
+
+        # custom rewards should not show up yet without balance
+        assert('customRewards' not in self.nodes[0].getpoolpair(1)['1'])
+
+        # Create and fund liquidity provider
+        provider = self.nodes[1].getnewaddress("", "legacy")
+
+        # Add pool liqudity
+        self.nodes[0].addpoolliquidity({
+            "*": ["1@" + token_a, "1@" + token_b]
+        }, provider)
+        self.nodes[0].generate(1)
+
+        # Provide pool reward for token a
+        self.nodes[0].accounttoaccount(collateral_a, {pool_collateral: "1@" + token_a})
+        self.nodes[0].generate(1)
+
+        # token a reward should be added to provider
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '0.99999000@GOLD#128'])
+
+        # Make sure amount reduced from token a
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['0.00001000@GOLD#128'])
+        self.nodes[0].generate(1)
+
+        # token a amount should be static as not enough funds to pay
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '0.99999000@GOLD#128'])
+
+        # Provide pool reward for token b
+        self.nodes[0].accounttoaccount(collateral_b, {pool_collateral: "1@" + token_b})
+        self.nodes[0].generate(1)
+
+        # token b reward should be added to provider but token a same as before
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '0.99999000@GOLD#128', '0.99999000@SILVER#129'])
+
+        # Make sure amount reduced from token a
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['0.00001000@GOLD#128', '0.00001000@SILVER#129'])
+        self.nodes[0].generate(1)
+
+        # token a and b amount should be static as not enough funds to pay
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '0.99999000@GOLD#128', '0.99999000@SILVER#129'])
+
+        # Fund addresses to avoid auto auth to send raw via node 1 easily
+        self.nodes[0].sendtoaddress(collateral_a, 1)
+        self.nodes[0].sendtoaddress(collateral_b, 1)
+        self.nodes[0].generate(1)
+
+        # Provide pool reward for token a and b
+        tx1 = self.nodes[0].accounttoaccount(collateral_a, {pool_collateral: "10@" + token_a})
+        tx2 = self.nodes[0].accounttoaccount(collateral_b, {pool_collateral: "10@" + token_b})
+
+        # Send raw on second node to make sure that it is present in mempool
+        rawtx1 = self.nodes[0].getrawtransaction(tx1)
+        rawtx2 = self.nodes[0].getrawtransaction(tx2)
+        self.nodes[1].sendrawtransaction(rawtx1)
+        self.nodes[1].sendrawtransaction(rawtx2)
+
+        # Generate block and trigger potential payouts
+        self.nodes[1].generate(1)
+        self.sync_blocks()
+
+        # Both token a and b should be present
+        assert_equal(self.nodes[1].getpoolpair(1)['1']['customRewards'], ['1.00000000@128', '1.00000000@129'])
+        assert_equal(self.nodes[0].getpoolpair(1)['1']['customRewards'], ['1.00000000@128', '1.00000000@129'])
+
+        # Generate 9 more blocks and trigger potential payouts
+        self.nodes[1].generate(9)
+
+        # token a and b rewards should be added to provider
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '10.99989000@GOLD#128', '10.99989000@SILVER#129'])
+
+        # Make sure amount reduced from token a
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['0.00011000@GOLD#128', '0.00011000@SILVER#129'])
+
+        # custom rewards should not show up yet without balance
+        assert('customRewards' not in self.nodes[0].getpoolpair(1)['1'])
+
+        # Top up of token a to test poolpair output
+        self.nodes[0].accounttoaccount(collateral_a, {pool_collateral: "10@" + token_a})
+        self.nodes[0].generate(1)
+
+        # Check only token a reward shows
+        assert_equal(self.nodes[0].getpoolpair(1)['1']['customRewards'], ['1.00000000@128'])
+
+        # Generate another block and trigger potential payout
+        self.nodes[0].generate(9)
+
+        # custom rewards should not show up yet without balance
+        assert('customRewards' not in self.nodes[0].getpoolpair(1)['1'])
+
+        # Top up of token b to test poolpair output
+        self.nodes[0].accounttoaccount(collateral_b, {pool_collateral: "10@" + token_b})
+        self.nodes[0].generate(1)
+
+        # Check only token a reward shows
+        assert_equal(self.nodes[0].getpoolpair(1)['1']['customRewards'], ['1.00000000@129'])
+
+        # Generate another block and trigger potential payout
+        self.nodes[0].generate(9)
+
+        # custom rewards should not show up yet without balance
+        assert('customRewards' not in self.nodes[0].getpoolpair(1)['1'])
+
+        # Create new token for reward
+        num_tokens = len(self.nodes[0].listtokens())
+        collateral_c = self.nodes[0].getnewaddress("", "legacy")
+        self.nodes[0].createtoken({
+            "symbol": "BRONZE",
+            "name": "bronze",
+            "collateralAddress": collateral_c
+        })
+        self.nodes[0].generate(1)
+
+        # Get token ID
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "BRONZE"):
+                token_c = idx
+
+        # Make sure there's an extra token
+        assert_equal(len(self.nodes[0].listtokens()), num_tokens + 1)
+
+        # Mint some tokens
+        self.nodes[0].minttokens(["100000@" + token_c])
+        self.nodes[0].generate(1)
+
+        # Top up of token c to test poolpair output before adding it to he pool
+        self.nodes[0].accounttoaccount(collateral_c, {pool_collateral: "10@" + token_c})
+        self.nodes[0].generate(1)
+
+        # Remove token a from rewards
+        updatepoolpair_tx = self.nodes[0].updatepoolpair({"pool": "1", "customReward": ["1@" + token_c]})
+        self.nodes[0].generate(1)
+
+        # Check that customReards shows up in getcustomtx
+        result = self.nodes[0].getcustomtx(updatepoolpair_tx)
+        assert_equal(result['results']['customRewards'], ["1.00000000@" + token_c])
+
+        # Check for new block reward and payout
+        assert_equal(self.nodes[1].getpoolpair(1)['1']['customRewards'], ['1.00000000@130'])
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '20.99979000@GOLD#128', '20.99979000@SILVER#129', '0.99999000@BRONZE#130'])
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['0.00021000@GOLD#128', '0.00021000@SILVER#129', '9.00001000@BRONZE#130'])
+
+        # Provide pool reward for token a
+        self.nodes[0].accounttoaccount(collateral_a, {pool_collateral: "10@" + token_a})
+        self.nodes[0].generate(1)
+
+        # Check for new block reward and payout
+        assert_equal(self.nodes[1].getpoolpair(1)['1']['customRewards'], ['1.00000000@128', '1.00000000@130'])
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '21.99978000@GOLD#128', '20.99979000@SILVER#129', '1.99998000@BRONZE#130'])
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['9.00022000@GOLD#128', '0.00021000@SILVER#129', '8.00002000@BRONZE#130'])
+
+        # Provide pool reward for token a
+        self.nodes[0].accounttoaccount(collateral_b, {pool_collateral: "10@" + token_b})
+        self.nodes[0].generate(1)
+
+        # Check for new block reward and payout
+        assert_equal(self.nodes[1].getpoolpair(1)['1']['customRewards'], ['1.00000000@128', '1.00000000@129', '1.00000000@130'])
+        assert_equal(self.nodes[1].getaccount(provider), ['0.99999000@SILVGOLD', '22.99977000@GOLD#128', '21.99978000@SILVER#129', '2.99997000@BRONZE#130'])
+        assert_equal(self.nodes[1].getaccount(pool_collateral), ['8.00023000@GOLD#128', '9.00022000@SILVER#129', '7.00003000@BRONZE#130'])
+
+if __name__ == '__main__':
+    TokensCustomPoolReward().main()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -131,6 +131,7 @@ class BlockchainTest(DefiTestFramework):
             'segwit': {'type': 'buried', 'active': True, 'height': 0},
             'amk': {'type': 'buried', 'active': False, 'height': 10000000},
             'bayfront': {'type': 'buried', 'active': False, 'height': 10000000},
+            'clarkequay': {'type': 'buried', 'active': False, 'height': 10000000},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -212,6 +212,7 @@ BASE_SCRIPTS = [
     'feature_cltv.py',
     'rpc_uptime.py',
     'wallet_resendwallettransactions.py',
+    'feature_custom_poolreward.py',
     'wallet_fallbackfee.py',
     'feature_minchainwork.py',
     'rpc_getblockstats.py',


### PR DESCRIPTION
Add Clarke Quay hard fork logic and pool pair custom token reward feature. This allows any token to be specified as a reward to be paid from the pool owner address. Token rewards can be set by either during creation by `createpoolpair` and `updatepoolpair`. `getpoolpair` and `listpoolpair` will show this additional reward under the key `customRewards` only if it is set and the pool owner has enough balance to cover the reward. Multiple rewards can be added to a single pool, these will stop being paid out once the balance in the owner address is depleted and will continue again if topped up. `getcustomtx` has been updated to show the addition of `customRewards` to `getpoolpair` and `listpoolpair`.