### PR TITLE
spv_listreceivedbyaddress

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -227,6 +227,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "spv_listanchors", 3, "maxConfs" },
     { "spv_sendtoaddress", 1, "amount" },
     { "spv_sendtoaddress", 2, "feerate" },
+    { "spv_listreceivedbyaddress", 0, "minconf" },
 
     { "createpoolpair", 0, "metadata" },
     { "createpoolpair", 1, "inputs" },

--- a/src/spv/bitcoin/BRWallet.cpp
+++ b/src/spv/bitcoin/BRWallet.cpp
@@ -182,18 +182,27 @@ static int _BRWalletContainsTx(BRWallet *wallet, const BRTransaction *tx)
     return r;
 }
 
-static int _BRWalletContainsUserTx(BRWallet *wallet, const BRTransaction *tx, const bool htlc = false)
+static int _BRWalletContainsUserTx(BRWallet *wallet, const BRTransaction *tx, const UInt160& addressFilter = UINT160_ZERO, const bool htlc = false)
 {
     int r = 0;
     const uint8_t *pkh;
+    const bool filterOnAddress = !UInt160Eq(UINT160_ZERO, addressFilter);
 
     for (size_t i = 0; ! r && i < tx->outCount; i++) {
         pkh = BRScriptPKH(tx->outputs[i].script, tx->outputs[i].scriptLen);
         if (pkh) {
             UInt160 hash160;
             UIntConvert(pkh, hash160);
-            if (wallet->userPKH->count(hash160)) r = 1;
-            if (htlc && wallet->htlcPKH->count(hash160)) r = 1;
+            if (BRWalletIsMine(wallet, hash160, htlc) != SPVTxType::None)
+            {
+                // Check if result matches address filter
+                if (filterOnAddress && !UInt160Eq(addressFilter, hash160))
+                {
+                    continue;
+                }
+
+                r = 1;
+            }
         }
     }
 
@@ -205,8 +214,16 @@ static int _BRWalletContainsUserTx(BRWallet *wallet, const BRTransaction *tx, co
         if (pkh) {
             UInt160 hash160;
             UIntConvert(pkh, hash160);
-            if (wallet->userPKH->count(hash160)) r = 1;
-            if (htlc && wallet->htlcPKH->count(hash160)) r = 1;
+            if (BRWalletIsMine(wallet, hash160, htlc) != SPVTxType::None)
+            {
+                // Check if result matches address filter
+                if (filterOnAddress && !UInt160Eq(addressFilter, hash160))
+                {
+                    continue;
+                }
+
+                r = 1;
+            }
         }
     }
 
@@ -308,16 +325,16 @@ bool BRWalletTxSpent(BRWallet *wallet, const BRTransaction *tx, const uint32_t o
     return false;
 }
 
-std::set<std::string> BRListUserTransactions(BRWallet *wallet)
+std::set<const BRTransaction*> BRListUserTransactions(BRWallet *wallet, const UInt160& addr)
 {
-    std::set<std::string> userTransactions;
+    std::set<const BRTransaction*> userTransactions;
     BRTransaction *tx;
 
     for (size_t i = 0; i < array_count(wallet->transactions); ++i) {
         tx = wallet->transactions[i];
 
-        if (_BRWalletContainsUserTx(wallet, tx, true /* HTLC */)) {
-            userTransactions.insert(to_uint256(tx->txHash).ToString());
+        if (_BRWalletContainsUserTx(wallet, tx, addr, true /* HTLC */)) {
+            userTransactions.insert(tx);
         }
     }
 
@@ -1554,6 +1571,21 @@ uint64_t BRWalletMaxOutputAmount(BRWallet *wallet)
     wallet->lock.unlock();
 
     return (amount > fee) ? amount - fee : 0;
+}
+
+SPVTxType BRWalletIsMine(BRWallet *wallet, const UInt160 &hash160, const bool htlc)
+{
+    if (wallet->userPKH->count(hash160))
+    {
+        return SPVTxType::Bech32;
+    }
+
+    if (htlc && wallet->htlcPKH->count(hash160))
+    {
+        return SPVTxType::HTLC;
+    }
+
+    return SPVTxType::None;
 }
 
 static void _setApplyFreeTx(void *info, void *tx)

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -37,6 +37,12 @@
 // Convert SPV UInt256 to Bitcoin uint256
 uint256 to_uint256(UInt256 const & i);
 
+enum class SPVTxType {
+    None,
+    HTLC,
+    Bech32
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -229,11 +235,14 @@ int64_t BRBitcoinAmount(int64_t localAmount, double price);
 }
 #endif
 
+// Whether an address belongs to the user
+SPVTxType BRWalletIsMine(BRWallet *wallet, const UInt160& hash160, const bool htlc);
+
 // Get HTLC secret for contract address.
 std::string BRGetHTLCSeed(BRWallet *wallet, const uint8_t *md20);
 
 // Returns a set of all user related TXIDs.
-std::set<std::string> BRListUserTransactions(BRWallet *wallet);
+std::set<const BRTransaction *> BRListUserTransactions(BRWallet *wallet, const UInt160& addr = UINT160_ZERO);
 
 // Returns a vector of all HTLC relates transactions
 std::vector<std::pair<BRTransaction *, size_t> > BRListHTLCReceived(BRWallet *wallet, const UInt160 &addr);

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -1321,6 +1321,59 @@ static UniValue spv_getrawtransaction(const JSONRPCRequest& request)
     return spv::pspv->GetRawTransactions(hash);
 }
 
+static UniValue spv_listreceivedbyaddress(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_listreceivedbyaddress",
+        "\nList balances by receiving address.\n",
+        {
+            {"minconf", RPCArg::Type::NUM, /* default */ "1", "The minimum number of confirmations before payments are included."},
+            {"address_filter", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "If present, only return information on this address."},
+        },
+        RPCResult{
+            "[\n"
+            "  {\n"
+            "    \"address\" : \"receivingaddress\",  (string) The receiving address\n"
+            "    \"type\" : \"type\",                 (string) Address type, Bech32 or HTLC\n"
+            "    \"amount\" : x.xxx,                  (numeric) The total amount in BTC received by the address\n"
+            "    \"confirmations\" : n,               (numeric) The number of confirmations of the most recent transaction included\n"
+            "    \"txids\": [\n"
+            "       \"txid\",                         (string) The ids of transactions received with the address \n"
+            "       ...\n"
+            "    ]\n"
+            "  }\n"
+            "  ,...\n"
+            "]\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_listreceivedbyaddress", "")
+            + HelpExampleCli("spv_listreceivedbyaddress", "6")
+            + HelpExampleRpc("spv_listreceivedbyaddress", "6")
+            + HelpExampleRpc("spv_listreceivedbyaddress", "6, \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\"")
+        },
+    }.Check(request);
+
+    if (!spv::pspv)
+    {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    // Minimum confirmations
+    int nMinDepth = 1;
+    if (!request.params[0].isNull())
+    {
+        nMinDepth = request.params[0].get_int();
+    }
+
+    // Address filter
+    std::string address;
+    if (!request.params[1].isNull())
+    {
+        address = request.params[1].get_str();
+    }
+
+    return spv::pspv->ListReceived(nMinDepth, address);
+}
+
 
 static const CRPCCommand commands[] =
 { //  category          name                        actor (function)            params
@@ -1351,6 +1404,7 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_listhtlcoutputs",        &spv_listhtlcoutputs,       { "address" }  },
   { "spv",      "spv_decodehtlcscript",       &spv_decodehtlcscript,      { "redeemscript" }  },
   { "spv",      "spv_gethtlcseed",            &spv_gethtlcseed,           { "address" }  },
+  { "spv",      "spv_listreceivedbyaddress",  &spv_listreceivedbyaddress, { "minconf", "address_filter" }  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
   { "hidden",   "spv_fundaddress",            &spv_fundaddress,           { "address" }  },
 };

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -43,6 +43,8 @@ class CScript;
 class CWallet;
 class UniValue;
 
+enum class SPVTxType;
+
 extern const int ENOSPV;
 extern const int EPARSINGTX;
 extern const int ETXNOTSIGNED;
@@ -138,17 +140,22 @@ public:
     std::string AddBitcoinAddress(const CPubKey &new_key);
     void AddBitcoinHash(const uint160 &userHash, const bool htlc = false);
     std::string DumpBitcoinPrivKey(const CWallet* pwallet, const std::string &strAddress);
-    int64_t GetBitcoinBalance();
-    virtual UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount, uint64_t feeRate);
-    UniValue ListTransactions();
-    UniValue GetHTLCReceived(const std::string &addr);
-    std::string GetRawTransactions(uint256& hash);
-    void RebuildBloomFilter();
     UniValue GetAddressPubkey(const CWallet *pwallet, const char *addr); // Used in HTLC creation
     CKeyID GetAddressKeyID(const char *addr);
+    SPVTxType IsMine(const char *address);
+
+    // Bitcoin Transaction related calls
+    int64_t GetBitcoinBalance();
+    std::string GetRawTransactions(uint256& hash);
+    UniValue ListTransactions();
+    UniValue ListReceived(int nMinDepth, std::string address);
+    void RebuildBloomFilter();
+    virtual UniValue SendBitcoins(CWallet* const pwallet, std::string address, int64_t amount, uint64_t feeRate);
+
+    // Bitcoin HTLC calls
+    UniValue GetHTLCReceived(const std::string &addr);
     std::string GetHTLCSeed(uint8_t* md20);
     UniValue CreateHTLCTransaction(CWallet* const pwallet, const char *scriptAddress, const char *destinationAddress, const std::string& seed, uint64_t feerate, bool seller);
-    uint64_t GetFeeRate();
 
 private:
     virtual void OnSendRawTx(BRTransaction * tx, std::promise<int> * promise);


### PR DESCRIPTION
Add spv_listreceivedbyaddress to the RPC interface. Shows type to allow app devs to filter out HTLC transactions.

```
defi-cli  -testnet spv_listreceivedbyaddress 0 tb1q5fuenp978svm2fckmmhqun9tg43agnkgr69yn9
[
  {
    "address": "tb1q5fuenp978svm2fckmmhqun9tg43agnkgr69yn9",
    "type": "Bech32",
    "amount": 0.00102546,
    "confirmations": 0,
    "txids": [
      "ac9c0897350f5becfe536af7ded35b9f0d88a52e6bfabaf5610f3aec45415488",
      "7e00775c8096ae0323b62c5d46a0b4fba48105e259e7b17da7c39100c3a564cc",
      "a2210fc25be6ff1ff4ba555254d36ebb4378b677da4d0f796db88fa1cfc5bbf0",
      "5452c0acbda3c7102462853c353d772ec529ee5cd23af9bd2a46325fd9285283"
    ]
  }
]
```
```
./defi-cli  -testnet spv_listreceivedbyaddress 2192 2MvtvXEYyv42jdjyxFCPwjiB35BKVmHVQHS
[
  {
    "address": "2MvtvXEYyv42jdjyxFCPwjiB35BKVmHVQHS",
    "type": "HTLC",
    "amount": 0.00050000,
    "confirmations": 2193,
    "txids": [
      "38e32154d7fe1ba4451ea997e81ac33607c3d3bb974180bd16de20e61fd30f1b",
      "0952467f7e021ae73610d8e8e04d26aa12cf859fe78d3fe582fbb572292aad32",
      "83492525b9aea3559e62287e9d40c32f7ed7eac594269da266192c22484dca67",
      "f20e918dd7a0d2a2d1b196b7f583555e177ad30d636125ba0b835383aaa512a9",
      "d7a7ca9432aa9b8c37936ecc6c3d07afc459b9078353e3cd1937dd77121cd4b1"
    ]
  }
]
```