### PR TITLE
Fix status in icx_getorder rpc

### DIFF
--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -70,6 +70,19 @@ std::unique_ptr<CICXOrderView::CICXOrderImpl> CICXOrderView::GetICXOrderByCreati
     return {};
 }
 
+uint8_t CICXOrderView::GetICXOrderStatus(OrderKey const & key) const
+{
+    auto status = ReadBy<ICXOrderOpenKey, uint8_t>(key);
+
+    if (!status)
+        status = ReadBy<ICXOrderCloseKey, uint8_t>(key);
+
+    if (status)
+        return (*status);
+
+    return {};
+}
+
 Res CICXOrderView::ICXCreateOrder(CICXOrderImpl const & order)
 {
     //this should not happen, but for sure
@@ -146,6 +159,19 @@ std::unique_ptr<CICXOrderView::CICXMakeOfferImpl> CICXOrderView::GetICXMakeOffer
     auto makeoffer = ReadBy<ICXMakeOfferCreationTx,CICXMakeOfferImpl>(txid);
     if (makeoffer)
         return MakeUnique<CICXMakeOfferImpl>(*makeoffer);
+    return {};
+}
+
+uint8_t CICXOrderView::GetICXMakeOfferStatus(TxidPairKey const & key) const
+{
+    auto status = ReadBy<ICXMakeOfferOpenKey, uint8_t>(key);
+
+    if (!status)
+        status = ReadBy<ICXMakeOfferCloseKey, uint8_t>(key);
+
+    if (status)
+        return (*status);
+
     return {};
 }
 

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -385,6 +385,7 @@ public:
 
     //Order
     std::unique_ptr<CICXOrderImpl> GetICXOrderByCreationTx(uint256 const & txid) const;
+    uint8_t GetICXOrderStatus(OrderKey const & key) const;
     Res ICXCreateOrder(CICXOrderImpl const & order);
     Res ICXUpdateOrder(CICXOrderImpl const & order);
     Res ICXCloseOrderTx(CICXOrderImpl const & order, uint8_t const);
@@ -395,6 +396,7 @@ public:
 
     //MakeOffer
     std::unique_ptr<CICXMakeOfferImpl> GetICXMakeOfferByCreationTx(uint256 const & txid) const;
+    uint8_t GetICXMakeOfferStatus(TxidPairKey const & key) const;
     Res ICXMakeOffer(CICXMakeOfferImpl const & makeoffer);
     Res ICXUpdateMakeOffer(CICXMakeOfferImpl const & makeoffer);
     Res ICXCloseMakeOfferTx(CICXMakeOfferImpl const & order, uint8_t const);

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -177,7 +177,7 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
                             {"tokenFrom|chainFrom", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Symbol or id of selling token/chain"},
                             {"chainTo|tokenTo", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Symbol or id of buying chain/token"},
                             {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of DFI token for fees and selling tokens in case of DFC/BTC order type"},
-                            {"receivePubkey", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "pubkey which can claim external HTLC in case of EXT/DFC order type"},
+                            {"receivePubkey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "pubkey which can claim external HTLC in case of EXT/DFC order type"},
                             {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "tokenFrom coins amount"},
                             {"orderPrice", RPCArg::Type::NUM, RPCArg::Optional::NO, "Price per unit"},
                             {"expiry", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Number of blocks until the order expires (Default: "
@@ -366,7 +366,7 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
                             {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "txid of order tx for which is the offer"},
                             {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "amount fulfilling the order"},
                             {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of DFI token and for receiving tokens in case of EXT/DFC order"},
-                            {"receivePubkey", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "pubkey which can claim external HTLC in case of EXT/DFC order type"},
+                            {"receivePubkey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "pubkey which can claim external HTLC in case of EXT/DFC order type"},
                             {"expiry", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Number of blocks until the offer expires (Default: "
                                 + std::to_string(CICXMakeOffer::DEFAULT_EXPIRY) + " DFI blocks)"},
                         },
@@ -1150,14 +1150,16 @@ UniValue icxgetorder(const JSONRPCRequest& request) {
     auto order = pcustomcsview->GetICXOrderByCreationTx(orderTxid);
     if (order)
     {
-        ret.pushKVs(icxOrderToJSON(*order,-1));
+        auto status = pcustomcsview->GetICXOrderStatus({order->idToken,order->creationTx});
+        ret.pushKVs(icxOrderToJSON(*order, status));
         return ret;
     }
 
     auto fillorder = pcustomcsview->GetICXMakeOfferByCreationTx(orderTxid);
     if (fillorder)
     {
-        ret.pushKVs(icxMakeOfferToJSON(*fillorder,-1));
+        auto status = pcustomcsview->GetICXMakeOfferStatus({fillorder->orderTx,fillorder->creationTx});
+        ret.pushKVs(icxMakeOfferToJSON(*fillorder, status));
         return ret;
     }
 

--- a/test/functional/feature_icx_orderbook.py
+++ b/test/functional/feature_icx_orderbook.py
@@ -116,6 +116,20 @@ class ICXOrderbookTest (DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
+        order = self.nodes[0].icx_getorder(orderTx)
+
+        assert_equal(order[orderTx]["status"], "OPEN")
+        assert_equal(order[orderTx]["type"], "INTERNAL")
+        assert_equal(order[orderTx]["tokenFrom"], symbolDFI)
+        assert_equal(order[orderTx]["chainTo"], "BTC")
+        assert_equal(order[orderTx]["ownerAddress"], accountDFI)
+        assert_equal(order[orderTx]["receivePubkey"], '037f9563f30c609b19fd435a19b8bde7d6db703012ba1aba72e9f42a87366d1941')
+        assert_equal(order[orderTx]["amountFrom"], Decimal('15'))
+        assert_equal(order[orderTx]["amountToFill"], Decimal('15'))
+        assert_equal(order[orderTx]["orderPrice"], Decimal('0.01000000'))
+        assert_equal(order[orderTx]["amountToFillInToAsset"], Decimal('0.1500000'))
+        assert_equal(order[orderTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 2880)
+
         beforeOffer = self.nodes[1].getaccount(accountBTC, {}, True)[idDFI]
 
         offerTx = self.nodes[1].icx_makeoffer({
@@ -131,6 +145,10 @@ class ICXOrderbookTest (DefiTestFramework):
         offer = self.nodes[0].icx_listorders({"orderTx": orderTx})
 
         assert_equal(len(offer), 2)
+
+        offer = self.nodes[0].icx_getorder(offerTx)
+
+        assert_equal(offer[offerTx]["status"], "OPEN")
 
         # Close offer
         closeOrder = self.nodes[1].icx_closeoffer(offerTx)["txid"]
@@ -150,6 +168,10 @@ class ICXOrderbookTest (DefiTestFramework):
         offer = self.nodes[0].icx_listorders({"orderTx": orderTx})
 
         assert_equal(len(offer), 1)
+
+        offer = self.nodes[0].icx_getorder(offerTx)
+
+        assert_equal(offer[offerTx]["status"], "CLOSED")
 
         # Check order exist
         order = self.nodes[0].icx_listorders()
@@ -171,6 +193,11 @@ class ICXOrderbookTest (DefiTestFramework):
         order = self.nodes[0].icx_listorders()
 
         assert_equal(len(order), 1)
+
+        order = self.nodes[0].icx_getorder(orderTx)
+
+        assert_equal(order[orderTx]["status"], "CLOSED")
+        assert_equal(order[orderTx]["type"], "INTERNAL")
 
         # DFI/BTC scenario
         # Open an order

--- a/test/functional/feature_icx_orderbook.py
+++ b/test/functional/feature_icx_orderbook.py
@@ -699,6 +699,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(len(offer), 2)
 
         self.nodes[1].generate(10)
+        self.sync_blocks()
 
         assert_equal(self.nodes[1].getaccount(accountBTC, {}, True)[idDFI], beforeOffer)
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Adding status in icx_getorder rpc. Fixing receivePubkey argument type to be string instead of number. Fixing failing ICX test. 

#### Which issue(s) does this PR fixes?:

Fixes #567