### PR TITLE
compile fix for current libboost

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -208,7 +208,7 @@ void ofstream::close()
 }
 #else // __GLIBCXX__
 
-static_assert(sizeof(*fs::path().BOOST_FILESYSTEM_C_STR) == sizeof(wchar_t),
+static_assert(sizeof(BOOST_FILESYSTEM_C_STR(*fs::path())) == sizeof(wchar_t),
     "Warning: This build is using boost::filesystem ofstream and ifstream "
     "implementations which will fail to open paths containing multibyte "
     "characters. You should delete this static_assert to ignore this warning, "

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(getwalletenv_file)
     std::string test_name = "test_name.dat";
     const fs::path datadir = GetDataDir();
     fs::path file_path = datadir / test_name;
-    std::ofstream f(file_path.BOOST_FILESYSTEM_C_STR);
+    std::ofstream f(BOOST_FILESYSTEM_C_STR(file_path));
     f.close();
 
     std::string filename;

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -30,7 +30,7 @@ InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainNam
     fs::create_directories(m_walletdir_path_cases["default"]);
     fs::create_directories(m_walletdir_path_cases["custom"]);
     fs::create_directories(m_walletdir_path_cases["relative"]);
-    std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
+    std::ofstream f(BOOST_FILESYSTEM_C_STR(m_walletdir_path_cases["file"]));
     f.close();
 }
 


### PR DESCRIPTION
/kind fix

fixes compile issues using current boost library (I haven't check which one exactly, but 1.77 broke and 1.66 keeps working)