### PR TITLE
Wipe confs/revote after new team. New getactivemasternodes call.

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -989,6 +989,18 @@ bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessa
         return false;
     }
 
+    const auto height = ::ChainActive().Height();
+    const auto team = pcustomcsview->GetConfirmTeam(height);
+    if (!team) {
+        LogPrint(BCLog::ANCHORING, "%s: Unable to get team for current height %d\n", __func__, height);
+        return false;
+    }
+
+    if (!team->count(signer)) {
+        LogPrint(BCLog::ANCHORING, "%s: Signer not part of current anchor confirm team\n", __func__);
+        return false;
+    }
+
     auto it = pcustomcsview->GetMasternodeIdByOperator(signer);
     if (!it || !pcustomcsview->GetMasternode(*it)->IsActive()) {
         LogPrint(BCLog::ANCHORING, "%s: Warning! Masternode with operator key %s does not exist or not active!\n", __func__, signer.ToString());

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -249,6 +249,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtokenstoaddress", 0, "from" },
     { "sendtokenstoaddress", 1, "to" },
     { "getanchorteams", 0, "blockHeight" },
+    { "getactivemasternodecount", 0, "blockCount" },
 };
 // clang-format on
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2810,9 +2810,6 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
             for (auto const & btcTxHash : rewardedAnchors) {
                 panchorAwaitingConfirms->EraseAnchor(btcTxHash);
             }
-            if (!IsInitialBlockDownload()) {
-                panchorAwaitingConfirms->ReVote();
-            }
         }
         for (auto const & nodeId : bannedCriminals) {
             pcriminals->RemoveCriminalProofs(nodeId);
@@ -2836,6 +2833,14 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
     if (pindexNew->nHeight >= Params().GetConsensus().DakotaHeight &&
             pindexNew->nHeight % Params().GetConsensus().mn.anchoringTeamChange == 0) {
         pcustomcsview->CalcAnchoringTeams(blockConnecting.stakeModifier, pindexNew);
+
+        // Delete old and now invalid anchor confirms
+        panchorAwaitingConfirms->Clear();
+
+        // Revote to pay any unrewarded anchor confirms
+        if (!IsInitialBlockDownload()) {
+            panchorAwaitingConfirms->ReVote();
+        }
     }
 
     int64_t nTime6 = GetTimeMicros(); nTimePostConnect += nTime6 - nTime5; nTimeTotal += nTime6 - nTime1;


### PR DESCRIPTION
Anchor confirms should be wiped on team change and then a revote is taken. New call added to view number of active masternodes in the last X number of blocks, defaults to 20,160 blocks, the number of blocks the anchor teams use to generate anchor teams. Reject conf from old team members rather than rely on GetQuorumFor to filter them out.