### PR TITLE
Fix DUSD loan payback bug due to missing short-circuit

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3490,17 +3490,23 @@ Res  SwapToDFIOverUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CS
     if (!token)
         return Res::Err("Cannot find token with id %s!", tokenId.ToString());
 
+    // TODO: Optimize double look up later when first token is DUSD. 
     auto dUsdToken = mnview.GetToken("DUSD");
     if (!dUsdToken)
         return Res::Err("Cannot find token DUSD");
 
-    auto poolTokendUSD = mnview.GetPoolPair(tokenId,dUsdToken->first);
-    if (!poolTokendUSD)
-        return Res::Err("Cannot find pool pair %s-DUSD!", token->symbol);
-
     auto pooldUSDDFI = mnview.GetPoolPair(dUsdToken->first, DCT_ID{0});
     if (!pooldUSDDFI)
         return Res::Err("Cannot find pool pair DUSD-DFI!");
+
+    // Short circuit if it's DUSD token.
+    if (tokenId == dUsdToken->first) {
+        return poolSwap.ExecuteSwap(mnview, {pooldUSDDFI->first});
+    }
+
+    auto poolTokendUSD = mnview.GetPoolPair(tokenId,dUsdToken->first);
+    if (!poolTokendUSD)
+        return Res::Err("Cannot find pool pair %s-DUSD!", token->symbol);
 
     // swap tokenID -> USD -> DFI
     auto res = poolSwap.ExecuteSwap(mnview, {poolTokendUSD->first, pooldUSDDFI->first});

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -929,6 +929,8 @@ public:
                 if (IsPoolShare) {
                     if (view.GetBalance(owner, balance.first).nValue == 0) {
                         view.DelShare(balance.first, owner);
+                    } else {
+                        view.SetShare(balance.first, owner, 0);
                     }
                 }
             }
@@ -1077,7 +1079,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
 
     CScript lastOwner;
     auto count = limit;
-    auto lastHeight = maxBlockHeight;
+    auto lastHeight = maxBlockHeight + 1;
 
     auto shouldContinueToNextAccountHistory = [&](AccountHistoryKey const & key, CLazySerialize<AccountHistoryValue> valueLazy) -> bool {
         if (!isMatchOwner(key.owner)) {
@@ -1125,7 +1127,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         if (lastOwner != key.owner) {
             view.Discard();
             lastOwner = key.owner;
-            lastHeight = maxBlockHeight;
+            lastHeight = maxBlockHeight + 1;
         }
 
         if (accountRecord && (tokenFilter.empty() || hasToken(value.diff))) {
@@ -1138,6 +1140,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         }
 
         if (!noRewards && count && lastHeight > workingHeight) {
+            accountRecord && ++workingHeight;
             onPoolRewards(view, key.owner, workingHeight, lastHeight,
                 [&](int32_t height, DCT_ID poolId, RewardType type, CTokenAmount amount) {
                     if (tokenFilter.empty() || hasToken({{amount.nTokenId, amount.nValue}})) {


### PR DESCRIPTION
/kind fix

- This fixes a bug due to which DUSD loans can become unpayable, since the internal consensus call starts searching for a DUSD-DUSD pool pair due to a missing specialised short-circuit for DUSD, while converting interest / excess to DFI.  
- It's a consensus change, and also an all internal consensus change and shouldn't affect any external surface. 