### PR TITLE
Test liquidity rewards when poolpair status is false

### DIFF
--- a/test/functional/feature_poolpair_liquidity.py
+++ b/test/functional/feature_poolpair_liquidity.py
@@ -360,6 +360,61 @@ class PoolLiquidityTest (DefiTestFramework):
 
         # assert_equal(len(self.nodes[0].getrawmempool()), 13) # removed txs for block
 
+        # Test liquidity reward when pool status is false
+        symbolBTC = "BTC"
+        symbolDFI = "DFI"
+        address = self.nodes[0].getnewaddress("", "legacy")
+
+        self.nodes[0].createtoken({
+            "symbol": symbolBTC,
+            "name": "BTC token",
+            "isDAT": True,
+            "collateralAddress": address
+        })
+        self.nodes[0].generate(1)
+
+        idDFI = list(self.nodes[0].gettoken(symbolDFI).keys())[0]
+        idBTC = list(self.nodes[0].gettoken(symbolBTC).keys())[0]
+
+        pool_pair_tx = self.nodes[0].createpoolpair({
+            "tokenA": idBTC,
+            "tokenB": idDFI,
+            "commission": Decimal('0.002'),
+            "status": True,
+            "ownerAddress": poolOwner,
+            "pairSymbol": "BTC-DFI",
+        }, [])
+        self.nodes[0].generate(1)
+
+        self.nodes[0].minttokens(["100@" + symbolBTC])
+        self.nodes[0].generate(1)
+
+        self.nodes[0].utxostoaccount({address: "100@DFI"})
+        self.nodes[0].generate(1)
+
+        self.nodes[0].addpoolliquidity({
+            address: ["100@" + symbolBTC, "100@" + symbolDFI]
+        }, address)
+        self.nodes[0].generate(1)
+
+        self.nodes[0].setgov({ "LP_DAILY_DFI_REWARD": 1 })
+        self.nodes[0].generate(1)
+
+        pool_pair_id = list(self.nodes[0].getpoolpair("BTC-DFI").keys())[0]
+        self.nodes[0].setgov({ "LP_SPLITS": { pool_pair_id: 1 }})
+        self.nodes[0].generate(1)
+
+        self.nodes[0].updatepoolpair({
+            "pool": pool_pair_tx,
+            "status": False
+        })
+        self.nodes[0].generate(1)
+
+        rewards = self.nodes[0].getaccount(address, {}, True)
+        self.nodes[0].generate(1)
+        rewardsAfter = self.nodes[0].getaccount(address, {}, True)
+
+        assert(rewardsAfter['0'] > rewards['0']) # Liquidity pool providers should keep getting rewards while pool status is false
 
 if __name__ == '__main__':
     PoolLiquidityTest ().main ()


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

Add functional test to assert that liquidity pool providers keep getting rewards after a poolpair status is set to false