### PR TITLE
spv_validateaddress

### DIFF
--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -1374,6 +1374,35 @@ static UniValue spv_listreceivedbyaddress(const JSONRPCRequest& request)
     return spv::pspv->ListReceived(nMinDepth, address);
 }
 
+static UniValue spv_validateaddress(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_validateaddress",
+        "\nCheck whether the given Bitcoin address is valid.\n",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Bitcoin address to validate"},
+        },
+        RPCResult{
+            "{\n"
+            "  \"isvalid\" : true|false,       (boolean) If the address is valid or not.\n"
+            "}\n"
+        },
+        RPCExamples{
+            HelpExampleCli("spv_validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
+            + HelpExampleRpc("spv_validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
+        },
+    }.Check(request);
+
+    if (!spv::pspv)
+    {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    const auto isValid = spv::pspv->ValidateAddress(request.params[0].get_str().c_str());
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("isvalid", isValid);
+    return ret;
+}
+
 
 static const CRPCCommand commands[] =
 { //  category          name                        actor (function)            params
@@ -1405,6 +1434,7 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_decodehtlcscript",       &spv_decodehtlcscript,      { "redeemscript" }  },
   { "spv",      "spv_gethtlcseed",            &spv_gethtlcseed,           { "address" }  },
   { "spv",      "spv_listreceivedbyaddress",  &spv_listreceivedbyaddress, { "minconf", "address_filter" }  },
+  { "spv",      "spv_validateaddress",        &spv_validateaddress,       { "address"}  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
   { "hidden",   "spv_fundaddress",            &spv_fundaddress,           { "address" }  },
 };

--- a/src/spv/spv_wrapper.cpp
+++ b/src/spv/spv_wrapper.cpp
@@ -1040,6 +1040,10 @@ SPVTxType CSpvWrapper::IsMine(const char *address)
     return BRWalletIsMine(wallet, addressFilter, true);
 }
 
+bool CSpvWrapper::ValidateAddress(const char *address)
+{
+    return BRAddressIsValid(address);
+}
 
 void publishedTxCallback(void *info, int error)
 {

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -143,6 +143,7 @@ public:
     UniValue GetAddressPubkey(const CWallet *pwallet, const char *addr); // Used in HTLC creation
     CKeyID GetAddressKeyID(const char *addr);
     SPVTxType IsMine(const char *address);
+    bool ValidateAddress(const char *address);
 
     // Bitcoin Transaction related calls
     int64_t GetBitcoinBalance();


### PR DESCRIPTION
Adds spv_validateaddress to validate Bitcoin addresses.

```
./src/defi-cli -testnet spv_validateaddress 2Mt3sxyF4X9gpbn8EvTaPTGpQuPV9BHnDAq
{
  "isvalid": true
}
```

```
./src/defi-cli -testnet -spv_validateaddress mhNT6ixwdp7ZAXZ54CoNFHCzj5FotYHJTP
{
  "isvalid": true
}
```

```
./src/defi-cli -testnet spv_validateaddress tb1q82nun63mf4c9nl6esr0pnrm8yayx0sg4d835eq
{
  "isvalid": true
}
```

```
./src/defi-cli -testnet spv_validateaddress thisisnotvalid
{
  "isvalid": false
}
```

