### PR TITLE
HTLC set min timeout

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -380,39 +380,6 @@ CWallet* GetWallet(const JSONRPCRequest& request) {
     return pwallet;
 }
 
-CPubKey PublickeyFromString(const std::string &pubkey)
-{
-    if (!IsHex(pubkey) || (pubkey.length() != 66 && pubkey.length() != 130))
-    {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid public key: " + pubkey);
-    }
-
-    return HexToPubKey(pubkey);
-}
-
-CScript CreateScriptForHTLC(const JSONRPCRequest& request, uint32_t& blocks, std::vector<unsigned char>& image)
-{
-    CPubKey seller_key = PublickeyFromString(request.params[0].get_str());
-    CPubKey refund_key = PublickeyFromString(request.params[1].get_str());
-
-    {
-        UniValue timeout;
-        if (!timeout.read(std::string("[") + request.params[2].get_str() + std::string("]")) || !timeout.isArray() || timeout.size() != 1)
-        {
-            throw JSONRPCError(RPC_TYPE_ERROR, "Error parsing JSON: " + request.params[3].get_str());
-        }
-
-        blocks = timeout[0].get_int();
-    }
-
-    if (blocks >= CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)
-    {
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid block denominated relative timeout");
-    }
-
-    return GetScriptForHTLC(seller_key, refund_key, image, blocks);
-}
-
 UniValue setgov(const JSONRPCRequest& request) {
     CWallet* const pwallet = GetWallet(request);
 

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -73,6 +73,5 @@ std::vector<CTxIn> GetAuthInputsSmart(CWallet* const pwallet, int32_t txVersion,
 std::string ScriptToString(CScript const& script);
 CAccounts GetAllMineAccounts(CWallet* const pwallet);
 CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalances& targetBalances, AccountSelectionMode selectionMode);
-CScript CreateScriptForHTLC(const JSONRPCRequest& request, uint32_t &blocks, std::vector<unsigned char>& image);
 
 #endif // DEFI_MASTERNODES_MN_RPC_H

--- a/test/functional/feature_bitcoin_htlc.py
+++ b/test/functional/feature_bitcoin_htlc.py
@@ -50,6 +50,13 @@ class BitcoinHTLCTests(DefiTestFramework):
             errorString = e.error['message']
             assert("Invalid block denominated relative timeout" in errorString)
 
+        # Try annd create a HTLC script below min blocks
+        try:
+            self.nodes[0].spv_createhtlc("0224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86", "035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be490", "8", seed_hash)
+        except JSONRPCException as e:
+            errorString = e.error['message']
+            assert("Timeout below minimum of" in errorString)
+
         # Try annd create a HTLC script with incorrect pubkey
         try:
             self.nodes[0].spv_createhtlc("0224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea", "035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be490", "10", seed_hash)


### PR DESCRIPTION
Set Bitcoin HTLC contract timeout as a minimum of 9 blocks. Move a couple of helper functions to the only place they are used, I originally thought DFI would use these same functions to create UTXO HTLCs! Add test for new min block count.