### PR TITLE
Add docker build to dev builds

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -43,6 +43,24 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
+        
+    # Linux build additionally pushes the docker images to docker hub on successful build
+    - name: Tag dockerhub build
+      if: ${{ github.repository == 'DeFiCh/ain' }}
+      run: >
+        docker tag defichain-x86_64-pc-linux-gnu:${{ env.BUILD_VERSION }}
+        defichain-x86_64-pc-linux-gnu:dockerhub-latest
+    - uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f
+    # Make sure to only build on ain repo. Also add in additional restrictions here if needed to
+    # make sure we don't push unnecessary images to docker
+      if: ${{ github.repository == 'DeFiCh/ain' }}
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        path: ./contrib/dockerfiles/dockerhub
+        dockerfile: ./contrib/dockerfiles/dockerhub/x86_64-pc-linux-gnu.dockerfile
+        repository: defi/defichain
+        tags: latest,${{ env.BUILD_VERSION }}
 
   windows:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -60,7 +60,7 @@ jobs:
         path: ./contrib/dockerfiles/dockerhub
         dockerfile: ./contrib/dockerfiles/dockerhub/x86_64-pc-linux-gnu.dockerfile
         repository: defi/defichain
-        tags: latest,${{ env.BUILD_VERSION }}
+        tags: ${{ env.BUILD_VERSION }}
 
   windows:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

Currently, a docker image is created and pushed on each release.
Jellyfish uses a docker container for hyper parallelized testing. Where multiple containers are spun up continuously for testing. It would be great if each PR in DeFiCh/ain creates a docker image and we can use that for testing.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #362

#### Additional comments?:
