### PR TITLE
Add masternode `timelock` to `CCustomTxRpcVisitor`, now can be retrieved via `decodecustomtx` RPC.

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -166,6 +166,15 @@ std::string CMasternode::GetHumanReadableState(State state)
     }
 }
 
+std::string CMasternode::GetTimelockToString(TimeLock timelock)
+{
+  switch (timelock) {
+    case FIVEYEAR : return "FIVEYEARTIMELOCK";
+    case TENYEAR  : return "TENYEARTIMELOCK";
+    default       : return "NOTIMELOCK";
+  }
+}
+
 bool operator==(CMasternode const & a, CMasternode const & b)
 {
     return (a.mintedBlocks == b.mintedBlocks &&

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -90,6 +90,7 @@ public:
     bool IsActive(int height) const;
 
     static std::string GetHumanReadableState(State state);
+    static std::string GetTimelockToString(TimeLock timelock);
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -70,6 +70,7 @@ public:
         rpcInfo.pushKV("masternodeoperator", EncodeDestination(obj.operatorType == 1 ?
                                                 CTxDestination(PKHash(obj.operatorAuthAddress)) :
                                                 CTxDestination(WitnessV0KeyHash(obj.operatorAuthAddress))));
+        rpcInfo.pushKV("timelock", CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(obj.timelock)));
     }
 
     void operator()(const CResignMasterNodeMessage& obj) const {

--- a/src/test/mn_timelock_tests.cpp
+++ b/src/test/mn_timelock_tests.cpp
@@ -1,0 +1,21 @@
+#include <test/setup_common.h>
+
+#include <masternodes/masternodes.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(mn_timelock_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(GetTimelockToString)
+{
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(CMasternode::ZEROYEAR), "NOTIMELOCK");
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(CMasternode::FIVEYEAR), "FIVEYEARTIMELOCK");
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(CMasternode::TENYEAR), "TENYEARTIMELOCK");
+
+    // from unit16_t
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(uint16_t {0})), "NOTIMELOCK");
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(uint16_t {260})), "FIVEYEARTIMELOCK");
+    BOOST_CHECK_EQUAL(CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(uint16_t {520})), "TENYEARTIMELOCK");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:
This will add masternode `timelock` to `CCustomTxRpcVisitor`. Then timelock data can be retrived with `decodecustomtx` or `getcustomtx` RPCs
#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
