### PR TITLE
Wipe mempool on restart or on failed block.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -846,7 +846,9 @@ int32_t ThreadStaker::operator()(ThreadStaker::Args args, CChainParams chainpara
         }
         catch (const std::runtime_error &e) {
             LogPrintf("ThreadStaker (%s): runtime error: %s\n", e.what(), operatorName);
-            return nMinted;
+
+            // Could be failed TX in mempool, wipe mempool and allow loop to continue.
+            mempool.clear();
         }
 
         nTried++;

--- a/src/validation.h
+++ b/src/validation.h
@@ -122,7 +122,7 @@ static const bool DEFAULT_TXINDEX = false;
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
-static const bool DEFAULT_PERSIST_MEMPOOL = true;
+static const bool DEFAULT_PERSIST_MEMPOOL = false;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 


### PR DESCRIPTION
If staked block fails TestBlockValidity assume bad TX was included, wipe mempool and allow loop to continue. Also wipe mempool on restart. We do not currently need mempool persistence between restarts.