### PR TITLE
Prevent accept bad hash block

### DIFF
--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -61,12 +61,12 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
     {
         // check that block minter exists and active at the height of the block
         AssertLockHeld(cs_main);
-        auto optMasternodeID = pcustomcsview->GetMasternodeIdByOperator(minter);
+        auto optMasternodeID = mnView->GetMasternodeIdByOperator(minter);
         if (!optMasternodeID) {
             return false;
         }
         masternodeID = *optMasternodeID;
-        auto nodePtr = pcustomcsview->GetMasternode(masternodeID);
+        auto nodePtr = mnView->GetMasternode(masternodeID);
         if (!nodePtr || !nodePtr->IsActive(blockHeader.height)) {
             return false;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4248,7 +4248,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
-        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus(), false); // false cause we can check pos context only on ConnectBlock
+        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus(), true); // we should check for bad hash block
         if (ret) {
             // Store to disk
             ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It should prevent bad actor to created bad hash block which can broke network.
In addition `ContextualCheckProofOfStake` take a parameter which is unused till now, it's the same for now.