### PR TITLE
Fix to activate increase of offer exipry after EunoPaya

### DIFF
--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -38,7 +38,8 @@ const uint8_t CICXOrder::STATUS_EXPIRED = 3;
 const std::string CICXOrder::CHAIN_BTC = "BTC";
 const std::string CICXOrder::TOKEN_BTC = "BTC";
 
-const uint32_t CICXMakeOffer::DEFAULT_EXPIRY = 20;
+const uint32_t CICXMakeOffer::DEFAULT_EXPIRY = 10;
+const uint32_t CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY = 20;
 const uint32_t CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT = 100;
 const uint8_t CICXMakeOffer::STATUS_OPEN = 0;
 const uint8_t CICXMakeOffer::STATUS_CLOSED = 1;
@@ -187,8 +188,6 @@ Res CICXOrderView::ICXMakeOffer(CICXMakeOfferImpl const & makeoffer)
         return Res::Err("makeoffer with creation tx %s already exists!", makeoffer.creationTx.GetHex());
     if (makeoffer.amount == 0)
         return Res::Err("offer amount must be greater than 0!");
-    if (makeoffer.expiry < CICXMakeOffer::DEFAULT_EXPIRY)
-        return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::DEFAULT_EXPIRY - 1);
 
     WriteBy<ICXMakeOfferCreationTx>(makeoffer.creationTx, makeoffer);
     WriteBy<ICXMakeOfferOpenKey>(TxidPairKey(makeoffer.orderTx, makeoffer.creationTx), CICXMakeOffer::STATUS_OPEN);

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -82,6 +82,7 @@ class CICXMakeOffer
 {
 public:
     static const uint32_t DEFAULT_EXPIRY; // default period in blocks after offer automatically expires
+    static const uint32_t EUNOSPAYA_DEFAULT_EXPIRY;
     static const uint32_t MAKER_DEPOSIT_REFUND_TIMEOUT; // minimum period in DFC blocks in which 2nd HTLC must be created, otherwise makerDeposit is refunded to maker
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLOSED;
@@ -92,7 +93,7 @@ public:
     CAmount amount = 0; // amount of asset to swap
     CScript ownerAddress; //address for DFI token for fees, and in case of BTC/DFC order for DFC asset
     CPubKey receivePubkey; // address or BTC pubkey in case of DFC/BTC order
-    uint32_t expiry = DEFAULT_EXPIRY; // when the offer exipres in number of blocks
+    uint32_t expiry = 0; // when the offer exipres in number of blocks
     CAmount takerFee = 0;
 
     ADD_SERIALIZE_METHODS;

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1211,6 +1211,12 @@ public:
         if (!order)
             return Res::Err("order with creation tx " + makeoffer.orderTx.GetHex() + " does not exists!");
 
+        if (static_cast<int>(height) < consensus.EunosPayaHeight && makeoffer.expiry < CICXMakeOffer::DEFAULT_EXPIRY)
+            return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::DEFAULT_EXPIRY - 1);
+
+        if (static_cast<int>(height) >= consensus.EunosPayaHeight && makeoffer.expiry < CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY)
+            return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY - 1);
+
         CScript txidAddr(makeoffer.creationTx.begin(), makeoffer.creationTx.end());
 
         if (order->orderType == CICXOrder::TYPE_INTERNAL) {

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1211,11 +1211,10 @@ public:
         if (!order)
             return Res::Err("order with creation tx " + makeoffer.orderTx.GetHex() + " does not exists!");
 
-        if (static_cast<int>(height) < consensus.EunosPayaHeight && makeoffer.expiry < CICXMakeOffer::DEFAULT_EXPIRY)
-            return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::DEFAULT_EXPIRY - 1);
+        auto expiry = static_cast<int>(height) < consensus.EunosPayaHeight ? CICXMakeOffer::DEFAULT_EXPIRY : CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY;
 
-        if (static_cast<int>(height) >= consensus.EunosPayaHeight && makeoffer.expiry < CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY)
-            return Res::Err("offer expiry must be greater than %d!", CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY - 1);
+        if (makeoffer.expiry < expiry)
+            return Res::Err("offer expiry must be greater than %d!", expiry - 1);
 
         CScript txidAddr(makeoffer.creationTx.begin(), makeoffer.creationTx.end());
 

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -455,6 +455,11 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
         }
 
         targetHeight = ::ChainActive().Height() + 1;
+
+        if (targetHeight < Params().GetConsensus().EunosPayaHeight)
+            makeoffer.expiry = CICXMakeOffer::DEFAULT_EXPIRY;
+        else
+            makeoffer.expiry = CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY;
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Fixing offer expiry default period to be 20 blocks after EunosPaya height
