### PR TITLE
Invalid tx should not be included in block

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -588,8 +588,8 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         if (!customTxPassed) {
             if (fUsingModified) {
                 mapModifiedTx.get<ancestor_score>().erase(modit);
-                failedTx.insert(iter);
             }
+            failedTx.insert(iter);
             continue;
         }
 


### PR DESCRIPTION
/kind fix

#### What this PR does / why we need it:

<s>It has 2 issues about me:</s>

1. Failed tx never be part of a block, i try to ensure it
<s>2. We use a view to ensure txs validation in a block not in isolation, but we fail to discard invalid view.</s>