### PR TITLE
Fix chain split

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -125,6 +125,7 @@ DEFI_TESTS =\
   test/multisig_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/mn_blocktime_tests.cpp \
   test/oracles_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -382,7 +382,7 @@ void CMasternodesView::SetMasternodeLastBlockTime(const CKeyID & minter, const u
     WriteBy<Staker>(MNBlockTimeKey{*nodeId, blockHeight}, time);
 }
 
-boost::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKeyID & minter)
+boost::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t height)
 {
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
@@ -398,7 +398,7 @@ boost::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKey
 
         // Get first result only and exit
         return false;
-    }, MNBlockTimeKey{*nodeId, std::numeric_limits<uint32_t>::max()});
+    }, MNBlockTimeKey{*nodeId, height - 1});
 
     if (time)
     {

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -159,7 +159,7 @@ public:
     Res UnResignMasternode(uint256 const & nodeId, uint256 const & resignTx);
 
     void SetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t &blockHeight, const int64_t &time);
-    boost::optional<int64_t> GetMasternodeLastBlockTime(const CKeyID & minter);
+    boost::optional<int64_t> GetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t height);
     void EraseMasternodeLastBlockTime(const uint256 &minter, const uint32_t& blockHeight);
 
     void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -25,7 +25,12 @@ UniValue mnToJSON(uint256 const & nodeId, CMasternode const& node, bool verbose)
         obj.pushKV("banTx", node.banTx.GetHex());
         obj.pushKV("state", CMasternode::GetHumanReadableState(node.GetState()));
         obj.pushKV("mintedBlocks", (uint64_t) node.mintedBlocks);
-        obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), node, GetTime()).getdouble());
+        int height;
+        {
+            LOCK(cs_main);
+            height = ChainActive().Height();
+        }
+        obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), node, height, GetTime()).getdouble());
 
         /// @todo add unlock height and|or real resign height
         ret.pushKV(nodeId.GetHex(), obj);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -734,7 +734,7 @@ namespace pos {
             pblock->height = tip->nHeight + 1;
             pblock->mintedBlocks = mintedBlocks + 1;
             pblock->stakeModifier = pos::ComputeStakeModifier(tip->stakeModifier, args.minterKey.GetPubKey().GetID());
-            auto stakerBlockTime = pcustomcsview->GetMasternodeLastBlockTime(args.operatorID);
+            auto stakerBlockTime = pcustomcsview->GetMasternodeLastBlockTime(args.operatorID, pblock->height);
 
             // No record. No stake blocks or post-fork createmastnode TX, use fork time.
             if (!stakerBlockTime)

--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -16,7 +16,7 @@ namespace pos {
         return Hash(ss.begin(), ss.end());
     }
 
-    arith_uint256 CalcCoinDayWeight(const Consensus::Params& params, const CMasternode& node, const int64_t coinstakeTime, const int64_t stakersBlockTime)
+    arith_uint256 CalcCoinDayWeight(const Consensus::Params& params, const CMasternode& node, const int64_t coinstakeTime, const int64_t height, const int64_t stakersBlockTime)
     {
         // Default to min age
         int64_t nTimeTx{params.pos.nStakeMinAge};
@@ -29,7 +29,7 @@ namespace pos {
         else
         {
             // Lookup stored valid blocktime. no optional value indicate no previous staked block.
-            if (auto lastBlockTime = pcustomcsview->GetMasternodeLastBlockTime(node.operatorAuthAddress))
+            if (auto lastBlockTime = pcustomcsview->GetMasternodeLastBlockTime(node.operatorAuthAddress, height))
             {
                 // Choose whatever is smaller, time since last stake or max age.
                 nTimeTx = std::min(coinstakeTime - *lastBlockTime, params.pos.nStakeMaxAge);
@@ -70,7 +70,7 @@ namespace pos {
                 return false;
             }
 
-            arith_uint256 coinDayWeight = CalcCoinDayWeight(params, *node, coinstakeTime, stakersBlockTime);
+            arith_uint256 coinDayWeight = CalcCoinDayWeight(params, *node, coinstakeTime, height, stakersBlockTime);
 
             // Increase target by coinDayWeight.
             return (hashProofOfStake / static_cast<uint64_t>( GetMnCollateralAmount( static_cast<int>(height) ) ) ) <= targetProofOfStake * coinDayWeight;

--- a/src/pos_kernel.h
+++ b/src/pos_kernel.h
@@ -22,7 +22,7 @@ namespace pos {
     uint256 CalcKernelHash(const uint256& stakeModifier, int64_t height, int64_t coinstakeTime, const uint256& masternodeID, const Consensus::Params& params);
 
     // Calculate target multiplier
-    arith_uint256 CalcCoinDayWeight(const Consensus::Params& params, const CMasternode& node, const int64_t coinstakeTime, const int64_t stakersBlockTime = 0);
+    arith_uint256 CalcCoinDayWeight(const Consensus::Params& params, const CMasternode& node, const int64_t coinstakeTime, const int64_t height, const int64_t stakersBlockTime = 0);
 
 /// Check whether stake kernel meets hash target
     bool CheckKernelHash(const uint256& stakeModifier, uint32_t nBits, int64_t height, int64_t coinstakeTime, uint64_t blockHeight, const uint256& masternodeID, const Consensus::Params& params, const int64_t stakersBlockTime = 0);

--- a/src/test/mn_blocktime_tests.cpp
+++ b/src/test/mn_blocktime_tests.cpp
@@ -1,0 +1,43 @@
+#include <test/setup_common.h>
+
+#include <masternodes/masternodes.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(mn_blocktime_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(retrieve_last_time)
+{
+    CCustomCSView mnview(*pcustomcsview.get());
+
+    // Create masternode
+    CMasternode mn;
+    std::vector<unsigned char> vec(20, '1');
+    uint160 bytes{vec};
+    CKeyID minter(bytes);
+    mn.operatorType = 1;
+    mn.ownerType = 1;
+    mn.operatorAuthAddress = minter;
+    mn.ownerAuthAddress = minter;
+    uint256 mnId = uint256S("1111111111111111111111111111111111111111111111111111111111111111");
+    mnview.CreateMasternode(mnId, mn);
+
+    // Add time records
+    mnview.SetMasternodeLastBlockTime(minter, 100, 1000);
+    mnview.SetMasternodeLastBlockTime(minter, 200, 2000);
+    mnview.SetMasternodeLastBlockTime(minter, 300, 3000);
+
+    // Make sure result is found and returns result previous to 200
+    const auto time200 = mnview.GetMasternodeLastBlockTime(minter, 200);
+    BOOST_CHECK_EQUAL(*time200, 1000);
+
+    // Make sure result is found and returns result previous to 200
+    const auto time300 = mnview.GetMasternodeLastBlockTime(minter, 300);
+    BOOST_CHECK_EQUAL(*time300, 2000);
+
+    // For max value we expect the last result
+    const auto timeMax = mnview.GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
+    BOOST_CHECK_EQUAL(*timeMax, 3000);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When a masternode creates a block the last block time is stored, this is used to calculate the coin-age and essentially resets the coin-age multiplier to zero. When the same masternode is staking on two nodes, a mempool difference causes the block hash to be different and the coin-age has been used to change the target difficulty a chain split will occur. The split nodes cannot accept each others blocks as the last entry in the masternode block time is there own which reset coin-age removing the target multiplier that was used to create the block, the result is that the block on the other chain is rejected as having a high hash. Invalidate the split block on one chain and it removes the last block time entry and allows it to accept the other chain.

This commit here uses the current height minus one when getting the last block time, we do not want to get the current or max block time in case of chain split.