### PR TITLE
Minor lint fix. Set Ubuntu 18.04 as minimum for tests and builds.

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
     env:
       BUILD_VERSION: latest # Computed
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,7 @@ on:
       - staging
       - ci/*
       - v*
+      - 1.[0-9]+.x
       
 jobs:
   unit_tests:
@@ -26,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
     env:
       BUILD_VERSION: latest # Computed
       GITHUB_PULL_REQUEST: ${{ github.event.number }}

--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       BUILD_VERSION: latest # Computed
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-18.04]
     env:
       BUILD_VERSION: latest # Computed
       GITHUB_PULL_REQUEST: ${{ github.event.number }}

--- a/test/functional/feature_criminals.py
+++ b/test/functional/feature_criminals.py
@@ -30,17 +30,6 @@ class CriminalsTest (DefiTestFramework):
     def setup_network(self):
         self.setup_nodes()
 
-        # for i in range(self.num_nodes - 1):
-        #     connect_nodes_bi(self.nodes, i, i + 1)
-        # self.sync_all()
-
-    def dumphashes(self, nodes=None, block = None):
-        if nodes is None:
-            nodes = range(self.num_nodes)
-        for i in nodes:
-            bl = self.nodes[i].getblockcount() if block is None else block
-            print ("Node%d: [%d] %s" % (i, bl, self.nodes[i].getblockhash(bl)))
-
     def erase_node(self, n):
         os.remove(os.path.join(self.nodes[n].datadir, 'regtest', 'wallets', 'wallet.dat'))
         shutil.rmtree(os.path.join(self.nodes[n].datadir, 'regtest', 'blocks'))
@@ -83,7 +72,7 @@ class CriminalsTest (DefiTestFramework):
         self.nodes[2].generate(5)
         connect_nodes_bi(self.nodes, 1, 2)
         self.sync_blocks(self.nodes[0:3])
-        # self.dumphashes()
+
         assert_equal(self.nodes[1].listmasternodes()[node0id]['state'], "ENABLED")
         assert_equal(self.nodes[1].listcriminalproofs(), proof)
 


### PR DESCRIPTION
Update Lint to run on 1.*.x branches with * being the wildcard. Minor fix for lint on the 1.7.x PR. Use Ubuntu 18.04 on all tests and builds.