### PR TITLE
Add spv_refundhtlcall

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -286,6 +286,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     { "spv_claimhtlc", 3, "feerate" },
     { "spv_refundhtlc", 2, "feerate" },
+    { "spv_refundhtlcall", 1, "feerate" },
     { "decodecustomtx", 1, "iswitness" },
 
     { "setmockcheckpoint", 0, "height" },

--- a/src/spv/bitcoin/BRTransaction.cpp
+++ b/src/spv/bitcoin/BRTransaction.cpp
@@ -659,7 +659,7 @@ int BRTransactionIsSigned(const BRTransaction *tx)
 // adds signatures to any inputs with NULL signatures that can be signed with any keys
 // forkId is 0 for bitcoin, 0x40 for b-cash, 0x4f for b-gold
 // returns true if tx is signed
-int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCount, HTLCScriptType htlcType, const uint8_t* seed, const uint8_t *redeemScript)
+int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCount, HTLCScriptType htlcType, const uint8_t* seed)
 {
     UInt160 pkh[keysCount];
     size_t i, j;
@@ -694,7 +694,7 @@ int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCo
         size_t elemsCount = BRScriptElements(elems, sizeof(elems)/sizeof(*elems), input->script, input->scriptLen);
         uint8_t pubKey[BRKeyPubKey(&keys[j], NULL, 0)];
         size_t pkLen = BRKeyPubKey(&keys[j], pubKey, sizeof(pubKey));
-        uint8_t sig[73], script[1 + sizeof(sig) + 1 + (seed ? seed[0] + (htlcType == ScriptTypeSeller ? 1 /* OP_1 */ : 0) + 1 /* pushdata */ + redeemScript[0]: sizeof(pubKey))];
+        uint8_t sig[73], script[1 + sizeof(sig) + 1 + (seed ? seed[0] + (htlcType == ScriptTypeSeller ? 1 /* OP_1 */ : 0) + 1 /* pushdata */ + input->scriptLen /* length */ + input->script[0] : sizeof(pubKey))];
         size_t sigLen, scriptLen;
         UInt256 md = UINT256_ZERO;
         
@@ -747,7 +747,7 @@ int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCo
             }
 
             // Add redeemscript
-            scriptLen += BRScriptPushData(&script[scriptLen], sizeof(script) - scriptLen, &redeemScript[1], redeemScript[0]);
+            scriptLen += BRScriptPushData(&script[scriptLen], sizeof(script) - scriptLen, input->script, input->scriptLen);
 
             BRTxInputSetSignature(input, script, scriptLen);
             BRTxInputSetWitness(input, script, 0);

--- a/src/spv/bitcoin/BRTransaction.h
+++ b/src/spv/bitcoin/BRTransaction.h
@@ -142,7 +142,7 @@ int BRTransactionIsSigned(const BRTransaction *tx);
 // adds signatures to any inputs with NULL signatures that can be signed with any keys
 // forkId is 0 for bitcoin, 0x40 for b-cash, 0x4f for b-gold
 // returns true if tx is signed
-int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCount, HTLCScriptType htlcType = ScriptTypeNone, const uint8_t* seed = nullptr, const uint8_t* redeemScript = nullptr);
+int BRTransactionSign(BRTransaction *tx, int forkId, BRKey keys[], size_t keysCount, HTLCScriptType htlcType = ScriptTypeNone, const uint8_t* seed = nullptr);
 
 // true if tx meets IsStandard() rules: https://bitcoin.org/en/developer-guide#standard-transactions
 int BRTransactionIsStandard(const BRTransaction *tx);

--- a/src/spv/bitcoin/BRWallet.cpp
+++ b/src/spv/bitcoin/BRWallet.cpp
@@ -230,12 +230,12 @@ static int _BRWalletContainsUserTx(BRWallet *wallet, const BRTransaction *tx, co
     return r;
 }
 
-static bool _BRWalletContainsHTLCOutput(BRWallet *wallet, const BRTransaction *tx, size_t &output, const UInt160& addressFilter)
+static bool _BRWalletContainsHTLCOutput(BRWallet *wallet, const BRTransaction *tx, std::vector<size_t> &output, const UInt160& addressFilter)
 {
     bool r = false;
     const uint8_t *pkh;
 
-    for (size_t i = 0; ! r && i < tx->outCount; i++)
+    for (size_t i = 0; i < tx->outCount; i++)
     {
         pkh = BRScriptPKH(tx->outputs[i].script, tx->outputs[i].scriptLen);
         if (pkh)
@@ -250,7 +250,7 @@ static bool _BRWalletContainsHTLCOutput(BRWallet *wallet, const BRTransaction *t
                     continue;
                 }
 
-                output = i;
+                output.push_back(i);
                 r = true;
             }
         }
@@ -345,15 +345,17 @@ std::vector<std::pair<BRTransaction*, size_t>> BRListHTLCReceived(BRWallet *wall
 {
     std::vector<std::pair<BRTransaction*, size_t>> htlcTransactions;
     BRTransaction *tx;
-    size_t output{0};
 
     for (size_t i = 0; i < array_count(wallet->transactions); ++i)
     {
+        std::vector<size_t> outputs;
         tx = wallet->transactions[i];
 
-        if (_BRWalletContainsHTLCOutput(wallet, tx, output, addr))
+        if (_BRWalletContainsHTLCOutput(wallet, tx, outputs, addr))
         {
-            htlcTransactions.emplace_back(tx, output);
+            for (const auto& out : outputs) {
+                htlcTransactions.emplace_back(tx, out);
+            }
         }
     }
 

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -169,7 +169,9 @@ public:
     // Bitcoin HTLC calls
     UniValue GetHTLCReceived(const std::string &addr);
     std::string GetHTLCSeed(uint8_t* md20);
-    UniValue CreateHTLCTransaction(CWallet* const pwallet, const char *scriptAddress, const char *destinationAddress, const std::string& seed, uint64_t feerate, bool seller);
+    std::pair<std::string, std::string> PrepareHTLCTransaction(CWallet* const pwallet, const char *scriptAddress, const char *destinationAddress, const std::string& seed, uint64_t feerate, bool seller);
+    std::pair<std::string, std::string> CreateHTLCTransaction(CWallet* const pwallet, const std::vector<std::pair<HTLCDetails, CScript>>& scriptDetails, const char *destinationAddress, const std::string& seed, uint64_t feerate, bool seller);
+    UniValue RefundAllHTLC(CWallet* const pwallet, const char *destinationAddress, uint64_t feeRate);
 
     // Get and set DB version
     int GetDBVersion();


### PR DESCRIPTION
Adds a call to refund all HTLCs in the wallet for which the correct private key is known and has enough confirmations.

Fixes a bug where only one HTLC output in a TX could be seen or spent.

