### PR TITLE
Make pspv destruction more deterministic avoiding edge-case deadlocks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1768,13 +1768,14 @@ bool AppInitMain(InitInterfaces& interfaces)
         panchorauths = MakeUnique<CAnchorAuthIndex>();
         panchorAwaitingConfirms.reset();
         panchorAwaitingConfirms = MakeUnique<CAnchorAwaitingConfirms>();
-        SetupAnchorSPVDatabases(gArgs.GetBoolArg("-spv_resync", fReindex || fReindexChainState));
 
         // Check if DB version changed
         if (spv::pspv && SPV_DB_VERSION != spv::pspv->GetDBVersion()) {
             SetupAnchorSPVDatabases(true);
             assert(spv::pspv->SetDBVersion() == SPV_DB_VERSION);
             LogPrintf("Cleared anchor and SPV dasebase. SPV DB version set to %d\n", SPV_DB_VERSION);
+        } else {
+            SetupAnchorSPVDatabases(gArgs.GetBoolArg("-spv_resync", fReindex || fReindexChainState));
         }
 
         if (spv::pspv) {


### PR DESCRIPTION
This fixes the edge case deadlocks that could hang the node due to spv destructors using up the locks.  

Note: The usage locks in destructors still have to be strictly disallowed, but making things deterministic for now to avoid deadlocking scenarios.

Context: 

- [Currently, this change](https://github.com/DeFiCh/ain/commit/20bd608730116a5683fde678cb1a5380c05681c6#diff-b1e19192258d83199d8adaa5ac31[…]4bfdd679bd8e8073815e69dL1749-R1781) causes the unintended side effect of destructing the spv::pspv multiple times, which locks on destructors (a past remnant from [this code]( 
 https://github.com/DeFiCh/ain/blob/20bd608730116a5683fde678cb1a5380c05681c6/src/spv/spv_wrapper.cpp#L301-L312)). 

/kind fix