### PR TITLE
Add AutoAuthPrep meta data to auto auth TXs

### DIFF
--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -54,10 +54,12 @@ enum class CustomTxType : unsigned char
     AnyAccountsToAccounts  = 'a',
     //set governance variable
     SetGovVariable       = 'G',
+    // Auto auth TX
+    AutoAuthPrep       = 'A',
 };
 
 inline CustomTxType CustomTxCodeToType(unsigned char ch) {
-    char const txtypes[] = "CRTMNnpuslrUbBaG";
+    char const txtypes[] = "CRTMNnpuslrUbBaGA";
     if (memchr(txtypes, ch, strlen(txtypes)))
         return static_cast<CustomTxType>(ch);
     else
@@ -83,6 +85,7 @@ inline std::string ToString(CustomTxType type) {
         case CustomTxType::AccountToAccount:    return "AccountToAccount";
         case CustomTxType::AnyAccountsToAccounts:   return "AnyAccountsToAccounts";
         case CustomTxType::SetGovVariable:      return "SetGovVariable";
+        case CustomTxType::AutoAuthPrep:        return "AutoAuth";
         default:                                return "None";
     }
 }

--- a/test/functional/feature_auth_return_change.py
+++ b/test/functional/feature_auth_return_change.py
@@ -30,8 +30,8 @@ class TokensAuthChange(DefiTestFramework):
         auth_tx = self.nodes[0].getrawtransaction(final_rawtx['vin'][0]['txid'], 1)
 
         # Auth TX outputs all belong to auth address
-        assert_equal(auth_tx['vout'][0]['scriptPubKey']['addresses'][0], owner)
-        assert_equal(len(auth_tx['vout']), 1)
+        assert_equal(auth_tx['vout'][1]['scriptPubKey']['addresses'][0], owner)
+        assert_equal(len(auth_tx['vout']), 2)
 
         # Two outputs, single input and change to auth address on final TX
         assert_equal(final_rawtx['vout'][1]['scriptPubKey']['addresses'][0], owner)


### PR DESCRIPTION
This PR adds meta data to the auto auth TXs so they can be filtered out on listtransactions and report their TX type in getcustomtx.