### PR TITLE
spv_getfeerate. SPV wallet fee filter for HTLC. SPV reset on reindex.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1753,7 +1753,7 @@ bool AppInitMain(InitInterfaces& interfaces)
 
         // Enable the anchors and spv by default
         bool anchorsEnabled = true; 
-        panchors = MakeUnique<CAnchorIndex>(nDefaultDbCache << 20, false, gArgs.GetBoolArg("-spv", anchorsEnabled) && gArgs.GetBoolArg("-spv_resync", false) /*fReset || fReindexChainState*/);
+        panchors = MakeUnique<CAnchorIndex>(nDefaultDbCache << 20, false, gArgs.GetBoolArg("-spv", anchorsEnabled) && gArgs.GetBoolArg("-spv_resync", fReindex || fReindexChainState));
 
         // load anchors after spv due to spv (and spv height) not set before (no last height yet)
         if (gArgs.GetBoolArg("-spv", anchorsEnabled)) {
@@ -1761,9 +1761,9 @@ bool AppInitMain(InitInterfaces& interfaces)
             if (Params().NetworkIDString() == "regtest") {
                 spv::pspv = MakeUnique<spv::CFakeSpvWrapper>();
             } else if (Params().NetworkIDString() == "test" || Params().NetworkIDString() == "devnet") {
-                spv::pspv = MakeUnique<spv::CSpvWrapper>(false, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
+                spv::pspv = MakeUnique<spv::CSpvWrapper>(false, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", fReindex || fReindexChainState));
             } else {
-                spv::pspv = MakeUnique<spv::CSpvWrapper>(true, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", false));
+                spv::pspv = MakeUnique<spv::CSpvWrapper>(true, nMinDbCache << 20, false, gArgs.GetBoolArg("-spv_resync", fReindex || fReindexChainState));
             }
         }
         panchors->Load();

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -153,11 +153,11 @@ void BRWalletSetFeePerKb(BRWallet *wallet, uint64_t feePerKb);
 
 // returns an unsigned transaction that sends the specified amount from the wallet to the given address
 // result must be freed using BRTransactionFree()
-BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr, std::string changeAddress, uint64_t feeRate);
+BRTransaction *BRWalletCreateTransaction(BRWallet *wallet, uint64_t amount, const char *addr, std::string changeAddress, uint64_t feeRate, std::string& errorMsg);
 
 // returns an unsigned transaction that satisifes the given transaction outputs
 // result must be freed using BRTransactionFree()
-BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount, std::string changeAddress, uint64_t feeRate = 0);
+BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput outputs[], size_t outCount, std::string changeAddress, std::string& errorMsg, uint64_t feeRate = 0);
 
 // signs any inputs in tx that can be signed using private keys from the wallet
 // seed is the master private key (wallet seed) corresponding to the master public key given when the wallet was created

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -1415,6 +1415,29 @@ static UniValue spv_getalladdresses(const JSONRPCRequest& request)
     return spv::pspv->GetAllAddress();
 }
 
+static UniValue spv_getfeerate(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"spv_getfeerate",
+               "\nReturns current fee rate in Sats per KB.\n",
+               {
+               },
+               RPCResult{
+                       "nnnn                  (Fee rate)\n"
+               },
+               RPCExamples{
+                       HelpExampleCli("spv_getfeerate", "")
+                       + HelpExampleRpc("spv_getfeerate", "")
+               },
+    }.Check(request);
+
+    if (!spv::pspv)
+    {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "spv module disabled");
+    }
+
+    return spv::pspv->GetFeeRate();
+}
+
 
 static const CRPCCommand commands[] =
 { //  category          name                        actor (function)            params
@@ -1448,6 +1471,7 @@ static const CRPCCommand commands[] =
   { "spv",      "spv_listreceivedbyaddress",  &spv_listreceivedbyaddress, { "minconf", "address_filter" }  },
   { "spv",      "spv_validateaddress",        &spv_validateaddress,       { "address"}  },
   { "spv",      "spv_getalladdresses",        &spv_getalladdresses,       { }  },
+  { "spv",      "spv_getfeerate",             &spv_getfeerate,            { }  },
   { "hidden",   "spv_setlastheight",          &spv_setlastheight,         { "height" }  },
   { "hidden",   "spv_fundaddress",            &spv_fundaddress,           { "address" }  },
 };

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -152,6 +152,7 @@ public:
 
     // Bitcoin Transaction related calls
     int64_t GetBitcoinBalance();
+    uint64_t GetFeeRate();
     std::string GetRawTransactions(uint256& hash);
     UniValue ListTransactions();
     UniValue ListReceived(int nMinDepth, std::string address);


### PR DESCRIPTION
Add call to check fee rate set by fee filter. Use wallet rate in HTLC refund and claim calls if more than fee rate provided. Reset SPV and anchors on reindex.