### PR TITLE
Refactor POS check method signatures and arg validations

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -43,8 +43,9 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
         assert(rewound);
 
         CValidationState validationState;
-        uint8_t subNode{0};
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(), false, subNode);
+        CheckContextState ctxState;
+        
+        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(), ctxState, false);
         assert(checked);
     }
 }

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -60,8 +60,8 @@ static void DuplicateInputs(benchmark::State& state)
 
     while (state.KeepRunning()) {
         CValidationState cvstate{};
-        uint8_t subNode{0};
-        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), false, subNode, false));
+        CheckContextState ctxState;
+        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), ctxState, false, false));
         assert(cvstate.GetRejectReason() == "bad-txns-inputs-duplicate");
     }
 }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -198,8 +198,9 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         return READ_STATUS_INVALID;
 
     CValidationState state;
-    uint8_t subNode{0};
-    if (!CheckBlock(block, state, Params().GetConsensus(), false, subNode)) {
+    CheckContextState ctxState;
+
+    if (!CheckBlock(block, state, Params().GetConsensus(), ctxState, false)) {
         // TODO: We really want to just check merkle tree manually here,
         // but that is expensive, and CheckBlock caches a block's
         // "checked-status" (in the CBlock?). CBlock should be able to

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -736,8 +736,7 @@ namespace pos {
                 CLockFreeGuard lock(pos::Staker::cs_MNLastBlockCreationAttemptTs);
                 pos::Staker::mapMNLastBlockCreationAttemptTs[masternodeID] = GetTime();
             }
-            uint8_t subNode{0};
-
+            CheckContextState ctxState;
             // Search backwards in time first
             if (currentTime > lastSearchTime) {
                 for (uint32_t t = 0; t < currentTime - lastSearchTime; ++t) {
@@ -746,7 +745,7 @@ namespace pos {
                     blockTime = ((uint32_t)currentTime - t);
 
                     if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
-                                             subNodesBlockTime, timelock, subNode))
+                                             subNodesBlockTime, timelock, ctxState))
                     {
                         LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
 
@@ -769,7 +768,7 @@ namespace pos {
                     blockTime = ((uint32_t)searchTime + t);
 
                     if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
-                                             subNodesBlockTime, timelock, subNode))
+                                             subNodesBlockTime, timelock, ctxState))
                     {
                         LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
 

--- a/src/pos.h
+++ b/src/pos.h
@@ -20,6 +20,15 @@ class CCoinsViewCache;
 
 class CCustomCSView;
 
+/// A state that's passed along between various 
+/// Check functions like CheckBlocks, ContextualCheckProofOfStake,
+/// CheckKernelHash, etc to maintain context across the
+/// calls. This is currently mainly only used in the context of
+/// subnet nodes. 
+struct CheckContextState {
+    uint8_t subNode = 0;
+};
+
 namespace pos {
 
     bool CheckStakeModifier(const CBlockIndex* pindexPrev, const CBlockHeader& blockHeader);
@@ -28,7 +37,7 @@ namespace pos {
     bool CheckHeaderSignature(const CBlockHeader& block);
 
 /// Check kernel hash target and coinstake signature
-    bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensus::Params& params, CCustomCSView* mnView, uint8_t& subNode);
+    bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensus::Params& params, CCustomCSView* mnView, CheckContextState& ctxState);
 
 /// Check kernel hash target and coinstake signature. Check that block coinstakeTx matches header
     bool CheckProofOfStake(const CBlockHeader& blockHeader, const CBlockIndex* pindexPrev, const Consensus::Params& params, CCustomCSView* mnView);

--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -38,7 +38,7 @@ namespace pos {
     }
 
     bool CheckKernelHash(const uint256& stakeModifier, uint32_t nBits, int64_t creationHeight, int64_t coinstakeTime, uint64_t blockHeight,
-                    const uint256& masternodeID, const Consensus::Params& params, const std::vector<int64_t> subNodesBlockTime, const uint16_t timelock, uint8_t& subNode) {
+                    const uint256& masternodeID, const Consensus::Params& params, const std::vector<int64_t> subNodesBlockTime, const uint16_t timelock, CheckContextState& ctxState) {
         // Base target
         arith_uint256 targetProofOfStake;
         targetProofOfStake.SetCompact(nBits);
@@ -54,7 +54,7 @@ namespace pos {
 
                 // Increase target by coinDayWeight.
                 if ((hashProofOfStake / static_cast<uint64_t>( GetMnCollateralAmount( static_cast<int>(creationHeight)))) <= targetProofOfStake * coinDayWeight) {
-                    subNode = i;
+                        ctxState.subNode = i;
                     return true;
                 }
             }

--- a/src/pos_kernel.h
+++ b/src/pos_kernel.h
@@ -6,6 +6,7 @@
 #include <consensus/params.h>
 #include <streams.h>
 #include <amount.h>
+#include <pos.h>
 
 class CWallet;
 class COutPoint;
@@ -27,7 +28,7 @@ namespace pos {
 
 /// Check whether stake kernel meets hash target
     bool CheckKernelHash(const uint256& stakeModifier, uint32_t nBits, int64_t creationHeight, int64_t coinstakeTime, uint64_t blockHeight,
-                         const uint256& masternodeID, const Consensus::Params& params, const std::vector<int64_t> subNodesBlockTime, const uint16_t timelock, uint8_t& subNode);
+                         const uint256& masternodeID, const Consensus::Params& params, const std::vector<int64_t> subNodesBlockTime, const uint16_t timelock, CheckContextState& ctxState);
 
 /// Stake Modifier (hash modifier of proof-of-stake)
     uint256 ComputeStakeModifier(const uint256& prevStakeModifier, const CKeyID& key);

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -79,9 +79,9 @@ static CBlock BuildBlockTestCase() {
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
     block.nTime = 0;
-    uint8_t subNode{0};
+    CheckContextState ctxState;
 
-    while (!pos::CheckKernelHash(block.stakeModifier, block.nBits, creationHeight, (int64_t) block.nTime, block.height, masternodeID, Params().GetConsensus(), {0, 0, 0, 0}, 0, subNode)) block.nTime++;
+    while (!pos::CheckKernelHash(block.stakeModifier, block.nBits, creationHeight, (int64_t) block.nTime, block.height, masternodeID, Params().GetConsensus(), {0, 0, 0, 0}, 0, ctxState)) block.nTime++;
 
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(std::move(block));
     auto err = pos::SignPosBlock(pblock, minterKey);

--- a/src/test/pos_tests.cpp
+++ b/src/test/pos_tests.cpp
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(calc_kernel)
                 pos::CalcKernelHash(stakeModifier, 1, coinstakeTime, mnID));
 
     uint32_t target = 0x1effffff;
-    uint8_t subNode{0};
-    BOOST_CHECK(pos::CheckKernelHash(stakeModifier, target, 1, coinstakeTime, 0, mnID, Params().GetConsensus(), {0, 0, 0, 0}, 0, subNode));
+    CheckContextState ctxState;
+    BOOST_CHECK(pos::CheckKernelHash(stakeModifier, target, 1, coinstakeTime, 0, mnID, Params().GetConsensus(), {0, 0, 0, 0}, 0, ctxState));
 
     uint32_t unattainableTarget = 0x00ffffff;
-    BOOST_CHECK(!pos::CheckKernelHash(stakeModifier, unattainableTarget, 1, coinstakeTime, 0, mnID, Params().GetConsensus(), {0, 0, 0, 0}, 0, subNode));
+    BOOST_CHECK(!pos::CheckKernelHash(stakeModifier, unattainableTarget, 1, coinstakeTime, 0, mnID, Params().GetConsensus(), {0, 0, 0, 0}, 0, ctxState));
 
 //    CKey key;
 //    key.MakeNewKey(true); // Need to use compressed keys in segwit or the signing will fail
@@ -140,19 +140,19 @@ BOOST_AUTO_TEST_CASE(contextual_check_pos)
     std::map<uint256, TestMasternodeKeys>::const_iterator pos = testMasternodeKeys.find(masternodeID);
     BOOST_CHECK(pos != testMasternodeKeys.end());
     CKey minterKey = pos->second.operatorKey;
-    uint8_t subNode{0};
+    CheckContextState ctxState;
 
-    BOOST_CHECK(pos::ContextualCheckProofOfStake((CBlockHeader)Params().GenesisBlock(), Params().GetConsensus(), pcustomcsview.get(), subNode));
+    BOOST_CHECK(pos::ContextualCheckProofOfStake((CBlockHeader)Params().GenesisBlock(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
 
 //    uint256 prev_hash = uint256S("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
     uint64_t height = 0;
     uint64_t mintedBlocks = 1;
     std::shared_ptr<CBlock> block = Block(Params().GenesisBlock().GetHash(), height, mintedBlocks);
 
-    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), subNode));
+    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
 
     block->height = 1;
-    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), subNode));
+    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
 }
 
 BOOST_AUTO_TEST_CASE(sign_pos_block)

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 #include <txmempool.h> // For CTxMemPool::cs
 #include <txdb.h>
 #include <versionbits.h>
+#include <pos.h>
 
 #include <algorithm>
 #include <atomic>
@@ -389,7 +390,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOS, uint8_t& subNode, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, CheckContextState& ctxState, bool fCheckPOS, bool fCheckMerkleRoot = true);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);


### PR DESCRIPTION
/kind refactor

- Introduces `CheckContextState` data structure to carry the context across method boundaries, instead of the subNode variable. The subNode var is a bit difficult to intuitively reason with on what this variable is, why it's passed into many Check* methods and what value to set it as for the callers. This  change makes this clearer, along with the ability to extend any additional context, without having to change function signatures, if needed. 
- Introduces `UpdateHeightValidation` to parse the fork height based args to avoid redundant code for validation.  
