### PR TITLE
Allow coin override while minter packages txs

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -595,7 +595,9 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
                 continue;
             }
 
-            AddCoins(coins, tx, nHeight);
+            // allow coin override, tx with same inputs
+            // will be removed for block while we connect it
+            AddCoins(coins, tx, nHeight, false); // do not check
 
             std::vector<unsigned char> metadata;
             CustomTxType txType = GuessCustomTxType(tx, metadata);


### PR DESCRIPTION

/kind fix

#### What this PR does / why we need it:

It prevents minter to stall while trying to package txs that wants to override coin(s) either both txs cannot be correct in same time
as well their coins have different heights as well.
