### PR TITLE
Minimize undo storage data

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -745,7 +745,7 @@ bool CCustomCSView::CalculateOwnerRewards(CScript const & owner, uint32_t target
     if (balanceHeight >= targetHeight) {
         return false;
     }
-    ForEachPoolPair([&] (DCT_ID const & poolId, CLazySerialize<CPoolPair>) {
+    ForEachPoolId([&] (DCT_ID const & poolId) {
         auto height = GetShare(poolId, owner);
         if (!height || *height >= targetHeight) {
             return true; // no share or target height is before a pool share' one

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -96,7 +96,7 @@ UniValue outputEntryToJSON(COutputEntry const & entry, CBlockIndex const * index
 
 static void onPoolRewards(CCustomCSView & view, CScript const & owner, uint32_t begin, uint32_t end, std::function<void(uint32_t, DCT_ID, uint8_t, CTokenAmount)> onReward) {
     CCustomCSView mnview(view);
-    view.ForEachPoolPair([&] (DCT_ID const & poolId, CLazySerialize<CPoolPair>) {
+    view.ForEachPoolId([&] (DCT_ID const & poolId) {
         auto height = view.GetShare(poolId, owner);
         if (!height || *height >= end) {
             return true; // no share or target height is before a pool share' one

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -185,10 +185,10 @@ UniValue listpoolpairs(const JSONRPCRequest& request) {
     LOCK(cs_main);
 
     UniValue ret(UniValue::VOBJ);
-    pcustomcsview->ForEachPoolPair([&](DCT_ID const & id, CLazySerialize<CPoolPair> pool) {
+    pcustomcsview->ForEachPoolPair([&](DCT_ID const & id, CPoolPair pool) {
         const auto token = pcustomcsview->GetToken(id);
         if (token) {
-            ret.pushKVs(poolToJSON(id, pool.get(), *token, verbose));
+            ret.pushKVs(poolToJSON(id, pool, *token, verbose));
         }
 
         limit--;

--- a/src/masternodes/undos.cpp
+++ b/src/masternodes/undos.cpp
@@ -7,24 +7,24 @@
 /// @attention make sure that it does not overlap with those in masternodes.cpp/tokens.cpp/undos.cpp/accounts.cpp !!!
 const unsigned char CUndosView::ByUndoKey::prefix = 'u';
 
-void CUndosView::ForEachUndo(std::function<bool(UndoKey, CLazySerialize<CUndo>)> callback, UndoKey const & start)
+void CUndosView::ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback, UndoKey const & start)
 {
     ForEach<ByUndoKey, UndoKey, CUndo>(callback, start);
 }
 
-Res CUndosView::SetUndo(UndoKey key, CUndo const & undo)
+Res CUndosView::SetUndo(UndoKey const & key, CUndo const & undo)
 {
     WriteBy<ByUndoKey>(key, undo);
     return Res::Ok();
 }
 
-Res CUndosView::DelUndo(UndoKey key)
+Res CUndosView::DelUndo(UndoKey const & key)
 {
     EraseBy<ByUndoKey>(key);
     return Res::Ok();
 }
 
-boost::optional<CUndo> CUndosView::GetUndo(UndoKey key) const
+boost::optional<CUndo> CUndosView::GetUndo(UndoKey const & key) const
 {
     CUndo val;
     bool ok = ReadBy<ByUndoKey>(key, val);

--- a/src/masternodes/undos.h
+++ b/src/masternodes/undos.h
@@ -11,11 +11,11 @@
 
 class CUndosView : public virtual CStorageView {
 public:
-    void ForEachUndo(std::function<bool(UndoKey, CLazySerialize<CUndo>)> callback, UndoKey const & start = {});
+    void ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback, UndoKey const & start = {});
 
-    boost::optional<CUndo> GetUndo(UndoKey key) const;
-    Res SetUndo(UndoKey key, CUndo const & undo);
-    Res DelUndo(UndoKey key);
+    boost::optional<CUndo> GetUndo(UndoKey const & key) const;
+    Res SetUndo(UndoKey const & key, CUndo const & undo);
+    Res DelUndo(UndoKey const & key);
 
     // tags
     struct ByUndoKey { static const unsigned char prefix; };

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -242,10 +242,7 @@ BOOST_AUTO_TEST_CASE(math_liquidity_and_trade)
 
 void SetPoolRewardPct(CCustomCSView & mnview, DCT_ID idPool, CAmount pct)
 {
-    auto optPool = mnview.GetPoolPair(idPool);
-    BOOST_REQUIRE(optPool);
-    optPool->rewardPct = pct;
-    mnview.SetPoolPair(idPool, 1, *optPool);
+    BOOST_REQUIRE(mnview.SetRewardPct(idPool, 1, pct));
 }
 
 void SetPoolTradeFees(CCustomCSView & mnview, DCT_ID idPool, CAmount A, CAmount B)
@@ -274,7 +271,7 @@ BOOST_AUTO_TEST_CASE(math_rewards)
 
     }
     // create shares
-    mnview.ForEachPoolPair([&] (DCT_ID const & idPool, CLazySerialize<CPoolPair>) {
+    mnview.ForEachPoolId([&] (DCT_ID const & idPool) {
 //            printf("pool id = %s\n", idPool.ToString().c_str());
         for (int i = 0; i < ProvidersCount; ++i) {
             CScript shareAddress = CScript(idPool.v * ProvidersCount + i);
@@ -303,7 +300,7 @@ BOOST_AUTO_TEST_CASE(math_rewards)
         /// DCT_ID{10} - 0
 
         // set "traded fees" here too, just to estimate proc.load
-        cache.ForEachPoolPair([&] (DCT_ID const & idPool, CLazySerialize<CPoolPair>) {
+        cache.ForEachPoolId([&] (DCT_ID const & idPool) {
             SetPoolTradeFees(cache, idPool, idPool.v * COIN, idPool.v * COIN*2);
             return true;
         });
@@ -373,7 +370,7 @@ BOOST_AUTO_TEST_CASE(owner_rewards)
     }
 
     // create shares
-    mnview.ForEachPoolPair([&] (DCT_ID const & idPool, CLazySerialize<CPoolPair>) {
+    mnview.ForEachPoolId([&] (DCT_ID const & idPool) {
         for (int i = 0; i < PoolCount; ++i) {
             Res res = AddPoolLiquidity(mnview, idPool, idPool.v*COIN, idPool.v*COIN, shareAddress[i]);
             BOOST_CHECK(res.ok);
@@ -382,12 +379,12 @@ BOOST_AUTO_TEST_CASE(owner_rewards)
     });
 
     mnview.ForEachPoolPair([&] (DCT_ID const & idPool, CPoolPair pool) {
-        pool.rewardPct = COIN/(idPool.v + 1);
         pool.blockCommissionA = idPool.v * COIN;
         pool.blockCommissionB = idPool.v * COIN * 2;
         pool.swapEvent = true;
         pool.ownerAddress = shareAddress[0];
         mnview.SetPoolPair(idPool, 1, pool);
+        mnview.SetRewardPct(idPool, 1, COIN/(idPool.v + 1));
         return true;
     });
 

--- a/test/functional/feature_poolpair.py
+++ b/test/functional/feature_poolpair.py
@@ -102,7 +102,7 @@ class PoolPairTest (DefiTestFramework):
         }, [])
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Error, there is already a poolpairwith same tokens, but different poolId" in errorString)
+        assert("Error, there is already a poolpair with same tokens, but different poolId" in errorString)
 
         # Creating another one
         trPP = self.nodes[0].createpoolpair({


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It aims to minimize undo storage data by preventing entire pool pair data structure serialize

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/cakedefi/defichain-private/issues/603
