### PR TITLE
Load minter last times into memory cache

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1711,6 +1711,10 @@ bool AppInitMain(InitInterfaces& interfaces)
         }
     }
 
+    // Load minter cache
+    auto minterCacheCount = pcustomcsview->LoadMinterCache();
+    LogPrintf("minter cache loaded with %d entries\n", minterCacheCount);
+
     // As LoadBlockIndex can take several minutes, it's possible the user
     // requested to kill the GUI during the last operation. If so, exit.
     // As the program has not fully started yet, Shutdown() is possibly overkill.

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -252,6 +252,9 @@ void CMasternodesView::DecrementMintedBy(const CKeyID & minter)
     assert(node);
     --node->mintedBlocks;
     WriteBy<ID>(*nodeId, *node);
+
+    // Erase from cache
+    minterTimeCache.erase(minter);
 }
 
 bool CMasternodesView::BanCriminal(const uint256 txid, std::vector<unsigned char> & metadata, int height)
@@ -382,11 +385,18 @@ void CMasternodesView::SetMasternodeLastBlockTime(const CKeyID & minter, const u
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
+    minterTimeCache[minter] = {blockHeight, time};
     WriteBy<Staker>(MNBlockTimeKey{*nodeId, blockHeight}, time);
 }
 
 boost::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t height)
 {
+    // Only return from cache if less than requested height to avoid chain split
+    const auto it = minterTimeCache.find(minter);
+    if (it != minterTimeCache.end() && it->second.first < height) {
+        return it->second.second;
+    }
+
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
@@ -397,6 +407,11 @@ boost::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKey
         if (key.masternodeID == nodeId)
         {
             time = blockTime;
+
+            // Add entry to cache if it was not found.
+            if (it == minterTimeCache.end()) {
+                minterTimeCache[minter] = {key.blockHeight, time};
+            }
         }
 
         // Get first result only and exit
@@ -443,6 +458,20 @@ Res CMasternodesView::UnResignMasternode(const uint256 & nodeId, const uint256 &
         return Res::Ok();
     }
     return Res::Err("No such masternode %s, resignTx: %s", nodeId.GetHex(), resignTx.GetHex());
+}
+
+size_t CMasternodesView::LoadMinterCache() {
+    ForEachMasternode([&](uint256 const& nodeId, CMasternode node)
+    {
+        // Load last block times into cache
+        if (node.IsActive()) {
+            GetMasternodeLastBlockTime(node.operatorAuthAddress, std::numeric_limits<uint32_t>::max());
+        }
+
+        return true;
+    }, {});
+
+    return minterTimeCache.size();
 }
 
 /*

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -133,6 +133,8 @@ struct MNBlockTimeKey
 
 class CMasternodesView : public virtual CStorageView
 {
+    std::map<CKeyID, std::pair<uint32_t, int64_t>> minterTimeCache;
+
 public:
 //    CMasternodesView() = default;
 
@@ -163,6 +165,8 @@ public:
     void EraseMasternodeLastBlockTime(const uint256 &minter, const uint32_t& blockHeight);
 
     void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});
+
+    size_t LoadMinterCache();
 
     // tags
     struct ID { static const unsigned char prefix; };

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -30,7 +30,11 @@ UniValue mnToJSON(uint256 const & nodeId, CMasternode const& node, bool verbose)
             LOCK(cs_main);
             height = ChainActive().Height();
         }
-        obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), node, height, GetTime()).getdouble());
+
+        // Only get targetMultiplier for active masternodes
+        if (node.IsActive()) {
+            obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), node, GetTime(), height).getdouble());
+        }
 
         /// @todo add unlock height and|or real resign height
         ret.pushKV(nodeId.GetHex(), obj);

--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -70,7 +70,7 @@ namespace pos {
                 return false;
             }
 
-            arith_uint256 coinDayWeight = CalcCoinDayWeight(params, *node, coinstakeTime, height, stakersBlockTime);
+            arith_uint256 coinDayWeight = CalcCoinDayWeight(params, *node, coinstakeTime, blockHeight, stakersBlockTime);
 
             // Increase target by coinDayWeight.
             return (hashProofOfStake / static_cast<uint64_t>( GetMnCollateralAmount( static_cast<int>(height) ) ) ) <= targetProofOfStake * coinDayWeight;


### PR DESCRIPTION
Add minter cache to get last block times from to speed up lookups.

Calling GetMasternodeLastBlockTime 1,000,000 times:
Without cache: 978 to 1,018 milliseconds
With cache: 368 to 379 milliseconds

Calling listmasternodes:
Without cache: 1,217 to 1,256 milliseconds
With cache: 143 to 164 milliseconds

Requested in the following issue: https://github.com/DeFiCh/ain/issues/427

Also resolves the following reported error with target multiplier reporting: https://github.com/DeFiCh/ain/issues/437