### PR TITLE
Check error msg after catch. Provide failing buyer pubkey case.

### DIFF
--- a/test/functional/feature_bitcoin_htlc.py
+++ b/test/functional/feature_bitcoin_htlc.py
@@ -220,35 +220,35 @@ class BitcoinHTLCTests(DefiTestFramework):
             self.nodes[0].spv_decodehtlcscript("63a821df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88210224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86675ab27521035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068ac")
         except JSONRPCException as e:
             errorString = e.error['message']
-            assert("Incorrect seed hash length" in errorString)
+        assert("Incorrect seed hash length" in errorString)
 
         # Incorrect seller pubkey length
         try:
             self.nodes[0].spv_decodehtlcscript("63a820df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88200224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86675ab27521035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068ac")
         except JSONRPCException as e:
             errorString = e.error['message']
-            assert("Seller pubkey incorrect pubkey length" in errorString)
+        assert("Seller pubkey incorrect pubkey length" in errorString)
 
         # Incorrect time length
         try:
             self.nodes[0].spv_decodehtlcscript("63a820df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88210224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea866750b27521035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068")
         except JSONRPCException as e:
             errorString = e.error['message']
-            assert("Incorrect timeout length" in errorString)
+        assert("Incorrect timeout length" in errorString)
 
         # Incorrect buyer pubkey length
         try:
-            self.nodes[0].spv_decodehtlcscript("63a820df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88210224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86675ab27521035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068ac")
+            self.nodes[0].spv_decodehtlcscript("63a820df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88210224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86675ab27520035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068ac")
         except JSONRPCException as e:
             errorString = e.error['message']
-            assert("Buyer pubkey incorrect pubkey length" in errorString)
+        assert("Buyer pubkey incorrect pubkey length" in errorString)
 
         # Incorrect redeemscript length
         try:
             self.nodes[0].spv_decodehtlcscript("63a820df95183883789f237977543885e1f82ddc045a3ba90c8f25b43a5b797a35d20e88210224e7de2f3a9d4cdc4fdc14601c75176287297c212aae9091404956955f1aea86675ab27521035fb3eadde611a39036e61d4c8288d1b896f2c94cee49e60a3d1c02236f4be49068")
         except JSONRPCException as e:
             errorString = e.error['message']
-            assert("Incorrect redeemscript length" in errorString)
+        assert("Incorrect redeemscript length" in errorString)
 
 if __name__ == '__main__':
     BitcoinHTLCTests().main()


### PR DESCRIPTION
Checking the error message was in the catch statement, so if there was no throw then the error message does not get checked. Happened to be that the buyer pubkey test was not actually throwing as the redeemscript was completely correct, an redeemscript with an invalid pubkey has been added.