### PR TITLE
Factor out usage of height field in CBlockIndex and CBlockHeader

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -45,7 +45,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
         CValidationState validationState;
         CheckContextState ctxState;
         
-        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(), ctxState, false);
+        bool checked = CheckBlock(block, validationState, chainParams->GetConsensus(), ctxState, false, 413567);
         assert(checked);
     }
 }

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -61,7 +61,7 @@ static void DuplicateInputs(benchmark::State& state)
     while (state.KeepRunning()) {
         CValidationState cvstate{};
         CheckContextState ctxState;
-        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), ctxState, false, false));
+        assert(!CheckBlock(block, cvstate, chainparams.GetConsensus(), ctxState, false, nHeight, false));
         assert(cvstate.GetRejectReason() == "bad-txns-inputs-duplicate");
     }
 }

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -174,7 +174,7 @@ bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const {
     return txn_available[index] != nullptr;
 }
 
-ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing) {
+ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, const int height) {
     assert(!header.IsNull());
     uint256 hash = header.GetHash();
     block = header;
@@ -200,7 +200,7 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
     CValidationState state;
     CheckContextState ctxState;
 
-    if (!CheckBlock(block, state, Params().GetConsensus(), ctxState, false)) {
+    if (!CheckBlock(block, state, Params().GetConsensus(), ctxState, false, height)) {
         // TODO: We really want to just check merkle tree manually here,
         // but that is expensive, and CheckBlock caches a block's
         // "checked-status" (in the CBlock?). CBlock should be able to

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -206,7 +206,7 @@ public:
     // extra_txn is a list of extra transactions to look at, in <witness hash, reference> form
     ReadStatus InitData(const CBlockHeaderAndShortTxIDs& cmpctblock, const std::vector<std::pair<uint256, CTransactionRef>>& extra_txn);
     bool IsTxAvailable(size_t index) const;
-    ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing);
+    ReadStatus FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing, const int height);
 };
 
 #endif // DEFI_BLOCKENCODINGS_H

--- a/src/chain.h
+++ b/src/chain.h
@@ -241,7 +241,7 @@ public:
         hashMerkleRoot = block.hashMerkleRoot;
         nTime          = block.nTime;
         nBits          = block.nBits;
-        height         = block.height;
+        height         = block.deprecatedHeight;
         mintedBlocks   = block.mintedBlocks;
         stakeModifier  = block.stakeModifier;
         sig            = block.sig;
@@ -276,7 +276,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.stakeModifier   = stakeModifier;
-        block.height         = height;
+        block.deprecatedHeight = height;
         block.mintedBlocks   = mintedBlocks;
         block.sig            = sig;
         return block;
@@ -438,7 +438,7 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.stakeModifier   = stakeModifier;
-        block.height          = height;
+        block.deprecatedHeight = height;
         block.mintedBlocks    = mintedBlocks;
         block.sig             = sig;
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -187,7 +187,7 @@ public:
     uint32_t nBits;
 
     // proof-of-stake specific fields
-    uint64_t height;
+    uint64_t deprecatedHeight;
     uint64_t mintedBlocks;
     uint256 stakeModifier; // hash modifier for proof-of-stake
     std::vector<unsigned char> sig;
@@ -222,7 +222,7 @@ public:
         nTime          = 0;
         nBits          = 0;
         stakeModifier  = uint256{};
-        height         = 0;
+        deprecatedHeight = 0;
         mintedBlocks   = 0;
         sig            = {};
         minterKeyID    = {};
@@ -241,7 +241,7 @@ public:
         hashMerkleRoot = block.hashMerkleRoot;
         nTime          = block.nTime;
         nBits          = block.nBits;
-        height         = block.deprecatedHeight;
+        deprecatedHeight = block.deprecatedHeight;
         mintedBlocks   = block.mintedBlocks;
         stakeModifier  = block.stakeModifier;
         sig            = block.sig;
@@ -276,7 +276,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.stakeModifier   = stakeModifier;
-        block.deprecatedHeight = height;
+        block.deprecatedHeight = deprecatedHeight;
         block.mintedBlocks   = mintedBlocks;
         block.sig            = sig;
         return block;
@@ -330,7 +330,7 @@ public:
         std::sort(pbegin, pend);
 
         // Only after FC and when we have a full set of times.
-        if (height >= Params().GetConsensus().FortCanningHeight && pend - pbegin == nMedianTimeSpan) {
+        if (nHeight >= Params().GetConsensus().FortCanningHeight && pend - pbegin == nMedianTimeSpan) {
             // Take the median of the top five.
             return pbegin[8];
         }
@@ -424,7 +424,7 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(stakeModifier);
-        READWRITE(height);
+        READWRITE(deprecatedHeight);
         READWRITE(mintedBlocks);
         READWRITE(sig);
     }
@@ -438,7 +438,7 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.stakeModifier   = stakeModifier;
-        block.deprecatedHeight = height;
+        block.deprecatedHeight = deprecatedHeight;
         block.mintedBlocks    = mintedBlocks;
         block.sig             = sig;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -65,7 +65,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, uint32_t nTime, uint3
     genesis.nTime           = nTime;
     genesis.nBits           = nBits;
     genesis.nVersion        = nVersion;
-    genesis.height          = 0;
+    genesis.deprecatedHeight = 0;
     genesis.stakeModifier   = uint256S("0");
     genesis.mintedBlocks    = 0;
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -785,7 +785,7 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
     std::map<arith_uint256, CKeyID, std::less<arith_uint256>> authMN;
     std::map<arith_uint256, CKeyID, std::less<arith_uint256>> confirmMN;
     ForEachMasternode([&] (uint256 const & id, CMasternode node) {
-        if(!node.IsActive(pindexNew->height))
+        if(!node.IsActive(pindexNew->nHeight))
             return true;
 
         // Not in our list of MNs from last week, skip.
@@ -820,7 +820,7 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
 
     {
         LOCK(cs_main);
-        SetAnchorTeams(authTeam, confirmTeam, pindexNew->height);
+        SetAnchorTeams(authTeam, confirmTeam, pindexNew->nHeight);
     }
 
     // Debug logging

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -83,7 +83,7 @@ UniValue outputEntryToJSON(COutputEntry const & entry, CBlockIndex const * index
     UniValue obj(UniValue::VOBJ);
 
     obj.pushKV("owner", EncodeDestination(entry.destination));
-    obj.pushKV("blockHeight", index->height);
+    obj.pushKV("blockHeight", index->nHeight);
     obj.pushKV("blockHash", index->GetBlockHash().GetHex());
     obj.pushKV("blockTime", index->GetBlockTime());
     if (pwtx->IsCoinBase()) {
@@ -155,7 +155,7 @@ static void searchInWallet(CWallet const * pwallet,
         auto* pwtx = &(*it);
 
         auto index = LookupBlockIndex(pwtx->hashBlock);
-        if (!index || index->height == 0) { // skip genesis block
+        if (!index || index->nHeight == 0) { // skip genesis block
             continue;
         }
 
@@ -1180,10 +1180,10 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
         count = limit;
         searchInWallet(pwallet, account, filter,
             [&](CBlockIndex const * index, CWalletTx const * pwtx) {
-                return txs.count(pwtx->GetHash()) || startBlock > index->height || index->height > maxBlockHeight;
+                return txs.count(pwtx->GetHash()) || startBlock > index->nHeight || index->nHeight > maxBlockHeight;
             },
             [&](COutputEntry const & entry, CBlockIndex const * index, CWalletTx const * pwtx) {
-                auto& array = ret.emplace(index->height, UniValue::VARR).first->second;
+                auto& array = ret.emplace(index->nHeight, UniValue::VARR).first->second;
                 array.push_back(outputEntryToJSON(entry, index, pwtx));
                 return --count != 0;
             }
@@ -1509,7 +1509,7 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
     if (shouldSearchInWallet) {
         searchInWallet(pwallet, owner, filter,
             [&](CBlockIndex const * index, CWalletTx const * pwtx) {
-                return txs.count(pwtx->GetHash()) || index->height > currentHeight;
+                return txs.count(pwtx->GetHash()) || index->nHeight > currentHeight;
             },
             [&count](COutputEntry const &, CBlockIndex const *, CWalletTx const *) {
                 ++count;

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -139,7 +139,7 @@ UniValue createmasternode(const JSONRPCRequest& request)
     bool eunosPaya;
     {
         LOCK(cs_main);
-        eunosPaya = ::ChainActive().Tip()->height >= Params().GetConsensus().EunosPayaHeight;
+        eunosPaya = ::ChainActive().Tip()->nHeight >= Params().GetConsensus().EunosPayaHeight;
     }
 
     // Get timelock if any
@@ -540,7 +540,7 @@ UniValue updatemasternode(const JSONRPCRequest& request)
     bool forkCanning;
     {
         LOCK(cs_main);
-        forkCanning = ::ChainActive().Tip()->height >= Params().GetConsensus().FortCanningHeight;
+        forkCanning = ::ChainActive().Tip()->nHeight >= Params().GetConsensus().FortCanningHeight;
     }
 
     if (!forkCanning) {
@@ -796,7 +796,7 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Masternode not found");
     }
 
-    auto lastHeight = ::ChainActive().Tip()->height + 1;
+    auto lastHeight = ::ChainActive().Tip()->nHeight + 1;
     const auto creationHeight = masternode->creationHeight;
 
     int depth{std::numeric_limits<int>::max()};
@@ -831,7 +831,7 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
         return masternodeBlocks(key.masternodeID, key.blockHeight);
     }, MNBlockTimeKey{mn_id, std::numeric_limits<uint32_t>::max()});
 
-    auto tip = ::ChainActive()[std::min(lastHeight, uint64_t(Params().GetConsensus().DakotaCrescentHeight)) - 1];
+    auto tip = ::ChainActive()[std::min(lastHeight, Params().GetConsensus().DakotaCrescentHeight) - 1];
 
     for (; tip && tip->nHeight > creationHeight && depth > 0; tip = tip->pprev, --depth) {
         auto id = pcustomcsview->GetMasternodeIdByOperator(tip->minterKey());

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -816,8 +816,8 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
         }
 
         if (auto tip = ::ChainActive()[blockHeight]) {
-            lastHeight = tip->height;
-            ret.pushKV(std::to_string(tip->height), tip->GetBlockHash().ToString());
+            lastHeight = tip->nHeight;
+            ret.pushKV(std::to_string(lastHeight), tip->GetBlockHash().ToString());
         }
 
         return true;
@@ -833,10 +833,10 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
 
     auto tip = ::ChainActive()[std::min(lastHeight, uint64_t(Params().GetConsensus().DakotaCrescentHeight)) - 1];
 
-    for (; tip && tip->height > creationHeight && depth > 0; tip = tip->pprev, --depth) {
+    for (; tip && tip->nHeight > creationHeight && depth > 0; tip = tip->pprev, --depth) {
         auto id = pcustomcsview->GetMasternodeIdByOperator(tip->minterKey());
         if (id && *id == mn_id) {
-            ret.pushKV(std::to_string(tip->height), tip->GetBlockHash().ToString());
+            ret.pushKV(std::to_string(tip->nHeight), tip->GetBlockHash().ToString());
         }
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -722,7 +722,7 @@ namespace pos {
             tip = ::ChainActive().Tip();
             masternodeID = *optMasternodeID;
             auto nodePtr = pcustomcsview->GetMasternode(masternodeID);
-            if (!nodePtr || !nodePtr->IsActive(tip->height + 1))
+            if (!nodePtr || !nodePtr->IsActive(tip->nHeight + 1))
             {
                 /// @todo may be new status for not activated (or already resigned) MN??
                 return Status::initWaiting;
@@ -730,7 +730,7 @@ namespace pos {
             mintedBlocks = nodePtr->mintedBlocks;
             if (args.coinbaseScript.empty()) {
                 // this is safe cause MN was found
-                if (tip->height >= chainparams.GetConsensus().FortCanningHeight && nodePtr->rewardAddressType != 0) {
+                if (tip->nHeight >= chainparams.GetConsensus().FortCanningHeight && nodePtr->rewardAddressType != 0) {
                     scriptPubKey = GetScriptForDestination(nodePtr->rewardAddressType == PKHashType ?
                         CTxDestination(PKHash(nodePtr->rewardAddress)) :
                         CTxDestination(WitnessV0KeyHash(nodePtr->rewardAddress))
@@ -746,7 +746,7 @@ namespace pos {
                 scriptPubKey = args.coinbaseScript;
             }
 
-            blockHeight = tip->height + 1;
+            blockHeight = tip->nHeight + 1;
             creationHeight = int64_t(nodePtr->creationHeight);
             blockTime = std::max(tip->GetMedianTimePast() + 1, GetAdjustedTime());
             timelock = pcustomcsview->GetTimelock(masternodeID, *nodePtr, blockHeight);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -292,7 +292,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-    pblock->height         = pindexPrev->nHeight + 1;
+    pblock->deprecatedHeight = pindexPrev->nHeight + 1;
     pblock->nBits          = pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus);
     if (myIDs) {
         pblock->stakeModifier  = pos::ComputeStakeModifier(pindexPrev->stakeModifier, myIDs->first);
@@ -844,7 +844,6 @@ namespace pos {
         auto pblock = std::make_shared<CBlock>(pblocktemplate->block);
 
         pblock->nBits = nBits;
-        pblock->height = blockHeight;
         pblock->mintedBlocks = mintedBlocks + 1;
         pblock->stakeModifier = std::move(stakeModifier);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2655,7 +2655,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         // possible optimization: stops when first quorum reached (irl, no need to walk deeper)
         auto topAnchor = panchors->GetActiveAnchor();
         // limit requested by the top anchor, if any
-        if (topAnchor && topAnchor->anchor.height > pLowRequested->height && topAnchor->anchor.height <= (uint64_t) ::ChainActive().Height()) {
+        if (topAnchor && topAnchor->anchor.height > pLowRequested->nHeight && topAnchor->anchor.height <= (uint64_t) ::ChainActive().Height()) {
             pLowRequested = ::ChainActive()[topAnchor->anchor.height];
             assert(pLowRequested);
         }

--- a/src/pos.h
+++ b/src/pos.h
@@ -37,7 +37,7 @@ namespace pos {
     bool CheckHeaderSignature(const CBlockHeader& block);
 
 /// Check kernel hash target and coinstake signature
-    bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensus::Params& params, CCustomCSView* mnView, CheckContextState& ctxState);
+    bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensus::Params& params, CCustomCSView* mnView, CheckContextState& ctxState, const int height);
 
 /// Check kernel hash target and coinstake signature. Check that block coinstakeTx matches header
     bool CheckProofOfStake(const CBlockHeader& blockHeader, const CBlockIndex* pindexPrev, const Consensus::Params& params, CCustomCSView* mnView);

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -19,7 +19,7 @@ uint256 CBlockHeader::GetHash() const
 uint256 CBlockHeader::GetHashToSign() const
 {
     CDataStream ss(SER_GETHASH, 0);
-    ss << nVersion << hashPrevBlock << hashMerkleRoot << nTime << nBits << height << mintedBlocks << stakeModifier;
+    ss << nVersion << hashPrevBlock << hashMerkleRoot << nTime << nBits << deprecatedHeight << mintedBlocks << stakeModifier;
     return Hash(ss.begin(), ss.end());
 }
 
@@ -32,7 +32,7 @@ std::string CBlock::ToString() const
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits,
-        height, mintedBlocks,
+        deprecatedHeight, mintedBlocks,
         vtx.size());
     for (const auto& tx : vtx) {
         s << "  " << tx->ToString() << "\n";

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -33,7 +33,7 @@ public:
     uint32_t nTime;
     uint32_t nBits;
 
-    uint64_t height;
+    uint64_t deprecatedHeight;
     uint64_t mintedBlocks;
     uint256 stakeModifier;
     std::vector<unsigned char> sig;
@@ -53,7 +53,7 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(stakeModifier);
-        READWRITE(height);
+        READWRITE(deprecatedHeight);
         READWRITE(mintedBlocks);
         READWRITE(sig);
     }
@@ -66,7 +66,7 @@ public:
         nTime = 0;
         nBits = 0;
         stakeModifier.SetNull();
-        height = 0;
+        deprecatedHeight = 0;
         mintedBlocks = 0;
         sig = {};
         recoveredPubKey = CPubKey{};
@@ -144,7 +144,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.stakeModifier  = stakeModifier;
-        block.height         = height;
+        block.deprecatedHeight = deprecatedHeight;
         block.mintedBlocks   = mintedBlocks;
         block.sig            = sig;
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -53,7 +53,7 @@ static CBlock BuildBlockTestCase() {
         tip = ::ChainActive().Tip();
 
         auto nodePtr = pcustomcsview->GetMasternode(masternodeID);
-        if (!nodePtr || !nodePtr->IsActive(tip->height))
+        if (!nodePtr || !nodePtr->IsActive(tip->nHeight))
             return {};
 
         mintedBlocks = nodePtr->mintedBlocks;

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -60,7 +60,7 @@ static CBlock BuildBlockTestCase() {
         creationHeight = int64_t(nodePtr->creationHeight);
     }
 
-    block.height = tip->nHeight + 1;
+    block.deprecatedHeight = tip->nHeight + 1;
     block.mintedBlocks = mintedBlocks + 1;
     block.stakeModifier = pos::ComputeStakeModifier(tip->stakeModifier, minterKey.GetPubKey().GetID());
 
@@ -81,7 +81,7 @@ static CBlock BuildBlockTestCase() {
     block.nTime = 0;
     CheckContextState ctxState;
 
-    while (!pos::CheckKernelHash(block.stakeModifier, block.nBits, creationHeight, (int64_t) block.nTime, block.height, masternodeID, Params().GetConsensus(), {0, 0, 0, 0}, 0, ctxState)) block.nTime++;
+    while (!pos::CheckKernelHash(block.stakeModifier, block.nBits, creationHeight, (int64_t) block.nTime, block.deprecatedHeight, masternodeID, Params().GetConsensus(), {0, 0, 0, 0}, 0, ctxState)) block.nTime++;
 
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(std::move(block));
     auto err = pos::SignPosBlock(pblock, minterKey);
@@ -130,21 +130,21 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         CBlock block2;
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            BOOST_CHECK(partialBlock.FillBlock(block2, {}) == READ_STATUS_INVALID); // No transactions
+            BOOST_CHECK(partialBlock.FillBlock(block2, {}, 0) == READ_STATUS_INVALID); // No transactions
             partialBlock = tmp;
         }
 
         // Wrong transaction
         {
             PartiallyDownloadedBlock tmp = partialBlock;
-            partialBlock.FillBlock(block2, {block.vtx[2]}); // Current implementation doesn't check txn here, but don't require that
+            partialBlock.FillBlock(block2, {block.vtx[2]}, 0); // Current implementation doesn't check txn here, but don't require that
             partialBlock = tmp;
         }
         bool mutated;
         BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
 
         CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[1]}) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block3, {block.vtx[1]}, 0) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
 
         CBlock block2;
         PartiallyDownloadedBlock partialBlockCopy = partialBlock;
-        BOOST_CHECK(partialBlock.FillBlock(block2, {}) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.FillBlock(block2, {}, 0) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
         bool mutated;
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());

--- a/src/test/pos_tests.cpp
+++ b/src/test/pos_tests.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<CBlock> Block( const uint256& prev_hash, const uint64_t& height,
     pblock->hashPrevBlock = prev_hash;
 
     pblock->mintedBlocks = mintedBlocks;
-    pblock->height = height;
+    pblock->deprecatedHeight = height;
 
     return pblock;
 }
@@ -142,17 +142,17 @@ BOOST_AUTO_TEST_CASE(contextual_check_pos)
     CKey minterKey = pos->second.operatorKey;
     CheckContextState ctxState;
 
-    BOOST_CHECK(pos::ContextualCheckProofOfStake((CBlockHeader)Params().GenesisBlock(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
+    BOOST_CHECK(pos::ContextualCheckProofOfStake((CBlockHeader)Params().GenesisBlock(), Params().GetConsensus(), pcustomcsview.get(), ctxState, 0));
 
 //    uint256 prev_hash = uint256S("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
     uint64_t height = 0;
     uint64_t mintedBlocks = 1;
     std::shared_ptr<CBlock> block = Block(Params().GenesisBlock().GetHash(), height, mintedBlocks);
 
-    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
+    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState, 0));
 
-    block->height = 1;
-    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState));
+    // Failure against a height of 1
+    BOOST_CHECK(!pos::ContextualCheckProofOfStake(*(CBlockHeader*)block.get(), Params().GetConsensus(), pcustomcsview.get(), ctxState, 1));
 }
 
 BOOST_AUTO_TEST_CASE(sign_pos_block)

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -214,7 +214,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
 
         mintedBlocks = nodePtr->mintedBlocks;
     }
-    block.height = tip->nHeight + 1;
+    block.deprecatedHeight = tip->nHeight + 1;
     block.mintedBlocks = mintedBlocks + 1;
     block.stakeModifier = pos::ComputeStakeModifier(tip->stakeModifier, minterKey.GetPubKey().GetID());
 

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -209,7 +209,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
         tip = ::ChainActive().Tip();
 
         auto nodePtr = pcustomcsview->GetMasternode(masternodeID);
-        if (!nodePtr || !nodePtr->IsActive(tip->height))
+        if (!nodePtr || !nodePtr->IsActive(tip->nHeight))
             throw std::runtime_error(std::string(__func__) + ": nodePtr does not exist");
 
         mintedBlocks = nodePtr->mintedBlocks;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -276,7 +276,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
                 //PoS
                 pindexNew->stakeModifier = diskindex.stakeModifier;
-                pindexNew->height = diskindex.height;
+                pindexNew->deprecatedHeight = diskindex.deprecatedHeight;
                 pindexNew->mintedBlocks = diskindex.mintedBlocks;
                 pindexNew->sig = diskindex.sig;
                 if (pindexNew->nHeight && !skipSigCheck) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5057,7 +5057,7 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
     auto topAnchor = panchors->GetActiveAnchor();
     CTeamView::CTeam team;
     int teamChange = tip->nHeight;
-    auto const teamDakota = pcustomcsview->GetAuthTeam(tip->height);
+    auto const teamDakota = pcustomcsview->GetAuthTeam(tip->nHeight);
     if (!teamDakota || teamDakota->empty()) {
         return;
     }
@@ -5068,12 +5068,12 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
 
     uint64_t topAnchorHeight = topAnchor ? static_cast<uint64_t>(topAnchor->anchor.height) : 0;
     // we have no need to ask for auths at all if we have topAnchor higher than current chain
-    if (tip->height <= topAnchorHeight) {
+    if (tip->nHeight <= topAnchorHeight) {
         return;
     }
 
     CBlockIndex const * pindexFork = ::ChainActive().FindFork(oldTip);
-    uint64_t forkHeight = pindexFork && (pindexFork->height >= (uint64_t)consensus.mn.anchoringFrequency) ? pindexFork->height - (uint64_t)consensus.mn.anchoringFrequency : 0;
+    uint64_t forkHeight = pindexFork && (pindexFork->nHeight >= (uint64_t)consensus.mn.anchoringFrequency) ? pindexFork->nHeight - (uint64_t)consensus.mn.anchoringFrequency : 0;
     // limit fork height - trim it by the top anchor, if any
     forkHeight = std::max(forkHeight, topAnchorHeight);
     pindexFork = ::ChainActive()[forkHeight];
@@ -5096,12 +5096,12 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
     for (CBlockIndex const * pindex = tip; pindex && pindex != pindexFork && teamChange >= 0; pindex = pindex->pprev, --teamChange) {
 
         // Only anchor by specified frequency
-        if (pindex->height % consensus.mn.anchoringFrequency != 0) {
+        if (pindex->nHeight % consensus.mn.anchoringFrequency != 0) {
             continue;
         }
 
         // Get start anchor height
-        int anchorHeight = static_cast<int>(pindex->height) - consensus.mn.anchoringFrequency;
+        int anchorHeight = static_cast<int>(pindex->nHeight) - consensus.mn.anchoringFrequency;
 
         // Get anchor block from specified time depth
         int64_t timeDepth = consensus.mn.anchoringTimeDepth;
@@ -5110,7 +5110,7 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
         }
 
         // Select a block further back to avoid Anchor too new error.
-        if (pindex->height >= consensus.FortCanningHeight) {
+        if (pindex->nHeight >= consensus.FortCanningHeight) {
             timeDepth += consensus.mn.anchoringAdditionalTimeDepth;
             while (anchorHeight > 0 && ::ChainActive()[anchorHeight]->nTime + timeDepth > pindex->nTime) {
                 --anchorHeight;
@@ -5136,7 +5136,7 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
         size_t prefixLength{CKeyID().size() - spv::BtcAnchorMarker.size() - sizeof(uint64_t)};
         std::vector<unsigned char> hashPrefix{pindex->GetBlockHash().begin(), pindex->GetBlockHash().begin() + prefixLength};
         teamDetailsVector.insert(teamDetailsVector.end(), spv::BtcAnchorMarker.begin(), spv::BtcAnchorMarker.end()); // 3 Bytes
-        uint64_t anchorCreationHeight = pindex->height;
+        uint64_t anchorCreationHeight = pindex->nHeight;
         teamDetailsVector.insert(teamDetailsVector.end(), reinterpret_cast<unsigned char*>(&anchorCreationHeight),
                                  reinterpret_cast<unsigned char*>(&anchorCreationHeight) + sizeof(uint64_t)); // 8 Bytes
         teamDetailsVector.insert(teamDetailsVector.end(), hashPrefix.begin(), hashPrefix.end()); // 9 Bytes

--- a/src/validation.h
+++ b/src/validation.h
@@ -391,7 +391,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, CheckContextState& ctxState, bool fCheckPOS, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, CheckContextState& ctxState, bool fCheckPOS, const int height, bool fCheckMerkleRoot = true);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);


### PR DESCRIPTION
As well as removing usage of the non-native height fields added by the external developers this PR fixes https://github.com/DeFiCh/ain/issues/977 and resolves a bug in getmasternodeblocks on testnet only. Before the height provided in a block header was correctly validated, some blocks were created with height set to 0, which resulted in the following getmasternodeblocks output.

```
./src/defi-cli -testnet getmasternodeblocks '{"id":"0ac60116b766f6672c9d299462e5e2a3c8a0f6e16ebc7a8503b5c3b5d9712c7b"}'
{
  "0": "740eb1268e5e39a97d6b387729079e46c435c2c6fc07dec5fe9cb8fe9a2c42d5"
}
```

This PR uses nHeight instead which will be set correctly, the output with the fix applied is.

```
./src/defi-cli -testnet getmasternodeblocks '{"id":"0ac60116b766f6672c9d299462e5e2a3c8a0f6e16ebc7a8503b5c3b5d9712c7b"}'
{
  "360068": "19e49b5967282d461d4522ba95aba7cf7e92f18d6d28661e48a9df0f5bc45fa8",
  "359951": "65051e096f09e00ccac996be6178f372cae47dabdc0dc166128ecb6e62e66d3a",
  "359673": "7c6c789ef6b1a4fa4350632e16d0e8728e2439c5f8d8b7d57659024c7fa92b77",
  "359472": "e181df1744d1d6de285a52c39524ef0126219419bad476fd44817fd1f81d3daa",
  "359372": "e3a6182ee47a2de496f3d707cb291c4b327788a65a92cafe3735144bb5ebaf20",
  "359352": "892a6df013a5a5f75f9db6bc24498dba20e6c10bdeac8015470f2f9df7d553de",
  "359116": "acc6c723cd48ad1a0a58d98bd31f0200d733bc1f29c0015843242f5c042a461a",
  "358278": "740eb1268e5e39a97d6b387729079e46c435c2c6fc07dec5fe9cb8fe9a2c42d5"
}
```

This is a list of all blocks on testnet that have the height field in CBlockHeader and in turn CBlockIndex set to 0. Columns are the actual height, recorded height which is all 0 and the block hash.

```
  "360424": "0 9fab975f2bc7ebbf678a9cd41405ff4a235cf9d9a0b03a55874b033e17927790",
  "360406": "0 674ab8efdbb0cc720c9cc86167e41f48f48183daeaf6d70781e96d8db2c649e2",
  "360078": "0 dea2cec4af8841f46f5ac3c569291ab33b7d2c7dfd05f1516be815ddd4b250fd",
  "360068": "0 19e49b5967282d461d4522ba95aba7cf7e92f18d6d28661e48a9df0f5bc45fa8",
  "359951": "0 65051e096f09e00ccac996be6178f372cae47dabdc0dc166128ecb6e62e66d3a",
  "359839": "0 5d77d41913e96b9569f390d4e00acdda4c07f26b05be8b5354a49a978e52e38b",
  "359676": "0 cb5384caea722c1e4b870cffe6b62dee227c5b8f6fb0d2777680d334567375f6",
  "359673": "0 7c6c789ef6b1a4fa4350632e16d0e8728e2439c5f8d8b7d57659024c7fa92b77",
  "359642": "0 f1ba68721113bfd65229977b306c2ee5f1531b0261c5e136838de9aa03397cfd",
  "359633": "0 cca9419512355694e3b1461c0f5ba81649a7844a9586b2910c4087606870a250",
  "359472": "0 e181df1744d1d6de285a52c39524ef0126219419bad476fd44817fd1f81d3daa",
  "359372": "0 e3a6182ee47a2de496f3d707cb291c4b327788a65a92cafe3735144bb5ebaf20",
  "359352": "0 892a6df013a5a5f75f9db6bc24498dba20e6c10bdeac8015470f2f9df7d553de",
  "359320": "0 a65175590e2f8b37a7f6f3d57bd628241dec59c43d01f631ed1c8803f7a971de",
  "359151": "0 6c91b55be97f3f2f023ff6bc127cc0656d626fbcd93b1744e79bfa9a3c225f57",
  "359116": "0 acc6c723cd48ad1a0a58d98bd31f0200d733bc1f29c0015843242f5c042a461a",
  "358835": "0 c0e37a05a8b0ee5fa62e0d9acde1ad1b2c971a511caf2efbe9477b95b8bd64d5",
  "358815": "0 7bc63ef0964a45f9bf6ef30ace9290400738e51ddc8d92969e8d692398c88d48",
  "358278": "0 740eb1268e5e39a97d6b387729079e46c435c2c6fc07dec5fe9cb8fe9a2c42d5"
```