### PR TITLE
Fix wrong number of openVaults and openAuctions in getloaninfo

### DIFF
--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -1245,10 +1245,14 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     auto height = ::ChainActive().Height() + 1;
     bool useNextPrice = false, requireLivePrice = true;
     auto lastBlockTime = ::ChainActive().Tip()->GetBlockTime();
-    uint64_t totalCollateralValue = 0, totalLoanValue = 0, totalVaults = 0;
-    pcustomcsview->ForEachVaultCollateral([&](const CVaultId& vaultId, const CBalances& collaterals) {
+    uint64_t totalCollateralValue = 0, totalLoanValue = 0, totalVaults = 0, totalAuctions = 0;
+
+    pcustomcsview->ForEachVault([&](const CVaultId& vaultId, const CVaultData& data) {
         LogPrint(BCLog::LOAN,"getloaninfo()->Vault(%s):\n", vaultId.GetHex());
-        auto rate = pcustomcsview->GetLoanCollaterals(vaultId, collaterals, height, lastBlockTime, useNextPrice, requireLivePrice);
+        auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
+        if (!collaterals)
+            collaterals = CBalances{};
+        auto rate = pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height, lastBlockTime, useNextPrice, requireLivePrice);
         if (rate)
         {
             totalCollateralValue += rate.val->totalCollaterals;
@@ -1257,6 +1261,11 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
         totalVaults++;
         return true;
     });
+
+    pcustomcsview->ForEachVaultAuction([&](const CVaultId& vaultId, const CAuctionData& data) {
+        totalAuctions++;
+        return true;
+    }, height);
 
     UniValue totalsObj{UniValue::VOBJ};
     auto totalLoanSchemes = static_cast<int>(listloanschemes(request).size());
@@ -1269,7 +1278,6 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     totalsObj.pushKV("loanTokens", totalLoanTokens);
     totalsObj.pushKV("loanValue", ValueFromUint(totalLoanValue));
     totalsObj.pushKV("openVaults", totalVaults);
-    auto totalAuctions = static_cast<int>(listauctions(request).size());
     totalsObj.pushKV("openAuctions", totalAuctions);
 
     UniValue defaultsObj{UniValue::VOBJ};


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Uses `ForEachVault` instead of `ForEachVaultCollateral` to get the correct number of open vaults and not the number of active vaults with collaterals.
Uses `ForEachVaultAuction` to iterate over each auctions instead of using `listauctions` RPC that limits to 100 by default.

#### Which issue(s) does this PR fixes?:

Fixes #985 