### PR TITLE
Move all anchors and validation to pending

### DIFF
--- a/src/masternodes/anchors.h
+++ b/src/masternodes/anchors.h
@@ -493,7 +493,7 @@ CAmount GetAnchorSubsidy(int anchorHeight, int prevAnchorHeight, const Consensus
 
 // thowing exceptions (not a bool due to more verbose rpc errors. may be 'status' or smth? )
 /// Validates all except tx confirmations
-bool ValidateAnchor(CAnchor const & anchor, bool& pending);
+bool ValidateAnchor(CAnchor const & anchor);
 
 // Validate anchor in the context of the active chain. This is used for anchor auths and anchors read from Bitcoin.
 bool ContextualValidateAnchor(const CAnchorData& anchor, CBlockIndex &anchorBlock, uint64_t &anchorCreationHeight);

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -577,6 +577,7 @@ UniValue spv_listanchorspending(const JSONRPCRequest& request)
         UniValue anchor(UniValue::VOBJ);
         anchor.pushKV("btcBlockHeight", static_cast<int>(rec.btcHeight));
         anchor.pushKV("btcTxHash", rec.txHash.ToString());
+        anchor.pushKV("previousAnchor", rec.anchor.previousAnchor.ToString());
         anchor.pushKV("defiBlockHeight", static_cast<int>(rec.anchor.height));
         anchor.pushKV("defiBlockHash", rec.anchor.blockHash.ToString());
         anchor.pushKV("rewardAddress", EncodeDestination(rewardDest));

--- a/src/spv/spv_wrapper.cpp
+++ b/src/spv/spv_wrapper.cpp
@@ -368,22 +368,9 @@ void CSpvWrapper::OnTxAdded(BRTransaction * tx)
         LogPrint(BCLog::SPV, "IsAnchorTx(): %s\n", txHash.ToString());
 
         LOCK(cs_main);
-
-        bool pending{false};
-        if (ValidateAnchor(anchor, pending)) {
-            LogPrint(BCLog::SPV, "valid anchor tx: %s\n", txHash.ToString());
-
-            if (panchors->AddAnchor(anchor, txHash, tx->blockHeight, false)) {
-                LogPrint(BCLog::SPV, "adding anchor %s\n", txHash.ToString());
-            }
-        } else if (pending) {
-            if (panchors->AddToAnchorPending(anchor, txHash, tx->blockHeight)) {
-                LogPrint(BCLog::SPV, "adding anchor to pending %s\n", txHash.ToString());
-            }
+        if (ValidateAnchor(anchor) && panchors->AddToAnchorPending(anchor, txHash, tx->blockHeight)) {
+            LogPrint(BCLog::SPV, "adding anchor to pending %s\n", txHash.ToString());
         }
-    }
-    else {
-        LogPrint(BCLog::SPV, "not an anchor tx %s\n", txHash.ToString());
     }
 }
 


### PR DESCRIPTION
Minor refactor as there are no more legacy anchors. Fix issue where anchor height not in chain were dropped, chain could still be syncing. Fix issue where previous anchor was still pending so new anchor was dropped. Add previous anchor info to spv_listanchorspending.