### PR TITLE
Flush when it's needed in reindex chainstate

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2496,7 +2496,7 @@ bool CChainState::FlushStateToDisk(
             nLastWrite = nNow;
         }
         static const size_t memoryCacheSizeMax = gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX) ? (nDefaultDbCache << 16) : (nDefaultDbCache << 10);
-        bool fMemoryCacheLarge = fDoFullFlush || (mode == FlushStateMode::PERIODIC && pcustomcsview->SizeEstimate() > memoryCacheSizeMax);
+        bool fMemoryCacheLarge = fDoFullFlush || (mode == FlushStateMode::IF_NEEDED && pcustomcsview->SizeEstimate() > memoryCacheSizeMax);
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fMemoryCacheLarge && !CoinsTip().GetBestBlock().IsNull()) {
             // Flush view first to estimate size on disk later


### PR DESCRIPTION
/kind fix

#### What this PR does / why we need it:

In `-reindex-chainstate` flush mode periodic isn't called

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/cakedefi/defichain-private/issues/423
