### PR TITLE
Faster calculation of anchoring teams

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -849,7 +849,7 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
     // Make sure height exist
     const auto anchorCreationBlock = ::ChainActive()[anchorCreationHeight];
     if (anchorCreationBlock == nullptr) {
-        LogPrintf("%s: Cannot get block from anchor team data: height %ld\n", __func__, anchorCreationHeight);
+        LogPrint(BCLog::ANCHORING, "%s: Cannot get block from anchor team data: height %ld\n", __func__, anchorCreationHeight);
 
         // Set to max to be used to avoid deleting pending anchor.
         anchorCreationHeight = std::numeric_limits<uint64_t>::max();
@@ -957,7 +957,7 @@ bool CAnchorAwaitingConfirms::EraseAnchor(AnchorTxHash const &txHash)
 
     auto & list = confirms.get<Confirm::ByAnchor>();
     auto count = list.erase(txHash); // should erase ALL with that key. Check it!
-    LogPrintf("AnchorConfirms::EraseAnchor: erase %d confirms for anchor %s\n", count, txHash.ToString());
+    LogPrint(BCLog::ANCHORING, "AnchorConfirms::EraseAnchor: erase %d confirms for anchor %s\n", count, txHash.ToString());
 
     return count > 0;
 }

--- a/src/test/mn_blocktime_tests.cpp
+++ b/src/test/mn_blocktime_tests.cpp
@@ -8,7 +8,7 @@ BOOST_FIXTURE_TEST_SUITE(mn_blocktime_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(retrieve_last_time)
 {
-    CCustomCSView mnview(*pcustomcsview.get());
+
 
     // Create masternode
     CMasternode mn;
@@ -20,24 +20,36 @@ BOOST_AUTO_TEST_CASE(retrieve_last_time)
     mn.operatorAuthAddress = minter;
     mn.ownerAuthAddress = minter;
     uint256 mnId = uint256S("1111111111111111111111111111111111111111111111111111111111111111");
+
+    CCustomCSView mnview(*pcustomcsview.get());
     mnview.CreateMasternode(mnId, mn);
 
     // Add time records
     mnview.SetMasternodeLastBlockTime(minter, 100, 1000);
     mnview.SetMasternodeLastBlockTime(minter, 200, 2000);
     mnview.SetMasternodeLastBlockTime(minter, 300, 3000);
+    mnview.Flush();
 
     // Make sure result is found and returns result previous to 200
-    const auto time200 = mnview.GetMasternodeLastBlockTime(minter, 200);
+    const auto time200 = pcustomcsview->GetMasternodeLastBlockTime(minter, 200);
     BOOST_CHECK_EQUAL(*time200, 1000);
 
     // Make sure result is found and returns result previous to 200
-    const auto time300 = mnview.GetMasternodeLastBlockTime(minter, 300);
+    const auto time300 = pcustomcsview->GetMasternodeLastBlockTime(minter, 300);
     BOOST_CHECK_EQUAL(*time300, 2000);
 
     // For max value we expect the last result
-    const auto timeMax = mnview.GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
+    const auto timeMax = pcustomcsview->GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
     BOOST_CHECK_EQUAL(*timeMax, 3000);
+
+    // Delete entry
+    CCustomCSView mnviewTwo(*pcustomcsview.get());
+    mnviewTwo.EraseMasternodeLastBlockTime(mnId, 300);
+    mnviewTwo.Flush();
+
+    // Should now return result before deleted entry
+    const auto time2001 = pcustomcsview->GetMasternodeLastBlockTime(minter, std::numeric_limits<uint32_t>::max());
+    BOOST_CHECK_EQUAL(*time2001, 2000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Calculating anchoring teams takes about 2,000 mn every 120 blocks during sync, the update here reduces that time to about 130 ms every 120 blocks.