### PR TITLE
Fix gettokenbalances

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -1773,12 +1773,8 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
 
     LOCK(cs_main);
     CBalances totalBalances;
-    CScript oldOwner;
     pcustomcsview->ForEachBalance([&](CScript const & owner, CTokenAmount const & balance) {
-        if (oldOwner == owner) {
-            totalBalances.Add(balance);
-        } else if (IsMineCached(*pwallet, owner) == ISMINE_SPENDABLE) {
-            oldOwner = owner;
+        if (IsMineCached(*pwallet, owner) == ISMINE_SPENDABLE) {
             totalBalances.Add(balance);
         }
         return true;


### PR DESCRIPTION
Now `gettokenbalances` and `getaccount` returns different token balances. It's due to balance to empty address, probably poolswap to empty address or so. `listaccounts` shows it on fist place.