### PR TITLE
SPV Bitcoin User Wallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1599,28 +1599,6 @@ bool AppInitMain(InitInterfaces& interfaces)
                     }
                 }
 
-                panchorauths.reset();
-                panchorauths = MakeUnique<CAnchorAuthIndex>();
-                panchorAwaitingConfirms.reset();
-                panchorAwaitingConfirms = MakeUnique<CAnchorAwaitingConfirms>();
-                panchors.reset();
-                // If users set masternode_operator set SPV default to enabled
-                bool anchorsEnabled{!gArgs.GetArgs("-masternode_operator").empty()};
-                panchors = MakeUnique<CAnchorIndex>(nDefaultDbCache << 20, false, gArgs.GetBoolArg("-spv", anchorsEnabled) && gArgs.GetBoolArg("-spv_resync", false) /*fReset || fReindexChainState*/);
-                // load anchors after spv due to spv (and spv height) not set before (no last height yet)
-
-                if (gArgs.GetBoolArg("-spv", anchorsEnabled)) {
-                    spv::pspv.reset();
-                    if (Params().NetworkIDString() == "regtest") {
-                        spv::pspv = MakeUnique<spv::CFakeSpvWrapper>();
-                    } else if (Params().NetworkIDString() == "test") {
-                        spv::pspv = MakeUnique<spv::CSpvWrapper>(false, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
-                    } else {
-                        spv::pspv = MakeUnique<spv::CSpvWrapper>(true, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
-                    }
-                }
-                panchors->Load();
-
                 // If necessary, upgrade from older database format.
                 // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 if (!::ChainstateActive().CoinsDB().Upgrade()) {
@@ -1745,11 +1723,44 @@ bool AppInitMain(InitInterfaces& interfaces)
         GetBlockFilterIndex(filter_type)->Start();
     }
 
-    // ********************************************************* Step 9: load wallet
+    // ********************************************************* Step 9.a: load wallet
     for (const auto& client : interfaces.chain_clients) {
         if (!client->load()) {
             return false;
         }
+    }
+
+    // ********************************************************* Step 9.b: load anchors / SPV wallet
+
+    try {
+        LOCK(cs_main);
+
+        panchorauths.reset();
+        panchorauths = MakeUnique<CAnchorAuthIndex>();
+        panchorAwaitingConfirms.reset();
+        panchorAwaitingConfirms = MakeUnique<CAnchorAwaitingConfirms>();
+        panchors.reset();
+
+        // If users set masternode_operator set SPV default to enabled
+        bool anchorsEnabled{!gArgs.GetArgs("-masternode_operator").empty()};
+        panchors = MakeUnique<CAnchorIndex>(nDefaultDbCache << 20, false, gArgs.GetBoolArg("-spv", anchorsEnabled) && gArgs.GetBoolArg("-spv_resync", false) /*fReset || fReindexChainState*/);
+
+        // load anchors after spv due to spv (and spv height) not set before (no last height yet)
+        if (gArgs.GetBoolArg("-spv", anchorsEnabled)) {
+            spv::pspv.reset();
+            if (Params().NetworkIDString() == "regtest") {
+                spv::pspv = MakeUnique<spv::CFakeSpvWrapper>();
+            } else if (Params().NetworkIDString() == "test") {
+                spv::pspv = MakeUnique<spv::CSpvWrapper>(false, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
+            } else {
+                spv::pspv = MakeUnique<spv::CSpvWrapper>(true, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
+            }
+        }
+        panchors->Load();
+
+    } catch (const std::exception& e) {
+        LogPrintf("%s\n", e.what());
+        return InitError("Error opening SPV database");
     }
 
     // ********************************************************* Step 10: data directory maintenance

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -153,6 +153,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::STAKING, "staking"},
     {BCLog::ANCHORING, "anchoring"},
     {BCLog::SPV, "spv"},
+    {BCLog::SPV_NET, "spv_net"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -57,6 +57,7 @@ namespace BCLog {
         STAKING     = (1 << 21),
         ANCHORING   = (1 << 22),
         SPV         = (1 << 23),
+        SPV_NET     = (1 << 24),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -227,6 +227,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "spv_listanchors", 1, "maxBtcHeight" },
     { "spv_listanchors", 2, "minConfs" },
     { "spv_listanchors", 3, "maxConfs" },
+    { "spv_sendtoaddress", 1, "amount" },
 
     { "createpoolpair", 0, "metadata" },
     { "createpoolpair", 1, "inputs" },

--- a/src/spv/bitcoin/BRChainParams.cpp
+++ b/src/spv/bitcoin/BRChainParams.cpp
@@ -128,6 +128,8 @@ static const char BRTestBip32xprv[] = "\x04\x35\x83\x94";
 static const char BRTestBip32xpub[] = "\x04\x35\x87\xCF";
 static const char BRTestBech32[] = "tb";
 
+static const char BRRegtestBech32[] = "bcrt";
+
 static const BRChainParams BRMainNetParamsRecord = {
     BRMainNetDNSSeeds,
     8333,                  // standardPort
@@ -161,6 +163,23 @@ static const BRChainParams BRTestNetParamsRecord = {
     BRTestBech32
 };
 const BRChainParams *BRTestNetParams = &BRTestNetParamsRecord;
+
+static const BRChainParams BRRegtestParamsRecord = {
+    BRTestNetDNSSeeds,
+    18443,                 // standardPort
+    0xdab5bffa,            // magicNumber
+    SERVICES_NODE_WITNESS, // services
+    BRTestNetVerifyDifficulty,
+    BRTestNetCheckpoints,
+    0,
+    239,
+    111,
+    196,
+    BRTestBip32xprv,
+    BRTestBip32xpub,
+    BRRegtestBech32
+};
+const BRChainParams *BRRegtestParams = &BRRegtestParamsRecord;
 
 int spv_mainnet = 1;
 

--- a/src/spv/bitcoin/BRChainParams.h
+++ b/src/spv/bitcoin/BRChainParams.h
@@ -54,6 +54,7 @@ typedef struct {
 
 extern const BRChainParams *BRMainNetParams;
 extern const BRChainParams *BRTestNetParams;
+extern const BRChainParams *BRRegtestParams;
 
 extern BRCheckPoint BRMainNetCheckpoints[30];
 extern BRCheckPoint BRTestNetCheckpoints[17];
@@ -61,7 +62,14 @@ extern BRCheckPoint BRTestNetCheckpoints[17];
 extern int spv_mainnet;
 
 static inline const BRChainParams *BRGetChainParams () {
-    return spv_mainnet ? BRMainNetParams : BRTestNetParams;
+    switch(spv_mainnet) {
+        case 0:
+            return BRTestNetParams;
+        case 2:
+            return BRRegtestParams;
+        default:
+            return BRMainNetParams;
+    }
 }
 
 #endif // BRChainParams_h

--- a/src/spv/bitcoin/BRPeer.cpp
+++ b/src/spv/bitcoin/BRPeer.cpp
@@ -29,6 +29,8 @@
 #include "BRArray.h"
 #include "BRCrypto.h"
 #include "BRInt.h"
+#include <logging.h>
+
 #include <stdlib.h>
 #include <float.h>
 #include <inttypes.h>
@@ -1373,6 +1375,13 @@ void BRPeerHostSafe(BRPeer const *peer, char *host)
     else inet_ntop(AF_INET6, &peer->address, host, INET6_ADDRSTRLEN);
 }
 
+std::string BRPeerHostString(BRPeer *peer) {
+    char host[INET6_ADDRSTRLEN];
+    BRPeerHostSafe(peer, host);
+
+    return std::string{host};
+}
+
 // connected peer version number
 uint32_t BRPeerVersion(BRPeer *peer)
 {
@@ -1417,7 +1426,7 @@ uint64_t BRPeerFeePerKb(BRPeer *peer)
 void BRPeerSendMessage(BRPeer *peer, const uint8_t *msg, size_t msgLen, const char *type)
 {
     if (msgLen > MAX_MSG_LENGTH) {
-        peer_log(peer, "failed to send %s, length %zu is too long", type, msgLen);
+        LogPrint(BCLog::SPV_NET, "Peer: %s failed to send %s, length %ld is too long\n", BRPeerHostString(peer), type, msgLen);
     }
     else {
         BRPeerContext *ctx = (BRPeerContext *)peer;
@@ -1438,7 +1447,7 @@ void BRPeerSendMessage(BRPeer *peer, const uint8_t *msg, size_t msgLen, const ch
         memcpy(&buf[off], hash, sizeof(uint32_t));
         off += sizeof(uint32_t);
         memcpy(&buf[off], msg, msgLen);
-        peer_log(peer, "sending %s", type);
+        LogPrint(BCLog::SPV_NET, "Peer: %s sending: %s\n", BRPeerHostString(peer), type);
         msgLen = 0;
         socket = _peerGetSocket(ctx);
         if (socket == INVALID_SOCKET) error = ENOTCONN;
@@ -1453,7 +1462,7 @@ void BRPeerSendMessage(BRPeer *peer, const uint8_t *msg, size_t msgLen, const ch
         }
         
         if (error) {
-            peer_log(peer, "send message error: %s, %s", type, strerror(error));
+            LogPrint(BCLog::SPV_NET, "Peer: %s send message error: %s, %s\n", BRPeerHostString(peer), type, strerror(error));
             BRPeerDisconnect(peer);
         }
     }

--- a/src/spv/bitcoin/BRPeer.h
+++ b/src/spv/bitcoin/BRPeer.h
@@ -33,7 +33,6 @@
 #include <inttypes.h>
 #include <boost/thread.hpp>
 
-//#ifndef __cplusplus
 /// define logs
 #define console_peer_log(peer, ...) { \
     if (spv_log2console) { \
@@ -86,10 +85,6 @@
 extern char const * spv_logfilename;
 extern int spv_log2console;
 extern boost::mutex log_mutex;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #ifndef INET6_ADDRSTRLEN // defined in netinet/in.h
 #define INET6_ADDRSTRLEN 46
@@ -221,6 +216,7 @@ void BRPeerSetNeedsFilterUpdate(BRPeer *peer, int needsFilterUpdate);
 // display name of peer address
 const char *BRPeerHost(BRPeer *peer);
 void BRPeerHostSafe(BRPeer const *peer, char *host);
+std::string BRPeerHostString(BRPeer *peer);
 
 // connected peer version number
 uint32_t BRPeerVersion(BRPeer *peer);
@@ -272,10 +268,5 @@ inline static int BRPeerEq(const void *peer, const void *otherPeer)
 
 // frees memory allocated for peer
 void BRPeerFree(BRPeer *peer);
-
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif // BRPeer_h

--- a/src/spv/bitcoin/BRPeerManager.cpp
+++ b/src/spv/bitcoin/BRPeerManager.cpp
@@ -27,6 +27,7 @@
 #include "BRSet.h"
 #include "BRArray.h"
 #include "BRInt.h"
+#include <logging.h>
 #include <shutdown.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -314,7 +315,7 @@ static void _BRPeerManagerLoadBloomFilter(BRPeerManager *manager, BRPeer *peer)
     txCount = BRWalletTxUnconfirmedBefore(manager->wallet, transactions, txCount, blockHeight);
     filter = BRBloomFilterNew(manager->fpRate, addrsCount + utxosCount + txCount + 100, (uint32_t)BRPeerHash(peer),
                               BLOOM_UPDATE_ALL); // BUG: XXX txCount not the same as number of spent wallet outputs
-    
+
     for (size_t i = 0; i < addrsCount; i++) { // add addresses to watch for tx receiveing money to the wallet
         UInt160 hash = UINT160_ZERO;
         
@@ -965,7 +966,7 @@ static void _peerRelayedTx(void *info, BRTransaction *tx)
     size_t relayCount = 0;
     
     manager->lock.lock();
-    peer_log(peer, "relayed tx: %s", u256hex(tx->txHash).c_str());
+    LogPrint(BCLog::SPV_NET, "Peer: %s relayed tx: %s\n", BRPeerHostString(peer), u256hex(tx->txHash));
     
     UInt256 hash = tx->txHash;
     for (size_t i = array_count(manager->publishedTx); i > 0; i--) { // see if tx is in list of published tx
@@ -1052,7 +1053,7 @@ static void _peerHasTx(void *info, UInt256 txHash)
     
     manager->lock.lock();
     tx = BRWalletTransactionForHash(manager->wallet, txHash);
-    peer_log(peer, "has tx: %s", u256hex(txHash).c_str());
+    LogPrint(BCLog::SPV_NET, "Peer: %s has tx: %s\n", BRPeerHostString(peer), u256hex(txHash));
 
     for (size_t i = array_count(manager->publishedTx); i > 0; i--) { // see if tx is in list of published tx
         if (UInt256Eq(manager->publishedTxHashes[i - 1], txHash)) {

--- a/src/spv/bitcoin/BRPeerManager.h
+++ b/src/spv/bitcoin/BRPeerManager.h
@@ -124,6 +124,9 @@ void BRPeerManagerFree(BRPeerManager *manager);
 // forced cancel pending callbacks for published txs (need for releasing spv module)
 void BRPeerManagerCancelPendingTxs(BRPeerManager *manager);
 
+// Rebuild and resend the bloom filter
+void BRPeerManagerRebuildBloomFilter(BRPeerManager *manager);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/spv/bitcoin/BRTransaction.h
+++ b/src/spv/bitcoin/BRTransaction.h
@@ -27,8 +27,10 @@
 
 #include "BRKey.h"
 #include "BRInt.h"
+
 #include <stddef.h>
 #include <inttypes.h>
+#include <string>
 
 #ifdef __cplusplus
 extern "C" {
@@ -148,6 +150,11 @@ inline static size_t BRTransactionHash(const void *tx)
 inline static int BRTransactionEq(const void *tx, const void *otherTx)
 {
     return (tx == otherTx || UInt256Eq(((const BRTransaction *)tx)->txHash, ((const BRTransaction *)otherTx)->txHash));
+}
+
+inline static std::string BRTransactionID(const BRTransaction &tx)
+{
+    return u256hex(tx.txHash);
 }
 
 // frees memory allocated for tx

--- a/src/spv/bitcoin/BRWallet.cpp
+++ b/src/spv/bitcoin/BRWallet.cpp
@@ -42,6 +42,11 @@
 //#include <pthread.h>
 #include <assert.h>
 
+bool UInt160Compare(const UInt160& a, const UInt160& b)
+{
+    return memcmp(&a, &b, sizeof(a)) < 0;
+}
+
 inline static size_t _pkhHash(const void *pkh)
 {
     return (size_t)UInt32GetLE(pkh);
@@ -56,7 +61,7 @@ inline static uint64_t _txFee(uint64_t feePerKb, size_t size)
 {
     uint64_t standardFee = size*TX_FEE_PER_KB/1000,       // standard fee based on tx size
              fee = (((size*feePerKb/1000) + 99)/100)*100; // fee using feePerKb, rounded up to nearest 100 satoshi
-    
+
     return (fee > standardFee) ? fee : standardFee;
 }
 
@@ -64,14 +69,14 @@ inline static uint64_t _txFee(uint64_t feePerKb, size_t size)
 inline static size_t _txChainIndex(const BRTransaction *tx, const UInt160 *chain)
 {
     const uint8_t *pkh;
-    
+
     for (size_t i = array_count(chain); i > 0; i--) {
         for (size_t j = 0; j < tx->outCount; j++) {
             pkh = BRScriptPKH(tx->outputs[j].script, tx->outputs[j].scriptLen);
             if (pkh && _pkhEq(pkh, &chain[i - 1])) return i - 1;
         }
     }
-    
+
     return -1;
 }
 
@@ -99,7 +104,7 @@ inline static void _BRWalletAddressFromHash160(BRWallet *wallet, char *addr, siz
         const uint8_t script[] = { OP_DUP, OP_HASH160, 20, h.u8[0], h.u8[1], h.u8[2], h.u8[3], h.u8[4], h.u8[5],
                                    h.u8[6], h.u8[7], h.u8[8], h.u8[9], h.u8[10], h.u8[11], h.u8[12], h.u8[13], h.u8[14],
                                    h.u8[15], h.u8[16], h.u8[17], h.u8[18], h.u8[19], OP_EQUALVERIFY, OP_CHECKSIG };
-        
+
         BRAddressFromScriptPubKey(addr, addrLen, script, sizeof(script));
     }
     else BRAddressFromHash160(addr, addrLen, &h);
@@ -110,11 +115,11 @@ inline static int _BRWalletTxIsAscending(BRWallet *wallet, const BRTransaction *
     if (! tx1 || ! tx2) return 0;
     if (tx1->blockHeight > tx2->blockHeight) return 1;
     if (tx1->blockHeight < tx2->blockHeight) return 0;
-    
+
     for (size_t i = 0; i < tx1->inCount; i++) {
         if (UInt256Eq(tx1->inputs[i].txHash, tx2->txHash)) return 1;
     }
-    
+
     for (size_t i = 0; i < tx2->inCount; i++) {
         if (UInt256Eq(tx2->inputs[i].txHash, tx1->txHash)) return 0;
     }
@@ -142,14 +147,14 @@ inline static int _BRWalletTxCompare(BRWallet *wallet, const BRTransaction *tx1,
 inline static void _BRWalletInsertTx(BRWallet *wallet, BRTransaction *tx)
 {
     size_t i = array_count(wallet->transactions);
-    
+
     array_set_count(wallet->transactions, i + 1);
-    
+
     while (i > 0 && _BRWalletTxCompare(wallet, wallet->transactions[i - 1], tx) > 0) {
         wallet->transactions[i] = wallet->transactions[i - 1];
         i--;
     }
-    
+
     wallet->transactions[i] = tx;
 }
 
@@ -163,15 +168,15 @@ static int _BRWalletContainsTx(BRWallet *wallet, const BRTransaction *tx)
         pkh = BRScriptPKH(tx->outputs[i].script, tx->outputs[i].scriptLen);
         if (pkh && BRSetContains(wallet->allPKH, pkh)) r = 1;
     }
-    
+
     for (size_t i = 0; ! r && i < tx->inCount; i++) {
         BRTransaction *t = (BRTransaction *)BRSetGet(wallet->allTx, &tx->inputs[i].txHash);
         uint32_t n = tx->inputs[i].index;
-        
+
         pkh = (t && n < t->outCount) ? BRScriptPKH(t->outputs[n].script, t->outputs[n].scriptLen) : NULL;
         if (pkh && BRSetContains(wallet->allPKH, pkh)) r = 1;
     }
-    
+
     return r;
 }
 
@@ -212,7 +217,7 @@ static void _BRWalletUpdateBalance(BRWallet *wallet)
     size_t i, j;
     BRTransaction *tx, *t;
     const uint8_t *pkh;
-    
+
     array_clear(wallet->utxos);
     array_clear(wallet->balanceHist);
     BRSetClear(wallet->spentOutputs);
@@ -233,7 +238,7 @@ static void _BRWalletUpdateBalance(BRWallet *wallet)
                 if (BRSetContains(wallet->spentOutputs, &tx->inputs[j]) ||
                     BRSetContains(wallet->invalidTx, &tx->inputs[j].txHash)) isInvalid = 1;
             }
-        
+
             if (isInvalid) {
                 BRSetAdd(wallet->invalidTx, tx);
                 array_add(wallet->balanceHist, balance);
@@ -249,7 +254,7 @@ static void _BRWalletUpdateBalance(BRWallet *wallet)
         // check if tx is pending
         if (tx->blockHeight == TX_UNCONFIRMED) {
             isPending = (BRTransactionVSize(tx) > TX_MAX_SIZE) ? 1 : 0; // check tx size is under TX_MAX_SIZE
-            
+
             for (j = 0; ! isPending && j < tx->outCount; j++) {
                 if (tx->outputs[j].amount < TX_MIN_OUTPUT_AMOUNT) isPending = 1; // check that no outputs are dust
             }
@@ -262,7 +267,7 @@ static void _BRWalletUpdateBalance(BRWallet *wallet)
                 if (BRSetContains(wallet->pendingTx, &tx->inputs[j].txHash)) isPending = 1; // check for pending inputs
                 // TODO: XXX handle BIP68 check lock time verify rules
             }
-            
+
             if (isPending) {
                 BRSetAdd(wallet->pendingTx, tx);
                 array_add(wallet->balanceHist, balance);
@@ -297,7 +302,7 @@ static void _BRWalletUpdateBalance(BRWallet *wallet)
             balance -= t->outputs[wallet->utxos[j - 1].n].amount;
             array_rm(wallet->utxos, j - 1);
         }
-        
+
         if (prevBalance < balance) wallet->totalReceived += balance - prevBalance;
         if (balance < prevBalance) wallet->totalSent += prevBalance - balance;
         array_add(wallet->balanceHist, balance);
@@ -358,11 +363,6 @@ BRWallet *BRWalletNew(BRTransaction *transactions[], size_t txCount, BRMasterPub
 
     _BRWalletUpdateBalance(wallet);
 
-    if (txCount > 0 && ! _BRWalletContainsTx(wallet, transactions[0])) { // verify transactions match master pubKey
-        BRWalletFree(wallet);
-        wallet = NULL;
-    }
-
     return wallet;
 }
 
@@ -411,12 +411,12 @@ size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimi
 
     // keep only the trailing contiguous block of addresses with no transactions
     while (i > 0 && ! BRSetContains(wallet->usedPKH, &chain[i - 1])) i--;
-    
+
     while (i + gapLimit > count) { // generate new addresses up to gapLimit
         BRKey key;
         uint8_t pubKey[BRBIP32PubKey(NULL, 0, wallet->masterPubKey, internal, count)];
         size_t len = BRBIP32PubKey(pubKey, sizeof(pubKey), wallet->masterPubKey, internal, (uint32_t)count);
-        
+
         if (! BRKeySetPubKey(&key, pubKey, len)) break;
         array_add(chain, BRKeyHash160(&key));
         count++;
@@ -444,7 +444,7 @@ size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimi
         for (i = array_count(wallet->internalChain); i > 0; i--) {
             BRSetAdd(wallet->allPKH, &wallet->internalChain[i - 1]);
         }
-        
+
         for (i = array_count(wallet->externalChain); i > 0; i--) {
             BRSetAdd(wallet->allPKH, &wallet->externalChain[i - 1]);
         }
@@ -454,7 +454,7 @@ size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimi
     return j;
 }
 
-bool BRWalletAddAddr(BRWallet *wallet, const uint8_t& pubKey, const size_t pkLen, BRAddress &addr)
+bool BRWalletAddSingleAddress(BRWallet *wallet, const uint8_t& pubKey, const size_t pkLen, BRAddress &addr)
 {
     assert(wallet != nullptr);
     wallet->lock.lock();
@@ -471,6 +471,7 @@ bool BRWalletAddAddr(BRWallet *wallet, const uint8_t& pubKey, const size_t pkLen
     size_t count = array_count(chain);
     auto hash = BRKeyHash160(&key);
     array_add(chain, hash);
+    wallet->userPKH.insert(hash);
 
     _BRWalletAddressFromHash160(wallet, addr.s, sizeof(addr), hash);
 
@@ -496,6 +497,45 @@ bool BRWalletAddAddr(BRWallet *wallet, const uint8_t& pubKey, const size_t pkLen
 
     wallet->lock.unlock();
     return true;
+}
+
+void BRWalletImportAddress(BRWallet *wallet, const uint160& userHash)
+{
+    assert(wallet != nullptr);
+    wallet->lock.lock();
+
+    UInt160* chain = wallet->externalChain;
+    assert(chain != nullptr);
+    UInt160 *origChain = chain;
+
+    UInt160 hash;
+    UInt160Convert(userHash.begin(), hash);
+
+    size_t count = array_count(chain);
+    array_add(chain, hash);
+    wallet->userPKH.insert(hash);
+
+    // was chain moved to a new memory location?
+    if (chain == origChain)
+    {
+        BRSetAdd(wallet->allPKH, &chain[count]);
+    }
+    else
+    {
+        wallet->externalChain = chain;
+
+        BRSetClear(wallet->allPKH); // clear and rebuild allAddrs
+
+        for (size_t i = array_count(wallet->internalChain); i > 0; --i) {
+            BRSetAdd(wallet->allPKH, &wallet->internalChain[i - 1]);
+        }
+
+        for (size_t i = array_count(wallet->externalChain); i > 0; --i) {
+            BRSetAdd(wallet->allPKH, &wallet->externalChain[i - 1]);
+        }
+    }
+
+    wallet->lock.unlock();
 }
 
 void BRWalletAddUserAddresses(BRWallet *wallet) {
@@ -536,6 +576,7 @@ void BRWalletAddUserAddresses(BRWallet *wallet) {
     wallet->lock.unlock();
 }
 
+
 // current wallet balance, not including transactions known to be invalid
 uint64_t BRWalletBalance(BRWallet *wallet)
 {
@@ -574,7 +615,7 @@ size_t BRWalletTransactions(BRWallet *wallet, BRTransaction *transactions[], siz
     for (size_t i = 0; transactions && i < txCount; i++) {
         transactions[i] = wallet->transactions[i];
     }
-    
+
     wallet->lock.unlock();
     return txCount;
 }
@@ -604,7 +645,7 @@ size_t BRWalletTxUnconfirmedBefore(BRWallet *wallet, BRTransaction *transactions
 uint64_t BRWalletTotalSent(BRWallet *wallet)
 {
     uint64_t totalSent;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     totalSent = wallet->totalSent;
@@ -616,7 +657,7 @@ uint64_t BRWalletTotalSent(BRWallet *wallet)
 uint64_t BRWalletTotalReceived(BRWallet *wallet)
 {
     uint64_t totalReceived;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     totalReceived = wallet->totalReceived;
@@ -628,7 +669,7 @@ uint64_t BRWalletTotalReceived(BRWallet *wallet)
 uint64_t BRWalletFeePerKb(BRWallet *wallet)
 {
     uint64_t feePerKb;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     feePerKb = wallet->feePerKb;
@@ -648,7 +689,7 @@ void BRWalletSetFeePerKb(BRWallet *wallet, uint64_t feePerKb)
 BRAddress BRWalletReceiveAddress(BRWallet *wallet)
 {
     BRAddress addr = BR_ADDRESS_NONE;
-    
+
     BRWalletUnusedAddrs(wallet, &addr, 1, 0);
     return addr;
 }
@@ -659,7 +700,7 @@ BRAddress BRWalletLegacyAddress(BRWallet *wallet)
     BRAddress addr = BR_ADDRESS_NONE;
     uint8_t script[] = { OP_DUP, OP_HASH160, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                          0, 0, 0, 0, 0, 0, 0, 0, 0, OP_EQUALVERIFY, OP_CHECKSIG };
-    
+
     BRWalletUnusedAddrs(wallet, &addr, 1, 0);
     if (BRAddressHash160(&script[3], addr.s)) BRAddressFromScriptPubKey(addr.s, sizeof(addr), script, sizeof(script));
     return addr;
@@ -670,7 +711,7 @@ BRAddress BRWalletLegacyAddress(BRWallet *wallet)
 size_t BRWalletAllAddrs(BRWallet *wallet, BRAddress addrs[], size_t addrsCount)
 {
     size_t i, internalCount = 0, externalCount = 0;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     internalCount = (! addrs || array_count(wallet->internalChain) < addrsCount) ?
@@ -696,7 +737,7 @@ int BRWalletContainsAddress(BRWallet *wallet, const char *addr)
 {
     int r = 0;
     UInt160 pkh = UINT160_ZERO;
-    
+
     assert(wallet != NULL);
     assert(addr != NULL);
     wallet->lock.lock();
@@ -711,7 +752,7 @@ int BRWalletAddressIsUsed(BRWallet *wallet, const char *addr)
 {
     int r = 0;
     UInt160 pkh = UINT160_ZERO;
-    
+
     assert(wallet != NULL);
     assert(addr != NULL);
     wallet->lock.lock();
@@ -723,28 +764,28 @@ int BRWalletAddressIsUsed(BRWallet *wallet, const char *addr)
 
 // returns an unsigned transaction that sends the specified amount from the wallet to the given address
 // result must be freed by calling BRTransactionFree()
-BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr)
+BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr, std::string changeAddress)
 {
     BRTxOutput o = BR_TX_OUTPUT_NONE;
-    
+
     assert(wallet != NULL);
     assert(amount > 0);
     assert(addr != NULL && BRAddressIsValid(addr));
     o.amount = amount;
     BRTxOutputSetAddress(&o, addr);
-    return BRWalletCreateTxForOutputs(wallet, &o, 1);
+    return BRWalletCreateTxForOutputs(wallet, &o, 1, changeAddress);
 }
 
 // returns an unsigned transaction that satisifes the given transaction outputs
 // result must be freed by calling BRTransactionFree()
-BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount)
+BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount, std::string changeAddress)
 {
     BRTransaction *tx, *transaction = BRTransactionNew();
     uint64_t feeAmount, amount = 0, balance = 0, minAmount;
-    size_t i, j, cpfpSize = 0;
+    size_t i, j;
     BRUTXO *o;
     BRAddress addr = BR_ADDRESS_NONE;
-    
+
     assert(wallet != NULL);
     assert(outputs != NULL && outCount > 0);
 
@@ -753,79 +794,81 @@ BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput out
         BRTransactionAddOutput(transaction, outputs[i].amount, outputs[i].script, outputs[i].scriptLen);
         amount += outputs[i].amount;
     }
-    
-    minAmount = BRWalletMinOutputAmount(wallet);
+
+    minAmount = BRWalletMinOutputAmountWithFeePerKb(wallet, MIN_FEE_PER_KB);
+
     wallet->lock.lock();
     feeAmount = _txFee(wallet->feePerKb, BRTransactionVSize(transaction) + TX_OUTPUT_SIZE);
-    
+
     // TODO: use up all UTXOs for all used addresses to avoid leaving funds in addresses whose public key is revealed
     // TODO: avoid combining addresses in a single transaction when possible to reduce information leakage
     // TODO: use up UTXOs received from any of the output scripts that this transaction sends funds to, to mitigate an
     //       attacker double spending and requesting a refund
     for (i = 0; i < array_count(wallet->utxos); i++) {
+
         o = &wallet->utxos[i];
         tx = (BRTransaction *)BRSetGet(wallet->allTx, o);
         if (! tx || o->n >= tx->outCount) continue;
         BRTransactionAddInput(transaction, tx->txHash, o->n, tx->outputs[o->n].amount,
                               tx->outputs[o->n].script, tx->outputs[o->n].scriptLen, NULL, 0, NULL, 0, TXIN_SEQUENCE);
-        
+
         if (BRTransactionVSize(transaction) + TX_OUTPUT_SIZE > TX_MAX_SIZE) { // transaction size-in-bytes too large
             BRTransactionFree(transaction);
             transaction = NULL;
-        
+
             // check for sufficient total funds before building a smaller transaction
             if (wallet->balance < amount + _txFee(wallet->feePerKb, 10 + array_count(wallet->utxos)*TX_INPUT_SIZE +
-                                                  (outCount + 1)*TX_OUTPUT_SIZE + cpfpSize)) break;
+                                                  (outCount + 1)*TX_OUTPUT_SIZE)) {
+                break;
+            }
+
             wallet->lock.unlock();
 
             if (outputs[outCount - 1].amount > amount + feeAmount + minAmount - balance) {
                 BRTxOutput newOutputs[outCount];
-                
+
                 for (j = 0; j < outCount; j++) {
                     newOutputs[j] = outputs[j];
                 }
-                
+
                 newOutputs[outCount - 1].amount -= amount + feeAmount - balance; // reduce last output amount
-                transaction = BRWalletCreateTxForOutputs(wallet, newOutputs, outCount);
+                transaction = BRWalletCreateTxForOutputs(wallet, newOutputs, outCount, changeAddress);
             }
-            else transaction = BRWalletCreateTxForOutputs(wallet, outputs, outCount - 1); // remove last output
+            else transaction = BRWalletCreateTxForOutputs(wallet, outputs, outCount - 1, changeAddress); // remove last output
 
             balance = amount = feeAmount = 0;
             wallet->lock.lock();
             break;
         }
-        
+
         balance += tx->outputs[o->n].amount;
-        
-//        // size of unconfirmed, non-change inputs for child-pays-for-parent fee
-//        // don't include parent tx with more than 10 inputs or 10 outputs
-//        if (tx->blockHeight == TX_UNCONFIRMED && tx->inCount <= 10 && tx->outCount <= 10 &&
-//            ! _BRWalletTxIsSend(wallet, tx)) cpfpSize += BRTransactionVSize(tx);
 
         // fee amount after adding a change output
-        feeAmount = _txFee(wallet->feePerKb, BRTransactionVSize(transaction) + TX_OUTPUT_SIZE + cpfpSize);
+        feeAmount = _txFee(wallet->feePerKb, BRTransactionVSize(transaction) + TX_OUTPUT_SIZE);
 
         // increase fee to round off remaining wallet balance to nearest 100 satoshi
         if (wallet->balance > amount + feeAmount) feeAmount += (wallet->balance - (amount + feeAmount)) % 100;
-        
-        if (balance == amount + feeAmount || balance >= amount + feeAmount + minAmount) break;
+
+        if (balance == amount + feeAmount || balance >= amount + feeAmount + minAmount) {
+            break;
+        }
     }
-    
+
     wallet->lock.unlock();
-    
+
     if (transaction && (outCount < 1 || balance < amount + feeAmount)) { // no outputs/insufficient funds
         BRTransactionFree(transaction);
         transaction = NULL;
     }
     else if (transaction && balance - (amount + feeAmount) > minAmount) { // add change output
         BRWalletUnusedAddrs(wallet, &addr, 1, 1);
-        uint8_t script[BRAddressScriptPubKey(NULL, 0, addr.s)];
-        size_t scriptLen = BRAddressScriptPubKey(script, sizeof(script), addr.s);
-    
+        uint8_t script[BRAddressScriptPubKey(NULL, 0, changeAddress.c_str())];
+        size_t scriptLen = BRAddressScriptPubKey(script, sizeof(script), changeAddress.c_str());
+
         BRTransactionAddOutput(transaction, balance - (amount + feeAmount), script, scriptLen);
         BRTransactionShuffleOutputs(transaction);
     }
-    
+
     return transaction;
 }
 
@@ -837,15 +880,15 @@ int BRWalletSignTransaction(BRWallet *wallet, BRTransaction *tx, const void *see
     uint32_t j, internalIdx[tx->inCount], externalIdx[tx->inCount];
     size_t i, internalCount = 0, externalCount = 0;
     int forkId, r = 0;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL);
     wallet->lock.lock();
     forkId = wallet->forkId;
-    
+
     for (i = 0; tx && i < tx->inCount; i++) {
         const uint8_t *pkh = BRScriptPKH(tx->inputs[i].script, tx->inputs[i].scriptLen);
-        
+
         for (j = (uint32_t)array_count(wallet->internalChain); pkh && j > 0; j--) {
             if (UInt160Eq(UInt160Get(pkh), wallet->internalChain[j - 1])) internalIdx[internalCount++] = j - 1;
         }
@@ -868,7 +911,7 @@ int BRWalletSignTransaction(BRWallet *wallet, BRTransaction *tx, const void *see
         for (i = 0; i < internalCount + externalCount; i++) BRKeyClean(&keys[i]);
     }
     else r = -1; // user canceled authentication
-    
+
     return r;
 }
 
@@ -876,7 +919,7 @@ int BRWalletSignTransaction(BRWallet *wallet, BRTransaction *tx, const void *see
 int BRWalletContainsTransaction(BRWallet *wallet, const BRTransaction *tx)
 {
     int r = 0;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL);
     wallet->lock.lock();
@@ -889,10 +932,10 @@ int BRWalletContainsTransaction(BRWallet *wallet, const BRTransaction *tx)
 int BRWalletRegisterTransaction(BRWallet *wallet, BRTransaction *tx)
 {
     int wasAdded = 0, r = 1;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL && BRTransactionIsSigned(tx));
-    
+
     if (tx && BRTransactionIsSigned(tx)) {
         wallet->lock.lock();
 
@@ -913,7 +956,7 @@ int BRWalletRegisterTransaction(BRWallet *wallet, BRTransaction *tx)
                 // BUG: XXX memory leak if tx is not added to wallet->allTx, and we can't just free it
             }
         }
-    
+
         wallet->lock.unlock();
     }
     else r = 0;
@@ -948,21 +991,21 @@ void BRWalletRemoveTransaction(BRWallet *wallet, UInt256 txHash)
             t = wallet->transactions[i - 1];
             if (t->blockHeight < tx->blockHeight) break;
             if (BRTransactionEq(tx, t)) continue;
-            
+
             for (size_t j = 0; j < t->inCount; j++) {
                 if (! UInt256Eq(t->inputs[j].txHash, txHash)) continue;
                 array_add(hashes, t->txHash);
                 break;
             }
         }
-        
+
         if (array_count(hashes) > 0) {
             wallet->lock.unlock();
-            
+
             for (size_t i = array_count(hashes); i > 0; i--) {
                 BRWalletRemoveTransaction(wallet, hashes[i - 1]);
             }
-            
+
             BRWalletRemoveTransaction(wallet, txHash);
         }
         else {
@@ -971,14 +1014,14 @@ void BRWalletRemoveTransaction(BRWallet *wallet, UInt256 txHash)
                 array_rm(wallet->transactions, i - 1);
                 break;
             }
-            
+
             _BRWalletUpdateBalance(wallet);
             wallet->lock.unlock();
-            
+
             // if this is for a transaction we sent, and it wasn't already known to be invalid, notify user
             if (BRWalletAmountSentByTx(wallet, tx) > 0 && BRWalletTransactionIsValid(wallet, tx)) {
                 recommendRescan = notifyUser = 1;
-                
+
                 for (size_t i = 0; i < tx->inCount; i++) { // only recommend a rescan if all inputs are confirmed
                     t = BRWalletTransactionForHash(wallet, tx->inputs[i].txHash);
                     if (t && t->blockHeight != TX_UNCONFIRMED) continue;
@@ -990,7 +1033,7 @@ void BRWalletRemoveTransaction(BRWallet *wallet, UInt256 txHash)
             if (wallet->balanceChanged) wallet->balanceChanged(wallet->callbackInfo, wallet->balance);
             if (wallet->txDeleted) wallet->txDeleted(wallet->callbackInfo, txHash, notifyUser, recommendRescan);
         }
-        
+
         array_free(hashes);
     }
     else wallet->lock.unlock();
@@ -1000,7 +1043,7 @@ void BRWalletRemoveTransaction(BRWallet *wallet, UInt256 txHash)
 BRTransaction *BRWalletTransactionForHash(BRWallet *wallet, UInt256 txHash)
 {
     BRTransaction *tx;
-    
+
     assert(wallet != NULL);
     assert(! UInt256IsZero(txHash));
     wallet->lock.lock();
@@ -1017,7 +1060,7 @@ int BRWalletTransactionIsValid(BRWallet *wallet, const BRTransaction *tx)
 
     assert(wallet != NULL);
     assert(tx != NULL && BRTransactionIsSigned(tx));
-    
+
     // TODO: XXX attempted double spends should cause conflicted tx to remain unverified until they're confirmed
     // TODO: XXX conflicted tx with the same wallet outputs should be presented as the same tx to the user
 
@@ -1038,7 +1081,7 @@ int BRWalletTransactionIsValid(BRWallet *wallet, const BRTransaction *tx)
             if (t && ! BRWalletTransactionIsValid(wallet, t)) r = 0;
         }
     }
-    
+
     return r;
 }
 
@@ -1049,7 +1092,7 @@ int BRWalletTransactionIsPending(BRWallet *wallet, const BRTransaction *tx)
     time_t now = time(NULL);
     uint32_t blockHeight;
     int r = 0;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL && BRTransactionIsSigned(tx));
     wallet->lock.lock();
@@ -1058,24 +1101,24 @@ int BRWalletTransactionIsPending(BRWallet *wallet, const BRTransaction *tx)
 
     if (tx && tx->blockHeight == TX_UNCONFIRMED) { // only unconfirmed transactions can be postdated
         if (BRTransactionVSize(tx) > TX_MAX_SIZE) r = 1; // check transaction size is under TX_MAX_SIZE
-        
+
         for (size_t i = 0; ! r && i < tx->inCount; i++) {
             if (tx->inputs[i].sequence < UINT32_MAX - 1) r = 1; // check for replace-by-fee
             if (tx->inputs[i].sequence < UINT32_MAX && tx->lockTime < TX_MAX_LOCK_HEIGHT &&
                 tx->lockTime > blockHeight + 1) r = 1; // future lockTime
             if (tx->inputs[i].sequence < UINT32_MAX && tx->lockTime > now) r = 1; // future lockTime
         }
-        
+
         for (size_t i = 0; ! r && i < tx->outCount; i++) { // check that no outputs are dust
             if (tx->outputs[i].amount < TX_MIN_OUTPUT_AMOUNT) r = 1;
         }
-        
+
         for (size_t i = 0; ! r && i < tx->inCount; i++) { // check if any inputs are known to be pending
             t = BRWalletTransactionForHash(wallet, tx->inputs[i].txHash);
             if (t && BRWalletTransactionIsPending(wallet, t)) r = 1;
         }
     }
-    
+
     return r;
 }
 
@@ -1091,13 +1134,13 @@ int BRWalletTransactionIsVerified(BRWallet *wallet, const BRTransaction *tx)
     if (tx && tx->blockHeight == TX_UNCONFIRMED) { // only unconfirmed transactions can be unverified
         if (tx->timestamp == 0 || ! BRWalletTransactionIsValid(wallet, tx) ||
             BRWalletTransactionIsPending(wallet, tx)) r = 0;
-            
+
         for (size_t i = 0; r && i < tx->inCount; i++) { // check if any inputs are known to be unverified
             t = BRWalletTransactionForHash(wallet, tx->inputs[i].txHash);
             if (t && ! BRWalletTransactionIsVerified(wallet, t)) r = 0;
         }
     }
-    
+
     return r;
 }
 
@@ -1110,18 +1153,18 @@ void BRWalletUpdateTransactions(BRWallet *wallet, const UInt256 txHashes[], size
     UInt256 hashes[txCount];
     int needsUpdate = 0;
     size_t i, j, k;
-    
+
     assert(wallet != NULL);
     assert(txHashes != NULL || txCount == 0);
     wallet->lock.lock();
     if (blockHeight > wallet->blockHeight) wallet->blockHeight = blockHeight;
-    
+
     for (i = 0, j = 0; txHashes && i < txCount; i++) {
         tx = (BRTransaction *)BRSetGet(wallet->allTx, &txHashes[i]);
         if (! tx || (tx->blockHeight == blockHeight && tx->timestamp == timestamp)) continue;
         tx->timestamp = timestamp;
         tx->blockHeight = blockHeight;
-        
+
         if (_BRWalletContainsTx(wallet, tx)) {
             for (k = array_count(wallet->transactions); k > 0; k--) { // remove and re-insert tx to keep wallet sorted
                 if (! BRTransactionEq(wallet->transactions[k - 1], tx)) continue;
@@ -1129,7 +1172,7 @@ void BRWalletUpdateTransactions(BRWallet *wallet, const UInt256 txHashes[], size
                 _BRWalletInsertTx(wallet, tx);
                 break;
             }
-            
+
             hashes[j++] = txHashes[i];
             if (BRSetContains(wallet->pendingTx, tx) || BRSetContains(wallet->invalidTx, tx)) needsUpdate = 1;
         }
@@ -1138,7 +1181,7 @@ void BRWalletUpdateTransactions(BRWallet *wallet, const UInt256 txHashes[], size
             BRTransactionFree(tx);
         }
     }
-    
+
     if (needsUpdate) _BRWalletUpdateBalance(wallet);
     wallet->lock.unlock();
     if (j > 0 && wallet->txUpdated) wallet->txUpdated(wallet->callbackInfo, hashes, j, blockHeight, timestamp);
@@ -1148,7 +1191,7 @@ void BRWalletUpdateTransactions(BRWallet *wallet, const UInt256 txHashes[], size
 void BRWalletSetTxUnconfirmedAfter(BRWallet *wallet, uint32_t blockHeight)
 {
     size_t i, j, count;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     wallet->blockHeight = blockHeight;
@@ -1162,7 +1205,7 @@ void BRWalletSetTxUnconfirmedAfter(BRWallet *wallet, uint32_t blockHeight)
         wallet->transactions[i + j]->blockHeight = TX_UNCONFIRMED;
         hashes[j] = wallet->transactions[i + j]->txHash;
     }
-    
+
     if (count > 0) _BRWalletUpdateBalance(wallet);
     wallet->lock.unlock();
     if (count > 0 && wallet->txUpdated) wallet->txUpdated(wallet->callbackInfo, hashes, count, TX_UNCONFIRMED, 0);
@@ -1173,17 +1216,17 @@ uint64_t BRWalletAmountReceivedFromTx(BRWallet *wallet, const BRTransaction *tx)
 {
     uint64_t amount = 0;
     const uint8_t *pkh;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL);
     wallet->lock.lock();
-    
+
     // TODO: don't include outputs below TX_MIN_OUTPUT_AMOUNT
     for (size_t i = 0; tx && i < tx->outCount; i++) {
         pkh = BRScriptPKH(tx->outputs[i].script, tx->outputs[i].scriptLen);
         if (pkh && BRSetContains(wallet->allPKH, pkh)) amount += tx->outputs[i].amount;
     }
-    
+
     wallet->lock.unlock();
     return amount;
 }
@@ -1192,11 +1235,11 @@ uint64_t BRWalletAmountReceivedFromTx(BRWallet *wallet, const BRTransaction *tx)
 uint64_t BRWalletAmountSentByTx(BRWallet *wallet, const BRTransaction *tx)
 {
     uint64_t amount = 0;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL);
     wallet->lock.lock();
-    
+
     for (size_t i = 0; tx && i < tx->inCount; i++) {
         BRTransaction *t = (BRTransaction *)BRSetGet(wallet->allTx, &tx->inputs[i].txHash);
         uint32_t n = tx->inputs[i].index;
@@ -1207,7 +1250,7 @@ uint64_t BRWalletAmountSentByTx(BRWallet *wallet, const BRTransaction *tx)
             if (pkh && BRSetContains(wallet->allPKH, pkh)) amount += t->outputs[n].amount;
         }
     }
-    
+
     wallet->lock.unlock();
     return amount;
 }
@@ -1216,27 +1259,27 @@ uint64_t BRWalletAmountSentByTx(BRWallet *wallet, const BRTransaction *tx)
 uint64_t BRWalletFeeForTx(BRWallet *wallet, const BRTransaction *tx)
 {
     uint64_t amount = 0;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL);
     wallet->lock.lock();
-    
+
     for (size_t i = 0; tx && i < tx->inCount && amount != UINT64_MAX; i++) {
         BRTransaction *t = (BRTransaction *)BRSetGet(wallet->allTx, &tx->inputs[i].txHash);
         uint32_t n = tx->inputs[i].index;
-        
+
         if (t && n < t->outCount) {
             amount += t->outputs[n].amount;
         }
         else amount = UINT64_MAX;
     }
-    
+
     wallet->lock.unlock();
-    
+
     for (size_t i = 0; tx && i < tx->outCount && amount != UINT64_MAX; i++) {
         amount -= tx->outputs[i].amount;
     }
-    
+
     return amount;
 }
 
@@ -1244,12 +1287,12 @@ uint64_t BRWalletFeeForTx(BRWallet *wallet, const BRTransaction *tx)
 uint64_t BRWalletBalanceAfterTx(BRWallet *wallet, const BRTransaction *tx)
 {
     uint64_t balance;
-    
+
     assert(wallet != NULL);
     assert(tx != NULL && BRTransactionIsSigned(tx));
     wallet->lock.lock();
     balance = wallet->balance;
-    
+
     for (size_t i = array_count(wallet->transactions); tx && i > 0; i--) {
         if (! BRTransactionEq(tx, wallet->transactions[i - 1])) continue;
         balance = wallet->balanceHist[i - 1];
@@ -1264,7 +1307,7 @@ uint64_t BRWalletBalanceAfterTx(BRWallet *wallet, const BRTransaction *tx)
 uint64_t BRWalletFeeForTxSize(BRWallet *wallet, size_t size)
 {
     uint64_t fee;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
     fee = _txFee(wallet->feePerKb, size);
@@ -1280,30 +1323,32 @@ uint64_t BRWalletFeeForTxAmount(BRWallet *wallet, uint64_t amount)
     BRTxOutput o = BR_TX_OUTPUT_NONE;
     BRTransaction *tx;
     uint64_t fee = 0, maxAmount = 0;
-    
+
     assert(wallet != NULL);
     assert(amount > 0);
     maxAmount = BRWalletMaxOutputAmount(wallet);
     o.amount = (amount < maxAmount) ? amount : maxAmount;
     BRTxOutputSetScript(&o, dummyScript, sizeof(dummyScript)); // unspendable dummy scriptPubKey
-    tx = BRWalletCreateTxForOutputs(wallet, &o, 1);
+    tx = BRWalletCreateTxForOutputs(wallet, &o, 1, {});
 
     if (tx) {
         fee = BRWalletFeeForTx(wallet, tx);
         BRTransactionFree(tx);
     }
-    
+
     return fee;
 }
 
 // outputs below this amount are uneconomical due to fees (TX_MIN_OUTPUT_AMOUNT is the absolute minimum output amount)
-uint64_t BRWalletMinOutputAmount(BRWallet *wallet)
+// use feePerKb UINT64_MAX to indicate that the wallet feePerKb should be used
+uint64_t BRWalletMinOutputAmountWithFeePerKb(BRWallet *wallet, uint64_t feePerKb)
 {
     uint64_t amount;
-    
+
     assert(wallet != NULL);
     wallet->lock.lock();
-    amount = (TX_MIN_OUTPUT_AMOUNT*wallet->feePerKb + MIN_FEE_PER_KB - 1)/MIN_FEE_PER_KB;
+    feePerKb = UINT64_MAX == feePerKb ? wallet->feePerKb : feePerKb;
+    amount = (TX_MIN_OUTPUT_AMOUNT*feePerKb + MIN_FEE_PER_KB - 1)/MIN_FEE_PER_KB;
     wallet->lock.unlock();
     return (amount > TX_MIN_OUTPUT_AMOUNT) ? amount : TX_MIN_OUTPUT_AMOUNT;
 }
@@ -1325,7 +1370,7 @@ uint64_t BRWalletMaxOutputAmount(BRWallet *wallet)
         if (! tx || o->n >= tx->outCount) continue;
         inCount++;
         amount += tx->outputs[o->n].amount;
-        
+
 //        // size of unconfirmed, non-change inputs for child-pays-for-parent fee
 //        // don't include parent tx with more than 10 inputs or 10 outputs
 //        if (tx->blockHeight == TX_UNCONFIRMED && tx->inCount <= 10 && tx->outCount <= 10 &&
@@ -1335,7 +1380,7 @@ uint64_t BRWalletMaxOutputAmount(BRWallet *wallet)
     txSize = 8 + BRVarIntSize(inCount) + TX_INPUT_SIZE*inCount + BRVarIntSize(2) + TX_OUTPUT_SIZE*2;
     fee = _txFee(wallet->feePerKb, txSize + cpfpSize);
     wallet->lock.unlock();
-    
+
     return (amount > fee) ? amount - fee : 0;
 }
 
@@ -1370,7 +1415,7 @@ void BRWalletFree(BRWallet *wallet)
 int64_t BRLocalAmount(int64_t amount, double price)
 {
     int64_t localAmount = llabs(amount)*price/SATOSHIS;
-    
+
     // if amount is not 0, but is too small to be represented in local currency, return minimum non-zero localAmount
     if (localAmount == 0 && amount != 0) localAmount = 1;
     return (amount < 0) ? -localAmount : localAmount;
@@ -1389,12 +1434,12 @@ int64_t BRBitcoinAmount(int64_t localAmount, double price)
         max = (lamt + 1)*SATOSHIS/price - 1; // maximum amount that safely matches localAmount
         amount = (min + max)/2; // average min and max
         while (overflowbits > 0) lamt *= 2, min *= 2, max *= 2, amount *= 2, overflowbits--;
-        
+
         if (amount >= MAX_MONEY) return (localAmount < 0) ? -MAX_MONEY : MAX_MONEY;
         while ((amount/p)*p >= min && p <= INT64_MAX/10) p *= 10; // lowest decimal precision matching localAmount
         p /= 10;
         amount = (amount/p)*p;
     }
-    
+
     return (localAmount < 0) ? -amount : amount;
 }

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -62,6 +62,9 @@ inline static int BRUTXOEq(const void *utxo, const void *otherUtxo)
 // Comparator for C++ containers of UInt160
 bool UInt160Compare(const UInt160& a, const UInt160& b);
 
+// Convert SPV UInt256 to Bitcoin uint256
+uint256 to_uint256(UInt256 const & i);
+
 typedef struct BRWalletStruct BRWallet;
 
 // allocates and populates a BRWallet struct that must be freed by calling BRWalletFree()
@@ -221,5 +224,11 @@ int64_t BRBitcoinAmount(int64_t localAmount, double price);
 #ifdef __cplusplus
 }
 #endif
+
+// Returns a set of all user related transactions.
+std::set<std::string> BRListUserTransactions(BRWallet *wallet);
+
+// Returns the raw hex encoded transaction data if found
+std::string BRGetRawTransaction(BRWallet *wallet, UInt256 txHash);
 
 #endif // BRWallet_h

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -29,7 +29,9 @@
 #include "BRAddress.h"
 #include "BRBIP32Sequence.h"
 #include "BRInt.h"
-#include <string.h>
+
+#include <string>
+#include <vector>
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,7 +62,7 @@ typedef struct BRWalletStruct BRWallet;
 
 // allocates and populates a BRWallet struct that must be freed by calling BRWalletFree()
 // forkId is 0 for bitcoin, 0x40 for b-cash
-BRWallet *BRWalletNew(BRTransaction *transactions[], size_t txCount, BRMasterPubKey mpk, int forkId);
+BRWallet *BRWalletNew(BRTransaction *transactions[], size_t txCount, BRMasterPubKey mpk, int forkId, std::vector<UInt160> userAddresses);
 
 // not thread-safe, set callbacks once after BRWalletNew(), before calling other BRWallet functions
 // info is a void pointer that will be passed along with each callback call
@@ -83,6 +85,12 @@ void BRWalletSetCallbacks(BRWallet *wallet, void *info,
 // addrs may be NULL to only generate addresses for BRWalletContainsAddress()
 // returns the number addresses written to addrs
 size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimit, uint32_t internal);
+
+// Add Bitcoin public key to SPV wallet from DeFi public key
+bool BRWalletAddAddr(BRWallet *wallet, const uint8_t &pubKey, const size_t pkLen, BRAddress& addr);
+
+// Add previously created Bitcoin addresses from DeFi address book
+void BRWalletAddUserAddresses(BRWallet *wallet, std::vector<UInt160> userAddresses);
 
 // returns the first unused external address (bech32 pay-to-witness-pubkey-hash)
 BRAddress BRWalletReceiveAddress(BRWallet *wallet);

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -58,6 +58,10 @@ inline static int BRUTXOEq(const void *utxo, const void *otherUtxo)
                                   ((const BRUTXO *)utxo)->n == ((const BRUTXO *)otherUtxo)->n));
 }
 
+
+// Comparator for C++ containers of UInt160
+bool UInt160Compare(const UInt160& a, const UInt160& b);
+
 typedef struct BRWalletStruct BRWallet;
 
 // allocates and populates a BRWallet struct that must be freed by calling BRWalletFree()
@@ -87,8 +91,11 @@ void BRWalletSetCallbacks(BRWallet *wallet, void *info,
 // returns the number addresses written to addrs
 size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimit, uint32_t internal);
 
+// Import single uint160 into wallet
+void BRWalletImportAddress(BRWallet *wallet, const uint160& userHash);
+
 // Add Bitcoin public key to SPV wallet from DeFi public key
-bool BRWalletAddAddr(BRWallet *wallet, const uint8_t &pubKey, const size_t pkLen, BRAddress& addr);
+bool BRWalletAddSingleAddress(BRWallet *wallet, const uint8_t &pubKey, const size_t pkLen, BRAddress& addr);
 
 // Add previously created Bitcoin addresses from DeFi address book
 void BRWalletAddUserAddresses(BRWallet *wallet);
@@ -136,11 +143,11 @@ void BRWalletSetFeePerKb(BRWallet *wallet, uint64_t feePerKb);
 
 // returns an unsigned transaction that sends the specified amount from the wallet to the given address
 // result must be freed using BRTransactionFree()
-BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr);
+BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr, std::string changeAddress);
 
 // returns an unsigned transaction that satisifes the given transaction outputs
 // result must be freed using BRTransactionFree()
-BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount);
+BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount, std::string changeAddress);
 
 // signs any inputs in tx that can be signed using private keys from the wallet
 // seed is the master private key (wallet seed) corresponding to the master public key given when the wallet was created
@@ -195,7 +202,7 @@ uint64_t BRWalletFeeForTxSize(BRWallet *wallet, size_t size);
 uint64_t BRWalletFeeForTxAmount(BRWallet *wallet, uint64_t amount);
 
 // outputs below this amount are uneconomical due to fees (TX_MIN_OUTPUT_AMOUNT is the absolute minimum output amount)
-uint64_t BRWalletMinOutputAmount(BRWallet *wallet);
+uint64_t BRWalletMinOutputAmountWithFeePerKb(BRWallet *wallet, uint64_t feePerKb);
 
 // maximum amount that can be sent from the wallet to a single address after fees
 uint64_t BRWalletMaxOutputAmount(BRWallet *wallet);

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -31,7 +31,7 @@
 #include "BRInt.h"
 
 #include <string>
-#include <vector>
+#include <set>
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,7 +62,8 @@ typedef struct BRWalletStruct BRWallet;
 
 // allocates and populates a BRWallet struct that must be freed by calling BRWalletFree()
 // forkId is 0 for bitcoin, 0x40 for b-cash
-BRWallet *BRWalletNew(BRTransaction *transactions[], size_t txCount, BRMasterPubKey mpk, int forkId, std::vector<UInt160> userAddresses);
+BRWallet *BRWalletNew(BRTransaction *transactions[], size_t txCount, BRMasterPubKey mpk, int forkId,
+                      std::set<UInt160, decltype(&UInt160Compare)>&& userAddresses);
 
 // not thread-safe, set callbacks once after BRWalletNew(), before calling other BRWallet functions
 // info is a void pointer that will be passed along with each callback call
@@ -90,7 +91,7 @@ size_t BRWalletUnusedAddrs(BRWallet *wallet, BRAddress addrs[], uint32_t gapLimi
 bool BRWalletAddAddr(BRWallet *wallet, const uint8_t &pubKey, const size_t pkLen, BRAddress& addr);
 
 // Add previously created Bitcoin addresses from DeFi address book
-void BRWalletAddUserAddresses(BRWallet *wallet, std::vector<UInt160> userAddresses);
+void BRWalletAddUserAddresses(BRWallet *wallet);
 
 // returns the first unused external address (bech32 pay-to-witness-pubkey-hash)
 BRAddress BRWalletReceiveAddress(BRWallet *wallet);

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -978,6 +978,54 @@ static UniValue spv_sendtoaddress(const JSONRPCRequest& request)
     return spv::pspv->SendBitcoins(pwallet, address, nAmount);
 }
 
+static UniValue spv_listtransactions(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_listransactions",
+        "\nReturns an array of all Bitcoin transaction hashes.\n",
+        {},
+        RPCResult{
+            "[                         (array of strings)\n"
+            "  \"txid\"                  (string) The transaction id.\n"
+            "  ...\n"
+            "]"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_listransactions", "")
+            + HelpExampleRpc("spv_listransactions", "")
+        },
+    }.Check(request);
+
+    if (!spv::pspv) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    return spv::pspv->ListTransactions();
+}
+
+static UniValue spv_getrawtransaction(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_gatrawtransaction",
+        "\nReturn the raw transaction data.\n",
+        {
+            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+        },
+        RPCResult{
+            "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_getrawtransaction", "\"txid\"")
+            + HelpExampleRpc("spv_getrawtransaction", "\"txid\"")
+        },
+    }.Check(request);
+
+    if (!spv::pspv) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    uint256 hash = ParseHashV(request.params[0], "");
+
+    return spv::pspv->GetRawTransactions(hash);
+}
 
 
 static const CRPCCommand commands[] =
@@ -1001,6 +1049,8 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_dumpprivkey",            &spv_dumpprivkey,           { }  },
   { "spv",      "spv_getbalance",             &spv_getbalance,            { }  },
   { "spv",      "spv_sendtoaddress",          &spv_sendtoaddress,         { "address", "amount" }  },
+  { "spv",      "spv_listtransactions",       &spv_listtransactions,      { }  },
+  { "spv",      "spv_getrawtransaction",      &spv_getrawtransaction,     { "txid" }  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
 };
 

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -848,6 +848,34 @@ UniValue spv_setlastheight(const JSONRPCRequest& request)
     return UniValue();
 }
 
+UniValue spv_fundaddress(const JSONRPCRequest& request)
+{
+    CWallet* const pwallet = GetWallet(request);
+
+    RPCHelpMan{"spv_fundaddress",
+        "\nFund a Bitcoin address (for test purposes only)\n",
+        {
+            {"address", RPCArg::Type::NUM, RPCArg::Optional::NO, "Bitcoin address to fund"},
+        },
+        RPCResult{
+            "\"txid\"                  (string) The transaction id.\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_fundaddress", "\"address\"")
+            + HelpExampleRpc("spv_fundaddress", "\"address\"")
+        },
+    }.Check(request);
+
+    auto fake_spv = static_cast<spv::CFakeSpvWrapper *>(spv::pspv.get());
+    if (!fake_spv) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "command disabled");
+    }
+
+    std::string strAddress = request.params[0].get_str();
+
+    return fake_spv->SendBitcoins(pwallet, strAddress, -1);
+}
+
 static UniValue spv_getnewaddress(const JSONRPCRequest& request)
 {
     CWallet* const pwallet = GetWallet(request);
@@ -1052,6 +1080,7 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_listtransactions",       &spv_listtransactions,      { }  },
   { "spv",      "spv_getrawtransaction",      &spv_getrawtransaction,     { "txid" }  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
+  { "hidden",   "spv_fundaddress",            &spv_fundaddress,           { "address" }  },
 };
 
 void RegisterSpvRPCCommands(CRPCTable &tableRPC)

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -866,6 +866,91 @@ UniValue spv_setlastheight(const JSONRPCRequest& request)
     return UniValue();
 }
 
+UniValue spv_getnewaddress(const JSONRPCRequest& request)
+{
+    CWallet* const pwallet = GetWallet(request);
+
+    RPCHelpMan{"spv_getnewaddress",
+        "\nCreates and adds a Bitcoin address to the SPV wallet\n",
+        {
+        },
+        RPCResult{
+            "\"none\"                  Returns nothing\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_getnewaddress", "")
+            + HelpExampleRpc("spv_getnewaddress", "")
+        },
+    }.Check(request);
+
+    if (!spv::pspv) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    LOCK(pwallet->cs_wallet);
+
+    pwallet->TopUpKeyPool();
+
+    // Generate a new key that is added to wallet
+    CPubKey new_key;
+    if (!pwallet->GetKeyFromPool(new_key)) {
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+        return false;
+    }
+
+    auto newAddress = spv::pspv->AddBitcoinAddress(new_key);
+    if (!newAddress.empty()) {
+        auto dest = GetDestinationForKey(new_key, OutputType::BECH32);
+        pwallet->SetAddressBook(dest, "", "spv");
+    }
+
+    return newAddress;
+}
+
+UniValue spv_dumpprivkey(const JSONRPCRequest& request)
+{
+    CWallet* const pwallet = GetWallet(request);
+
+    RPCHelpMan{"spv_dumpprivkey",
+        "\nReveals the private key corresponding to 'address'.\n",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The BTC address for the private key"},
+        },
+        RPCResult{
+            "\"key\"                (string) The private key\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_dumpprivkey", "\"myaddress\"")
+            + HelpExampleRpc("spv_dumpprivkey", "\"myaddress\"")
+        },
+    }.Check(request);
+
+    auto locked_chain = pwallet->chain().lock();
+    LOCK(pwallet->cs_wallet);
+
+    std::string strAddress = request.params[0].get_str();
+
+    return spv::pspv->DumpBitcoinPrivKey(pwallet, strAddress);
+}
+
+UniValue spv_getbalance(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_getbalance",
+        "\nReturns the Bitcoin balance of the SPV wallet\n",
+        {
+        },
+        RPCResult{
+        "amount                 (numeric) The total amount in BTC received in the SPV wallet.\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_getbalance", "")
+            + HelpExampleRpc("spv_getbalance", "")
+        },
+    }.Check(request);
+
+    return ValueFromAmount(spv::pspv->GetBitcoinBalance());
+}
+
 
 static const CRPCCommand commands[] =
 { //  category          name                        actor (function)            params
@@ -883,7 +968,10 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_listanchorrewardconfirms",     &spv_listanchorrewardconfirms,    { }  },
   { "spv",      "spv_listanchorrewards",      &spv_listanchorrewards,     { }  },
   { "spv",      "spv_listanchorsunrewarded",  &spv_listanchorsunrewarded, { }  },
-  { "spv",      "spv_listanchorspending",     &spv_listanchorspending, { }  },
+  { "spv",      "spv_listanchorspending",     &spv_listanchorspending,    { }  },
+  { "spv",      "spv_getnewaddress",          &spv_getnewaddress,         { }  },
+  { "spv",      "spv_dumpprivkey",            &spv_dumpprivkey,           { }  },
+  { "spv",      "spv_getbalance",             &spv_getbalance,            { }  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
 };
 

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -37,7 +37,9 @@ typedef struct BRTransactionStruct BRTransaction;
 typedef struct BRPeerStruct BRPeer;
 
 class CAnchor;
+class CPubKey;
 class CScript;
+class CWallet;
 
 namespace spv
 {
@@ -109,6 +111,11 @@ public:
 
     // Get time stamp of Bitcoin TX
     uint32_t ReadTxTimestamp(uint256 const & hash);
+
+    // Bitcoin Address calls
+    std::string AddBitcoinAddress(const CPubKey &new_key);
+    std::string DumpBitcoinPrivKey(const CWallet* pwallet, const std::string &strAddress);
+    uint64_t GetBitcoinBalance();
 
 private:
     virtual void OnSendRawTx(BRTransaction * tx, std::promise<int> * promise);

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -53,8 +53,6 @@ namespace spv
 
 typedef std::vector<uint8_t> TBytes;
 
-uint256 to_uint256(UInt256 const & i);
-
 static const TBytes BtcAnchorMarker = { 'D', 'F', 'A'}; // 0x444641
 
 /// @todo test this amount of dust for p2wsh due to spv is very dumb and checks only for 546 (p2pkh)
@@ -123,8 +121,10 @@ public:
     std::string AddBitcoinAddress(const CPubKey &new_key);
     void AddBitcoinHash(const uint160 &userHash);
     std::string DumpBitcoinPrivKey(const CWallet* pwallet, const std::string &strAddress);
-    UniValue GetBitcoinBalance();
+    int64_t GetBitcoinBalance();
     UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount);
+    UniValue ListTransactions();
+    std::string GetRawTransactions(uint256& hash);
 
 private:
     virtual void OnSendRawTx(BRTransaction * tx, std::promise<int> * promise);

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -40,6 +40,13 @@ class CAnchor;
 class CPubKey;
 class CScript;
 class CWallet;
+class UniValue;
+
+extern const int ENOSPV;
+extern const int EPARSINGTX;
+extern const int ETXNOTSIGNED;
+
+std::string DecodeSendResult(int result);
 
 namespace spv
 {
@@ -114,8 +121,10 @@ public:
 
     // Bitcoin Address calls
     std::string AddBitcoinAddress(const CPubKey &new_key);
+    void AddBitcoinHash(const uint160 &userHash);
     std::string DumpBitcoinPrivKey(const CWallet* pwallet, const std::string &strAddress);
-    uint64_t GetBitcoinBalance();
+    UniValue GetBitcoinBalance();
+    UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount);
 
 private:
     virtual void OnSendRawTx(BRTransaction * tx, std::promise<int> * promise);

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -69,7 +69,6 @@ private:
     boost::shared_ptr<CDBWrapper> db;
     boost::scoped_ptr<CDBBatch> batch;
 
-    BRWallet *wallet = nullptr;
     BRPeerManager *manager = nullptr;
     std::string spv_internal_logfilename;
 
@@ -77,6 +76,9 @@ private:
     using db_block_rec = std::pair<TBytes, uint32_t>;                       // serialized block, blockHeight
 
     bool initialSync = true;
+
+protected:
+    BRWallet *wallet = nullptr;
 
 public:
     CSpvWrapper(bool isMainnet, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
@@ -122,7 +124,7 @@ public:
     void AddBitcoinHash(const uint160 &userHash);
     std::string DumpBitcoinPrivKey(const CWallet* pwallet, const std::string &strAddress);
     int64_t GetBitcoinBalance();
-    UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount);
+    virtual UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount);
     UniValue ListTransactions();
     std::string GetRawTransactions(uint256& hash);
 
@@ -210,7 +212,7 @@ protected:
 class CFakeSpvWrapper : public CSpvWrapper
 {
 public:
-    CFakeSpvWrapper() : CSpvWrapper(false, 1 << 23, true, true) {}
+    CFakeSpvWrapper();
 
     void Connect() override;
     void Disconnect() override;
@@ -221,6 +223,7 @@ public:
     uint32_t GetEstimatedBlockHeight() const override { return lastBlockHeight+1000; } // dummy
 
     void OnSendRawTx(BRTransaction * tx, std::promise<int> * promise) override;
+    UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount) override;
 
     uint32_t lastBlockHeight = 0;
     bool isConnected = false;

--- a/src/spv/support/BRLargeInt.h
+++ b/src/spv/support/BRLargeInt.h
@@ -123,12 +123,6 @@ inline static void UInt160Convert(const uint8_t* hash160, UInt160& spv160)
     memcpy(&spv160, hash160, sizeof(UInt160));
 }
 
-// Comparator for C++ containers of UInt160
-inline static bool UInt160Compare(const UInt160& a, const UInt160& b)
-{
-    return memcmp(&a, &b, sizeof(a)) < 0;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/spv/support/BRLargeInt.h
+++ b/src/spv/support/BRLargeInt.h
@@ -25,7 +25,12 @@
 #ifndef BRLargeInt_h
 #define BRLargeInt_h
 
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <logging.h>
+
 #include <inttypes.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -112,6 +117,17 @@ inline static UInt256 UInt256Reverse(UInt256 u)
                                 u.u8[ 7], u.u8[ 6], u.u8[5],  u.u8[ 4], u.u8[ 3], u.u8[ 2], u.u8[ 1], u.u8[ 0] } });
 }
 
+// Copy uint8_t array to SPV's UInt160
+inline static void UInt160Convert(const uint8_t* hash160, UInt160& spv160)
+{
+    memcpy(&spv160, hash160, sizeof(UInt160));
+}
+
+// Comparator for C++ containers of UInt160
+inline static bool UInt160Compare(const UInt160& a, const UInt160& b)
+{
+    return memcmp(&a, &b, sizeof(a)) < 0;
+}
 
 #ifdef __cplusplus
 }

--- a/src/spv/support/BRLargeInt.h
+++ b/src/spv/support/BRLargeInt.h
@@ -117,14 +117,15 @@ inline static UInt256 UInt256Reverse(UInt256 u)
                                 u.u8[ 7], u.u8[ 6], u.u8[5],  u.u8[ 4], u.u8[ 3], u.u8[ 2], u.u8[ 1], u.u8[ 0] } });
 }
 
-// Copy uint8_t array to SPV's UInt160
-inline static void UInt160Convert(const uint8_t* hash160, UInt160& spv160)
-{
-    memcpy(&spv160, hash160, sizeof(UInt160));
-}
-
 #ifdef __cplusplus
 }
 #endif
+
+// Copy uint8_t array to SPV's UInt160
+template<typename T>
+inline static void UIntConvert(const uint8_t* source, T& destination)
+{
+    memcpy(&destination, source, sizeof(T));
+}
 
 #endif // BRLargeInt_h

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -859,9 +859,6 @@ private:
      */
     uint256 m_last_block_processed GUARDED_BY(cs_wallet);
 
-    //! Fetches a key from the keypool
-    bool GetKeyFromPool(CPubKey &key, bool internal = false);
-
 public:
     /*
      * Main wallet lock.
@@ -1187,6 +1184,9 @@ public:
     std::map<CTxDestination, CAmount> GetAddressBalances(interfaces::Chain::Lock& locked_chain);
 
     std::set<CTxDestination> GetLabelAddresses(const std::string& label) const;
+
+    //! Fetches a key from the keypool. Public for use in SPV.
+    bool GetKeyFromPool(CPubKey &key, bool internal = false);
 
     bool GetNewDestination(const OutputType type, const std::string label, CTxDestination& dest, std::string& error);
     bool GetNewChangeDestination(const OutputType type, CTxDestination& dest, std::string& error);

--- a/test/functional/feature_bitcoin_wallet.py
+++ b/test/functional/feature_bitcoin_wallet.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test the Bitcoin SPV wallet"""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+from test_framework.authproxy import JSONRPCException
+from decimal import Decimal
+
+class BitcoinSPVTests(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [
+            [ "-dummypos=1", "-spv=1"],
+        ]
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        # Set up wallet
+        self.nodes[0].spv_setlastheight(1)
+        address = self.nodes[0].spv_getnewaddress()
+        txid = self.nodes[0].spv_fundaddress(address)
+
+        # Should now have a balance of 1 Bitcoin
+        result = self.nodes[0].spv_getbalance()
+        assert_equal(result, Decimal("1.00000000"))
+
+        # Make sure tx is present in wallet
+        txs = self.nodes[0].spv_listtransactions()
+        assert_equal(txs[0], txid)
+
+        # Get private key for address and import into wallet.
+        # Should not throw any error.
+        priv_key = self.nodes[0].spv_dumpprivkey(address)
+        result = self.nodes[0].importprivkey(priv_key)
+
+        # Try and send to null address
+        try:
+            dummy_address = "000000000000000000000000000000000000000000"
+            self.nodes[0].spv_sendtoaddress(dummy_address, 0.1)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            assert("Invalid address" in errorString)
+
+        # Send to external address
+        dummy_address = "bcrt1qfpnmx6jrn30yvscrw9spudj5aphyrc8es6epva"
+        result = self.nodes[0].spv_sendtoaddress(dummy_address, 0.1)
+        assert_equal(result['sendmessage'], "Success")
+
+        # Make sure tx is present in wallet
+        txs = self.nodes[0].spv_listtransactions()
+        assert(result['txid'] in txs)
+
+        # Make sure balance reduced
+        balance = self.nodes[0].spv_getbalance()
+        assert_equal(balance, Decimal("0.89998800"))
+
+        # Send to self
+        result = self.nodes[0].spv_sendtoaddress(address, 0.1)
+        assert_equal(result['sendmessage'], "Success")
+
+        # Make sure tx is present in wallet
+        txs = self.nodes[0].spv_listtransactions()
+        assert(result['txid'] in txs)
+
+        # Make sure balance reduced
+        balance = self.nodes[0].spv_getbalance()
+        assert_equal(balance, Decimal("0.89997600"))
+
+        # Let's find the output that matches our address
+        # One is the send-to-self and the other change.
+        # This also tests spv_getrawtransaction
+        raw_tx = self.nodes[0].spv_getrawtransaction(result['txid'])
+        decoded_tx = self.nodes[0].decoderawtransaction(raw_tx)
+        output_one = decoded_tx['vout'][0]['scriptPubKey']['addresses'][0]
+        output_two = decoded_tx['vout'][1]['scriptPubKey']['addresses'][0]
+
+        # Let's get the private key from the DeFi wallet
+        if output_one == address:
+            wallet_priv_key = self.nodes[0].dumpprivkey(output_one)
+            change_address = output_two
+        else:
+            wallet_priv_key = self.nodes[0].dumpprivkey(output_two)
+            change_address = output_one
+
+        # Private keys should match
+        change_priv_key = self.nodes[0].spv_dumpprivkey(output_two)
+        wallet_change_priv_key = self.nodes[0].dumpprivkey(output_two)
+        assert_equal(wallet_priv_key, priv_key)
+        assert_equal(wallet_change_priv_key, change_priv_key)
+
+if __name__ == '__main__':
+    BitcoinSPVTests().main()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -96,7 +96,7 @@ class CompactBlocksTest(DefiTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
-            "-acceptnonstdtxn=1", "-dummypos=1", "-nospv"
+            "-acceptnonstdtxn=1", "-dummypos=1"
         ]]
         self.utxos = []
 

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -16,7 +16,7 @@ from test_framework.util import (
 class DisconnectBanTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [['-dummypos=1', '-nospv'], ['-dummypos=1', '-nospv']]
+        self.extra_args = [['-dummypos=1'], ['-dummypos=1']]
 
     def run_test(self):
         self.log.info("Test setban and listbanned RPCs")

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -22,7 +22,7 @@ class InvalidBlockRequestTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-whitelist=127.0.0.1", "-dummypos=1", "-nospv"]]
+        self.extra_args = [["-whitelist=127.0.0.1", "-dummypos=1"]]
 
     def run_test(self):
         # Add p2p connection to node0

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -14,7 +14,7 @@ class InvalidLocatorTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = False
-        self.extra_args = [["-dummypos=1", "-nospv"]]
+        self.extra_args = [["-dummypos=1"]]
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -28,7 +28,6 @@ class InvalidTxRequestTest(DefiTestFramework):
         self.extra_args = [[
             "-acceptnonstdtxn=1",
             "-dummypos=1",
-            "-nospv",
         ]]
         self.setup_clean_chain = True
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -40,7 +40,7 @@ class NodeNetworkLimitedTest(DefiTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        self.extra_args = [['-prune=550', '-addrmantest', '-dummypos=1', '-nospv'], ['-dummypos=1', '-nospv'], ['-dummypos=1', '-nospv']]
+        self.extra_args = [['-prune=550', '-addrmantest', '-dummypos=1'], ['-dummypos=1'], ['-dummypos=1']]
 
     def disconnect_all(self):
         disconnect_nodes(self.nodes[0], 1)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -96,7 +96,6 @@ class TestNode():
             "-uacomment=testnode%d" % i,
             "-masternode_operator="+self.get_genesis_keys().operatorAuthAddress,
             "-dummypos=1",
-            "-nospv",
             "-txnotokens=1",
         ]
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -120,6 +120,7 @@ BASE_SCRIPTS = [
     'feature_anchor_rewards.py',
     'feature_anchorauths_pruning.py',
     'feature_autoauth.py',
+    'feature_bitcoin_wallet.py',
     'feature_communitybalance_reorg.py',
     'feature_auth_return_change.py',
     'feature_criminals.py',


### PR DESCRIPTION
Add the ability to send and receive Bitcoins directly in the DeFi wallet via SPV. This PR adds the following commands.

spv_dumpprivkey ADDRESS
Return the private key that relates to the address provided.

spv_getbalance
Displays the Bitcoin balance.

spv_getnewaddress
Returns a new Bitcoin address generated from a pubkey held in the DeFiChain wallet.

spv_getrawtransaction TXID
Get raw transaction that relates to the provided TXID if found.

spv_listtransactions
Returns an array of all user related TXIDs in the wallet.

spv_sendtoaddress ADDRESS AMOUNT
Send Bitcoin.

spv_fundaddress (For function test framework)
Hidden command used in testing to fund the Bitcoin wallet via a dummy transaction.