### PR TITLE
Correct use of views in anchors

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -625,7 +625,7 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
         CKeyID minter;
         if (pindex->GetBlockHeader().ExtractMinterKey(minter)) {
             LOCK(cs_main);
-            auto id = pcustomcsview->GetMasternodeIdByOperator(minter);
+            auto id = GetMasternodeIdByOperator(minter);
             if (id) {
                 masternodeIDs.insert(*id);
             }
@@ -670,7 +670,7 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
 
     {
         LOCK(cs_main);
-        pcustomcsview->SetAnchorTeams(authTeam, confirmTeam, pindexNew->height);
+        SetAnchorTeams(authTeam, confirmTeam, pindexNew->height);
     }
 
     // Debug logging

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1452,7 +1452,7 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction con
         return Res::ErrDbg("bad-ar-sigs", "anchor signatures are incorrect");
     }
 
-    auto team = pcustomcsview->GetConfirmTeam(height - 1);
+    auto team = mnview.GetConfirmTeam(height - 1);
     if (!team) {
         return Res::ErrDbg("bad-ar-team", "could not get confirm team for height: %d", height - 1);
     }


### PR DESCRIPTION
CalcAnchoringTeams should use its own GetMasternodeIdByOperator and ApplyAnchorRewardTxPlus should use mnview provided.