### PR TITLE
Fix connection issues on Windows

### DIFF
--- a/src/spv/bitcoin/BRPeerManager.h
+++ b/src/spv/bitcoin/BRPeerManager.h
@@ -33,11 +33,7 @@
 #include <stddef.h>
 #include <inttypes.h>
 
-#ifdef WIN32
-#define PEER_MAX_CONNECTIONS 1
-#else
 #define PEER_MAX_CONNECTIONS 3
-#endif
 
 typedef struct BRPeerManagerStruct BRPeerManager;
 


### PR DESCRIPTION
Select IPv4/IPv6 before calling _BRPeerOpenSocket. For Windows update setsockopt to not constantly drop connections.