### PR TITLE
Use full path of wallet file in IsMineCached

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -14,6 +14,7 @@
 #include <script/standard.h>
 #include <validation.h>
 #include <wallet/wallet.h>
+#include <wallet/walletutil.h>
 
 #include <algorithm>
 #include <functional>
@@ -616,9 +617,10 @@ bool CRewardsHistoryStorage::Flush()
 isminetype IsMineCached(CWallet const & wallet, CScript const & script)
 {
     static std::unordered_map<std::string, std::map<CScript, isminetype>> mineCached;
-    auto it = mineCached.find(wallet.GetName());
+    const auto& walletFilePath = wallet.GetLocation().GetFilePath();
+    auto it = mineCached.find(walletFilePath);
     if (it == mineCached.end()) {
-        it = mineCached.emplace(wallet.GetName(), std::map<CScript, isminetype>{}).first;
+        it = mineCached.emplace(walletFilePath, std::map<CScript, isminetype>{}).first;
     }
     auto mIt = it->second.find(script);
     if (mIt == it->second.end()) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -96,6 +96,7 @@ WalletLocation::WalletLocation(const std::string& name)
     : m_name(name)
     , m_path(fs::absolute(name, GetWalletDir()))
 {
+    m_file_path = (m_path / m_name).string();
 }
 
 bool WalletLocation::Exists() const

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -7,6 +7,7 @@
 
 #include <fs.h>
 
+#include <string>
 #include <vector>
 
 //! Get the path of the wallet directory.
@@ -18,11 +19,12 @@ std::vector<fs::path> ListWalletDir();
 //! The WalletLocation class provides wallet information.
 class WalletLocation final
 {
+    std::string m_file_path;
     std::string m_name;
     fs::path m_path;
 
 public:
-    explicit WalletLocation() {}
+    WalletLocation() = default;
     explicit WalletLocation(const std::string& name);
 
     //! Get wallet name.
@@ -30,6 +32,9 @@ public:
 
     //! Get wallet absolute path.
     const fs::path& GetPath() const { return m_path; }
+
+    //! Get wallet absolute file path.
+    const std::string& GetFilePath() const { return m_file_path; }
 
     //! Return whether the wallet exists.
     bool Exists() const;


### PR DESCRIPTION
Prior this patch IsMineCached use wallet file name to cache the results but that can be a problem if name is same in different location. This patch aims to fix that issue by storing full file path.