### PR TITLE
Fix to remove collateral token when factor set to 0

### DIFF
--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -189,7 +189,7 @@ UniValue getcollateraltoken(const JSONRPCRequest& request) {
     {
         start.first = idToken;
         auto collToken = pcustomcsview->HasLoanSetCollateralToken(start);
-        if (collToken)
+        if (collToken && collToken->factor)
         {
             ret.pushKVs(setCollateralTokenToJSON(*collToken));
         }
@@ -206,7 +206,7 @@ UniValue getcollateraltoken(const JSONRPCRequest& request) {
 
         currentToken = key.first;
         auto collToken = pcustomcsview->GetLoanSetCollateralToken(collTokenTx);
-        if (collToken)
+        if (collToken && collToken->factor)
         {
             ret.pushKVs(setCollateralTokenToJSON(*collToken));
         }

--- a/test/functional/feature_loan_setcollateraltoken.py
+++ b/test/functional/feature_loan_setcollateraltoken.py
@@ -17,8 +17,8 @@ class LoanSetCollateralTokenTest (DefiTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-fortcanningheight=50', '-eunosheight=1', '-txindex=1'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-fortcanningheight=50', '-eunosheight=1', '-txindex=1']]
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-fortcanningheight=50', '-eunosheight=50', '-txindex=1'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-fortcanningheight=50', '-eunosheight=50', '-txindex=1']]
 
     def run_test(self):
         assert_equal(len(self.nodes[0].listtokens()), 1) # only one token == DFI
@@ -165,6 +165,17 @@ class LoanSetCollateralTokenTest (DefiTestFramework):
         assert_equal(collTokens[collTokenTx2]["token"], symbolBTC)
         assert_equal(collTokens[collTokenTx2]["factor"], Decimal('0.9'))
         assert_equal(collTokens[collTokenTx2]["activateAfterBlock"], 129)
+
+        collTokenTx4 = self.nodes[0].setcollateraltoken({
+                                    'token': idBTC,
+                                    'factor': 0,
+                                    'priceFeedId': oracle_id1})
+
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        collTokens = self.nodes[0].getcollateraltoken()
+        assert_equal(len(collTokens), 1)
 
 if __name__ == '__main__':
     LoanSetCollateralTokenTest().main()


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Fix to remove token as collateral when `setcollateraltoken` tx with factor 0 is made
