### PR TITLE
Only check previous anchor when SPV enabled

### DIFF
--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -791,8 +791,8 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
 {
     AssertLockHeld(cs_main);
 
-    // Validate previous anchor
-    if (!anchor.previousAnchor.IsNull())
+    // Validate previous anchor. Set spv::pspv to allow anchor auth relay on non-SPV nodes.
+    if (spv::pspv && !anchor.previousAnchor.IsNull())
     {
         auto prev = panchors->GetAnchorByTx(anchor.previousAnchor);
         CAnchorIndex::AnchorRec pending;


### PR DESCRIPTION
This change applies to P2P anchor auth data, on non-SPV nodes it skips checks related to the context of the anchor chain which these nodes will not have available. There is still other validation which makes sure everything else is still correct including that the signature matches the team. Only SPV nodes make use of this anchor data, but we want all nodes to be able to relay the data for a consistent service.