### PR TITLE
Make account history own database

### DIFF
--- a/src/flushablestorage.h
+++ b/src/flushablestorage.h
@@ -59,6 +59,7 @@ public:
     virtual bool Read(const TBytes& key, TBytes& value) const = 0;
     virtual std::unique_ptr<CStorageKVIterator> NewIterator() = 0;
     virtual size_t SizeEstimate() const = 0;
+    virtual void Discard() = 0;
     virtual bool Flush() = 0;
 };
 
@@ -152,6 +153,11 @@ public:
         end.clear();
         begin.clear();
         return result;
+    }
+    void Discard() override {
+        end.clear();
+        begin.clear();
+        batch.Clear();
     }
     size_t SizeEstimate() const override {
         return batch.SizeEstimate();
@@ -299,6 +305,9 @@ public:
         }
         changed.clear();
         return true;
+    }
+    void Discard() override {
+        changed.clear();
     }
     size_t SizeEstimate() const override {
         return memusage::DynamicUsage(changed);
@@ -478,7 +487,7 @@ public:
     }
 
     bool Flush() { return DB().Flush(); }
-
+    void Discard() { DB().Discard(); }
     size_t SizeEstimate() const { return DB().SizeEstimate(); }
 
 protected:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1600,6 +1600,12 @@ bool AppInitMain(InitInterfaces& interfaces)
                 // Ensure we are on latest DB version
                 pcustomcsview->SetDbVersion(CCustomCSView::DbVersion);
 
+                // make account history db
+                paccountHistoryDB.reset();
+                if (gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX)) {
+                    paccountHistoryDB = MakeUnique<CAccountHistoryStorage>(GetDataDir() / "history", nCustomCacheSize, false, fReset || fReindexChainState);
+                }
+
                 // If necessary, upgrade from older database format.
                 // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 if (!::ChainstateActive().CoinsDB().Upgrade()) {

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -7,9 +7,7 @@
 #include <masternodes/masternodes.h>
 #include <key_io.h>
 
-#include <limits>
-
-/// @attention make sure that it does not overlap with those in masternodes.cpp/tokens.cpp/undos.cpp/accounts.cpp !!!
+/// @Note it's in own database
 const unsigned char CAccountsHistoryView::ByAccountHistoryKey::prefix = 'h';
 
 void CAccountsHistoryView::ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start)
@@ -17,8 +15,85 @@ void CAccountsHistoryView::ForEachAccountHistory(std::function<bool(AccountHisto
     ForEach<ByAccountHistoryKey, AccountHistoryKey, AccountHistoryValue>(callback, start);
 }
 
-Res CAccountsHistoryView::SetAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
+Res CAccountsHistoryView::WriteAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
 {
     WriteBy<ByAccountHistoryKey>(key, value);
     return Res::Ok();
 }
+
+Res CAccountsHistoryView::EraseAccountHistory(const AccountHistoryKey& key)
+{
+    EraseBy<ByAccountHistoryKey>(key);
+    return Res::Ok();
+}
+
+CAccountHistoryStorage::CAccountHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
+    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe))
+{
+}
+
+CAccountsHistoryWriter::CAccountsHistoryWriter(CCustomCSView & storage, uint32_t height, uint32_t txn, const uint256& txid, uint8_t type, CAccountsHistoryView* historyView)
+    : CStorageView(new CFlushableStorageKV(storage.GetRaw())), height(height), txn(txn), txid(txid), type(type), historyView(historyView)
+{
+}
+
+Res CAccountsHistoryWriter::AddBalance(CScript const & owner, CTokenAmount amount)
+{
+    auto res = CCustomCSView::AddBalance(owner, amount);
+    if (historyView && res.ok && amount.nValue != 0) {
+        diffs[owner][amount.nTokenId] += amount.nValue;
+    }
+    return res;
+}
+
+Res CAccountsHistoryWriter::SubBalance(CScript const & owner, CTokenAmount amount)
+{
+    auto res = CCustomCSView::SubBalance(owner, amount);
+    if (historyView && res.ok && amount.nValue != 0) {
+        diffs[owner][amount.nTokenId] -= amount.nValue;
+    }
+    return res;
+}
+
+bool CAccountsHistoryWriter::Flush()
+{
+    if (historyView) {
+        for (const auto& diff : diffs) {
+            historyView->WriteAccountHistory({diff.first, height, txn}, {txid, type, diff.second});
+        }
+    }
+    return CCustomCSView::Flush();
+}
+
+CAccountsHistoryEraser::CAccountsHistoryEraser(CCustomCSView & storage, uint32_t height, uint32_t txn, CAccountsHistoryView* historyView)
+    : CStorageView(new CFlushableStorageKV(storage.GetRaw())), height(height), txn(txn), historyView(historyView)
+{
+}
+
+Res CAccountsHistoryEraser::AddBalance(CScript const & owner, CTokenAmount)
+{
+    if (historyView) {
+        accounts.insert(owner);
+    }
+    return Res::Ok();
+}
+
+Res CAccountsHistoryEraser::SubBalance(CScript const & owner, CTokenAmount)
+{
+    if (historyView) {
+        accounts.insert(owner);
+    }
+    return Res::Ok();
+}
+
+bool CAccountsHistoryEraser::Flush()
+{
+    if (historyView) {
+        for (const auto& account : accounts) {
+            historyView->EraseAccountHistory({account, height, txn});
+        }
+    }
+    return CCustomCSView::Flush();
+}
+
+std::unique_ptr<CAccountHistoryStorage> paccountHistoryDB;

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -768,40 +768,6 @@ bool CCustomCSView::CalculateOwnerRewards(CScript const & owner, uint32_t target
     return UpdateBalancesHeight(owner, targetHeight);
 }
 
-CAccountsHistoryStorage::CAccountsHistoryStorage(CCustomCSView & storage, uint32_t height, uint32_t txn, const uint256& txid, uint8_t type)
-    : CStorageView(new CFlushableStorageKV(storage.GetRaw())), height(height), txn(txn), txid(txid), type(type)
-{
-    acindex = gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX);
-}
-
-Res CAccountsHistoryStorage::AddBalance(CScript const & owner, CTokenAmount amount)
-{
-    auto res = CCustomCSView::AddBalance(owner, amount);
-    if (acindex && res.ok && amount.nValue != 0) {
-        diffs[owner][amount.nTokenId] += amount.nValue;
-    }
-    return res;
-}
-
-Res CAccountsHistoryStorage::SubBalance(CScript const & owner, CTokenAmount amount)
-{
-    auto res = CCustomCSView::SubBalance(owner, amount);
-    if (acindex && res.ok && amount.nValue != 0) {
-        diffs[owner][amount.nTokenId] -= amount.nValue;
-    }
-    return res;
-}
-
-bool CAccountsHistoryStorage::Flush()
-{
-    if (acindex) {
-        for (const auto& diff : diffs) {
-            SetAccountHistory({diff.first, height, txn}, {txid, type, diff.second});
-        }
-    }
-    return CCustomCSView::Flush();
-}
-
 std::map<CKeyID, CKey> AmISignerNow(CAnchorData::CTeam const & team)
 {
     AssertLockHeld(cs_main);

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -10,7 +10,6 @@
 #include <pubkey.h>
 #include <serialize.h>
 #include <masternodes/accounts.h>
-#include <masternodes/accountshistory.h>
 #include <masternodes/anchors.h>
 #include <masternodes/incentivefunding.h>
 #include <masternodes/tokens.h>
@@ -240,7 +239,6 @@ class CCustomCSView
         , public CAnchorRewardsView
         , public CTokensView
         , public CAccountsView
-        , public CAccountsHistoryView
         , public CCommunityBalancesView
         , public CUndosView
         , public CPoolPairView
@@ -284,21 +282,6 @@ public:
     CStorageKV& GetRaw() {
         return DB();
     }
-};
-
-class CAccountsHistoryStorage : public CCustomCSView
-{
-    bool acindex;
-    const uint32_t height;
-    const uint32_t txn;
-    const uint256 txid;
-    const uint8_t type;
-    std::map<CScript, TAmounts> diffs;
-public:
-    CAccountsHistoryStorage(CCustomCSView & storage, uint32_t height, uint32_t txn, const uint256& txid, uint8_t type);
-    Res AddBalance(CScript const & owner, CTokenAmount amount) override;
-    Res SubBalance(CScript const & owner, CTokenAmount amount) override;
-    bool Flush();
 };
 
 std::map<CKeyID, CKey> AmISignerNow(CAnchorData::CTeam const & team);

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -19,6 +19,7 @@ class CTxMemPool;
 class CCoinsViewCache;
 
 class CCustomCSView;
+class CAccountsHistoryView;
 
 static const std::vector<unsigned char> DfTxMarker = {'D', 'f', 'T', 'x'};  // 44665478
 
@@ -209,9 +210,9 @@ CCustomTxMessage customTypeToMessage(CustomTxType txType);
 bool IsMempooledCustomTxCreate(const CTxMemPool& pool, const uint256& txid);
 Res RpcInfo(const CTransaction& tx, uint32_t height, CustomTxType& type, UniValue& results);
 Res CustomMetadataParse(uint32_t height, const Consensus::Params& consensus, const std::vector<unsigned char>& metadata, CCustomTxMessage& txMessage);
-Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height, uint64_t time = 0, uint32_t txn = 0);
+Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height, uint64_t time = 0, uint32_t txn = 0, CAccountsHistoryView* historyView = nullptr);
+Res RevertCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height, uint32_t txn = 0, CAccountsHistoryView* historyView = nullptr);
 Res CustomTxVisit(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, uint32_t height, const Consensus::Params& consensus, const CCustomTxMessage& txMessage, uint64_t time = 0);
-Res RevertCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height);
 ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView& mnview, const CTransaction& tx, int height, const uint256& prevStakeModifier, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
 ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView& mnview, const CTransaction& tx, int height, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
 

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1,3 +1,4 @@
+#include <masternodes/accountshistory.h>
 #include <masternodes/mn_rpc.h>
 
 std::string tokenAmountString(CTokenAmount const& amount) {
@@ -880,9 +881,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         accounts = request.params[0].getValStr();
     }
 
-    const auto acindex = gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX);
-
-    if (!acindex) {
+    if (!paccountHistoryDB) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "-acindex is needed for account history");
     }
 
@@ -1036,7 +1035,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
     };
 
     AccountHistoryKey startKey{account, maxBlockHeight, std::numeric_limits<uint32_t>::max()};
-    view.ForEachAccountHistory(shouldContinueToNextAccountHistory, startKey);
+    paccountHistoryDB->ForEachAccountHistory(shouldContinueToNextAccountHistory, startKey);
 
     if (shouldSearchInWallet) {
         count = limit;
@@ -1094,9 +1093,7 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
         accounts = request.params[0].getValStr();
     }
 
-    const auto acindex = gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX);
-
-    if (!acindex) {
+    if (!paccountHistoryDB) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "-acindex is need for account history");
     }
 
@@ -1203,7 +1200,7 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
     };
 
     AccountHistoryKey startAccountKey{owner, currentHeight, std::numeric_limits<uint32_t>::max()};
-    view.ForEachAccountHistory(shouldContinueToNextAccountHistory, startAccountKey);
+    paccountHistoryDB->ForEachAccountHistory(shouldContinueToNextAccountHistory, startAccountKey);
 
     if (shouldSearchInWallet) {
         searchInWallet(pwallet, owner, filter,

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -440,31 +440,4 @@ BOOST_AUTO_TEST_CASE(LowerBoundTest)
     }
 }
 
-BOOST_AUTO_TEST_CASE(AccountHistoryDescOrderTest)
-{
-    CCustomCSView view(*pcustomcsview);
-
-    view.SetAccountHistory({ {}, 5021, 0 }, {});
-    view.SetAccountHistory({ {}, 5022, 1 }, {});
-    view.SetAccountHistory({ {}, 5023, 2 }, {});
-    view.SetAccountHistory({ {}, 5024, 3 }, {});
-    view.SetAccountHistory({ {}, 5025, 4 }, {});
-    view.SetAccountHistory({ {}, 5026, 5 }, {});
-
-    uint32_t startBlock = 5021; // exclude
-    uint32_t maxBlockHeight = 5025;
-    auto blockCount = maxBlockHeight;
-
-    view.ForEachAccountHistory([&](AccountHistoryKey const & key, AccountHistoryValue) {
-        if (startBlock > key.blockHeight || key.blockHeight > maxBlockHeight) {
-            return true;
-        }
-
-        BOOST_CHECK_EQUAL(blockCount, key.blockHeight);
-        --blockCount;
-
-        return true;
-    }, { {}, maxBlockHeight, std::numeric_limits<uint32_t>::max() });
-}
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

/kind feature

#### What this PR does / why we need it:

Account history is optional feature it should not be part of blockchain directory, it will limit memory usage since it's flushed on every block.

Fixes https://github.com/cakedefi/defichain-private/issues/604