### PR TITLE
Ensure masternode owner address is actually owned by the wallet

### DIFF
--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -95,6 +95,10 @@ UniValue createmasternode(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorAddress (" + operatorAddress + ") does not refer to a P2PKH or P2WPKH address");
     }
 
+    if (!::IsMine(*pwallet, ownerDest)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Address (%s) is not owned by the wallet", EncodeDestination(ownerDest)));
+    }
+
     CKeyID const operatorAuthKey = operatorDest.which() == 1 ? CKeyID(*boost::get<PKHash>(&operatorDest)) : CKeyID(*boost::get<WitnessV0KeyHash>(&operatorDest));
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);

--- a/test/functional/rpc_mn_basic.py
+++ b/test/functional/rpc_mn_basic.py
@@ -11,8 +11,11 @@
 from test_framework.test_framework import DefiTestFramework
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, \
-    connect_nodes_bi
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    assert_raises_rpc_error,
+)
 
 class MasternodesRpcBasicTest (DefiTestFramework):
     def set_test_params(self):
@@ -46,6 +49,9 @@ class MasternodesRpcBasicTest (DefiTestFramework):
 
         # Create node0
         self.nodes[0].generate(1)
+        collateral1 = self.nodes[1].getnewaddress("", "legacy")
+        assert_raises_rpc_error(-8, "Address ({}) is not owned by the wallet".format(collateral1),  self.nodes[0].createmasternode, collateral1)
+
         idnode0 = self.nodes[0].createmasternode(
             collateral0
         )


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It prevents masternode creator to stole its collateral at unreachable address

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/cakedefi/defichain-private/issues/496
