### PR TITLE
Increase masternode registration and resign delay

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,6 +125,7 @@ public:
         consensus.DakotaHeight = 678000; // 1st March 2021
         consensus.DakotaCrescentHeight = 733000; // 25th March 2021
         consensus.EunosHeight = std::numeric_limits<int>::max();
+        consensus.EunosSimsHeight = consensus.EunosHeight;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -155,11 +156,12 @@ public:
 
         // Masternodes' params
         consensus.mn.activationDelay = 10;
+        consensus.mn.newActivationDelay = 1008;
         consensus.mn.resignDelay = 60;
+        consensus.mn.newResignDelay = 2 * consensus.mn.newActivationDelay;
         consensus.mn.creationFee = 10 * COIN;
         consensus.mn.collateralAmount = 1000000 * COIN;
         consensus.mn.collateralAmountDakota = 20000 * COIN;
-        consensus.mn.historyFrame = 300;
         consensus.mn.anchoringTeamSize = 5;
         consensus.mn.anchoringFrequency = 15;
 
@@ -336,6 +338,7 @@ public:
         consensus.DakotaHeight = 220680;
         consensus.DakotaCrescentHeight = 287700;
         consensus.EunosHeight = 427040; // 21st May 2021
+        consensus.EunosSimsHeight = 435800; // 24th May 2021
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -366,11 +369,12 @@ public:
 
         // Masternodes' params
         consensus.mn.activationDelay = 10;
+        consensus.mn.newActivationDelay = 1008;
         consensus.mn.resignDelay = 60;
+        consensus.mn.newResignDelay = 2 * consensus.mn.newActivationDelay;
         consensus.mn.creationFee = 10 * COIN;
         consensus.mn.collateralAmount = 1000000 * COIN;
         consensus.mn.collateralAmountDakota = 20000 * COIN;
-        consensus.mn.historyFrame = 300;
         consensus.mn.anchoringTeamSize = 5;
         consensus.mn.anchoringFrequency = 15;
 
@@ -513,6 +517,7 @@ public:
         consensus.DakotaHeight = 10;
         consensus.DakotaCrescentHeight = 10;
         consensus.EunosHeight = 10;
+        consensus.EunosSimsHeight = 10;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -541,11 +546,12 @@ public:
 
         // Masternodes' params
         consensus.mn.activationDelay = 10;
+        consensus.mn.newActivationDelay = 1008;
         consensus.mn.resignDelay = 60;
+        consensus.mn.newResignDelay = 2 * consensus.mn.newActivationDelay;
         consensus.mn.creationFee = 10 * COIN;
         consensus.mn.collateralAmount = 1000000 * COIN;
         consensus.mn.collateralAmountDakota = 20000 * COIN;
-        consensus.mn.historyFrame = 300;
         consensus.mn.anchoringTeamSize = 5;
         consensus.mn.anchoringFrequency = 15;
 
@@ -680,6 +686,7 @@ public:
         consensus.DakotaHeight = 10000000;
         consensus.DakotaCrescentHeight = 10000000;
         consensus.EunosHeight = 10000000;
+        consensus.EunosSimsHeight = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -708,11 +715,12 @@ public:
 
         // Masternodes' params
         consensus.mn.activationDelay = 10;
+        consensus.mn.newActivationDelay = 20;
         consensus.mn.resignDelay = 10;
+        consensus.mn.newResignDelay = 2 * consensus.mn.newActivationDelay;
         consensus.mn.creationFee = 1 * COIN;
         consensus.mn.collateralAmount = 10 * COIN;
         consensus.mn.collateralAmountDakota = 2 * COIN;
-        consensus.mn.historyFrame = 300;
         consensus.mn.anchoringTeamSize = 3;
         consensus.mn.anchoringFrequency = 15;
 
@@ -927,6 +935,7 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             height = std::numeric_limits<int>::max();
         }
         consensus.EunosHeight = static_cast<int>(height);
+        consensus.EunosSimsHeight = static_cast<int>(height);
     }
 
     if (!args.IsArgSet("-vbparams")) return;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -84,10 +84,10 @@ struct Params {
     int ClarkeQuayHeight;
     /** Fourth major fork **/
     int DakotaHeight;
-    /** Fifth major fork **/
     int DakotaCrescentHeight;
-    /** Sixth major fork **/
+    /** Fifth major fork **/
     int EunosHeight;
+    int EunosSimsHeight;
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;
     /** Trackable burn address */
@@ -150,7 +150,8 @@ struct Params {
         CAmount collateralAmountDakota;
         int activationDelay;
         int resignDelay; // same delay for criminal ban
-        int historyFrame;
+        int newActivationDelay;
+        int newResignDelay; // same delay for criminal ban
         int anchoringTeamSize;
         int anchoringFrequency; // create every Nth block
 

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -33,9 +33,8 @@ class CBlockIndex;
 class CTransaction;
 
 // Works instead of constants cause 'regtest' differs (don't want to overcharge chainparams)
-int GetMnActivationDelay();
-int GetMnResignDelay();
-int GetMnHistoryFrame();
+int GetMnActivationDelay(int height);
+int GetMnResignDelay(int height);
 CAmount GetTokenCollateralAmount();
 CAmount GetMnCreationFee(int height);
 CAmount GetTokenCreationFee(int height);
@@ -80,9 +79,9 @@ public:
     CMasternode();
 
     State GetState() const;
-    State GetState(int h) const;
+    State GetState(int height) const;
     bool IsActive() const;
-    bool IsActive(int h) const;
+    bool IsActive(int height) const;
 
     static std::string GetHumanReadableState(State state);
 

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -154,7 +154,7 @@ UniValue resignmasternode(const JSONRPCRequest& request)
 
     RPCHelpMan{"resignmasternode",
                "\nCreates (and submits to local node and network) a transaction resigning your masternode. Collateral will be unlocked after " +
-               std::to_string(GetMnResignDelay()) + " blocks.\n"
+               std::to_string(GetMnResignDelay(::ChainActive().Height())) + " blocks.\n"
                                                     "The last optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must belong to the MN's owner (collateral) address" +
                HelpRequiringPassphrase(pwallet) + "\n",
                {

--- a/test/functional/rpc_mn_basic.py
+++ b/test/functional/rpc_mn_basic.py
@@ -177,8 +177,24 @@ class MasternodesRpcBasicTest (DefiTestFramework):
         signedTx = self.nodes[0].signrawtransactionwithwallet(cmTx)
         assert_equal(signedTx['complete'], True)
         assert_raises_rpc_error(-26, 'masternode creation needs owner auth', self.nodes[0].sendrawtransaction, signedTx['hex'])
-        self.nodes[0].createmasternode(self.nodes[0].getnewaddress("", "legacy"))
+
+        # Test new register delay
+        mnTx = self.nodes[0].createmasternode(self.nodes[0].getnewaddress("", "legacy"))
         self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].listmasternodes({}, False)[mnTx], "PRE_ENABLED")
+        self.nodes[0].generate(19)
+        assert_equal(self.nodes[0].listmasternodes({}, False)[mnTx], "PRE_ENABLED")
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].listmasternodes({}, False)[mnTx], "ENABLED")
+
+        # Test new resign delay
+        self.nodes[0].resignmasternode(mnTx)
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].listmasternodes()[mnTx]['state'], "PRE_RESIGNED")
+        self.nodes[0].generate(39)
+        assert_equal(self.nodes[0].listmasternodes()[mnTx]['state'], "PRE_RESIGNED")
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].listmasternodes()[mnTx]['state'], "RESIGNED")
 
 if __name__ == '__main__':
     MasternodesRpcBasicTest ().main ()


### PR DESCRIPTION
Increase masternode registration to 1,008 blocks and resignation to 2,016 blocks.