### PR TITLE
Update CODEOWNERS to individuals instead of team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Define individuals that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                                   @Bushstar @bvbfan @monstrobishi @fuxingloh
+/.github/                                                   @uzyn @Bushstar @bvbfan @Mixa84 @surangap @ShengguangXiao @monstrobishi @fuxingloh
 
-/src/                                                       @Bushstar @bvbfan @monstrobishi @Mixa84 @surangap @ShengguangXiao
+/src/                                                       @uzyn @Bushstar @bvbfan @Mixa84 @surangap @ShengguangXiao @monstrobishi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Define individuals that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                                   @Bushstar @monstrobishi @fuxingloh
+/.github/                                                   @Bushstar @bvbfan @monstrobishi @fuxingloh
 
 /src/                                                       @Bushstar @bvbfan @monstrobishi @Mixa84 @surangap @ShengguangXiao

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,6 @@
 # Define individuals that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-SECURITY.md                                                 @DeFiCh/admin
-CONTRIBUTING.md                                             @DeFiCh/admin
-/.github/                                                   @DeFiCh/admin
-/.github/workflows/oss-governance-bot.yml                   @fuxingloh
-/.github/governance.yml                                     @fuxingloh
+/.github/                                                   @Bushstar @monstrobishi @fuxingloh
 
-/src/                                                       @DeFiCh/blockchain
+/src/                                                       @Bushstar @bvbfan @monstrobishi @Mixa84 @surangap @ShengguangXiao


### PR DESCRIPTION
#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

Moved CODEOWNERS to individuals instead of teams for better accountability and ownership of specified files. All other projects in @DeFiCh have already moved individuals CODEOWNERS. The purpose of doing so; creates less meaningless bureaucracy and instead allow any individuals (and community) to take ownership of any specific components within the repo.

> For reference https://github.com/DeFiCh/jellyfish/blob/main/.github/CODEOWNERS for more detailed component ownership.

