### PR TITLE
Refactor: RPC oracles take array instead of string

### DIFF
--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -22,8 +22,6 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
-    "src/masternodes/rpc_oracles.cpp:.*stoul"
-    "src/masternodes/rpc_oracles.cpp:.*stoll"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue|spv/)"


### PR DESCRIPTION

/kind refactor

#### What this PR does / why we need it:

Using json arrays instead of raw strings in rpc methods

Fixes #360 
