### PR TITLE
Change daily LP rewards automatically on subsidy reduction

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -459,6 +459,7 @@ void SetupServerArgs()
     gArgs.AddArg("-masternode_operator=<address>", "Masternode operator address (default: empty)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-dummypos", "Flag to skip PoS-related checks (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-txnotokens", "Flag to force old tx serialization (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-subsidytest", "Flag to enable new subsidy rules (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-anchorquorum", "Min quorum size (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-spv", "Enable SPV to bitcoin blockchain (default: 1)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-criminals", "punishment of criminal nodes (default: 0, regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
@@ -18,8 +18,12 @@ UniValue LP_DAILY_DFI_REWARD::Export() const {
     return ValueFromAmount(dailyReward);
 }
 
-Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView &) const
+Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView & view) const
 {
+    if (view.GetLastHeight() >= static_cast<uint32_t>(Params().GetConsensus().EunosHeight)) {
+        return Res::Err("Cannot be set manually after Eunos hard fork");
+    }
+
     // nothing to do
     return Res::Ok();
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1131,14 +1131,15 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
     CAmount nSubsidy = consensusParams.baseBlockSubsidy;
 
-    if (Params().NetworkIDString() != CBaseChainParams::REGTEST || consensusParams.EunosHeight == 1)
+    if (Params().NetworkIDString() != CBaseChainParams::REGTEST ||
+            (Params().NetworkIDString() == CBaseChainParams::REGTEST && gArgs.GetBoolArg("-subsidytest", false)))
     {
         if (nHeight >= consensusParams.EunosHeight)
         {
             nSubsidy = consensusParams.newBaseBlockSubsidy;
             const size_t reductions = (nHeight - consensusParams.EunosHeight) / consensusParams.emissionReductionPeriod;
 
-            // See if we already have thie reduction calculated and return if found.
+            // See if we already have this reduction calculated and return if found.
             if (subsidyReductions.find(reductions) != subsidyReductions.end())
             {
                 return subsidyReductions[reductions];
@@ -2085,7 +2086,18 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height)
             for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies)
             {
                 CAmount subsidy = CalculateCoinbaseReward(blockReward, kv.second);
-                mnview.SubCommunityBalance(kv.first, subsidy);
+
+                // Remove Swap, Futures and Options balances from Unallocated
+                if (kv.first == CommunityAccountType::Swap ||
+                    kv.first == CommunityAccountType::Futures ||
+                    kv.first == CommunityAccountType::Options)
+                {
+                    mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                }
+                else
+                {
+                    mnview.SubCommunityBalance(kv.first, subsidy);
+                }
             }
         }
         else
@@ -2570,6 +2582,27 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     { // old data pruning and other (some processing made for the whole block)
         // make all changes to the new cache/snapshot to make it possible to take a diff later:
         CCustomCSView cache(mnview);
+
+        // Hard coded LP_DAILY_DFI_REWARD change
+        if (pindex->nHeight >= chainparams.GetConsensus().EunosHeight)
+        {
+            const auto& incentivePair = chainparams.GetConsensus().newNonUTXOSubsidies.find(CommunityAccountType::IncentiveFunding);
+            if (incentivePair != chainparams.GetConsensus().newNonUTXOSubsidies.end())
+            {
+                CAmount subsidy = CalculateCoinbaseReward(GetBlockSubsidy(pindex->nHeight, chainparams.GetConsensus()), incentivePair->second);
+                // Change daily LP reward if it has changed
+                auto var = cache.GetVariable(LP_DAILY_DFI_REWARD::TypeName());
+                if (var) {
+                    // Cast to avoid UniValue in GovVariable Export/Import
+                    auto lpVar = dynamic_cast<LP_DAILY_DFI_REWARD*>(var.get());
+                    if (lpVar && lpVar->dailyReward != subsidy) {
+                        lpVar->dailyReward = subsidy;
+                        lpVar->Apply(cache, pindex->nHeight);
+                        cache.SetVariable(*lpVar);
+                    }
+                }
+            }
+        }
 
         // hardfork commissions update
         CAmount distributed = cache.UpdatePoolRewards(

--- a/test/functional/feature_burn_address.py
+++ b/test/functional/feature_burn_address.py
@@ -106,10 +106,8 @@ class BurnAddressTest(DefiTestFramework):
         assert_equal(result[0]['type'], 'AccountToAccount')
         assert_equal(result[0]['amounts'][0], '1.00000000@DFI')
 
-        # Auto auth from failed accounttoaccount
-        assert_equal(result[1]['owner'], 'mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG')
-        assert_equal(result[1]['type'], 'None')
-        assert_equal(result[1]['amounts'][0], '0.99988640@DFI')
+        # Auto auth burnt amount
+        auth_burn_amount = result[1]['amounts'][0][0:10]
 
         # Send to burn address with accounttoutxos
         self.nodes[0].accounttoutxos(funded_address, {burn_address:"2@0"})
@@ -150,7 +148,7 @@ class BurnAddressTest(DefiTestFramework):
         # Test output of getburninfo
         result = self.nodes[0].getburninfo()
         assert_equal(result['address'], burn_address)
-        assert_equal(result['amount'], Decimal('12.99988640'))
+        assert_equal(result['amount'], Decimal('12.00000000') + Decimal(auth_burn_amount))
         assert_equal(result['tokens'][0], '1.00000000@DFI')
         assert_equal(result['tokens'][1], '100.00000000@GOLD#128')
         assert_equal(result['feeburn'], Decimal('2.00000000'))

--- a/test/functional/feature_dfip8_communitybalances.py
+++ b/test/functional/feature_dfip8_communitybalances.py
@@ -14,10 +14,9 @@ class Dfip8Test(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [['-txnotokens=0', '-amkheight=1', '-eunosheight=1']]
+        self.extra_args = [['-txnotokens=0', '-amkheight=1', '-eunosheight=1', '-subsidytest=1']]
 
     def run_test(self):
-
         self.nodes[0].generate(1)
 
         result = self.nodes[0].listcommunitybalances()
@@ -62,6 +61,35 @@ class Dfip8Test(DefiTestFramework):
         assert_equal(getblock['nonutxo'][0]['Burnt'], Decimal('144.55193810'))
 
         # First reduction plus one
+        self.nodes[0].generate(1)
+
+        result = self.nodes[0].listcommunitybalances()
+
+        assert_equal(result['AnchorReward'], Decimal('12.31052976'))
+        assert_equal(result['IncentiveFunding'], Decimal('15665.14913832'))
+        assert_equal(result['Burnt'], Decimal('22337.45627620'))
+
+        getblock = self.nodes[0].getblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
+
+        assert_equal(getblock['nonutxo'][0]['AnchorReward'], Decimal('0.07966488'))
+        assert_equal(getblock['nonutxo'][0]['IncentiveFunding'], Decimal('101.37356916'))
+        assert_equal(getblock['nonutxo'][0]['Burnt'], Decimal('144.55193810'))
+
+        # Invalidate a block and test rollback
+        self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
+        result = self.nodes[0].listcommunitybalances()
+
+        assert_equal(result['AnchorReward'], Decimal('12.23086488'))
+        assert_equal(result['IncentiveFunding'], Decimal('15563.77556916'))
+        assert_equal(result['Burnt'], Decimal('22192.90433810'))
+
+        getblock = self.nodes[0].getblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
+
+        assert_equal(getblock['nonutxo'][0]['AnchorReward'], Decimal('0.07966488'))
+        assert_equal(getblock['nonutxo'][0]['IncentiveFunding'], Decimal('101.37356916'))
+        assert_equal(getblock['nonutxo'][0]['Burnt'], Decimal('144.55193810'))
+
+        #Go forward again to first reduction
         self.nodes[0].generate(1)
 
         result = self.nodes[0].listcommunitybalances()


### PR DESCRIPTION
Change the daily LP rewards on the hard fork and each subsequent subsidy reduction. Prevent manual changing of daily LP rewards after the hard fork.

Also subtract from the burn community balance on chain rollback.