### PR TITLE
net: Add a community-operated DNS seed for defichain mainnet nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -247,6 +247,7 @@ public:
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
         vSeeds.emplace_back("seed.defichain.io");
+        vSeeds.emplace_back("seed.mydeficha.in");
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 


### PR DESCRIPTION
Add a community-operated DNS seed for defichain mainnet nodes.

#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
Independence from only one DNS seed provider, more decentralization

#### Which issue(s) does this PR fixes?:
More reliable finding of a node when starting the defichain
