### PR TITLE
Fix delay for masternode activation/resign delay

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -113,17 +113,20 @@ CMasternode::State CMasternode::GetState() const
 
 CMasternode::State CMasternode::GetState(int height) const
 {
+    int EunosPayaHeight = Params().GetConsensus().EunosPayaHeight;
+
     if (resignHeight == -1) { // enabled or pre-enabled
         // Special case for genesis block
-        if (creationHeight == 0 || (height < Params().GetConsensus().EunosPayaHeight && height >= creationHeight + GetMnActivationDelay(height))
-            || (height >= Params().GetConsensus().EunosPayaHeight && height >= creationHeight + GetMnActivationDelay(creationHeight))) {
+        int activationDelay = height < EunosPayaHeight ? GetMnActivationDelay(height) : GetMnActivationDelay(creationHeight);
+        if (creationHeight == 0 || height >= creationHeight + activationDelay) {
                 return State::ENABLED;
         }
         return State::PRE_ENABLED;
     }
+
     if (resignHeight != -1) { // pre-resigned or resigned
-        if ((height < Params().GetConsensus().EunosPayaHeight && height < resignHeight + GetMnResignDelay(height))
-            || (height >= Params().GetConsensus().EunosPayaHeight && height < resignHeight + GetMnResignDelay(resignHeight))) {
+        int resignDelay = height < EunosPayaHeight ? GetMnResignDelay(height) : GetMnResignDelay(resignHeight);
+        if (height < resignHeight + resignDelay) {
                 return State::PRE_RESIGNED;
         }
         return State::RESIGNED;

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -115,14 +115,16 @@ CMasternode::State CMasternode::GetState(int height) const
 {
     if (resignHeight == -1) { // enabled or pre-enabled
         // Special case for genesis block
-        if (creationHeight == 0 || height >= creationHeight + GetMnActivationDelay(creationHeight)) {
-            return State::ENABLED;
+        if (creationHeight == 0 || (height < Params().GetConsensus().EunosPayaHeight && height >= creationHeight + GetMnActivationDelay(height))
+            || (height >= Params().GetConsensus().EunosPayaHeight && height >= creationHeight + GetMnActivationDelay(creationHeight))) {
+                return State::ENABLED;
         }
         return State::PRE_ENABLED;
     }
     if (resignHeight != -1) { // pre-resigned or resigned
-        if (height < resignHeight + GetMnResignDelay(resignHeight)) {
-            return State::PRE_RESIGNED;
+        if ((height < Params().GetConsensus().EunosPayaHeight && height < resignHeight + GetMnResignDelay(height))
+            || (height >= Params().GetConsensus().EunosPayaHeight && height < resignHeight + GetMnResignDelay(resignHeight))) {
+                return State::PRE_RESIGNED;
         }
         return State::RESIGNED;
     }

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -115,13 +115,13 @@ CMasternode::State CMasternode::GetState(int height) const
 {
     if (resignHeight == -1) { // enabled or pre-enabled
         // Special case for genesis block
-        if (creationHeight == 0 || height >= creationHeight + GetMnActivationDelay(height)) {
+        if (creationHeight == 0 || height >= creationHeight + GetMnActivationDelay(creationHeight)) {
             return State::ENABLED;
         }
         return State::PRE_ENABLED;
     }
     if (resignHeight != -1) { // pre-resigned or resigned
-        if (height < resignHeight + GetMnResignDelay(height)) {
+        if (height < resignHeight + GetMnResignDelay(resignHeight)) {
             return State::PRE_RESIGNED;
         }
         return State::RESIGNED;


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
When checking the state of MN, instead of getting the delay from params for current height it will use the height when MN was created/resigned. This way it will keep old delay and new delays set after some height will apply only on MNs create/resigned after that height.

#### Which issue(s) does this PR fixes?:

Close #635 
