### PR TITLE
Fix calculating owner rewards and returning takerFee on close offer.

### DIFF
--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -84,7 +84,7 @@ Res CICXOrderView::ICXCreateOrder(CICXOrderImpl const & order)
     if (order.orderPrice == 0)
         return Res::Err("order price must be greater than 0!");
     if (order.expiry < CICXOrder::DEFAULT_EXPIRY)
-        return Res::Err("order expiry must be greater than %d!", CICXOrder::DEFAULT_EXPIRY);
+        return Res::Err("order expiry must be greater than %d!", CICXOrder::DEFAULT_EXPIRY - 1);
 
     OrderKey key(order.idToken, order.creationTx);
     WriteBy<ICXOrderCreationTx>(order.creationTx, order);
@@ -157,7 +157,7 @@ Res CICXOrderView::ICXMakeOffer(CICXMakeOfferImpl const & makeoffer)
     if (makeoffer.amount == 0)
         return Res::Err("offer amount must be greater than 0!");
     if (makeoffer.expiry < CICXMakeOffer::DEFAULT_EXPIRY)
-        return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::DEFAULT_EXPIRY);
+        return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::DEFAULT_EXPIRY - 1);
 
     WriteBy<ICXMakeOfferCreationTx>(makeoffer.creationTx, makeoffer);
     WriteBy<ICXMakeOfferOpenKey>(TxidPairKey(makeoffer.orderTx, makeoffer.creationTx), CICXMakeOffer::STATUS_OPEN);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2668,7 +2668,10 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!res)
                         LogPrintf("Can't subtract balance from order txidaddr: %s\n", res.msg);
                     else
+                    {
+                        cache.CalculateOwnerRewards(order->ownerAddress,pindex->nHeight);
                         cache.AddBalance(order->ownerAddress, amount);
+                    }
                 }
 
                 cache.ICXCloseOrderTx(*order, status);
@@ -2699,7 +2702,10 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!res)
                         LogPrintf("Can't subtract takerFee from offer txidAddr: %s\n", res.msg);
                     else
+                    {
+                        cache.CalculateOwnerRewards(offer->ownerAddress,pindex->nHeight);
                         cache.AddBalance(offer->ownerAddress, takerFee);
+                    }
                 }
 
                 cache.ICXCloseMakeOfferTx(*offer, status);
@@ -2731,6 +2737,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!cache.HasICXSubmitEXTHTLCOpen(dfchtlc->offerTx))
                     {
                         CTokenAmount makerDeposit{DCT_ID{0}, offer->takerFee};
+                        cache.CalculateOwnerRewards(order->ownerAddress,pindex->nHeight);
                         cache.AddBalance(order->ownerAddress, makerDeposit);
                         refund = true;
                     }
@@ -2752,7 +2759,10 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!res)
                         LogPrintf("Can't subtract balance from dfc htlc txidaddr: %s\n", res.msg);
                     else
+                    {
+                        cache.CalculateOwnerRewards(ownerAddress,pindex->nHeight);
                         cache.AddBalance(ownerAddress, amount);
+                    }
 
                     cache.ICXCloseDFCHTLC(*dfchtlc, status);
                 }
@@ -2782,6 +2792,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                     if (!cache.HasICXSubmitDFCHTLCOpen(exthtlc->offerTx))
                     {
                         CTokenAmount makerDeposit{DCT_ID{0}, offer->takerFee};
+                        cache.CalculateOwnerRewards(order->ownerAddress,pindex->nHeight);
                         cache.AddBalance(order->ownerAddress, makerDeposit);
                         cache.ICXCloseEXTHTLC(*exthtlc, status);
                     }

--- a/test/functional/feature_icx_orderbook.py
+++ b/test/functional/feature_icx_orderbook.py
@@ -116,6 +116,8 @@ class ICXOrderbookTest (DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
+        beforeOffer = self.nodes[1].getaccount(accountBTC, {}, True)[idDFI]
+
         offerTx = self.nodes[1].icx_makeoffer({
                                     'orderTx': orderTx,
                                     'amount': 0.10,
@@ -124,11 +126,13 @@ class ICXOrderbookTest (DefiTestFramework):
         self.nodes[1].generate(1)
         self.sync_blocks()
 
+        assert_equal(self.nodes[1].getaccount(accountBTC, {}, True)[idDFI], beforeOffer - Decimal('0.01000000'))
+
         offer = self.nodes[0].icx_listorders({"orderTx": orderTx})
 
         assert_equal(len(offer), 2)
 
-        # Close order
+        # Close offer
         closeOrder = self.nodes[1].icx_closeoffer(offerTx)["txid"]
         rawCloseOrder = self.nodes[1].getrawtransaction(closeOrder, 1)
         authTx = self.nodes[1].getrawtransaction(rawCloseOrder['vin'][0]['txid'], 1)
@@ -140,6 +144,8 @@ class ICXOrderbookTest (DefiTestFramework):
 
         self.nodes[1].generate(1)
         self.sync_blocks()
+
+        assert_equal(self.nodes[1].getaccount(accountBTC, {}, True)[idDFI], beforeOffer)
 
         offer = self.nodes[0].icx_listorders({"orderTx": orderTx})
 
@@ -754,7 +760,6 @@ class ICXOrderbookTest (DefiTestFramework):
 
         self.nodes[1].generate(1)
         self.sync_blocks()
-
 
         self.nodes[0].generate(2880)
         self.sync_blocks()


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
It's needed to ensure account history will not include rewards calculation amount{s}