### PR TITLE
getcustomtxcodes RPC

### DIFF
--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1018,6 +1018,9 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
             if (str.size() == 1) {
                 txType = CustomTxCodeToType(str[0]);
             }
+            if (txType == CustomTxType::None) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid tx type (" + str + ")");
+            }
         }
         if (!optionsObj["limit"].isNull()) {
             limit = (uint32_t) optionsObj["limit"].get_int64();
@@ -1267,6 +1270,8 @@ UniValue listburnhistory(const JSONRPCRequest& request) {
                 // Will search for type ::None if txtype not found.
                 txType = CustomTxCodeToType(str[0]);
                 txTypeSearch = true;
+            } else {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid tx type (" + str + ")");
             }
         }
 
@@ -1414,6 +1419,9 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
             const auto str = optionsObj["txtype"].get_str();
             if (str.size() == 1) {
                 txType = CustomTxCodeToType(str[0]);
+            }
+            if (txType == CustomTxType::None) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid tx type (" + str + ")");
             }
         }
     }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1810,8 +1810,8 @@ UniValue getburninfo(const JSONRPCRequest& request) {
     return result;
 }
 
-UniValue listcustomtxtypes(const JSONRPCRequest& request) {
-    RPCHelpMan{"listcustomtxtypes",
+UniValue getcustomtxcodes(const JSONRPCRequest& request) {
+    RPCHelpMan{"getcustomtxcodes",
                "\nList all available custom transaction types.\n",
                {
                },
@@ -1819,8 +1819,8 @@ UniValue listcustomtxtypes(const JSONRPCRequest& request) {
                        "{\"1\": \"ICXCreateOrder\", \"2\": \"ICXMakeOffer\", ...}     (object) List of custom transaction types { [single letter representation]: custom transaction type name}\n"
                },
                RPCExamples{
-                       HelpExampleCli("listcustomtxtypes", "")
-                       + HelpExampleRpc("listcustomtxtypes", "")
+                       HelpExampleCli("getcustomtxcodes", "")
+                       + HelpExampleRpc("getcustomtxcodes", "")
                },
     }.Check(request);
 
@@ -1851,7 +1851,7 @@ static const CRPCCommand commands[] =
     {"accounts",    "listcommunitybalances", &listcommunitybalances, {}},
     {"accounts",    "sendtokenstoaddress",   &sendtokenstoaddress,   {"from", "to", "selectionMode"}},
     {"accounts",    "getburninfo",           &getburninfo,           {}},
-    {"accounts",    "listcustomtxtypes",     &listcustomtxtypes,     {}},
+    {"accounts",    "getcustomtxcodes",      &getcustomtxcodes,      {}},
 };
 
 void RegisterAccountsRPCCommands(CRPCTable& tableRPC) {

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1816,7 +1816,7 @@ UniValue listcustomtxtypes(const JSONRPCRequest& request) {
                {
                },
                RPCResult{
-                       "{\"ICXCreateOrder\": \"1\", \"ICXMakeOffer\": \"2\", ...}     (object) List of custom transaction types { [name]: single letter representation }\n"
+                       "{\"1\": \"ICXCreateOrder\", \"2\": \"ICXMakeOffer\", ...}     (object) List of custom transaction types { [single letter representation]: custom transaction type name}\n"
                },
                RPCExamples{
                        HelpExampleCli("listcustomtxtypes", "")
@@ -1828,7 +1828,7 @@ UniValue listcustomtxtypes(const JSONRPCRequest& request) {
     for (auto i = 0; i < std::numeric_limits<uint8_t>::max(); i++) {
         auto type = CustomTxCodeToType(i);
         if (type != CustomTxType::None && type != CustomTxType::Reject) {
-            typeObj.pushKV(ToString(type), std::string(1, i));
+            typeObj.pushKV(std::string(1, i), ToString(type));
         }
     }
     return typeObj;

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1802,6 +1802,30 @@ UniValue getburninfo(const JSONRPCRequest& request) {
     return result;
 }
 
+UniValue listcustomtxtypes(const JSONRPCRequest& request) {
+    RPCHelpMan{"listcustomtxtypes",
+               "\nList all available custom transaction types.\n",
+               {
+               },
+               RPCResult{
+                       "{\"ICXCreateOrder\": \"1\", \"ICXMakeOffer\": \"2\", ...}     (object) List of custom transaction types { [name]: single letter representation }\n"
+               },
+               RPCExamples{
+                       HelpExampleCli("listcustomtxtypes", "")
+                       + HelpExampleRpc("listcustomtxtypes", "")
+               },
+    }.Check(request);
+
+    UniValue typeObj(UniValue::VOBJ);
+    for (auto i = 0; i < std::numeric_limits<uint8_t>::max(); i++) {
+        auto type = CustomTxCodeToType(i);
+        if (type != CustomTxType::None && type != CustomTxType::Reject) {
+            typeObj.pushKV(ToString(type), std::string(1, i));
+        }
+    }
+    return typeObj;
+}
+
 static const CRPCCommand commands[] =
 {
 //  category        name                     actor (function)        params
@@ -1819,6 +1843,7 @@ static const CRPCCommand commands[] =
     {"accounts",    "listcommunitybalances", &listcommunitybalances, {}},
     {"accounts",    "sendtokenstoaddress",   &sendtokenstoaddress,   {"from", "to", "selectionMode"}},
     {"accounts",    "getburninfo",           &getburninfo,           {}},
+    {"accounts",    "listcustomtxtypes",     &listcustomtxtypes,     {}},
 };
 
 void RegisterAccountsRPCCommands(CRPCTable& tableRPC) {

--- a/test/functional/rpc_getcustomtxcodes.py
+++ b/test/functional/rpc_getcustomtxcodes.py
@@ -3,7 +3,7 @@
 # Copyright (c) DeFi Blockchain Developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""Test listcustomtxtypes RPC."""
+"""Test getcustomtxcodes RPC."""
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -12,7 +12,7 @@ from test_framework.util import (
     assert_equal,
 )
 
-class RPClistCustomTxTypes(DefiTestFramework):
+class RPCgetCustomTxCodes(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
@@ -44,7 +44,7 @@ class RPClistCustomTxTypes(DefiTestFramework):
         self.nodes[0].minttokens(["300@" + token_a])
         self.nodes[0].generate(1)
 
-        tx_list = self.nodes[0].listcustomtxtypes()
+        tx_list = self.nodes[0].getcustomtxcodes()
         for (key, value) in tx_list.items():
             if value == "MintToken":
                 mint_token_tx_key = key
@@ -84,4 +84,4 @@ class RPClistCustomTxTypes(DefiTestFramework):
             assert_equal(e.error['message'], "Invalid tx type (wrong)")
 
 if __name__ == '__main__':
-    RPClistCustomTxTypes().main ()
+    RPCgetCustomTxCodes().main ()

--- a/test/functional/rpc_listcustomtxtypes.py
+++ b/test/functional/rpc_listcustomtxtypes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test listaccounthistory RPC."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import (
+    assert_equal,
+)
+
+class RPClistCustomTxTypes(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50'],
+        ]
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+
+        # collateral address
+        collateral_a = self.nodes[0].getnewaddress("", "legacy")
+
+        # Create token
+        self.nodes[0].createtoken({
+            "symbol": "GOLD",
+            "name": "gold",
+            "collateralAddress": collateral_a
+        })
+        self.nodes[0].generate(1)
+
+        # Get token ID
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "GOLD"):
+                token_a = idx
+
+        # Mint some tokens
+        self.nodes[0].minttokens(["300@" + token_a])
+        self.nodes[0].generate(1)
+
+        tx_list = self.nodes[0].listcustomtxtypes()
+        print("tx_list", tx_list)
+
+        list_history = self.nodes[0].listaccounthistory("mine", {"txtype": tx_list["MintToken"]})
+        assert_equal(len(list_history), 1)
+        assert_equal(list_history[0]["type"], "MintToken")
+
+        burn_history = self.nodes[0].listburnhistory({"txtype": tx_list["CreateToken"]})
+        assert_equal(len(burn_history), 1)
+        assert_equal(burn_history[0]["type"], "CreateToken")
+
+        list_history_count = self.nodes[0].accounthistorycount()
+        list_history_count_mint = self.nodes[0].accounthistorycount("mine", {"txtype": tx_list["MintToken"]})
+        assert(list_history_count_mint < list_history_count)
+        assert_equal(list_history_count_mint, 1)
+
+if __name__ == '__main__':
+    RPClistCustomTxTypes().main ()

--- a/test/functional/rpc_listcustomtxtypes.py
+++ b/test/functional/rpc_listcustomtxtypes.py
@@ -6,6 +6,7 @@
 """Test listaccounthistory RPC."""
 
 from test_framework.test_framework import DefiTestFramework
+from test_framework.authproxy import JSONRPCException
 
 from test_framework.util import (
     assert_equal,
@@ -44,7 +45,6 @@ class RPClistCustomTxTypes(DefiTestFramework):
         self.nodes[0].generate(1)
 
         tx_list = self.nodes[0].listcustomtxtypes()
-        print("tx_list", tx_list)
 
         list_history = self.nodes[0].listaccounthistory("mine", {"txtype": tx_list["MintToken"]})
         assert_equal(len(list_history), 1)
@@ -58,6 +58,25 @@ class RPClistCustomTxTypes(DefiTestFramework):
         list_history_count_mint = self.nodes[0].accounthistorycount("mine", {"txtype": tx_list["MintToken"]})
         assert(list_history_count_mint < list_history_count)
         assert_equal(list_history_count_mint, 1)
+
+        invalid_tx_type = "wrong"
+        assert not (invalid_tx_type in tx_list.values())
+
+        # should fail with invalid custom tx type
+        try:
+            self.nodes[0].listaccounthistory("mine", {"txtype": invalid_tx_type})
+        except JSONRPCException as e:
+            assert_equal(e.error['message'], "Invalid tx type (wrong)")
+
+        try:
+            self.nodes[0].listburnhistory({"txtype": invalid_tx_type})
+        except JSONRPCException as e:
+            assert_equal(e.error['message'], "Invalid tx type (wrong)")
+
+        try:
+            self.nodes[0].accounthistorycount("mine", {"txtype": invalid_tx_type})
+        except JSONRPCException as e:
+            assert_equal(e.error['message'], "Invalid tx type (wrong)")
 
 if __name__ == '__main__':
     RPClistCustomTxTypes().main ()

--- a/test/functional/rpc_listcustomtxtypes.py
+++ b/test/functional/rpc_listcustomtxtypes.py
@@ -45,22 +45,27 @@ class RPClistCustomTxTypes(DefiTestFramework):
         self.nodes[0].generate(1)
 
         tx_list = self.nodes[0].listcustomtxtypes()
+        for (key, value) in tx_list.items():
+            if value == "MintToken":
+                mint_token_tx_key = key
+            if value == "CreateToken":
+                create_token_tx_key = key
 
-        list_history = self.nodes[0].listaccounthistory("mine", {"txtype": tx_list["MintToken"]})
+        list_history = self.nodes[0].listaccounthistory("mine", {"txtype": mint_token_tx_key})
         assert_equal(len(list_history), 1)
         assert_equal(list_history[0]["type"], "MintToken")
 
-        burn_history = self.nodes[0].listburnhistory({"txtype": tx_list["CreateToken"]})
+        burn_history = self.nodes[0].listburnhistory({"txtype": create_token_tx_key})
         assert_equal(len(burn_history), 1)
         assert_equal(burn_history[0]["type"], "CreateToken")
 
         list_history_count = self.nodes[0].accounthistorycount()
-        list_history_count_mint = self.nodes[0].accounthistorycount("mine", {"txtype": tx_list["MintToken"]})
+        list_history_count_mint = self.nodes[0].accounthistorycount("mine", {"txtype": mint_token_tx_key})
         assert(list_history_count_mint < list_history_count)
         assert_equal(list_history_count_mint, 1)
 
         invalid_tx_type = "wrong"
-        assert not (invalid_tx_type in tx_list.values())
+        assert not (invalid_tx_type in tx_list.keys())
 
         # should fail with invalid custom tx type
         try:

--- a/test/functional/rpc_listcustomtxtypes.py
+++ b/test/functional/rpc_listcustomtxtypes.py
@@ -3,7 +3,7 @@
 # Copyright (c) DeFi Blockchain Developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-"""Test listaccounthistory RPC."""
+"""Test listcustomtxtypes RPC."""
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -243,7 +243,7 @@ BASE_SCRIPTS = [
     'feature_filelock.py',
     'p2p_unrequested_blocks.py',
     'rpc_listaccounthistory.py',
-    'rpc_listcustomtxtypes.py',
+    'rpc_getcustomtxcodes.py',
     'feature_includeconf.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -243,6 +243,7 @@ BASE_SCRIPTS = [
     'feature_filelock.py',
     'p2p_unrequested_blocks.py',
     'rpc_listaccounthistory.py',
+    'rpc_listcustomtxtypes.py',
     'feature_includeconf.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

Adds a RPC method to list all available custom transaction types

#### Which issue(s) does this PR fixes?:

Fixes #806

#### Additional comments?:

This RPC method is needed to use txtype filter in `listburnhistory`, `listaccounthistory` and `accounthistorycount`