### PR TITLE
SPV: Skip pending anchor until block confirmed

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -547,15 +547,16 @@ void CAnchorIndex::CheckPendingAnchors()
         }
 
         uint32_t timestamp = spv::pspv->ReadTxTimestamp(rec.txHash);
+        auto blockHeight = spv::pspv->ReadTxBlockHeight(rec.txHash);
 
-        // Do not delete, TX time still pending.
-        if (timestamp == 0 || timestamp == std::numeric_limits<int32_t>::max()) {
+        // Do not delete, TX time still pending. If block height is set to max we cannot trust the timestamp.
+        if (timestamp == 0 || blockHeight == std::numeric_limits<int32_t>::max()) {
             continue;
         }
 
         // Here we can check new rule that Bitcoin blocktime is three hours more than DeFi anchored block
         if (anchorBlock.nTime > timestamp - Params().GetConsensus().mn.anchoringTimeDepth) {
-            LogPrint(BCLog::ANCHORING, "DeFi anchor time not deep enough. DeFi: %d Bitcoin: %d\n", anchorBlock.nTime, timestamp);
+            LogPrint(BCLog::ANCHORING, "Anchor too new. DeFi: %d Bitcoin: %d Anchor: %s\n", anchorBlock.nTime, timestamp, rec.txHash.ToString());
             deletePending.insert(rec.txHash);
             continue;
         }

--- a/src/spv/spv_wrapper.cpp
+++ b/src/spv/spv_wrapper.cpp
@@ -541,7 +541,7 @@ uint32_t CSpvWrapper::ReadTxBlockHeight(uint256 const & hash)
     }
 
     // If not found return the default value of an unconfirmed TX.
-    return std::numeric_limits<uint32_t>::max();
+    return std::numeric_limits<int32_t>::max();
 }
 
 void CSpvWrapper::EraseTx(uint256 const & hash)


### PR DESCRIPTION
Timestamp can be set to system time and not blocktime before the transaction is actually confirmed. We should consider an anchor TX with a blockheight of max int32 still pending even if a timestamp is set.

Correction also made in this PR to the newly created ReadTxBlockHeight by returning the correct unconfirmed block value of max int32.