### PR TITLE
Reject paid confirmations. Only vote if not in IBD.

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -977,24 +977,32 @@ bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessa
 
     CKeyID signer = confirmMessage.GetSigner();
     if (signer.IsNull()) {
-        LogPrintf("%s: Warning! Signature incorrect. btcTxHash: %s confirmMessageHash: %s Key: %s\n", __func__, confirmMessage.btcTxHash.ToString(), confirmMessage.GetHash().ToString(), signer.ToString());
+        LogPrint(BCLog::ANCHORING, "%s: Warning! Signature incorrect. btcTxHash: %s confirmMessageHash: %s Key: %s\n",
+                 __func__, confirmMessage.btcTxHash.ToString(), confirmMessage.GetHash().ToString(), signer.ToString());
         return false;
     }
 
     auto it = pcustomcsview->GetMasternodeIdByOperator(signer);
     if (!it || !pcustomcsview->GetMasternode(*it)->IsActive()) {
-        LogPrintf("%s: Warning! Masternode with operator key %s does not exist or not active!\n", __func__, signer.ToString());
+        LogPrint(BCLog::ANCHORING, "%s: Warning! Masternode with operator key %s does not exist or not active!\n", __func__, signer.ToString());
         return false;
     }
 
     CBlockIndex* anchorIndex = ::ChainActive()[confirmMessage.anchorHeight];
     if (!anchorIndex) {
-        return error("%s: Active chain does not contain block height %d!", __func__, confirmMessage.anchorHeight);
+        LogPrint(BCLog::ANCHORING, "%s: Active chain does not contain block height %d\n", __func__, confirmMessage.anchorHeight);
+        return false;
     }
 
     if (anchorIndex->GetBlockHash() != confirmMessage.dfiBlockHash) {
-        return error("%s: Anchor and blockchain mismatch at height %d. Expected %s found %s",
-                     __func__, confirmMessage.anchorHeight, anchorIndex->GetBlockHash().ToString(), confirmMessage.dfiBlockHash.ToString());
+        LogPrint(BCLog::ANCHORING, "%s: Anchor and blockchain mismatch at height %d. Expected %s found %s\n",
+                 __func__, confirmMessage.anchorHeight, anchorIndex->GetBlockHash().ToString(), confirmMessage.dfiBlockHash.ToString());
+        return false;
+    }
+
+    if (auto reward = pcustomcsview->GetRewardForAnchor(confirmMessage.btcTxHash)) {
+        LogPrint(BCLog::ANCHORING, "%s: Anchor already paid. DeFi Transaction: %s\n", __func__, reward->ToString());
+        return false;
     }
 
     return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2421,7 +2421,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 return false;
             }
 
-            LogPrintf("Got anchor auth, hash %s, blockheight: %d\n", auth.GetHash().ToString(), auth.height);
+            LogPrint(BCLog::ANCHORING, "Got anchor auth, hash %s, blockheight: %d\n", auth.GetHash().ToString(), auth.height);
 
             // if valid, add and rebroadcast
             if (panchorauths->ValidateAuth(auth)) {
@@ -2445,7 +2445,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LOCK(cs_main);
 
         if (!panchorAwaitingConfirms->GetConfirm(confirmMessage.GetHash())) {
-            LogPrintf("Got anchor confirm, hash %s, Anchor Message hash: %d\n", confirmMessage.GetHash().ToString(), confirmMessage.btcTxHash.ToString());
+            LogPrint(BCLog::ANCHORING, "Got anchor confirm, hash %s, Anchor Message hash: %d\n", confirmMessage.GetHash().ToString(), confirmMessage.btcTxHash.ToString());
             // if valid, AND UNIQUE AGAINST VOTER (this is encapsulated in the index itself) - add and rebroadcast
             if (panchorAwaitingConfirms->Validate(confirmMessage) && panchorAwaitingConfirms->Add(confirmMessage)) {
                 RelayAnchorConfirm(confirmMessage.GetHash(), *connman, pfrom);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2658,7 +2658,9 @@ bool CChainState::DisconnectTip(CValidationState& state, const CChainParams& cha
                 panchorAwaitingConfirms->Add(confirm);
             }
             // we do not clear ALL votes (even they are stale) for the case of rapid tip changing. At least, they'll be deleted after their rewards
-            panchorAwaitingConfirms->ReVote();
+            if (!IsInitialBlockDownload()) {
+                panchorAwaitingConfirms->ReVote();
+            }
         }
         for (auto const & cr : disconnectedCriminals) {
             pcriminals->AddCriminalProof(cr.first, cr.second.blockHeader, cr.second.conflictBlockHeader);
@@ -2808,7 +2810,9 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
             for (auto const & btcTxHash : rewardedAnchors) {
                 panchorAwaitingConfirms->EraseAnchor(btcTxHash);
             }
-            panchorAwaitingConfirms->ReVote();
+            if (!IsInitialBlockDownload()) {
+                panchorAwaitingConfirms->ReVote();
+            }
         }
         for (auto const & nodeId : bannedCriminals) {
             pcriminals->RemoveCriminalProofs(nodeId);


### PR DESCRIPTION
Update to not create anchor confirms during reindex and check if an anchor confirm has already been paid when accepting it via P2P.

Old bug where already paid anchors get new anchor confirms created for payment due to the payment for those anchors not yet being present in the chain yet. This does not result in an anchor being paid as when staking resumes the miner checks for payment and a TX that tries to pay an already paid anchor fails. The created anchor confirm for the already paid anchor is valid and will persist on the network which is also problematic.