### PR TITLE
Use actual blocktime when storing TX.

### DIFF
--- a/src/spv/bitcoin/BRPeerManager.cpp
+++ b/src/spv/bitcoin/BRPeerManager.cpp
@@ -1258,7 +1258,7 @@ static void _peerRelayedBlock(void *info, BRMerkleBlock *block)
     prev = (BRMerkleBlock *)BRSetGet(manager->blocks, &block->prevBlock);
 
     if (prev) {
-        txTime = block->timestamp/2 + prev->timestamp/2;
+        txTime = block->timestamp;
         block->height = prev->height + 1;
     }
 


### PR DESCRIPTION
Anchors can end up with time too new error as TX time is mostly set as half the current block time plus half the previous block time. Taking the following error, the block time is 1624342316 however the actual block time is 1624342948.

`2021-06-22T06:25:57Z Anchor too new. DeFi: 1624332030 Bitcoin: 1624342316 Anchor: bceb153c5b0e15e931365f936c95167b06ffaf2a3222c152969c8d17466f0a8f`

 However if we take half the time of the previous block and half the time of the block the TX is in we get...

`(1624342948÷2)+(1624341684÷2) = 1624342316`

1624342316 is the time shown in the log. The update here uses the actual block time, I can only guess that they were trying to set the time of the TX as being somewhere between the current and previous block which is problematic for the time base rules added to the anchoring system.

Resolves https://github.com/DeFiCh/ain/issues/550