### PR TITLE
Fix accounts performance issue

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -42,7 +42,7 @@ CBloomFilter::CBloomFilter(const unsigned int nElements, const double nFPRate, c
 inline unsigned int CBloomFilter::Hash(unsigned int nHashNum, const std::vector<unsigned char>& vDataToHash) const
 {
     // 0xFBA4C795 chosen as it guarantees a reasonable bit difference between nHashNum values.
-    return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash) % (vData.size() * 8);
+    return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash.data(), vDataToHash.size()) % (vData.size() * 8);
 }
 
 void CBloomFilter::insert(const std::vector<unsigned char>& vKey)
@@ -232,7 +232,7 @@ CRollingBloomFilter::CRollingBloomFilter(const unsigned int nElements, const dou
 
 /* Similar to CBloomFilter::Hash */
 static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, const std::vector<unsigned char>& vDataToHash) {
-    return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash);
+    return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash.data(), vDataToHash.size());
 }
 
 

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -12,18 +12,18 @@ inline uint32_t ROTL32(uint32_t x, int8_t r)
     return (x << r) | (x >> (32 - r));
 }
 
-unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash)
+unsigned int MurmurHash3(unsigned int nHashSeed, const uint8_t *vDataToHash, uint32_t vDataSize)
 {
     // The following is MurmurHash3 (x86_32), see http://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
     uint32_t h1 = nHashSeed;
     const uint32_t c1 = 0xcc9e2d51;
     const uint32_t c2 = 0x1b873593;
 
-    const int nblocks = vDataToHash.size() / 4;
+    const int nblocks = vDataSize / 4;
 
     //----------
     // body
-    const uint8_t* blocks = vDataToHash.data();
+    const uint8_t* blocks = vDataToHash;
 
     for (int i = 0; i < nblocks; ++i) {
         uint32_t k1 = ReadLE32(blocks + i*4);
@@ -39,11 +39,11 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 
     //----------
     // tail
-    const uint8_t* tail = vDataToHash.data() + nblocks * 4;
+    const uint8_t* tail = vDataToHash + nblocks * 4;
 
     uint32_t k1 = 0;
 
-    switch (vDataToHash.size() & 3) {
+    switch (vDataSize & 3) {
         case 3:
             k1 ^= tail[2] << 16;
         case 2:
@@ -58,7 +58,7 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 
     //----------
     // finalization
-    h1 ^= vDataToHash.size();
+    h1 ^= vDataSize;
     h1 ^= h1 >> 16;
     h1 *= 0x85ebca6b;
     h1 ^= h1 >> 13;

--- a/src/hash.h
+++ b/src/hash.h
@@ -214,7 +214,7 @@ uint256 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL
     return ss.GetHash();
 }
 
-unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash);
+unsigned int MurmurHash3(unsigned int nHashSeed, const uint8_t *vDataToHash, uint32_t vDataSize);
 
 void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
 

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -280,8 +280,12 @@ void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CA
                 feeA = liquidityReward(poolSwap.blockCommissionA, liquidity, totalLiquidity);
                 feeB = liquidityReward(poolSwap.blockCommissionB, liquidity, totalLiquidity);
             }
-            onReward(RewardType::Commission, {tokenIds->idTokenA, feeA}, height);
-            onReward(RewardType::Commission, {tokenIds->idTokenB, feeB}, height);
+            if (feeA) {
+                onReward(RewardType::Commission, {tokenIds->idTokenA, feeA}, height);
+            }
+            if (feeB) {
+                onReward(RewardType::Commission, {tokenIds->idTokenB, feeB}, height);
+            }
         }
         // custom rewards
         for (const auto& reward : customRewards.balances) {

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -10,12 +10,17 @@
 
 #include <boost/test/unit_test.hpp>
 
+uint32_t MurmurHash3Proxy(uint32_t seed, const std::vector<uint8_t> &data)
+{
+    return MurmurHash3(seed, data.data(), data.size());
+}
+
 BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(murmurhash3)
 {
 
-#define T(expected, seed, data) BOOST_CHECK_EQUAL(MurmurHash3(seed, ParseHex(data)), expected)
+#define T(expected, seed, data) BOOST_CHECK_EQUAL(MurmurHash3Proxy(seed, ParseHex(data)), expected)
 
     // Test MurmurHash3 with various inputs. Of course this is retested in the
     // bloom filter tests - they would fail if MurmurHash3() had any problems -

--- a/src/wallet/ismine.cpp
+++ b/src/wallet/ismine.cpp
@@ -6,6 +6,7 @@
 #include <wallet/ismine.h>
 
 #include <key.h>
+#include <hash.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
@@ -193,9 +194,17 @@ isminetype IsMine(const CWallet& keystore, const CTxDestination& dest)
     return IsMine(keystore, script);
 }
 
+struct CScriptHash
+{
+    uint32_t operator()(const CScript & script) const
+    {
+        return MurmurHash3(0x1234, script.data(), script.size());
+    }
+};
+
 struct CCacheInfo
 {
-    std::map<CScript, isminetype> mineData;
+    std::unordered_map<CScript, isminetype, CScriptHash> mineData;
     std::array<boost::signals2::scoped_connection, 2> connects;
 };
 


### PR DESCRIPTION
/kind fix

#### What this PR does / why we need it:

- It's address not only listaccounthistory but other commands that want to make filter by addresses owned by the wallet.

- Account history order is fixed in `listaccounthistory mine` as well.

- It prevents showing 0.00000000 commissions history

Fixes #470 

#### Additional comments?:
