### PR TITLE
Remove EunosSims

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,7 +125,6 @@ public:
         consensus.DakotaHeight = 678000; // 1st March 2021
         consensus.DakotaCrescentHeight = 733000; // 25th March 2021
         consensus.EunosHeight = 894000; // 3rd June 2021
-        consensus.EunosSimsHeight = consensus.EunosHeight;
         consensus.EunosKampungHeight = 895743;
         consensus.EunosPayaHeight = 1052000;
 
@@ -344,7 +343,6 @@ public:
         consensus.DakotaHeight = 220680;
         consensus.DakotaCrescentHeight = 287700;
         consensus.EunosHeight = 354950;
-        consensus.EunosSimsHeight = consensus.EunosHeight;
         consensus.EunosKampungHeight = consensus.EunosHeight;
         consensus.EunosPayaHeight = 463300;
 
@@ -525,7 +523,6 @@ public:
         consensus.DakotaHeight = 10;
         consensus.DakotaCrescentHeight = 10;
         consensus.EunosHeight = 150;
-        consensus.EunosSimsHeight = consensus.EunosHeight;
         consensus.EunosKampungHeight = consensus.EunosHeight;
         consensus.EunosPayaHeight = 300;
 
@@ -698,7 +695,6 @@ public:
         consensus.DakotaHeight = 10000000;
         consensus.DakotaCrescentHeight = 10000000;
         consensus.EunosHeight = 10000000;
-        consensus.EunosSimsHeight = 10000000;
         consensus.EunosKampungHeight = 10000000;
         consensus.EunosPayaHeight = 10000000;
 
@@ -967,7 +963,6 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             height = std::numeric_limits<int>::max();
         }
         consensus.EunosHeight = static_cast<int>(height);
-        consensus.EunosSimsHeight = static_cast<int>(height);
         consensus.EunosKampungHeight = static_cast<int>(height);
         consensus.EunosPayaHeight = static_cast<int>(height);
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -87,7 +87,6 @@ struct Params {
     int DakotaCrescentHeight;
     /** Fifth major fork **/
     int EunosHeight;
-    int EunosSimsHeight;
     int EunosKampungHeight;
     int EunosPayaHeight;
     /** Foundation share after AMK, normalized to COIN = 100% */

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 
 int GetMnActivationDelay(int height)
 {
-    if (height < Params().GetConsensus().EunosSimsHeight) {
+    if (height < Params().GetConsensus().EunosHeight) {
         return Params().GetConsensus().mn.activationDelay;
     }
 
@@ -60,7 +60,7 @@ int GetMnActivationDelay(int height)
 
 int GetMnResignDelay(int height)
 {
-    if (height < Params().GetConsensus().EunosSimsHeight) {
+    if (height < Params().GetConsensus().EunosHeight) {
         return Params().GetConsensus().mn.resignDelay;
     }
 


### PR DESCRIPTION
EunosSims is now unused after the following commit.

https://github.com/DeFiCh/ain/commit/8e82eadb7527584238c9ab6c9bdc2b55e5b67799#diff-ff53e63501a5e89fd650b378c9708274df8ad5d38fcffa6c64be417c4d438b6d