### PR TITLE
ICX hardfork fixes

### DIFF
--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -297,12 +297,17 @@ std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::HasICXSubmi
 
 bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPreEunosPaya)
 {
+    bool result = false;
+
+    if (HasICXSubmitDFCHTLCOpen(offertxid))
+        result = true;
     if (isPreEunosPaya)
-        return HasICXSubmitDFCHTLCOpen(offertxid) ? true : false;
+        return (result);
     auto it = LowerBound<ICXSubmitDFCHTLCCloseKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
-        return true;
-    return false;
+        result = true;
+
+    return (result);
 }
 
 std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::GetICXSubmitEXTHTLCByCreationTx(const uint256 & txid) const
@@ -370,12 +375,17 @@ std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmi
 
 bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPreEunosPaya)
 {
+    bool result = false;
+
+    if (HasICXSubmitEXTHTLCOpen(offertxid))
+        result = true;
     if (isPreEunosPaya)
-        return HasICXSubmitEXTHTLCOpen(offertxid) ? true : false;
+        return (result);
     auto it = LowerBound<ICXSubmitEXTHTLCCloseKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
-        return true;
-    return false;
+        result = true;
+
+    return (result);
 }
 
 std::unique_ptr<CICXOrderView::CICXClaimDFCHTLCImpl> CICXOrderView::GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const

--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -295,13 +295,12 @@ std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::HasICXSubmi
     return {};
 }
 
-bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid)
+bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPreEunosPaya)
 {
-    auto it = LowerBound<ICXSubmitDFCHTLCOpenKey>(TxidPairKey{offertxid, {}});
+    if (isPreEunosPaya)
+        return HasICXSubmitDFCHTLCOpen(offertxid) ? true : false;
+    auto it = LowerBound<ICXSubmitDFCHTLCCloseKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
-        return true;
-    auto it1 = LowerBound<ICXSubmitDFCHTLCCloseKey>(TxidPairKey{offertxid, {}});
-    if (it1.Valid() && it1.Key().first == offertxid)
         return true;
     return false;
 }
@@ -369,13 +368,12 @@ std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmi
     return {};
 }
 
-bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid)
+bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPreEunosPaya)
 {
-    auto it = LowerBound<ICXSubmitEXTHTLCOpenKey>(TxidPairKey{offertxid, {}});
+    if (isPreEunosPaya)
+        return HasICXSubmitEXTHTLCOpen(offertxid) ? true : false;
+    auto it = LowerBound<ICXSubmitEXTHTLCCloseKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
-        return true;
-    auto it1 = LowerBound<ICXSubmitEXTHTLCCloseKey>(TxidPairKey{offertxid, {}});
-    if (it1.Valid() && it1.Key().first == offertxid)
         return true;
     return false;
 }

--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -295,6 +295,17 @@ std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::HasICXSubmi
     return {};
 }
 
+bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid)
+{
+    auto it = LowerBound<ICXSubmitDFCHTLCOpenKey>(TxidPairKey{offertxid, {}});
+    if (it.Valid() && it.Key().first == offertxid)
+        return true;
+    auto it1 = LowerBound<ICXSubmitDFCHTLCCloseKey>(TxidPairKey{offertxid, {}});
+    if (it1.Valid() && it1.Key().first == offertxid)
+        return true;
+    return false;
+}
+
 std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::GetICXSubmitEXTHTLCByCreationTx(const uint256 & txid) const
 {
     auto submitexthtlc = ReadBy<ICXSubmitEXTHTLCCreationTx,CICXSubmitEXTHTLCImpl>(txid);
@@ -356,6 +367,17 @@ std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmi
     if (it.Valid() && it.Key().first == offertxid)
         return GetICXSubmitEXTHTLCByCreationTx(it.Key().second);
     return {};
+}
+
+bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid)
+{
+    auto it = LowerBound<ICXSubmitEXTHTLCOpenKey>(TxidPairKey{offertxid, {}});
+    if (it.Valid() && it.Key().first == offertxid)
+        return true;
+    auto it1 = LowerBound<ICXSubmitEXTHTLCCloseKey>(TxidPairKey{offertxid, {}});
+    if (it1.Valid() && it1.Key().first == offertxid)
+        return true;
+    return false;
 }
 
 std::unique_ptr<CICXOrderView::CICXClaimDFCHTLCImpl> CICXOrderView::GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -413,6 +413,8 @@ public:
     void ForEachICXSubmitDFCHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
     void ForEachICXSubmitDFCHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
     std::unique_ptr<CICXSubmitDFCHTLCImpl> HasICXSubmitDFCHTLCOpen(uint256 const & offertxid);
+    bool ExistedICXSubmitDFCHTLC(uint256 const & offertxid);
+
 
     //SubmitEXTHTLC
     std::unique_ptr<CICXSubmitEXTHTLCImpl> GetICXSubmitEXTHTLCByCreationTx(uint256 const & txid) const;
@@ -422,6 +424,7 @@ public:
     void ForEachICXSubmitEXTHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
     void ForEachICXSubmitEXTHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
     std::unique_ptr<CICXSubmitEXTHTLCImpl> HasICXSubmitEXTHTLCOpen(uint256 const & offertxid);
+    bool ExistedICXSubmitEXTHTLC(uint256 const & offertxid);
 
     //ClaimDFCHTLC
     std::unique_ptr<CICXClaimDFCHTLCImpl> GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const;

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -413,7 +413,7 @@ public:
     void ForEachICXSubmitDFCHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
     void ForEachICXSubmitDFCHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
     std::unique_ptr<CICXSubmitDFCHTLCImpl> HasICXSubmitDFCHTLCOpen(uint256 const & offertxid);
-    bool ExistedICXSubmitDFCHTLC(uint256 const & offertxid);
+    bool ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPreEunosPaya);
 
 
     //SubmitEXTHTLC
@@ -424,7 +424,7 @@ public:
     void ForEachICXSubmitEXTHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
     void ForEachICXSubmitEXTHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
     std::unique_ptr<CICXSubmitEXTHTLCImpl> HasICXSubmitEXTHTLCOpen(uint256 const & offertxid);
-    bool ExistedICXSubmitEXTHTLC(uint256 const & offertxid);
+    bool ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPreEunosPaya);
 
     //ClaimDFCHTLC
     std::unique_ptr<CICXClaimDFCHTLCImpl> GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const;

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1384,7 +1384,7 @@ public:
 
             CAmount calcAmount(static_cast<CAmount>((arith_uint256(dfchtlc->amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
             if (submitexthtlc.amount != calcAmount)
-                return Res::Err("amount %d must be equal to calculated dfchtlc amount %d", submitexthtlc.amount, calcAmount);
+                return Res::Err("amount must be equal to calculated dfchtlc amount");
 
             if (submitexthtlc.hash != dfchtlc->hash)
                 return Res::Err("Invalid hash, external htlc hash is different than dfc htlc hash");

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1646,7 +1646,7 @@ public:
             // subtract the balance from txidAddr and return to owner
             CScript txidAddr(offer->creationTx.begin(), offer->creationTx.end());
             CalculateOwnerRewards(offer->ownerAddress);
-            if (!isPreEunosPaya)
+            if (isPreEunosPaya)
             {
                 res = ICXTransfer(order->idToken, offer->amount, txidAddr, offer->ownerAddress);
                 if (!res)

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -455,8 +455,11 @@ public:
     }
 
     Res CheckICXTx() const {
-        if (tx.vout.size() != 2) {
+        if (static_cast<int>(height) < consensus.EunosPayaHeight && tx.vout.size() != 2) {
             return Res::Err("malformed tx vouts ((wrong number of vouts)");
+        }
+        if (static_cast<int>(height) >= consensus.EunosPayaHeight && tx.vout[0].nValue != 0) {
+            return Res::Err("malformed tx vouts, first vout must be OP_RETURN vout with value 0");
         }
         return Res::Ok();
     }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1631,9 +1631,9 @@ public:
         offer->closeTx = closeoffer.creationTx;
         offer->closeHeight = closeoffer.creationHeight;
 
-        if (order->orderType == CICXOrder::TYPE_INTERNAL &&
-            ((static_cast<int>(height) < consensus.EunosPayaHeight && !mnview.HasICXSubmitDFCHTLCOpen(offer->creationTx)) ||
-            (static_cast<int>(height) >= consensus.EunosPayaHeight && !mnview.ExistedICXSubmitDFCHTLC(offer->creationTx))))
+        bool isPreEunosPaya = static_cast<int>(height) < consensus.EunosPayaHeight;
+
+        if (order->orderType == CICXOrder::TYPE_INTERNAL && !mnview.ExistedICXSubmitDFCHTLC(offer->creationTx, isPreEunosPaya))
         {
             // subtract takerFee from txidAddr and return to owner
             CScript txidAddr(offer->creationTx.begin(), offer->creationTx.end());
@@ -1646,14 +1646,13 @@ public:
             // subtract the balance from txidAddr and return to owner
             CScript txidAddr(offer->creationTx.begin(), offer->creationTx.end());
             CalculateOwnerRewards(offer->ownerAddress);
-            if (static_cast<int>(height) < consensus.EunosPayaHeight)
+            if (!isPreEunosPaya)
             {
                 res = ICXTransfer(order->idToken, offer->amount, txidAddr, offer->ownerAddress);
                 if (!res)
                     return res;
             }
-            if ((static_cast<int>(height) < consensus.EunosPayaHeight && !mnview.HasICXSubmitEXTHTLCOpen(offer->creationTx)) ||
-                (static_cast<int>(height) >= consensus.EunosPayaHeight && !mnview.ExistedICXSubmitEXTHTLC(offer->creationTx)))
+            if (!mnview.ExistedICXSubmitEXTHTLC(offer->creationTx, isPreEunosPaya))
             {
                 res = ICXTransfer(DCT_ID{0}, offer->takerFee, txidAddr, offer->ownerAddress);
                 if (!res)

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -1291,8 +1291,7 @@ UniValue icxlisthtlcs(const JSONRPCRequest& request) {
                             {
                                 {"offerTx",RPCArg::Type::STR, RPCArg::Optional::NO, "Offer txid  for which to list all HTLCS"},
                                 {"limit",  RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum number of orders to return (default: 20)"},
-                                {"refunded", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display refunded HTLC (default: false)"},
-                                {"claimed",  RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display claimed HTLCs (default: false)"},
+                                {"closed",  RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display also claimed, expired and refunded HTLCs (default: false)"},
 
                             },
                         },

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -1196,7 +1196,7 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
     size_t limit = 50;
     std::string tokenSymbol, chain;
     uint256 orderTxid;
-    bool closed = false;
+    bool closed = false, offers = false;
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
     if (request.params.size() > 0)
@@ -1204,7 +1204,11 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
         UniValue byObj = request.params[0].get_obj();
         if (!byObj["token"].isNull()) tokenSymbol = trim_ws(byObj["token"].getValStr());
         if (!byObj["chain"].isNull()) chain = trim_ws(byObj["chain"].getValStr());
-        if (!byObj["orderTx"].isNull()) orderTxid = uint256S(byObj["orderTx"].getValStr());
+        if (!byObj["orderTx"].isNull())
+        {
+            orderTxid = uint256S(byObj["orderTx"].getValStr());
+            offers = true;
+        }
         if (!byObj["limit"].isNull()) limit = (size_t) byObj["limit"].get_int64();
         if (!byObj["closed"].isNull()) closed = byObj["closed"].get_bool();
     }
@@ -1244,7 +1248,7 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
 
         return ret;
     }
-    else if (!orderTxid.IsNull())
+    else if (offers)
     {
         auto offerkeylambda = [&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
             if (key.first != orderTxid)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2710,7 +2710,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
                 if (status == CICXSubmitDFCHTLC::STATUS_EXPIRED && order->orderType == CICXOrder::TYPE_INTERNAL)
                 {
-                    if (!cache.HasICXSubmitEXTHTLCOpen(dfchtlc->offerTx))
+                    if (!cache.ExistedICXSubmitEXTHTLC(dfchtlc->offerTx))
                     {
                         CTokenAmount makerDeposit{DCT_ID{0}, offer->takerFee};
                         cache.CalculateOwnerRewards(order->ownerAddress,pindex->nHeight);
@@ -2765,7 +2765,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
                 if (status == CICXSubmitEXTHTLC::STATUS_EXPIRED && order->orderType == CICXOrder::TYPE_EXTERNAL)
                 {
-                    if (!cache.HasICXSubmitDFCHTLCOpen(exthtlc->offerTx))
+                    if (!cache.ExistedICXSubmitDFCHTLC(exthtlc->offerTx))
                     {
                         CTokenAmount makerDeposit{DCT_ID{0}, offer->takerFee};
                         cache.CalculateOwnerRewards(order->ownerAddress,pindex->nHeight);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2671,8 +2671,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                 CScript txidAddr(offer->creationTx.begin(),offer->creationTx.end());
                 CTokenAmount takerFee{DCT_ID{0}, offer->takerFee};
 
-                if ((order->orderType == CICXOrder::TYPE_INTERNAL && !cache.HasICXSubmitDFCHTLCOpen(offer->creationTx)) ||
-                    (order->orderType == CICXOrder::TYPE_EXTERNAL && !cache.HasICXSubmitEXTHTLCOpen(offer->creationTx)))
+                if ((order->orderType == CICXOrder::TYPE_INTERNAL && !cache.ExistedICXSubmitDFCHTLC(offer->creationTx)) ||
+                    (order->orderType == CICXOrder::TYPE_EXTERNAL && !cache.ExistedICXSubmitEXTHTLC(offer->creationTx)))
                 {
                     auto res = cache.SubBalance(txidAddr,takerFee);
                     if (!res)

--- a/test/functional/feature_icx_orderbook_errors.py
+++ b/test/functional/feature_icx_orderbook_errors.py
@@ -299,7 +299,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'timeout': 15})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("amount 100000 must be equal to calculated dfchtlc amount 1000000" in errorString)
+        assert("amount must be equal to calculated dfchtlc amount" in errorString)
 
         # more amount
         try:
@@ -312,7 +312,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'timeout': 15})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("amount 10000000 must be equal to calculated dfchtlc amount 1000000" in errorString)
+        assert("amount must be equal to calculated dfchtlc amount" in errorString)
 
         # different hash
         try:


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
PR contains fixes for the following issues:
- Not able to manually close offer on BTC/DFI order
- Trying to refund takerFee when offer expires if atomic swap already started and takerFee burnt. No more message in the log
- Always recalculating takerFee on HTLC create and leads to negative amount in refund which is not possible
- Not able to create tx if there is no change due to check for 2 vouts on every ICX tx
- Several small and rpc fixes
-
#### Which issue(s) does this PR fixes?:

Fixes #555
Fixes #583 
Fixes #595 

#### Additional comments?:
Fixes will activate on EunosPaya height
