### PR TITLE
Native CORS support for defichain

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -205,6 +205,9 @@ static std::string RequestMethodString(HTTPRequest::RequestMethod m)
     case HTTPRequest::PUT:
         return "PUT";
         break;
+    case HTTPRequest::OPTIONS:
+        return "OPTIONS";
+        break;
     default:
         return "unknown";
     }
@@ -386,9 +389,14 @@ bool InitHTTPServer()
         return false;
     }
 
+    // Defaults + OPTIONS
+    auto allowed_methods = EVHTTP_REQ_GET | EVHTTP_REQ_HEAD | EVHTTP_REQ_POST;
+    allowed_methods |= EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS;
+
     evhttp_set_timeout(http, gArgs.GetArg("-rpcservertimeout", DEFAULT_HTTP_SERVER_TIMEOUT));
     evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
     evhttp_set_max_body_size(http, MAX_DESER_SIZE);
+    evhttp_set_allowed_methods(http, allowed_methods);
     evhttp_set_gencb(http, http_request_cb, nullptr);
 
     if (!HTTPBindAddresses(http)) {
@@ -631,6 +639,9 @@ HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod() const
         break;
     case EVHTTP_REQ_PUT:
         return PUT;
+        break;
+    case EVHTTP_REQ_OPTIONS:
+        return OPTIONS;
         break;
     default:
         return UNKNOWN;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -69,7 +69,8 @@ public:
         GET,
         POST,
         HEAD,
-        PUT
+        PUT,
+        OPTIONS,
     };
 
     /** Get requested URI.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -581,6 +581,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcallowcors=<host>", "Allow CORS requests from the given host origin. Include scheme and port (eg: -rpcallowcors=http://127.0.0.1:5000)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -10,6 +10,7 @@
 enum HTTPStatusCode
 {
     HTTP_OK                    = 200,
+    HTTP_NO_CONTENT            = 204,
     HTTP_BAD_REQUEST           = 400,
     HTTP_UNAUTHORIZED          = 401,
     HTTP_FORBIDDEN             = 403,

--- a/test/functional/interface_http_cors.py
+++ b/test/functional/interface_http_cors.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC HTTP CORS."""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import assert_equal, str_to_b64str
+
+import http.client
+import urllib.parse
+
+class HTTPCorsTest (DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.cors_origin = "http://localhost:8000"
+        self.extra_args = [["-rpcallowcors=" + self.cors_origin]]
+
+    def run_test(self):
+
+        url = urllib.parse.urlparse(self.nodes[0].url)
+        authpair = url.username + ':' + url.password
+
+        #same should be if we add keep-alive because this should be the std. behaviour
+        headers = {"Authorization": "Basic " + str_to_b64str(authpair), "Connection": "keep-alive"}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        res = conn.getresponse()
+        self.check_cors_headers(res)
+        assert_equal(res.status, http.client.OK)
+        res.close()
+
+
+        conn.request('OPTIONS', '/', '{"method": "getbestblockhash"}', headers)
+        res = conn.getresponse()
+        self.check_cors_headers(res)
+        assert_equal(res.status, http.client.NO_CONTENT)
+        res.close()
+
+    def check_cors_headers(self, res):
+        assert_equal(res.getheader("Access-Control-Allow-Origin"), self.cors_origin)
+        assert_equal(res.getheader("Access-Control-Allow-Credentials"), "true")
+        assert_equal(res.getheader("Access-Control-Allow-Methods"), "POST, GET, OPTIONS")
+        assert_equal(res.getheader("Access-Control-Allow-Headers"), "Content-Type, Authorization")
+
+
+if __name__ == '__main__':
+    HTTPCorsTest ().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -164,6 +164,7 @@ BASE_SCRIPTS = [
     'feature_mine_cached.py',
     'feature_mempool_dakota.py',
     'interface_http.py',
+    'interface_http_cors.py',
     'interface_rpc.py',
     'rpc_psbt.py',
     'rpc_users.py',


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

## What kind of PR is this?:

/kind feature

## What this PR does / why we need it:

This adds native support for CORS for the RPC API. 

This enables the following:
- Allows whitelisting communication from browser, only for the specific given origins. 
- Ability to build web based apps that can use the RPC API when explicitly specified

## Details

This adds the following flags to defid:

```
-rpcallowcors=<host> Allow CORS requests from the given host origin. 
Include scheme and port (eg: -rpcallowcors=http://127.0.0.1:5000)
```

When the defid is executed with, for instance: `defid -rpcallowcors=http://127.0.0.1:5000`

This PR adds CORS support that's needed by modern browsers to allow the specific origin to communicate with node directly. 

Note: Using wildcards for Origin `*` is *NOT* supported, since this also sets up the `Allow-Credentials` flag that according to RFC requires that the the origin is explicit. 

This enables scenarios like https://github.com/DeFiCh/app/pull/766 natively with defichain without the need for proxies that often complicates end to end security.

Example:  

![Screenshot from 2021-04-18 18-43-52](https://user-images.githubusercontent.com/559409/115147102-0461c200-a077-11eb-8a91-33a4c0734b60.png)

![Screenshot from 2021-04-18 18-57-01](https://user-images.githubusercontent.com/559409/115147325-08daaa80-a078-11eb-85af-8ba1745d06d8.png)

