### PR TITLE
Optimize COracle::SupportsPair search

### DIFF
--- a/src/masternodes/oracles.cpp
+++ b/src/masternodes/oracles.cpp
@@ -10,7 +10,7 @@
 
 bool COracle::SupportsPair(const std::string& token, const std::string& currency) const
 {
-    return availablePairs.count(std::make_pair(token, currency)) > 0;
+    return availablePairs.find(std::make_pair(token, currency)) != availablePairs.end();
 }
 
 Res COracle::SetTokenPrice(const std::string& token, const std::string& currency, CAmount amount, int64_t timestamp)

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -929,6 +929,8 @@ public:
                 if (IsPoolShare) {
                     if (view.GetBalance(owner, balance.first).nValue == 0) {
                         view.DelShare(balance.first, owner);
+                    } else {
+                        view.SetShare(balance.first, owner, 0);
                     }
                 }
             }
@@ -1077,7 +1079,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
 
     CScript lastOwner;
     auto count = limit;
-    auto lastHeight = maxBlockHeight;
+    auto lastHeight = maxBlockHeight + 1;
 
     auto shouldContinueToNextAccountHistory = [&](AccountHistoryKey const & key, CLazySerialize<AccountHistoryValue> valueLazy) -> bool {
         if (!isMatchOwner(key.owner)) {
@@ -1125,7 +1127,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         if (lastOwner != key.owner) {
             view.Discard();
             lastOwner = key.owner;
-            lastHeight = maxBlockHeight;
+            lastHeight = maxBlockHeight + 1;
         }
 
         if (accountRecord && (tokenFilter.empty() || hasToken(value.diff))) {
@@ -1138,6 +1140,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         }
 
         if (!noRewards && count && lastHeight > workingHeight) {
+            accountRecord && ++workingHeight;
             onPoolRewards(view, key.owner, workingHeight, lastHeight,
                 [&](int32_t height, DCT_ID poolId, RewardType type, CTokenAmount amount) {
                     if (tokenFilter.empty() || hasToken({{amount.nTokenId, amount.nValue}})) {


### PR DESCRIPTION
Improve search from O(n) to O(log n). `std::set` uses red black trees. Low hanging fruit on a mild hotspot function when we have many pairs. 

/kind fix