### PR TITLE
Check for watch address change

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -3459,6 +3459,10 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
             return true;
         }
 
+        if (isMine && !(IsMineCached(*pwallet, key.owner) & filter)) {
+            return true;
+        }
+
         const auto & value = valueLazy.get();
 
         if (CustomTxType::None != txType && value.category != uint8_t(txType)) {
@@ -3521,6 +3525,10 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
             }
 
             if (shouldSkipBlock(key.blockHeight)) {
+                return true;
+            }
+
+            if (isMine && !(IsMineCached(*pwallet, key.owner) & filter)) {
                 return true;
             }
 
@@ -3663,6 +3671,10 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
             return false;
         }
 
+        if (isMine && !(IsMineCached(*pwallet, key.owner) & filter)) {
+            return true;
+        }
+
         const auto& value = valueLazy.get();
 
         if(!tokenFilter.empty() && !hasToken(value.diff)) {
@@ -3713,6 +3725,10 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
     auto shouldContinueToNextReward = [&](RewardHistoryKey const & key, CLazySerialize<RewardHistoryValue> valueLazy) -> bool {
         if (!owner.empty() && owner != key.owner) {
             return false;
+        }
+
+        if (isMine && !(IsMineCached(*pwallet, key.owner) & filter)) {
+            return true;
         }
 
         if(!tokenFilter.empty()) {


### PR DESCRIPTION
It checks for changes between `listaccounthistory` calls, if you don't have full index adding address for watch only still not work.
Fixes https://github.com/cakedefi/defichain-private/issues/401