### PR TITLE
Update build and client versions

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -39,12 +39,12 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
     git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
 fi
 
-if [ -n "$DESC" ]; then
+if [ -n "$BUILD_VERSION" ]; then
+    NEWINFO="#define BUILD_DESC \"$BUILD_VERSION\""
+elif [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""
 elif [ -n "$SUFFIX" ]; then
     NEWINFO="#define BUILD_SUFFIX $SUFFIX"
-elif [ -n "$BUILD_VERSION" ]; then
-    NEWINFO="#define BUILD_DESC \"$BUILD_VERSION\""
 else
     NEWINFO="// No build information available"
 fi

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -13,7 +13,7 @@
  * for both defid and defi-qt, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("Satoshi");
+const std::string CLIENT_NAME("Defichain");
 
 /**
  * Client version number


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It change order of version deduction to prefer specified build version over git one
Specify client to Defichain

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/cakedefi/defichain-private/issues/486
