### PR TITLE
Eunos Paya revised height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,7 +125,7 @@ public:
         consensus.DakotaCrescentHeight = 733000; // 25th March 2021
         consensus.EunosHeight = 894000; // 3rd June 2021
         consensus.EunosKampungHeight = 895743;
-        consensus.EunosPayaHeight = 1052000;
+        consensus.EunosPayaHeight = 1072000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,7 +125,7 @@ public:
         consensus.DakotaCrescentHeight = 733000; // 25th March 2021
         consensus.EunosHeight = 894000; // 3rd June 2021
         consensus.EunosKampungHeight = 895743;
-        consensus.EunosPayaHeight = 1072000;
+        consensus.EunosPayaHeight = 1072000; // Aug 05, 2021.
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks


### PR DESCRIPTION
Revised height to `1072000`. Approx. Thursday 05, August - 7.30am UTC / 3.30pm SGT.

/kind chore