### PR TITLE
Ensure connect block is flushed its data

### DIFF
--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -64,6 +64,9 @@ namespace pos {
         // been since a masternode staked a block.
         if (blockHeight >= static_cast<uint64_t>(Params().GetConsensus().DakotaCrescentHeight))
         {
+            // at this point we want to be sure ConnectBlock is finished
+            // the should be flushed and we will use the fresh data
+            LOCK(cs_main);
             auto node = pcustomcsview->GetMasternode(masternodeID);
             if (!node)
             {


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It ensures the view is up-to-date by Connect block and therefor not allow new block to come. 