### PR TITLE
Pin github-actions to a full length commit SHA

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -16,7 +16,7 @@ on:
       - ci/*
       - v*
 jobs:
-  
+
   linux:
   # We use a matrix since it's easier to migrate upwards, add new
   # test on multiple, then remove old without creating friction.
@@ -26,17 +26,19 @@ jobs:
         os: [ubuntu-16.04]
     env:
       BUILD_VERSION: latest # Computed
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
     - name: Build and package
       run: TARGETS="x86_64-pc-linux-gnu" ./make.sh docker-release-git
+
     - name: Publish artifact - x86_64-pc-linux-gnu
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
-  
+
   windows:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -44,17 +46,19 @@ jobs:
         os: [ubuntu-18.04]
     env:
       BUILD_VERSION: latest # Computed
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
     - name: Build and package
       run: TARGETS="x86_64-w64-mingw32" ./make.sh docker-release-git
+
     - name: Publish artifact - x86_64-w64-mingw32
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
-  
+
   macos:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -62,13 +66,15 @@ jobs:
         os: [ubuntu-18.04]
     env:
       BUILD_VERSION: latest # Computed
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
     - name: Build and package
       run: TARGETS="x86_64-apple-darwin11" ./make.sh docker-release-git
+
     - name: Publish artifact - x86_64-apple-darwin11
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz

--- a/.github/workflows/prune-artifacts.yaml
+++ b/.github/workflows/prune-artifacts.yaml
@@ -1,4 +1,4 @@
-# This is a script to remove all artifacts every month. By default it's 3 months, I think. 
+# This is a script to remove all artifacts every month. By default it's 3 months, I think.
 # This may be removed in the future when we don't have so many builds which could end up
 # filling up the storage space
 
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Prune artifacts
-      uses: c-hive/gha-remove-artifacts@v1
+      uses: c-hive/gha-remove-artifacts@24dc23384a1fa6a058b79c73727ae0cb2200ca4c
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         age: '4 weeks'

--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -9,15 +9,15 @@ jobs:
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
       run: ./make.sh docker-release-git
 
     - name: Publish artifacts
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
@@ -29,7 +29,7 @@ jobs:
         docker tag defichain-x86_64-pc-linux-gnu:${{ env.BUILD_VERSION }}
         defichain-x86_64-pc-linux-gnu:dockerhub-latest
 
-    - uses: docker/build-push-action@v1
+    - uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f
     # Make sure to only build on ain repo. Also add in additional restrictions here if needed to
     # make sure we don't push unnecessary images to docker
       if: ${{ github.repository == 'DeFiCh/ain' }}
@@ -46,33 +46,33 @@ jobs:
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
       run: TARGETS="x86_64-w64-mingw32" ./make.sh docker-release-git
-      
+
     - name: Publish artifact - x86_64-w64-mingw32
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
-  
+
   macos:
     runs-on: ubuntu-18.04
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
       run: TARGETS="x86_64-apple-darwin11" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-apple-darwin11
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
@@ -86,9 +86,9 @@ jobs:
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')
-    
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: compute build version
       run: ./make.sh git-version
@@ -97,10 +97,10 @@ jobs:
       run: rm -rf *
 
     - name: get all build artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843
 
     - name: zip package for windows
-      run: | 
+      run: |
         set -e
         cd defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         tar xzf defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
@@ -109,7 +109,7 @@ jobs:
 
     - name: Gets latest created release info
       id: latest_release_info
-      uses: jossef/action-latest-release-info@v1.1.0
+      uses: jossef/action-latest-release-info@66a3e0617254c7acfaae82263597ea3e89df6fb9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -123,7 +123,7 @@ jobs:
         sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz > ././defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz.SHA256
 
     - name: Upload release asset - linux
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -133,7 +133,7 @@ jobs:
         asset_content_type: application/gzip
 
     - name: Upload checksum - linux
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -143,7 +143,7 @@ jobs:
         asset_content_type: text/plain
 
     - name: Upload release asset - windows
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -153,7 +153,7 @@ jobs:
         asset_content_type: application/zip
 
     - name: Upload checksum asset - windows
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -163,7 +163,7 @@ jobs:
         asset_content_type: text/plain
 
     - name: Upload release asset - macos
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -173,7 +173,7 @@ jobs:
         asset_content_type: application/gzip
 
     - name: Upload checksum asset - macos
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

[docs.github.com/security-hardening-for-github-actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions)
[github.blog/collision-detection-on-github-com](https://github.blog/2017-03-20-sha-1-collision-detection-on-github-com/)

### Changes & Notes
* `upload-artifact@v2-preview` is updated to use `upload-artifact@v2`
  * `DeFiCh/app` uses `upload-artifact@v2` too, aka `e448a9b857ee2131e752b06002bf0e093c65e571`
* `docker/build-push-action@v1` has been updated to `v2` with significant changes that are not backwards compatible, I will keep it as `v1` as it's not deprecated.

### Actions are pinned to these SHA
* https://github.com/actions/checkout/commits/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
* https://github.com/actions/upload-artifact/commits/e448a9b857ee2131e752b06002bf0e093c65e571
* https://github.com/actions/download-artifact/commits/4a7a711286f30c025902c28b541c10e147a9b843
* https://github.com/docker/build-push-action/commits/3e7a4f6646880c6f63758d73ac32392d323eaf8f
* https://github.com/jossef/action-latest-release-info/commits/66a3e0617254c7acfaae82263597ea3e89df6fb9
* https://github.com/actions/upload-release-asset/commits/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
* https://github.com/c-hive/gha-remove-artifacts/commits/24dc23384a1fa6a058b79c73727ae0cb2200ca4c