### PR TITLE
Remove redundant isNull check on RPCArg::Optional::No arguments

### DIFF
--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -184,14 +184,10 @@ UniValue getcollateraltoken(const JSONRPCRequest& request) {
                     "{...}     (object) Json object with collateral token information\n"
                 },
                 RPCExamples{
-                    HelpExampleCli("getcollateraltoken", "DFI")
+                    HelpExampleCli("getcollateraltoken", "DFI") +
+                    HelpExampleRpc("getcollateraltoken", R"("DFI")")
                 },
      }.Check(request);
-
-    RPCTypeCheck(request.params, {UniValue::VSTR}, false);
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 1 must be non-null and expected as string for token symbol or id");
 
     UniValue ret(UniValue::VOBJ);
     std::string tokenSymbol = request.params[0].get_str();
@@ -440,9 +436,6 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
     pwallet->BlockUntilSyncedToCurrentChain();
 
     RPCTypeCheck(request.params, {UniValueType(), UniValue::VOBJ, UniValue::VARR}, false);
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 0 must be non-null and expected as string with token symbol, id or creation txid");
 
     std::string const tokenStr = trim_ws(request.params[0].getValStr());
     UniValue metaObj = request.params[1].get_obj();
@@ -556,14 +549,10 @@ UniValue getloantoken(const JSONRPCRequest& request)
         RPCResult{
             "{...}     (object) Json object with loan token information\n"},
         RPCExamples{
-            HelpExampleCli("getloantoken", "DFI")},
-    }
-        .Check(request);
-
-    RPCTypeCheck(request.params, {UniValue::VSTR}, false);
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-            "Invalid parameters, arguments 1 must be non-null and expected as string for token symbol or id");
+            HelpExampleCli("getloantoken", "DFI") +
+            HelpExampleRpc("getloantoken", "DFI")
+        },
+    }.Check(request);
 
     UniValue ret(UniValue::VOBJ);
     std::string tokenSymbol = request.params[0].get_str();
@@ -980,9 +969,6 @@ UniValue getloanscheme(const JSONRPCRequest& request) {
                },
     }.Check(request);
 
-    if(request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter id, argument must be non-null");
-
     auto loanSchemeId = request.params[0].getValStr();
 
     if (loanSchemeId.empty() || loanSchemeId.length() > 8)
@@ -1048,10 +1034,6 @@ UniValue takeloan(const JSONRPCRequest& request) {
     pwallet->BlockUntilSyncedToCurrentChain();
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 1 must be non-null and expected as object at least with "
-                           "{\"vaultId\",\"amounts\"}");
 
     UniValue metaObj = request.params[0].get_obj();
     UniValue const & txInputs = request.params[1];
@@ -1154,10 +1136,6 @@ UniValue paybackloan(const JSONRPCRequest& request) {
     pwallet->BlockUntilSyncedToCurrentChain();
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, argument 1 must be non-null and expected as object at least with "
-                           "{\"vaultId\",\"amounts\"}");
 
     UniValue metaObj = request.params[0].get_obj();
     UniValue const & txInputs = request.params[1];
@@ -1242,7 +1220,6 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     UniValue ret{UniValue::VOBJ};
 
     LOCK(cs_main);
-
 
     auto height = ::ChainActive().Height() + 1;
     bool useNextPrice = false, requireLivePrice = true;
@@ -1366,7 +1343,6 @@ UniValue getinterest(const JSONRPCRequest& request) {
 
     return ret;
 }
-
 
 static const CRPCCommand commands[] =
 {

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -521,8 +521,6 @@ UniValue getvault(const JSONRPCRequest& request) {
                },
     }.Check(request);
 
-    RPCTypeCheck(request.params, {UniValue::VSTR}, false);
-
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
 
     LOCK(cs_main);
@@ -585,9 +583,6 @@ UniValue updatevault(const JSONRPCRequest& request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, arguments 1 must be non-null");
-
     int targetHeight;
     CVaultMessage vault;
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
@@ -611,11 +606,6 @@ UniValue updatevault(const JSONRPCRequest& request) {
         vault.schemeId
     };
 
-    if (request.params[1].isNull()){
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 2 must be non-null and expected as object at least with one of"
-                           "{\"ownerAddress\",\"loanSchemeId\"}");
-    }
     UniValue params = request.params[1].get_obj();
     if (params["ownerAddress"].isNull() && params["loanSchemeId"].isNull())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "At least ownerAddress OR loanSchemeId must be set");
@@ -711,9 +701,6 @@ UniValue deposittovault(const JSONRPCRequest& request) {
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    if (request.params[0].isNull() || request.params[1].isNull() || request.params[2].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, arguments must be non-null");
-
     // decode vaultId
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
     auto from = DecodeScript(request.params[1].get_str());
@@ -796,9 +783,6 @@ UniValue withdrawfromvault(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot withdrawfromvault while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
-
-    if (request.params[0].isNull() || request.params[1].isNull() || request.params[2].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, arguments must be non-null");
 
     // decode vaultId
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Remove redundant isNull check on RPCArg::Optional::No arguments.
This checks are not needed. It is handled by RPCArg parsing.
