### PR TITLE
Hard code required SPV solution to related DeFi network

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -460,10 +460,8 @@ void SetupServerArgs()
     gArgs.AddArg("-txnotokens", "Flag to force old tx serialization (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-anchorquorum", "Min quorum size (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-spv", "Enable SPV to bitcoin blockchain (default: 0, unless masternode)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-fakespv", "Fake SPV for testing purposes (default: 0, regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-criminals", "punishment of criminal nodes (default: 0, regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-spv_resync", "Flag to reset spv database and resync from zero block (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-spv_testnet", "Flag to use bitcoin testnet instead of main (default: 0)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-spv_rescan", "Block height to rescan from (default: 0 = off)", ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     gArgs.AddArg("-amkheight", "AMK fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontheight", "Bayfront fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
@@ -1613,10 +1611,12 @@ bool AppInitMain(InitInterfaces& interfaces)
 
                 if (gArgs.GetBoolArg("-spv", anchorsEnabled)) {
                     spv::pspv.reset();
-                    if (gArgs.GetBoolArg("-fakespv", false) && Params().NetworkIDString() == "regtest") {
+                    if (Params().NetworkIDString() == "regtest") {
                         spv::pspv = MakeUnique<spv::CFakeSpvWrapper>();
+                    } else if (Params().NetworkIDString() == "test") {
+                        spv::pspv = MakeUnique<spv::CSpvWrapper>(false, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
                     } else {
-                        spv::pspv = MakeUnique<spv::CSpvWrapper>(!gArgs.GetBoolArg("-spv_testnet", false), nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
+                        spv::pspv = MakeUnique<spv::CSpvWrapper>(true, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
                     }
                 }
                 panchors->Load();

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -77,7 +77,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
                                            DecodeSecret("cPGEaz8AGiM71NGMRybbCqFNRcuUhg3uGvyY4TFE1BZC26EW2PkC")};
 
     gArgs.ForceSetArg("-masternode_operator", "mps7BdmwEF2vQ9DREDyNPibqsuSRZ8LuwQ"); // matches with [1] masternode from regtest chainparams (and with testMasternodeKeys.begin())
-    gArgs.ForceSetArg("-spv_testnet", "1");
     CTxOut::SERIALIZE_FORCED_TO_OLD_IN_TESTS = true;
     fCriminals = true;
     fIsFakeNet = true;

--- a/test/functional/feature_anchor_rewards.py
+++ b/test/functional/feature_anchor_rewards.py
@@ -20,9 +20,9 @@ class AnchorRewardsTest (DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
+            [ "-dummypos=1", "-spv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
+            [ "-dummypos=1", "-spv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
+            [ "-dummypos=1", "-spv=1", '-amkheight=0', "-anchorquorum=2", "-dakotaheight=1"],
         ]
         self.setup_clean_chain = True
 

--- a/test/functional/feature_anchorauths.py
+++ b/test/functional/feature_anchorauths.py
@@ -19,9 +19,9 @@ class AnchorAuthsTest (DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
         ]
         self.setup_clean_chain = True
 

--- a/test/functional/feature_anchorauths_pruning.py
+++ b/test/functional/feature_anchorauths_pruning.py
@@ -18,7 +18,7 @@ class AnchorsAuthsPruningTest (DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", '-amkheight=0', "-dakotaheight=1"],
+            [ "-dummypos=1", "-spv=1", '-amkheight=0', "-dakotaheight=1"],
         ]
         self.setup_clean_chain = True
 

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -17,9 +17,9 @@ class AnchorsTest (DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
-            [ "-dummypos=1", "-spv=1", "-fakespv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
+            [ "-dummypos=1", "-spv=1", "-clarkequayheight=0"],
         ]
         self.setup_clean_chain = True
 

--- a/test/functional/feature_criminals.py
+++ b/test/functional/feature_criminals.py
@@ -24,7 +24,6 @@ class CriminalsTest (DefiTestFramework):
             [ "-dummypos=0", "-criminals=0"],
             [ "-dummypos=0", "-criminals=1"],
             [ "-dummypos=0", "-criminals=0"],
-            # [ "-dummypos=1", "-spv=1", "-fakespv=1", "-txindex=1", "-anchorquorum=2"],
         ]
         self.setup_clean_chain = True
 


### PR DESCRIPTION
If SPV is enabled for testnet or regtest and spv_testnet or fakespv are not set respectively then the following error occurs.

`Assertion failed: (memcmp(&mpk, &BR_MASTER_PUBKEY_NONE, sizeof(mpk)) != 0)`

This introduces some confusion for users and seems unnecessary, if you are on regtest then fakespv is required and if you are on testnet then spv_testnet is required. This PR hard codes fakespv to regtest and spv_testnet to testnet to avoid the assertion.