### PR TITLE
Prevent race when multiple masternode operators are running

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -803,7 +803,7 @@ int32_t ThreadStaker::operator()(ThreadStaker::Args args, CChainParams chainpara
         if (found) {
             break;
         }
-        static uint64_t time = 0;
+        static std::atomic<uint64_t> time{0};
         if (GetSystemTimeInSeconds() - time > 120) {
             LogPrintf("ThreadStaker (%s): unlock wallet to start minting...\n", operatorName);
             time = GetSystemTimeInSeconds();


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It's possible, not so common, but let secure time variable from race access, when multiple thread are stuck in locked wallet.