### PR TITLE
Limit GetAggregatePrice to take COracleView instead of the larger CCustomView

### DIFF
--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -315,7 +315,7 @@ Res RevertCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CT
 Res CustomTxVisit(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, uint32_t height, const Consensus::Params& consensus, const CCustomTxMessage& txMessage, uint64_t time = 0);
 ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView& mnview, const CTransaction& tx, int height, const uint256& prevStakeModifier, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
 ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView& mnview, const CTransaction& tx, int height, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
-ResVal<CAmount> GetAggregatePrice(CCustomCSView& view, const std::string& token, const std::string& currency, uint64_t lastBlockTime);
+ResVal<CAmount> GetAggregatePrice(COracleView& view, const std::string& token, const std::string& currency, uint64_t lastBlockTime);
 bool IsVaultPriceValid(CCustomCSView& mnview, const CVaultId& vaultId, uint32_t height);
 Res SwapToDFIOverUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CScript const & from, CScript const & to, uint32_t height);
 

--- a/src/masternodes/rpc_oracles.cpp
+++ b/src/masternodes/rpc_oracles.cpp
@@ -825,7 +825,7 @@ UniValue listlatestrawprices(const JSONRPCRequest &request) {
     return result;
 }
 
-ResVal<CAmount> GetAggregatePrice(CCustomCSView& view, const std::string& token, const std::string& currency, uint64_t lastBlockTime) {
+ResVal<CAmount> GetAggregatePrice(COracleView& view, const std::string& token, const std::string& currency, uint64_t lastBlockTime) {
     arith_uint256 weightedSum = 0;
     uint64_t numLiveOracles = 0, sumWeights = 0;
     view.ForEachOracle([&](const COracleId&, COracle oracle) {
@@ -869,7 +869,7 @@ ResVal<CAmount> GetAggregatePrice(CCustomCSView& view, const std::string& token,
 
 namespace {
 
-    UniValue GetAllAggregatePrices(CCustomCSView& view, uint64_t lastBlockTime, const UniValue& paginationObj) {
+    UniValue GetAllAggregatePrices(COracleView& view, uint64_t lastBlockTime, const UniValue& paginationObj) {
 
         size_t limit = 100;
         int start = 0;


### PR DESCRIPTION
COracleView methods take a larger scope unnecessarily to `CCustomView`, when `COracleView` is sufficient. This prevents us from having better self-containment. 

For instance, `GetAggregatePrice` cannot be called from any of the `COracleView` methods, without a reference to the larger `CCustomView` even though it's unnecessary. 