### PR TITLE
Adding variable for make args, ignore .vscode dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .code
 .idea
+.vscode
 build
 
 *.tar.gz

--- a/make.sh
+++ b/make.sh
@@ -17,6 +17,7 @@ setup_vars() {
     RELEASE_DIR=${RELEASE_DIR:-"./build"}
 
     EXTRA_BUILD_OPTS=${EXTRA_BUILD_OPTS:-}
+    EXTRA_MAKE_ARGS=${EXTRA_MAKE_ARGS:-}
 
     # shellcheck disable=SC2206
     # This intentionally word-splits the array as env arg can only be strings.
@@ -74,6 +75,7 @@ help() {
 build() {
     local target=${1:-"x86_64-pc-linux-gnu"}
     local extra_build_opts=${EXTRA_BUILD_OPTS:-}
+    local extra_make_args=${EXTRA_MAKE_ARGS:-}
 
     echo "> build: ${target}"
     pushd ./depends >/dev/null
@@ -83,7 +85,7 @@ build() {
     ./autogen.sh
     # XREF: #make-configure
     ./configure --prefix="$(pwd)/depends/${target}" ${extra_build_opts}
-    make
+    make $extra_make_args
 }
 
 deploy() {


### PR DESCRIPTION

Using Visual Studio Code as IDE will create local config files so I'm adding them in .gitignore.

If initial build is ran with make.sh it will issue make without parameter for number of jobs. Adding environment variable with which additional arguments could be passed to make.