### PR TITLE
Surangap/regtest chainparams jellyfish

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -671,12 +671,12 @@ class CRegTestParams : public CChainParams {
 public:
     explicit CRegTestParams(const ArgsManager& args) {
         strNetworkID = "regtest";
-        bool isJelifish = false;
-        isJelifish = gArgs.GetBoolArg("-jellyfish_regtest", false);
-        consensus.nSubsidyHalvingInterval = (isJelifish) ? 210000 : 150;
-        consensus.baseBlockSubsidy = (isJelifish) ? 100 * COIN : 50 * COIN;
+        bool isJellyfish = false;
+        isJellyfish = gArgs.GetBoolArg("-jellyfish_regtest", false);
+        consensus.nSubsidyHalvingInterval = (isJellyfish) ? 210000 : 150;
+        consensus.baseBlockSubsidy = (isJellyfish) ? 100 * COIN : 50 * COIN;
         consensus.newBaseBlockSubsidy = 40504000000;
-        consensus.emissionReductionPeriod = (isJelifish) ? 32690 : 150;
+        consensus.emissionReductionPeriod = (isJellyfish) ? 32690 : 150;
         consensus.emissionReductionAmount = 1658; // 1.658%
         consensus.BIP16Exception = uint256();
         consensus.BIP34Height = 500; // BIP34 activated on regtest (Used in functional tests)
@@ -811,7 +811,7 @@ public:
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("mfdefichainDSTBurnAddressXXXZcE1vs", *this));
 
-        if (isJelifish) {
+        if (isJellyfish) {
           std::vector<CTxOut> initdist;
           // first 2 owner & first 2 operator get 100 mill DFI
           initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU", *this))));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -812,31 +812,31 @@ public:
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("mfdefichainDSTBurnAddressXXXZcE1vs", *this));
 
         if (isJellyfish) {
-          std::vector<CTxOut> initdist;
-          // first 2 owner & first 2 operator get 100 mill DFI
-          initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU", *this))));
-          initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy", *this))));
-          initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7", *this))));
-          initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mps7BdmwEF2vQ9DREDyNPibqsuSRZ8LuwQ", *this))));
-          initdist.push_back(CTxOut(consensus.baseBlockSubsidy, GetScriptForDestination(DecodeDestination("mud4VMfbBqXNpbt8ur33KHKx8pk3npSq8c", *this))));
+            std::vector<CTxOut> initdist;
+            // first 2 owner & first 2 operator get 100 mill DFI
+            initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU", *this))));
+            initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy", *this))));
+            initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7", *this))));
+            initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("mps7BdmwEF2vQ9DREDyNPibqsuSRZ8LuwQ", *this))));
+            initdist.push_back(CTxOut(consensus.baseBlockSubsidy, GetScriptForDestination(DecodeDestination("mud4VMfbBqXNpbt8ur33KHKx8pk3npSq8c", *this))));
 
-          // 6th masternode owner. for initdist tests
-          genesis = CreateGenesisBlock(1579045065, 0x207fffff, 1, initdist,CreateGenesisMasternodes()); // old=1296688602
-          consensus.hashGenesisBlock = genesis.GetHash();
+            // 6th masternode owner. for initdist tests
+            genesis = CreateGenesisBlock(1579045065, 0x207fffff, 1, initdist,CreateGenesisMasternodes()); // old=1296688602
+            consensus.hashGenesisBlock = genesis.GetHash();
 
-          assert(consensus.hashGenesisBlock == uint256S("0xd744db74fb70ed42767ae028a129365fb4d7de54ba1b6575fb047490554f8a7b"));
-          assert(genesis.hashMerkleRoot == uint256S("0x5615dbbb379da893dd694e02d25a7955e1b7471db55f42bbd82b5d3f5bdb8d38"));
+            assert(consensus.hashGenesisBlock == uint256S("0xd744db74fb70ed42767ae028a129365fb4d7de54ba1b6575fb047490554f8a7b"));
+            assert(genesis.hashMerkleRoot == uint256S("0x5615dbbb379da893dd694e02d25a7955e1b7471db55f42bbd82b5d3f5bdb8d38"));
         }
         else {
-          genesis = CreateGenesisBlock(1579045065, 0x207fffff, 1, {
-                                         CTxOut(consensus.baseBlockSubsidy,
-                                         GetScriptForDestination(DecodeDestination("mud4VMfbBqXNpbt8ur33KHKx8pk3npSq8c", *this)) // 6th masternode owner. for initdist tests
-                                         )},
-                                     CreateGenesisMasternodes()); // old=1296688602
-          consensus.hashGenesisBlock = genesis.GetHash();
+            genesis = CreateGenesisBlock(1579045065, 0x207fffff, 1, {
+                                          CTxOut(consensus.baseBlockSubsidy,
+                                          GetScriptForDestination(DecodeDestination("mud4VMfbBqXNpbt8ur33KHKx8pk3npSq8c", *this)) // 6th masternode owner. for initdist tests
+                                          )},
+                                      CreateGenesisMasternodes()); // old=1296688602
+            consensus.hashGenesisBlock = genesis.GetHash();
 
-          assert(consensus.hashGenesisBlock == uint256S("0x0091f00915b263d08eba2091ba70ba40cea75242b3f51ea29f4a1b8d7814cd01"));
-          assert(genesis.hashMerkleRoot == uint256S("0xc4b6f1f9a7bbb61121b949b57be05e8651e7a0c55c38eb8aaa6c6602b1abc444"));
+            assert(consensus.hashGenesisBlock == uint256S("0x0091f00915b263d08eba2091ba70ba40cea75242b3f51ea29f4a1b8d7814cd01"));
+            assert(genesis.hashMerkleRoot == uint256S("0xc4b6f1f9a7bbb61121b949b57be05e8651e7a0c55c38eb8aaa6c6602b1abc444"));
         }
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -472,6 +472,7 @@ void SetupServerArgs()
     gArgs.AddArg("-dakotaheight", "Dakota fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-dakotacrescentheight", "DakotaCrescent fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-eunosheight", "Eunos fork activation height (regtest only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-jellyfish_regtest", "Configure the regtest network for jellyfish testing", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/test/functional/feature_jellyfish_initial_funds.py
+++ b/test/functional/feature_jellyfish_initial_funds.py
@@ -3,18 +3,13 @@
 # Copyright (c) DeFi Blockchain Developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""Test the masternodes RPC.
+"""Test the availability of required initial funds for jellyfish test containers.
 """
 
 from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
-    assert_array_result,
     assert_equal,
-    assert_fee_amount,
-    assert_raises_rpc_error,
-    connect_nodes_bi,
-    wait_until,
 )
 
 class JellyfishInitialFundsTest (DefiTestFramework):

--- a/test/functional/feature_jellyfish_initial_funds.py
+++ b/test/functional/feature_jellyfish_initial_funds.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test the masternodes RPC.
+"""
+
+from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    assert_fee_amount,
+    assert_raises_rpc_error,
+    connect_nodes_bi,
+    wait_until,
+)
+
+class JellyfishInitialFundsTest (DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # pass -jellyfish_regtest=1 option to enable regtest params required for jellyfish test containers
+        self.extra_args = [['-jellyfish_regtest=1']]
+
+    def run_test(self):
+        node = self.nodes[0]
+        # generate one block
+        node.generate(1)
+
+        #check balances. should have 200000100 DFI immature balance
+        walletinfo = node.getwalletinfo()
+        assert_equal(walletinfo['immature_balance'], 200000100)
+        assert_equal(walletinfo['balance'], 0)
+
+if __name__ == '__main__':
+    JellyfishInitialFundsTest ().main ()

--- a/test/functional/feature_jellyfish_initial_funds.py
+++ b/test/functional/feature_jellyfish_initial_funds.py
@@ -6,7 +6,6 @@
 """Test the availability of required initial funds for jellyfish test containers.
 """
 
-from test_framework.blocktools import add_witness_commitment, create_block, create_coinbase
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -191,6 +191,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_tx.py',
     'feature_assumevalid.py',
     'example_test.py',
+    'feature_jellyfish_initial_funds.py',
     'wallet_txn_doublespend.py',
     'wallet_txn_clone.py --mineblock',
     'feature_notifications.py',


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:
Added optional argument `-jellyfish_regtest=1` to enable an extra 100 mill DFI to the first 2 owners and operator in `regtest`. This is to provide a sufficient amount of UTXO for testing without accumulation.

Also changed emission in `-regtest` to match `-mainnet` params as jellyfish & playground needs them for complex setup scenario. Slower accumulation = longer tests. Playground balance can be spent by anyone in the sandbox env.

Affected projects:

https://github.com/DeFiCh/playground
https://github.com/DeFiCh/jellyfish
https://github.com/DeFiCh/whale
https://github.com/DeFiCh/ocean
https://github.com/DeFiCh/wallet

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
