### PR TITLE
Timelock expiration

### DIFF
--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -161,7 +161,7 @@ public:
 
     void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});
 
-    boost::optional<uint16_t> GetTimelock(const uint256& nodeId) const;
+    uint16_t GetTimelock(const uint256& nodeId, const CMasternode& node) const;
 
     // tags
     struct ID { static const unsigned char prefix; };

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -161,7 +161,7 @@ public:
 
     void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});
 
-    uint16_t GetTimelock(const uint256& nodeId, const CMasternode& node) const;
+    uint16_t GetTimelock(const uint256& nodeId, const CMasternode& node, const uint64_t height) const;
 
     // tags
     struct ID { static const unsigned char prefix; };

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -36,7 +36,7 @@ UniValue mnToJSON(uint256 const & nodeId, CMasternode const& node, bool verbose,
         }
         obj.pushKV("localMasternode", localMasternode);
 
-        auto timelock = pcustomcsview->GetTimelock(nodeId);
+        const auto timelock = pcustomcsview->GetTimelock(nodeId, node);
 
         // Only get targetMultiplier for active masternodes
         if (node.IsActive()) {
@@ -50,12 +50,12 @@ UniValue mnToJSON(uint256 const & nodeId, CMasternode const& node, bool verbose,
                 }
             }
 
-            obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), GetTime(), timelock ? *timelock : 0,
+            obj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), GetTime(), timelock,
                                                                   stakerBlockTime ? *stakerBlockTime : 0).getdouble());
         }
 
-        if (timelock && *timelock > 0) {
-            obj.pushKV("timelock", strprintf("%d years", *timelock / 52));
+        if (timelock) {
+            obj.pushKV("timelock", strprintf("%d years", timelock / 52));
         }
 
         /// @todo add unlock height and|or real resign height

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -36,11 +36,11 @@ UniValue mnToJSON(uint256 const & nodeId, CMasternode const& node, bool verbose,
         }
         obj.pushKV("localMasternode", localMasternode);
 
-        const auto timelock = pcustomcsview->GetTimelock(nodeId, node);
+        auto currentHeight = ChainActive().Height();
+        uint16_t timelock = pcustomcsview->GetTimelock(nodeId, node, currentHeight);
 
         // Only get targetMultiplier for active masternodes
         if (node.IsActive()) {
-            auto currentHeight = ChainActive().Height();
             auto usedHeight = currentHeight <= Params().GetConsensus().EunosHeight ? node.creationHeight : currentHeight;
             auto stakerBlockTime = pcustomcsview->GetMasternodeLastBlockTime(node.operatorAuthAddress, usedHeight);
             // No record. No stake blocks or post-fork createmastnode TX, use fork time.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -681,6 +681,7 @@ namespace pos {
         CBlockIndex* tip;
         int64_t height;
         boost::optional<int64_t> stakerBlockTime;
+        uint16_t timelock;
 
         {
             LOCK(cs_main);
@@ -708,6 +709,7 @@ namespace pos {
             height = tip->height + 1;
             creationHeight = int64_t(nodePtr->creationHeight);
             blockTime = std::max(tip->GetMedianTimePast() + 1, GetAdjustedTime());
+            timelock = pcustomcsview->GetTimelock(masternodeID, *nodePtr);
 
             stakerBlockTime = pcustomcsview->GetMasternodeLastBlockTime(args.operatorID, height);
             // No record. No stake blocks or post-fork createmastnode TX, use fork time.
@@ -720,7 +722,6 @@ namespace pos {
 
         auto nBits = pos::GetNextWorkRequired(tip, blockTime, chainparams.GetConsensus());
         auto stakeModifier = pos::ComputeStakeModifier(tip->stakeModifier, args.minterKey.GetPubKey().GetID());
-        const auto timelock = pcustomcsview->GetTimelock(masternodeID);
 
         // Set search time if null or last block has changed
         if (!nLastCoinStakeSearchTime || lastBlockSeen != tip->GetBlockHash()) {
@@ -749,7 +750,7 @@ namespace pos {
                     blockTime = ((uint32_t)currentTime - t);
 
                     if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, height, masternodeID, chainparams.GetConsensus(),
-                                             stakerBlockTime ? *stakerBlockTime : 0, timelock ? *timelock : 0))
+                                             stakerBlockTime ? *stakerBlockTime : 0, timelock))
                     {
                         LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
 
@@ -772,7 +773,7 @@ namespace pos {
                     blockTime = ((uint32_t)searchTime + t);
 
                     if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, height, masternodeID, chainparams.GetConsensus(),
-                                             stakerBlockTime ? *stakerBlockTime : 0, timelock ? *timelock : 0))
+                                             stakerBlockTime ? *stakerBlockTime : 0, timelock))
                     {
                         LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -709,7 +709,7 @@ namespace pos {
             height = tip->height + 1;
             creationHeight = int64_t(nodePtr->creationHeight);
             blockTime = std::max(tip->GetMedianTimePast() + 1, GetAdjustedTime());
-            timelock = pcustomcsview->GetTimelock(masternodeID, *nodePtr);
+            timelock = pcustomcsview->GetTimelock(masternodeID, *nodePtr, height);
 
             stakerBlockTime = pcustomcsview->GetMasternodeLastBlockTime(args.operatorID, height);
             // No record. No stake blocks or post-fork createmastnode TX, use fork time.

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -74,7 +74,7 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
             return false;
         }
         creationHeight = int64_t(nodePtr->creationHeight);
-        timelock = mnView->GetTimelock(masternodeID, *nodePtr);
+        timelock = mnView->GetTimelock(masternodeID, *nodePtr, blockHeader.height);
 
         auto usedHeight = blockHeader.height <= params.EunosHeight ? creationHeight : blockHeader.height;
         stakerBlockTime = mnView->GetMasternodeLastBlockTime(nodePtr->operatorAuthAddress, usedHeight);

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -60,6 +60,7 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
     uint256 masternodeID;
     int64_t creationHeight;
     boost::optional<int64_t> stakerBlockTime;
+    uint16_t timelock;
     {
         // check that block minter exists and active at the height of the block
         AssertLockHeld(cs_main);
@@ -73,6 +74,7 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
             return false;
         }
         creationHeight = int64_t(nodePtr->creationHeight);
+        timelock = mnView->GetTimelock(masternodeID, *nodePtr);
 
         auto usedHeight = blockHeader.height <= params.EunosHeight ? creationHeight : blockHeader.height;
         stakerBlockTime = mnView->GetMasternodeLastBlockTime(nodePtr->operatorAuthAddress, usedHeight);
@@ -84,11 +86,9 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
         }
     }
 
-    const auto timelock = mnView->GetTimelock(masternodeID);
-
     // checking PoS kernel is faster, so check it first
     if (!CheckKernelHash(blockHeader.stakeModifier, blockHeader.nBits, creationHeight, blockHeader.GetBlockTime(),blockHeader.height,
-                         masternodeID, params, stakerBlockTime ? *stakerBlockTime : 0, timelock ? *timelock : 0)) {
+                         masternodeID, params, stakerBlockTime ? *stakerBlockTime : 0, timelock)) {
         return false;
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -246,7 +246,8 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("blocks",           (int)::ChainActive().Height());
+    int height = static_cast<int>(::ChainActive().Height());
+    obj.pushKV("blocks",           height);
     if (BlockAssembler::m_last_block_weight) obj.pushKV("currentblockweight", *BlockAssembler::m_last_block_weight);
     if (BlockAssembler::m_last_block_num_txs) obj.pushKV("currentblocktx", *BlockAssembler::m_last_block_num_txs);
     obj.pushKV("difficulty",       (double)GetDifficulty(::ChainActive().Tip()));
@@ -288,7 +289,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             subObj.pushKV("lastblockcreationattempt", (lastBlockCreationAttemptTs != 0) ? FormatISO8601DateTime(lastBlockCreationAttemptTs) : "0");
         }
 
-        const auto timelock = pcustomcsview->GetTimelock(mnId.second, *nodePtr);
+        const auto timelock = pcustomcsview->GetTimelock(mnId.second, *nodePtr, height);
 
         // Get targetMultiplier if node is active
         if (nodePtr->IsActive()) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -288,7 +288,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             subObj.pushKV("lastblockcreationattempt", (lastBlockCreationAttemptTs != 0) ? FormatISO8601DateTime(lastBlockCreationAttemptTs) : "0");
         }
 
-        auto timelock = pcustomcsview->GetTimelock(mnId.second);
+        const auto timelock = pcustomcsview->GetTimelock(mnId.second, *nodePtr);
 
         // Get targetMultiplier if node is active
         if (nodePtr->IsActive()) {
@@ -301,12 +301,12 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
                     stakerBlockTime = std::min(GetTime() - block->GetBlockTime(), Params().GetConsensus().pos.nStakeMaxAge);
                 }
             }
-            subObj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), GetTime(), timelock ? *timelock : 0,
+            subObj.pushKV("targetMultiplier", pos::CalcCoinDayWeight(Params().GetConsensus(), GetTime(), timelock,
                                                                      stakerBlockTime ? *stakerBlockTime : 0).getdouble());
         }
 
-        if (timelock && *timelock > 0) {
-            obj.pushKV("timelock", strprintf("%d years", *timelock / 52));
+        if (timelock) {
+            obj.pushKV("timelock", strprintf("%d years", timelock / 52));
         }
 
         mnArr.push_back(subObj);

--- a/test/functional/feature_longterm_lockin.py
+++ b/test/functional/feature_longterm_lockin.py
@@ -105,13 +105,13 @@ class MasternodesTimelockTest (DefiTestFramework):
             self.nodes[0].resignmasternode(nodeid5)
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Trying to resign masternode before expiration" in errorString)
+        assert("Trying to resign masternode before timelock expiration" in errorString)
 
         try:
             self.nodes[0].resignmasternode(nodeid10)
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Trying to resign masternode before expiration" in errorString)
+        assert("Trying to resign masternode before timelock expiration" in errorString)
 
         # Time travel five years
         self.nodes[0].set_mocktime(int(time.time()) + (5 * 365 * 24 * 60 * 60))
@@ -123,6 +123,9 @@ class MasternodesTimelockTest (DefiTestFramework):
         result5 = self.nodes[0].getmasternode(nodeid5)
         assert_equal(result5[nodeid5]['state'], 'ENABLED')
 
+        # Timelock should no longer be present
+        assert_equal('timelock' not in result5[nodeid5], True)
+
         # Resign 5 year MN
         self.nodes[0].resignmasternode(nodeid5)
 
@@ -131,7 +134,7 @@ class MasternodesTimelockTest (DefiTestFramework):
             self.nodes[0].resignmasternode(nodeid10)
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("Trying to resign masternode before expiration" in errorString)
+        assert("Trying to resign masternode before timelock expiration" in errorString)
 
         # Generate enough blocks to confirm resignation
         self.nodes[0].generate(41)
@@ -143,6 +146,13 @@ class MasternodesTimelockTest (DefiTestFramework):
 
         # Generate enough future blocks to create average future time
         self.nodes[0].generate(40)
+
+        # Check state
+        result10 = self.nodes[0].getmasternode(nodeid10)
+        assert_equal(result10[nodeid10]['state'], 'ENABLED')
+
+        # Timelock should no longer be present
+        assert_equal('timelock' not in result10[nodeid10], True)
 
         # Resign 10 year MN
         self.nodes[0].resignmasternode(nodeid10)

--- a/test/functional/feature_longterm_lockin.py
+++ b/test/functional/feature_longterm_lockin.py
@@ -117,7 +117,7 @@ class MasternodesTimelockTest (DefiTestFramework):
         self.nodes[0].set_mocktime(int(time.time()) + (5 * 365 * 24 * 60 * 60))
 
         # Generate enough future blocks to create average future time
-        self.nodes[0].generate(40)
+        self.nodes[0].generate(41)
 
         # Check state
         result5 = self.nodes[0].getmasternode(nodeid5)
@@ -145,7 +145,7 @@ class MasternodesTimelockTest (DefiTestFramework):
         self.nodes[0].set_mocktime(int(time.time()) + (10 * 365 * 24 * 60 * 60))
 
         # Generate enough future blocks to create average future time
-        self.nodes[0].generate(40)
+        self.nodes[0].generate(41)
 
         # Check state
         result10 = self.nodes[0].getmasternode(nodeid10)


### PR DESCRIPTION
If timelock has expired return 0 from GetTimelock. This approach will result in timelock expiration being calculated when checking proof-of-stake during block connection just once and only if the MN generating the block has a timelock value set. An alternative would be to check every single masternode on every connected block and zero any expired timelocks in the DB, this would also have to be reversed on reorg, this approach seems heavier.

The impact on stakers needs to be observed, will a single node running 50 MNs be able to stake all of them every second?