### PR TITLE
Do not read stream out of its bounds in FindByte

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -853,10 +853,13 @@ public:
     void FindByte(char ch) {
         while (true) {
             if (nReadPos == nSrcPos)
-                Fill();
-            if (vchBuf[nReadPos % vchBuf.size()] == ch)
-                break;
-            nReadPos++;
+                if (!Fill())
+                    throw std::ios_base::failure("CBufferedFile::FindByte: fail to read");
+                if (nReadPos >= vchBuf.size())
+                    throw std::ios_base::failure("CBufferedFile::FindByte: fail to find");
+                if (vchBuf[nReadPos] == ch)
+                    break;
+                nReadPos++;
         }
     }
 };


### PR DESCRIPTION
It address the high memory usage on `-reindex`, It can read over and over again the file and accept same blocks which can lead to high memory usage. If that's not help i prefer to just purge old files on `-reindex`