### PR TITLE
Refactor JSON response preventing unnecessary copies

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -79,8 +79,9 @@ static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const Uni
     else if (code == RPC_METHOD_NOT_FOUND)
         nStatus = HTTP_NOT_FOUND;
 
-    std::string strReply = JSONRPCReply(NullUniValue, objError, id);
+    auto strReply = JSONRPCReplyObj(NullUniValue, objError, id).write();
 
+    strReply += '\n';
     req->WriteHeader("Content-Type", "application/json");
     req->WriteReply(nStatus, strReply);
 }
@@ -217,17 +218,16 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
         if (valRequest.isObject()) {
             jreq.parse(valRequest);
 
-            UniValue result = tableRPC.execute(jreq);
-
             // Send reply
-            strReply = JSONRPCReply(result, NullUniValue, jreq.id);
+            strReply = JSONRPCReplyObj(tableRPC.execute(jreq), NullUniValue, jreq.id).write();
 
         // array of requests
         } else if (valRequest.isArray())
-            strReply = JSONRPCExecBatch(jreq, valRequest.get_array());
+            strReply = JSONRPCExecBatch(jreq, valRequest).write();
         else
             throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
 
+        strReply += '\n';
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strReply);
     } catch (const UniValue& objError) {

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -42,12 +42,6 @@ UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const Un
     return reply;
 }
 
-std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id)
-{
-    UniValue reply = JSONRPCReplyObj(result, error, id);
-    return reply.write() + "\n";
-}
-
 UniValue JSONRPCError(int code, const std::string& message)
 {
     UniValue error(UniValue::VOBJ);

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -12,7 +12,6 @@
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);
 UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const UniValue& id);
-std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id);
 UniValue JSONRPCError(int code, const std::string& message);
 
 /** Generate a new RPC authentication cookie and write it to disk */

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -342,34 +342,28 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
 
 static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
 {
-    UniValue rpc_result(UniValue::VOBJ);
-
     try {
         jreq.parse(req);
-
-        UniValue result = tableRPC.execute(jreq);
-        rpc_result = JSONRPCReplyObj(result, NullUniValue, jreq.id);
+        return JSONRPCReplyObj(tableRPC.execute(jreq), NullUniValue, jreq.id);
     }
     catch (const UniValue& objError)
     {
-        rpc_result = JSONRPCReplyObj(NullUniValue, objError, jreq.id);
+        return JSONRPCReplyObj(NullUniValue, objError, jreq.id);
     }
     catch (const std::exception& e)
     {
-        rpc_result = JSONRPCReplyObj(NullUniValue,
-                                     JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
+        return JSONRPCReplyObj(NullUniValue,
+                               JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
     }
-
-    return rpc_result;
 }
 
-std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
+UniValue JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
 {
     UniValue ret(UniValue::VARR);
     for (unsigned int reqIdx = 0; reqIdx < vReq.size(); reqIdx++)
         ret.push_back(JSONRPCExecOne(jreq, vReq[reqIdx]));
 
-    return ret.write() + "\n";
+    return ret;
 }
 
 /**

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -167,7 +167,7 @@ extern CRPCTable tableRPC;
 void StartRPC();
 void InterruptRPC();
 void StopRPC();
-std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
+UniValue JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
 // Retrieves any serialization flags requested in command line argument
 int RPCSerializationFlags();


### PR DESCRIPTION

/kind refactor

`JSONRPCReplyObj` does not double the reserved memory by adding result to new instance of `UniValue`