### PR TITLE
Set testnet EP fork and increment PROTOCOL_VERSION.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -346,7 +346,7 @@ public:
         consensus.EunosHeight = 354950;
         consensus.EunosSimsHeight = consensus.EunosHeight;
         consensus.EunosKampungHeight = consensus.EunosHeight;
-        consensus.EunosPayaHeight = std::numeric_limits<int>::max();
+        consensus.EunosPayaHeight = 463300;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70017;
+static const int PROTOCOL_VERSION = 70018;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Testnet fork set to 10am SGT 16 July 2021.