### PR TITLE
Fix list* RPC consistency with defid flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -585,6 +585,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcallowcors=<host>", "Allow CORS requests from the given host origin. Include scheme and port (eg: -rpcallowcors=http://127.0.0.1:5000)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcjsonformat=<format>", "Format list as specificed json format. (Options are 'object' and 'array')", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -437,7 +437,7 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
         UniValue result;
         for (const auto& command : it->second) {
             if (ExecuteCommand(*command, request, result, &command == &it->second.back())) {
-                return result;
+                return FormatResult(request, result);
             }
         }
     }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -734,3 +734,32 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
     }
     return ret;
 }
+
+UniValue FormatListResult(const UniValue& result) {
+    if (result.isObject() && gArgs.GetArg("-rpcjsonformat", "") == "array") {
+        UniValue ret(UniValue::VARR);
+        for (const auto& key : result.getKeys()) {
+            auto elem = result[key];
+            elem.pushKV("id", key);
+            ret.push_back(elem);
+        }
+        return ret;
+    } else if (result.isArray() && gArgs.GetArg("-rpcjsonformat", "") == "object") {
+        UniValue object{UniValue::VOBJ};
+        std::vector<UniValue> values{result.getValues()};
+
+        int listSize = result.size();
+        for (int i = 0; i < listSize; i++) {
+            object.pushKV(std::to_string(i), values.at(i));
+        }
+        return object;
+    }
+    return result;
+}
+
+UniValue FormatResult(const JSONRPCRequest &request, const UniValue& result) {
+    if (request.strMethod.find("list") != std::string::npos) {
+        return FormatListResult(result);
+    }
+    return result;
+}

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -20,6 +20,8 @@
 
 #include <variant>
 
+#include <util/system.h>
+
 class FillableSigningProvider;
 class CPubKey;
 class CScript;
@@ -89,6 +91,8 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
 
 /** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider);
+
+UniValue FormatResult(const JSONRPCRequest &request, const UniValue& result);
 
 struct RPCArg {
     enum class Type {

--- a/test/functional/feature_jsonformat.py
+++ b/test/functional/feature_jsonformat.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test jsonformat flag"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import assert_equal
+
+class JsonFormatTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ['-txnotokens=0', '-amkheight=50', '-eunosheight=101'],
+            ['-txnotokens=0', '-amkheight=50', '-eunosheight=101', '-rpcjsonformat=array'],
+            ['-txnotokens=0', '-amkheight=50', '-eunosheight=101', '-rpcjsonformat=object'],
+        ]
+
+    def run_test(self):
+        default_listmasternodes = self.nodes[0].listmasternodes({}, False)
+        array_listmasternodes = self.nodes[1].listmasternodes({}, False)
+        object_listmasternodes = self.nodes[2].listmasternodes({}, False)
+
+        assert(type (array_listmasternodes) is list)
+        assert_equal(default_listmasternodes, object_listmasternodes)
+
+        default_listtokens = self.nodes[0].listtokens()
+        array_listtokens = self.nodes[1].listtokens()
+        object_listtokens = self.nodes[2].listtokens()
+
+        assert(type (array_listtokens) is list)
+        assert_equal(default_listtokens, object_listtokens)
+
+        default_listaccounts = self.nodes[0].listaccounts()
+        array_listaccounts = self.nodes[1].listaccounts()
+        object_listaccounts = self.nodes[2].listaccounts()
+
+        assert(type (object_listaccounts) is dict)
+        assert_equal(default_listaccounts, array_listaccounts)
+
+if __name__ == '__main__':
+    JsonFormatTest().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -274,6 +274,7 @@ BASE_SCRIPTS = [
     'feature_eunos_balances.py',
     'feature_sendutxosfrom.py',
     'feature_update_mn.py',
+    'feature_jsonformat.py',
     'feature_block_reward.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

- Adds a flag to defid to format list RPC as object or array.
- Keeps backward compatibility by omitting flag
- lighter than #897

- Example output :
  
```
cat defi.conf
rpcjsonformat=array

./src/defi-cli -testnet listmasternodes '{"limit":2}'
[
  {
    "ownerAuthAddress": "7MpAUiHtgwFm3pDAfVK7a64vsrz9yFsHjK",
    "operatorAuthAddress": "7MP5V6tAxrL466a4wqL5xbUE3DQnJrvpwf",
    "rewardAddress": "",
    "creationHeight": 435638,
    "resignHeight": 519711,
    "resignTx": "8e8b0bd7dc6270b638dcce2a4bd1904d711d23a749431f494aa77b6f93706bfd",
    "banTx": "0000000000000000000000000000000000000000000000000000000000000000",
    "state": "RESIGNED",
    "mintedBlocks": 46,
    "ownerIsMine": false,
    "operatorIsMine": false,
    "localMasternode": false,
    "id": "41a26cfef6d73d26933e304be45104c3dc85462a396ae2986ff1b1569f462d00"
  },
  {
    "ownerAuthAddress": "7KaNzvfYxLpSiYQwFw9BYCaVoxypWZNkWW",
    "operatorAuthAddress": "79oQZ8xxcyaqsJ6xov5vhG2eVxhPiiynm2",
    "rewardAddress": "",
    "creationHeight": 248858,
    "resignHeight": 267237,
    "resignTx": "3bc251e6ba6c7991799d678707c1e68c33b2b4b8605bce68911dbd2d5b69f1b8",
    "banTx": "0000000000000000000000000000000000000000000000000000000000000000",
    "state": "RESIGNED",
    "mintedBlocks": 0,
    "ownerIsMine": false,
    "operatorIsMine": false,
    "localMasternode": false,
    "id": "b998589d8b3333ca6c65c410a298d7a5751e547cdfdcdae20e6808459ff7ac00"
  }
]
```

```
cat defi.conf
rpcjsonformat=object

{
  "0": {
    "token": "DFI",
    "tokenId": "897dcc7567cd883d9e77e06ee786856db3708c27b75da936e55072fc5300ba89",
    "factor": 1.00000000,
    "fixedIntervalPriceId": "DFI/USD",
    "activateAfterBlock": 686335
  },
  "1": {
    "token": "BTC",
    "tokenId": "7705ba258dc7c2a7fb8a8e55d65726d83fbeadcabd9b857f29527dbe4da46f99",
    "factor": 1.00000000,
    "fixedIntervalPriceId": "BTC/USD",
    "activateAfterBlock": 686308
  },
  "2": {
    "token": "ETH",
    "tokenId": "356c9fce2d11579eb4f724fc410090a8fb740dea1bb7f87a01c46c2f466ec0e7",
    "factor": 0.70000000,
    "fixedIntervalPriceId": "ETH/USD",
    "activateAfterBlock": 686308
  }
}
```

#### Discussion

- Can add a flag or header to override defid flag if needed.