### PR TITLE
Change the minimum timeout for HTLCs to ~12h period.

### DIFF
--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -38,7 +38,7 @@ const uint8_t CICXOrder::STATUS_EXPIRED = 3;
 const std::string CICXOrder::CHAIN_BTC = "BTC";
 const std::string CICXOrder::TOKEN_BTC = "BTC";
 
-const uint32_t CICXMakeOffer::DEFAULT_EXPIRY = 10;
+const uint32_t CICXMakeOffer::DEFAULT_EXPIRY = 20;
 const uint32_t CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT = 100;
 const uint8_t CICXMakeOffer::STATUS_OPEN = 0;
 const uint8_t CICXMakeOffer::STATUS_CLOSED = 1;
@@ -47,6 +47,8 @@ const CAmount CICXMakeOffer::DEFAULT_TAKER_FEE_PER_BTC = AmountFromValue(0.003);
 
 const uint32_t CICXSubmitDFCHTLC::MINIMUM_TIMEOUT = 500;
 const uint32_t CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT = 250;
+const uint32_t CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT = 1440;
+const uint32_t CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT = 480;
 const uint8_t CICXSubmitDFCHTLC::STATUS_OPEN = 0;
 const uint8_t CICXSubmitDFCHTLC::STATUS_CLAIMED = 1;
 const uint8_t CICXSubmitDFCHTLC::STATUS_REFUNDED = 2;
@@ -54,8 +56,11 @@ const uint8_t CICXSubmitDFCHTLC::STATUS_EXPIRED = 3;
 
 const uint32_t CICXSubmitEXTHTLC::MINIMUM_TIMEOUT = 30;
 const uint32_t CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT = 15;
+const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_TIMEOUT = 72;
+const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT = 24;
 // constant for calculating BTC block period in DFI block period per hour (BTC estimated to 6 blocks/h, DFI to 96 blocks/h)
 const uint32_t CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS = 16;
+const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS = 20;
 const uint8_t CICXSubmitEXTHTLC::STATUS_OPEN = 0;
 const uint8_t CICXSubmitEXTHTLC::STATUS_CLOSED = 1;
 const uint8_t CICXSubmitEXTHTLC::STATUS_EXPIRED = 3;

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -142,7 +142,9 @@ class CICXSubmitDFCHTLC
 {
 public:
     static const uint32_t MINIMUM_TIMEOUT; // minimum period in blocks after htlc automatically timeouts and funds are returned to owner when it is first htlc
+    static const uint32_t EUNOSPAYA_MINIMUM_TIMEOUT;
     static const uint32_t MINIMUM_2ND_TIMEOUT; // minimum period in blocks after htlc automatically timeouts and funds are returned to owner when it is second htlc
+    static const uint32_t EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLAIMED;
     static const uint8_t STATUS_REFUNDED;
@@ -152,7 +154,7 @@ public:
     uint256 offerTx; // txid for which offer is this HTLC
     CAmount amount = 0; // amount that is put in HTLC
     uint256 hash; // hash for the hash lock part
-    uint32_t timeout = MINIMUM_TIMEOUT; // timeout (absolute in blocks) for timelock part
+    uint32_t timeout = 0; // timeout (absolute in blocks) for timelock part
 
     ADD_SERIALIZE_METHODS;
 
@@ -195,8 +197,11 @@ class CICXSubmitEXTHTLC
 {
 public:
     static const uint32_t MINIMUM_TIMEOUT; // default period in blocks after htlc timeouts when it is first htlc
+    static const uint32_t EUNOSPAYA_MINIMUM_TIMEOUT;
     static const uint32_t MINIMUM_2ND_TIMEOUT; // default period in blocks after htlc timeouts when it is second htlc
+    static const uint32_t EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
     static const uint32_t BTC_BLOCKS_IN_DFI_BLOCKS; // number of BTC blocks in DFI blocks period
+    static const uint32_t EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS; // number of BTC blocks in DFI blocks period
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLOSED;
     static const uint8_t STATUS_EXPIRED;

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1268,8 +1268,14 @@ public:
             if (!mnview.HasICXMakeOfferOpen(offer->orderTx, submitdfchtlc.offerTx))
                 return Res::Err("offerTx (%s) has expired", submitdfchtlc.offerTx.GetHex());
 
-            if (submitdfchtlc.timeout < CICXSubmitDFCHTLC::MINIMUM_TIMEOUT)
-                return Res::Err("timeout must be greater than %d", CICXSubmitDFCHTLC::MINIMUM_TIMEOUT - 1);
+            uint32_t timeout;
+            if (static_cast<int>(height) < consensus.EunosPayaHeight)
+                timeout = CICXSubmitDFCHTLC::MINIMUM_TIMEOUT;
+            else
+                timeout = CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
+
+            if (submitdfchtlc.timeout < timeout)
+                return Res::Err("timeout must be greater than %d", timeout - 1);
 
             srcAddr = CScript(order->creationTx.begin(), order->creationTx.end());
 
@@ -1338,10 +1344,22 @@ public:
                 return Res::Err("Invalid hash, dfc htlc hash is different than extarnal htlc hash - %s != %s",
                         submitdfchtlc.hash.GetHex(),exthtlc->hash.GetHex());
 
-            if (submitdfchtlc.timeout < CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT)
-                return Res::Err("timeout must be greater than %d", CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT - 1);
+            uint32_t timeout, btcBlocksInDfi;
+            if (static_cast<int>(height) < consensus.EunosPayaHeight)
+            {
+                timeout = CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT;
+                btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
+            }
+            else
+            {
+                timeout = CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
+                btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
+            }
 
-            if (submitdfchtlc.timeout >= (exthtlc->creationHeight + (exthtlc->timeout * CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS)) - height)
+            if (submitdfchtlc.timeout < timeout)
+                return Res::Err("timeout must be greater than %d", timeout - 1);
+
+            if (submitdfchtlc.timeout >= (exthtlc->creationHeight + (exthtlc->timeout * btcBlocksInDfi)) - height)
                 return Res::Err("timeout must be less than expiration period of 1st htlc in DFI blocks");
         }
 
@@ -1393,10 +1411,22 @@ public:
             if (submitexthtlc.hash != dfchtlc->hash)
                 return Res::Err("Invalid hash, external htlc hash is different than dfc htlc hash");
 
-            if (submitexthtlc.timeout < CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT)
-                return Res::Err("timeout must be greater than %d", CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT - 1);
+            uint32_t timeout, btcBlocksInDfi;
+            if (static_cast<int>(height) < consensus.EunosPayaHeight)
+            {
+                timeout = CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT;
+                btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
+            }
+            else
+            {
+                timeout = CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
+                btcBlocksInDfi = CICXSubmitEXTHTLC::EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS;
+            }
 
-            if (submitexthtlc.timeout * CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS >= (dfchtlc->creationHeight + dfchtlc->timeout) - height)
+            if (submitexthtlc.timeout < timeout)
+                return Res::Err("timeout must be greater than %d", timeout - 1);
+
+            if (submitexthtlc.timeout * btcBlocksInDfi >= (dfchtlc->creationHeight + dfchtlc->timeout) - height)
                 return Res::Err("timeout must be less than expiration period of 1st htlc in DFC blocks");
         } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
 
@@ -1406,8 +1436,14 @@ public:
             if (!mnview.HasICXMakeOfferOpen(offer->orderTx, submitexthtlc.offerTx))
                 return Res::Err("offerTx (%s) has expired", submitexthtlc.offerTx.GetHex());
 
-            if (submitexthtlc.timeout < CICXSubmitEXTHTLC::MINIMUM_TIMEOUT)
-                return Res::Err("timeout must be greater than %d", CICXSubmitEXTHTLC::MINIMUM_TIMEOUT - 1);
+            uint32_t timeout;
+            if (static_cast<int>(height) < consensus.EunosPayaHeight)
+                timeout = CICXSubmitEXTHTLC::MINIMUM_TIMEOUT;
+            else
+                timeout = CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
+
+            if (submitexthtlc.timeout < timeout)
+                return Res::Err("timeout must be greater than %d", timeout - 1);
 
             CScript offerTxidAddr(offer->creationTx.begin(), offer->creationTx.end());
 

--- a/test/functional/feature_icx_orderbook.py
+++ b/test/functional/feature_icx_orderbook.py
@@ -318,15 +318,14 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(offer[offerTx]["amount"], Decimal('0.10000000'))
         assert_equal(offer[offerTx]["ownerAddress"], accountBTC)
         assert_equal(offer[offerTx]["takerFee"], Decimal('0.01000000'))
-        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 10)
+        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 20)
 
         beforeDFCHTLC = self.nodes[0].getaccount(accountDFI, {}, True)[idDFI]
 
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 10,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -349,7 +348,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[dfchtlcTx]["amount"], Decimal('10.00000000'))
         assert_equal(htlcs[dfchtlcTx]["amountInEXTAsset"], Decimal('0.10000000'))
         assert_equal(htlcs[dfchtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
-        assert_equal(htlcs[dfchtlcTx]["timeout"], 500)
+        assert_equal(htlcs[dfchtlcTx]["timeout"], 1440)
 
         exthtlcTx = self.nodes[1].icx_submitexthtlc({
                                     'offerTx': offerTx,
@@ -357,7 +356,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})["txid"]
+                                    'timeout': 24})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()
@@ -373,7 +372,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[exthtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
         assert_equal(htlcs[exthtlcTx]["htlcScriptAddress"], '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N')
         assert_equal(htlcs[exthtlcTx]["ownerPubkey"], '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252')
-        assert_equal(htlcs[exthtlcTx]["timeout"], 15)
+        assert_equal(htlcs[exthtlcTx]["timeout"], 24)
 
         beforeClaim0 = self.nodes[0].getaccount(accountDFI, {}, True)[idDFI]
         beforeClaim1 = self.nodes[1].getaccount(accountBTC, {}, True)[idDFI]
@@ -439,14 +438,13 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(offer[offerTx]["amount"], Decimal('0.10000000'))
         assert_equal(offer[offerTx]["ownerAddress"], accountBTC)
         assert_equal(offer[offerTx]["takerFee"], Decimal('0.01000000'))
-        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 10)
+        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 20)
 
 
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 5,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -467,7 +465,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[dfchtlcTx]["amount"], Decimal('5.00000000'))
         assert_equal(htlcs[dfchtlcTx]["amountInEXTAsset"], Decimal('0.05000000'))
         assert_equal(htlcs[dfchtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
-        assert_equal(htlcs[dfchtlcTx]["timeout"], 500)
+        assert_equal(htlcs[dfchtlcTx]["timeout"], 1440)
 
         exthtlcTx = self.nodes[1].icx_submitexthtlc({
                                     'offerTx': offerTx,
@@ -475,7 +473,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})["txid"]
+                                    'timeout': 24})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()
@@ -491,7 +489,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[exthtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
         assert_equal(htlcs[exthtlcTx]["htlcScriptAddress"], '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N')
         assert_equal(htlcs[exthtlcTx]["ownerPubkey"], '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252')
-        assert_equal(htlcs[exthtlcTx]["timeout"], 15)
+        assert_equal(htlcs[exthtlcTx]["timeout"], 24)
 
         beforeClaim0 = self.nodes[0].getaccount(accountDFI, {}, True)[idDFI]
         beforeClaim1 = self.nodes[1].getaccount(accountBTC, {}, True)[idDFI]
@@ -577,7 +575,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(offer[offerTx]["ownerAddress"], accountBTC)
         assert_equal(offer[offerTx]["receivePubkey"], '037f9563f30c609b19fd435a19b8bde7d6db703012ba1aba72e9f42a87366d1941')
         assert_equal(offer[offerTx]["takerFee"], Decimal('0.30000000'))
-        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 10)
+        assert_equal(offer[offerTx]["expireHeight"], self.nodes[0].getblockchaininfo()["blocks"] + 20)
 
 
         exthtlcTx = self.nodes[0].icx_submitexthtlc({
@@ -586,7 +584,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 30})["txid"]
+                                    'timeout': 72})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -611,13 +609,12 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[exthtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
         assert_equal(htlcs[exthtlcTx]["htlcScriptAddress"], '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N')
         assert_equal(htlcs[exthtlcTx]["ownerPubkey"], '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252')
-        assert_equal(htlcs[exthtlcTx]["timeout"], 30)
+        assert_equal(htlcs[exthtlcTx]["timeout"], 72)
 
         dfchtlcTx = self.nodes[1].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 2000,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 400})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()
@@ -631,7 +628,7 @@ class ICXOrderbookTest (DefiTestFramework):
         assert_equal(htlcs[dfchtlcTx]["amount"], Decimal('2000.00000000'))
         assert_equal(htlcs[dfchtlcTx]["amountInEXTAsset"], Decimal('2.00000000'))
         assert_equal(htlcs[dfchtlcTx]["hash"], '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220')
-        assert_equal(htlcs[dfchtlcTx]["timeout"], 400)
+        assert_equal(htlcs[dfchtlcTx]["timeout"], 480)
 
 
         beforeClaim = self.nodes[0].getaccount(accountDFI, {}, True)[idDFI]
@@ -699,8 +696,7 @@ class ICXOrderbookTest (DefiTestFramework):
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 15,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -724,7 +720,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})["txid"]
+                                    'timeout': 24})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()
@@ -776,7 +772,7 @@ class ICXOrderbookTest (DefiTestFramework):
         offer = self.nodes[0].icx_listorders({"orderTx": orderTxDFI})
         assert_equal(len(offer), 2)
 
-        self.nodes[1].generate(10)
+        self.nodes[1].generate(20)
 
         assert_equal(self.nodes[1].getaccount(accountBTC, {}, True)[idDFI], beforeOffer)
 
@@ -796,8 +792,7 @@ class ICXOrderbookTest (DefiTestFramework):
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 10,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
         self.nodes[0].generate(1)
 
         assert_equal(self.nodes[0].getaccount(accountDFI, {}, True)[idDFI], beforeDFCHTLC - Decimal('0.01000000'))
@@ -849,7 +844,7 @@ class ICXOrderbookTest (DefiTestFramework):
         offer = self.nodes[0].icx_listorders({"orderTx": orderTxBTC})
         assert_equal(len(offer), 2)
 
-        self.nodes[1].generate(10)
+        self.nodes[1].generate(20)
         self.sync_blocks()
 
         assert_equal(self.nodes[1].getaccount(accountBTC, {}, True)[idDFI], beforeOffer)
@@ -876,7 +871,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 30})["txid"]
+                                    'timeout': 72})["txid"]
 
         self.nodes[0].generate(1)
 
@@ -924,8 +919,7 @@ class ICXOrderbookTest (DefiTestFramework):
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 10,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
         self.nodes[0].generate(1)
         self.sync_blocks()
 
@@ -935,7 +929,7 @@ class ICXOrderbookTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})["txid"]
+                                    'timeout': 24})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()

--- a/test/functional/feature_icx_orderbook_errors.py
+++ b/test/functional/feature_icx_orderbook_errors.py
@@ -226,7 +226,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})
+                                    'timeout': 24})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("offer ("+ offerTx + ") needs to have dfc htlc submitted first, but no dfc htlc found!" in errorString)
@@ -236,8 +236,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 1,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount 0.00000000 is less than 0.00100000" in errorString)
@@ -250,8 +249,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 2,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be lower or equal the offer one" in errorString)
@@ -262,16 +260,15 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'offerTx': offerTx,
                                     'amount': 1,
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 499})
+                                    'timeout': 1439})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("timeout must be greater than 499" in errorString)
+        assert("timeout must be greater than 1439" in errorString)
 
         dfchtlcTx = self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 1,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -281,8 +278,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[0].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 1,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("dfc htlc already submitted" in errorString)
@@ -296,7 +292,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})
+                                    'timeout': 24})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be equal to calculated dfchtlc amount" in errorString)
@@ -309,7 +305,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})
+                                    'timeout': 24})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be equal to calculated dfchtlc amount" in errorString)
@@ -322,7 +318,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0000000029fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})
+                                    'timeout': 24})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("Invalid hash, external htlc hash is different than dfc htlc hash" in errorString)
@@ -335,10 +331,10 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 10})
+                                    'timeout': 23})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("timeout must be greater than 14" in errorString)
+        assert("timeout must be greater than 23" in errorString)
 
         # timeout more than expiration of dfc htlc
         try:
@@ -348,7 +344,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 32})
+                                    'timeout': 73})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("timeout must be less than expiration period of 1st htlc in DFC blocks" in errorString)
@@ -359,7 +355,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 15})["txid"]
+                                    'timeout': 24})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()
@@ -493,8 +489,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[1].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 1,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("offer ("+ offerTx + ") needs to have ext htlc submitted first, but no external htlc found" in errorString)
@@ -507,7 +502,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 30})
+                                    'timeout': 72})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be lower or equal the offer one" in errorString)
@@ -520,10 +515,10 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 29})
+                                    'timeout': 71})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("timeout must be greater than 29" in errorString)
+        assert("timeout must be greater than 71" in errorString)
 
         self.nodes[0].icx_submitexthtlc({
                                     'offerTx': offerTx,
@@ -531,7 +526,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 30})["txid"]
+                                    'timeout': 72})["txid"]
 
         self.nodes[0].generate(1)
         self.sync_blocks()
@@ -544,7 +539,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
                                     'htlcScriptAddress': '13sJQ9wBWh8ssihHUgAaCmNWJbBAG5Hr9N',
                                     'ownerPubkey': '036494e7c9467c8c7ff3bf29e841907fb0fa24241866569944ea422479ec0e6252',
-                                    'timeout': 30})
+                                    'timeout': 72})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("ext htlc already submitted" in errorString)
@@ -554,8 +549,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[1].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 0.5,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 400})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be equal to calculated exthtlc amount" in errorString)
@@ -565,8 +559,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
             self.nodes[1].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 2,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 400})
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("amount must be equal to calculated exthtlc amount" in errorString)
@@ -577,10 +570,10 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'offerTx': offerTx,
                                     'amount': 1,
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 249})
+                                    'timeout': 479})
         except JSONRPCException as e:
             errorString = e.error['message']
-        assert("timeout must be greater than 249" in errorString)
+        assert("timeout must be greater than 479" in errorString)
 
         # timeout more than expiration of ext htlc
         try:
@@ -588,7 +581,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
                                     'offerTx': offerTx,
                                     'amount': 1,
                                     'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 500})
+                                    'timeout': 1441})
         except JSONRPCException as e:
             errorString = e.error['message']
         assert("timeout must be less than expiration period of 1st htlc in DFI blocks" in errorString)
@@ -596,8 +589,7 @@ class ICXOrderbookErrorTest (DefiTestFramework):
         dfchtlcTx = self.nodes[1].icx_submitdfchtlc({
                                     'offerTx': offerTx,
                                     'amount': 1,
-                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220',
-                                    'timeout': 450})["txid"]
+                                    'hash': '957fc0fd643f605b2938e0631a61529fd70bd35b2162a21d978c41e5241a5220'})["txid"]
 
         self.nodes[1].generate(1)
         self.sync_blocks()


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Increasing timeout period for timelock on HTLCs.
For DFC HTLC when it is first HTLC it will be 1440 blocks (~12h), and when second 480 (~4h)
For BTC HTLC when it is first HTLC it will be 72 BTC blocks (~1440 DFC blocks - ~12h), and when second 24 (~480 - ~4h)

Offer will now have default expiration period of 20 blocks.
