### PR TITLE
Fix active/nextprice block calculation

### DIFF
--- a/src/masternodes/rpc_oracles.cpp
+++ b/src/masternodes/rpc_oracles.cpp
@@ -534,9 +534,8 @@ bool diffInHour(int64_t time1, int64_t time2) {
 }
 
 std::pair<int, int> GetFixedIntervalPriceBlocks(int currentHeight, const CCustomCSView &mnview){
-    auto FCHeight = Params().GetConsensus().FortCanningHeight;
     auto fixedBlocks = mnview.GetIntervalBlock();
-    auto nextPriceBlock = currentHeight + (fixedBlocks - ((currentHeight - FCHeight) % fixedBlocks));
+    auto nextPriceBlock = currentHeight + (fixedBlocks - ((currentHeight) % fixedBlocks));
     auto activePriceBlock = nextPriceBlock - fixedBlocks;
     return {activePriceBlock, nextPriceBlock};
 }

--- a/test/functional/feature_loan_priceupdate.py
+++ b/test/functional/feature_loan_priceupdate.py
@@ -169,8 +169,8 @@ class PriceUpdateTest (DefiTestFramework):
         fixedPrice = self.nodes[0].getfixedintervalprice("TSLA/USD")
         assert_equal(fixedPrice['activePrice'], Decimal(15.00000000))
         assert_equal(fixedPrice['nextPrice'], Decimal(15.00000000))
-        assert_equal(fixedPrice['activePriceBlock'], 325)
-        assert_equal(fixedPrice['nextPriceBlock'], 331)
+        assert_equal(fixedPrice['activePriceBlock'], 324)
+        assert_equal(fixedPrice['nextPriceBlock'], 330)
 
         oracle2_prices = [
             {"currency": "USD", "tokenAmount": "15@TSLA"},
@@ -287,15 +287,15 @@ class PriceUpdateTest (DefiTestFramework):
         assert_equal(fixedPrice['isLive'], False)
         assert_equal(fixedPrice['activePrice'], Decimal('22.50000000'))
         assert_equal(fixedPrice['nextPrice'], Decimal('57.50000000'))
-        assert_equal(fixedPrice['nextPriceBlock'], 349)
-        assert_equal(fixedPrice['activePriceBlock'], 343)
+        assert_equal(fixedPrice['nextPriceBlock'], 348)
+        assert_equal(fixedPrice['activePriceBlock'], 342)
         self.nodes[0].generate(6)
         fixedPrice = self.nodes[0].getfixedintervalprice("TSLA/USD")
         assert_equal(fixedPrice['isLive'], True)
         assert_equal(fixedPrice['activePrice'], Decimal('57.50000000'))
         assert_equal(fixedPrice['nextPrice'], Decimal('57.50000000'))
-        assert_equal(fixedPrice['nextPriceBlock'], 355)
-        assert_equal(fixedPrice['activePriceBlock'], 349)
+        assert_equal(fixedPrice['nextPriceBlock'], 354)
+        assert_equal(fixedPrice['activePriceBlock'], 348)
 
         fixedPriceList = self.nodes[0].listfixedintervalprices()
         assert_equal(len(fixedPriceList), 3)


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:
fixed return value of `GetFixedIntervalPriceBlocks()` used in `getfixedintervalprice` and `getloaninfo` 
