### PR TITLE
Remove minter cache

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1709,10 +1709,6 @@ bool AppInitMain(InitInterfaces& interfaces)
         }
     }
 
-    // Load minter cache
-    auto minterCacheCount = pcustomcsview->LoadMinterCache();
-    LogPrintf("minter cache loaded with %d entries\n", minterCacheCount);
-
     // As LoadBlockIndex can take several minutes, it's possible the user
     // requested to kill the GUI during the last operation. If so, exit.
     // As the program has not fully started yet, Shutdown() is possibly overkill.

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -133,8 +133,6 @@ struct MNBlockTimeKey
 
 class CMasternodesView : public virtual CStorageView
 {
-    std::map<CKeyID, std::pair<uint32_t, int64_t>> minterTimeCache;
-
 public:
 //    CMasternodesView() = default;
 
@@ -165,8 +163,6 @@ public:
     void EraseMasternodeLastBlockTime(const uint256 &minter, const uint32_t& blockHeight);
 
     void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});
-
-    size_t LoadMinterCache();
 
     // tags
     struct ID { static const unsigned char prefix; };

--- a/src/test/mn_blocktime_tests.cpp
+++ b/src/test/mn_blocktime_tests.cpp
@@ -19,25 +19,29 @@ BOOST_AUTO_TEST_CASE(retrieve_last_time)
     mn.ownerType = 1;
     mn.operatorAuthAddress = minter;
     mn.ownerAuthAddress = minter;
-    uint256 mnId = uint256S("1111111111111111111111111111111111111111111111111111111111111111");
+    uint256 mnId = uint256S(std::string(64, 1));
     mnview.CreateMasternode(mnId, mn);
 
     // Add time records
     mnview.SetMasternodeLastBlockTime(minter, 100, 1000);
     mnview.SetMasternodeLastBlockTime(minter, 200, 2000);
     mnview.SetMasternodeLastBlockTime(minter, 300, 3000);
+    mnview.Flush();
 
     // Make sure result is found and returns result previous to 200
-    const auto time200 = mnview.GetMasternodeLastBlockTime(minter, 200);
+    const auto time200 = pcustomcsview->GetMasternodeLastBlockTime(minter, 200);
     BOOST_CHECK_EQUAL(*time200, 1000);
 
     // Make sure result is found and returns result previous to 200
-    const auto time300 = mnview.GetMasternodeLastBlockTime(minter, 300);
+    const auto time300 = pcustomcsview->GetMasternodeLastBlockTime(minter, 300);
     BOOST_CHECK_EQUAL(*time300, 2000);
 
     // For max value we expect the last result
-    const auto timeMax = mnview.GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
+    const auto timeMax = pcustomcsview->GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
     BOOST_CHECK_EQUAL(*timeMax, 3000);
+
+    const auto time2001 = pcustomcsview->GetMasternodeLastBlockTime(minter, 200);
+    BOOST_CHECK_EQUAL(*time2001, 1000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

Cache can be used only over levedb records.