### PR TITLE
Reject custom TX with unknown or none type and TX with extra opcodes

### DIFF
--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -66,7 +66,8 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
 
 bool ParseScriptByMarker(CScript const & script,
                          const std::vector<unsigned char> & marker,
-                         std::vector<unsigned char> & metadata)
+                         std::vector<unsigned char> & metadata,
+                         bool& metaOpcodeCheck)
 {
     opcodetype opcode;
     auto pc = script.begin();
@@ -79,22 +80,31 @@ bool ParseScriptByMarker(CScript const & script,
     || memcmp(&metadata[0], &marker[0], marker.size()) != 0) {
         return false;
     }
+
+    // Check that no more opcodes are found in the script
+    if (metaOpcodeCheck) {
+        if (script.GetOp(pc, opcode)) {
+            metaOpcodeCheck = false;
+            return false;
+        }
+    }
+
     metadata.erase(metadata.begin(), metadata.begin() + marker.size());
     return true;
 }
 
-bool IsAnchorRewardTx(CTransaction const & tx, std::vector<unsigned char> & metadata)
+bool IsAnchorRewardTx(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metaOpcodeCheck)
 {
     if (!tx.IsCoinBase() || tx.vout.size() != 2 || tx.vout[0].nValue != 0) {
         return false;
     }
-    return ParseScriptByMarker(tx.vout[0].scriptPubKey, DfAnchorFinalizeTxMarker, metadata);
+    return ParseScriptByMarker(tx.vout[0].scriptPubKey, DfAnchorFinalizeTxMarker, metadata, metaOpcodeCheck);
 }
 
-bool IsAnchorRewardTxPlus(CTransaction const & tx, std::vector<unsigned char> & metadata)
+bool IsAnchorRewardTxPlus(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metaOpcodeCheck)
 {
     if (!tx.IsCoinBase() || tx.vout.size() != 2 || tx.vout[0].nValue != 0) {
         return false;
     }
-    return ParseScriptByMarker(tx.vout[0].scriptPubKey, DfAnchorFinalizeTxMarkerPlus, metadata);
+    return ParseScriptByMarker(tx.vout[0].scriptPubKey, DfAnchorFinalizeTxMarkerPlus, metadata, metaOpcodeCheck);
 }

--- a/src/consensus/tx_check.h
+++ b/src/consensus/tx_check.h
@@ -26,8 +26,9 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fChe
 
 bool ParseScriptByMarker(CScript const & script,
                          const std::vector<unsigned char> & marker,
-                         std::vector<unsigned char> & metadata);
-bool IsAnchorRewardTx(CTransaction const & tx, std::vector<unsigned char> & metadata);
-bool IsAnchorRewardTxPlus(CTransaction const & tx, std::vector<unsigned char> & metadata);
+                         std::vector<unsigned char> & metadata,
+                         bool& metaOpcodeCheck);
+bool IsAnchorRewardTx(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metaOpcodeCheck = false);
+bool IsAnchorRewardTxPlus(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metaOpcodeCheck = false);
 
 #endif // DEFI_CONSENSUS_TX_CHECK_H

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1904,9 +1904,13 @@ Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTr
         return res;
     }
     std::vector<unsigned char> metadata;
-    auto txType = GuessCustomTxType(tx, metadata);
+    const auto metadataValidation = height >= consensus.FortCanningHeight;
+    auto txType = GuessCustomTxType(tx, metadata, metadataValidation);
     if (txType == CustomTxType::None) {
         return res;
+    }
+    if (metadataValidation && txType == CustomTxType::Reject) {
+        return Res::ErrCode(CustomTxErrCodes::Fatal, "Invalid custom transaction");
     }
     auto txMessage = customTypeToMessage(txType);
     CAccountsHistoryWriter view(mnview, height, txn, tx.GetHash(), uint8_t(txType), historyView, burnView);

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -34,6 +34,8 @@ enum CustomTxErrCodes : uint32_t {
 enum class CustomTxType : uint8_t
 {
     None = 0,
+    Reject = 1, // Invalid TX type. Returned by GuessCustomTxType on invalid custom TX.
+
     // masternodes:
     CreateMasternode      = 'C',
     ResignMasternode      = 'R',
@@ -107,6 +109,7 @@ inline CustomTxType CustomTxCodeToType(uint8_t ch) {
         case CustomTxType::ICXClaimDFCHTLC:
         case CustomTxType::ICXCloseOrder:
         case CustomTxType::ICXCloseOffer:
+        case CustomTxType::Reject:
         case CustomTxType::None:
             return type;
     }
@@ -290,15 +293,24 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView& mnview, const CTransactio
 /*
  * Checks if given tx is probably one of 'CustomTx', returns tx type and serialized metadata in 'data'
 */
-inline CustomTxType GuessCustomTxType(CTransaction const & tx, std::vector<unsigned char> & metadata){
+inline CustomTxType GuessCustomTxType(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metadataValidation = false){
     if (tx.vout.empty()) {
         return CustomTxType::None;
     }
-    if (!ParseScriptByMarker(tx.vout[0].scriptPubKey, DfTxMarker, metadata)) {
+    const auto metaCheckState = metadataValidation;
+    if (!ParseScriptByMarker(tx.vout[0].scriptPubKey, DfTxMarker, metadata, metadataValidation)) {
+        // If meta length check bool changes state reject TX
+        if (metadataValidation != metaCheckState) {
+            return CustomTxType::Reject;
+        }
         return CustomTxType::None;
     }
     auto txType = CustomTxCodeToType(metadata[0]);
     metadata.erase(metadata.begin());
+    // Reject if marker has been found but no known type or None explicitly set.
+    if (txType == CustomTxType::None) {
+        return CustomTxType::Reject;
+    }
     return txType;
 }
 

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -535,8 +535,8 @@ UniValue isappliedcustomtx(const JSONRPCRequest& request) {
     RPCHelpMan{"isappliedcustomtx",
                "\nChecks that custom transaction was affected on chain\n",
                {
-                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "A transaction hash"},
-                    {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The height of block which contain tx"}
+                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A transaction hash"},
+                    {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of block which contain tx"}
                },
                RPCResult{
                        "(bool) The boolean indicate that custom transaction was affected on chain\n"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4184,8 +4184,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         TBytes dummy;
         for (unsigned int i = 1; i < block.vtx.size(); i++) {
             if (block.vtx[i]->IsCoinBase() &&
-                !IsAnchorRewardTx(*block.vtx[i], dummy) &&
-                !IsAnchorRewardTxPlus(*block.vtx[i], dummy))
+                !IsAnchorRewardTx(*block.vtx[i], dummy, block.height >= consensusParams.FortCanningHeight) &&
+                !IsAnchorRewardTxPlus(*block.vtx[i], dummy, block.height >= consensusParams.FortCanningHeight))
                 return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-cb-multiple", "more than one coinbase");
         }
     }


### PR DESCRIPTION
After FortCanning if any custom TX has the DfTx marker but has an unknown type which will resolve to None or has None explicitly set then it will be rejected. Also any custom TX which has additional opcodes after the metadata will be rejected.

The `CustomTxType::Reject` is for convenience to make use of the same return type from `GuessCustomTxType`, it will not be seen elsewhere on the blockchain. If someone sets Reject before FC it resolves to None as any other unknown type would do, and after FC it would be rejected by mempool and block validation.