### PR TITLE
Implement `getaccounthistory` RPC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -418,7 +418,7 @@ void SetupServerArgs()
     hidden_args.emplace_back("-sysperms");
 #endif
     gArgs.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-acindex", strprintf("Maintain a full account history index, tracking all accounts balances changes. Used by the listaccounthistory and accounthistorycount rpc calls (default: %u)", DEFAULT_ACINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-acindex", strprintf("Maintain a full account history index, tracking all accounts balances changes. Used by the listaccounthistory, getaccounthistory and accounthistorycount rpc calls (default: %u)", DEFAULT_ACINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-vaultindex", strprintf("Maintain a full vault history index, tracking all vault changes. Used by the listvaulthistory rpc call (default: %u)", DEFAULT_VAULTINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blockfilterindex=<type>",
                  strprintf("Maintain an index of compact filters by block (default: %s, values: %s).", DEFAULT_BLOCKFILTERINDEX, ListBlockFilterTypes()) +

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -19,6 +19,11 @@ Res CAccountsHistoryView::WriteAccountHistory(const AccountHistoryKey& key, cons
     return Res::Ok();
 }
 
+boost::optional<AccountHistoryValue> CAccountsHistoryView::ReadAccountHistory(AccountHistoryKey const & key) const
+{
+    return ReadBy<ByAccountHistoryKey, AccountHistoryValue>(key);
+}
+
 Res CAccountsHistoryView::EraseAccountHistory(const AccountHistoryKey& key)
 {
     EraseBy<ByAccountHistoryKey>(key);

--- a/src/masternodes/accountshistory.h
+++ b/src/masternodes/accountshistory.h
@@ -60,6 +60,7 @@ class CAccountsHistoryView : public virtual CStorageView
 {
 public:
     Res WriteAccountHistory(AccountHistoryKey const & key, AccountHistoryValue const & value);
+    boost::optional<AccountHistoryValue> ReadAccountHistory(AccountHistoryKey const & key) const;
     Res EraseAccountHistory(AccountHistoryKey const & key);
     void ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, CLazySerialize<AccountHistoryValue>)> callback, AccountHistoryKey const & start = {});
 

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1211,7 +1211,7 @@ UniValue getaccounthistory(const JSONRPCRequest& request) {
                     {"owner", RPCArg::Type::STR, RPCArg::Optional::NO,
                         "Single account ID (CScript or address)."},
                     {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO,
-                        "Height to iterate from (downto genesis block)."},
+                        "Block Height to search in."},
                     {"txn", RPCArg::Type::NUM, RPCArg::Optional::NO,
                         "for order in block."},
                },

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1211,24 +1211,24 @@ UniValue getaccounthistory(const JSONRPCRequest& request) {
                {
                     {"owner", RPCArg::Type::STR, RPCArg::Optional::NO,
                         "Single account ID (CScript or address)."},
-                    {"blockHeight", RPCArg::Type::STR, RPCArg::Optional::NO,
+                    {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO,
                         "Height to iterate from (downto genesis block)."},
-                    {"txn", RPCArg::Type::STR, RPCArg::Optional::NO,
+                    {"txn", RPCArg::Type::NUM, RPCArg::Optional::NO,
                         "for order in block."},
                },
                RPCResult{
                        "{}  An object with account history information\n"
                },
                RPCExamples{
-                       HelpExampleCli("getaccounthistory", "cscript 160 10")
-                       + HelpExampleCli("getaccounthistory", "cscript, 160, 10")
+                       HelpExampleCli("getaccounthistory", "mxxA2sQMETJFbXcNbNbUzEsBCTn1JSHXST 103 2")
+                       + HelpExampleCli("getaccounthistory", "mxxA2sQMETJFbXcNbNbUzEsBCTn1JSHXST, 103, 2")
                },
     }.Check(request);
 
     std::string accountId = request.params[0].getValStr();
     CScript owner = DecodeScript(accountId);
-    uint32_t blockHeight = std::stoul(request.params[1].getValStr());
-    uint32_t txn = std::stoul(request.params[2].getValStr());
+    uint32_t blockHeight = request.params[1].get_int();
+    uint32_t txn = request.params[2].get_int();
 
     if (!paccountHistoryDB) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "-acindex is needed for account history");

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -301,6 +301,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listpoolshares", 2, "is_mine_only" },
 
     { "listaccounthistory", 1, "options" },
+    { "getaccounthistory", 1, "blockHeight" },
+    { "getaccounthistory", 2, "txn" },
     { "listburnhistory", 0, "options" },
     { "accounthistorycount", 1, "options" },
 

--- a/test/functional/rpc_getaccounthistory.py
+++ b/test/functional/rpc_getaccounthistory.py
@@ -55,34 +55,28 @@ class TokensRPCGetAccountHistory(DefiTestFramework):
         # Get node 0 results
         results = self.nodes[0].listaccounthistory(collateral_a)
 
-        # Expect two sends, two receives and one mint tokens
-        assert_equal(len(results), 5)
+        # An account history from listaccounthistory and gettaccounthistory must be matched
+        expected = results[0]
+        self.log.info("owner:%s blockHeight:%s txn:%s", expected['owner'], expected['blockHeight'], expected['txn'])
 
-        # Account history from listaccounthistory and gettaccounthistory must be matched
-        for txs in results:
-            self.log.info("owner:%s blockHeight:%s txn:%s", txs['owner'], txs['blockHeight'], txs['txn'])
-            history = self.nodes[0].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
-            assert_equal('owner' in history, True)
-            assert_equal(history['owner'], txs['owner'])
-            assert_equal(history['blockHeight'], txs['blockHeight'])
-            assert_equal(history['txn'], txs['txn'])
-            assert_equal(history['txid'], txs['txid'])
+        history = self.nodes[0].getaccounthistory(expected['owner'], expected['blockHeight'], expected['txn'])
+        assert_equal(history['owner'], expected['owner'])
+        assert_equal(history['blockHeight'], expected['blockHeight'])
+        assert_equal(history['txn'], expected['txn'])
+        assert_equal(history['type'], expected['type'])
 
         # Get node 1 results
         results = self.nodes[1].listaccounthistory(collateral_a)
 
-        # Expect one mint token TX
-        assert_equal(len(results), 1)
+        # An account history from listaccounthistory and gettaccounthistory must be matched
+        expected = results[0]
+        self.log.info("owner:%s blockHeight:%s txn:%s", expected['owner'], expected['blockHeight'], expected['txn'])
 
-        # Account history from listaccounthistory and gettaccounthistory must be matched
-        for txs in results:
-            self.log.info("owner:%s blockHeight:%s txn:%s", txs['owner'], txs['blockHeight'], txs['txn'])
-            history = self.nodes[1].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
-            assert_equal('owner' in history, True)
-            assert_equal(history['owner'], txs['owner'])
-            assert_equal(history['blockHeight'], txs['blockHeight'])
-            assert_equal(history['txn'], txs['txn'])
-            assert_equal(history['txid'], txs['txid'])
+        history = self.nodes[1].getaccounthistory(expected['owner'], expected['blockHeight'], expected['txn'])
+        assert_equal(history['owner'], expected['owner'])
+        assert_equal(history['blockHeight'], expected['blockHeight'])
+        assert_equal(history['txn'], expected['txn'])
+        assert_equal(history['type'], expected['type'])
 
 if __name__ == '__main__':
     TokensRPCGetAccountHistory().main ()

--- a/test/functional/rpc_getaccounthistory.py
+++ b/test/functional/rpc_getaccounthistory.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test getaccounthistory RPC."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import (
+    assert_equal
+)
+
+class TokensRPCGetAccountHistory(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50'],
+            ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50'],
+            ['-acindex=1', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=50'],
+        ]
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+        num_tokens = len(self.nodes[0].listtokens())
+
+        # collateral address
+        collateral_a = self.nodes[0].getnewaddress("", "legacy")
+
+        # Create token
+        self.nodes[0].createtoken({
+            "symbol": "GOLD",
+            "name": "gold",
+            "collateralAddress": collateral_a
+        })
+        self.nodes[0].generate(1)
+
+        # Make sure there's an extra token
+        assert_equal(len(self.nodes[0].listtokens()), num_tokens + 1)
+
+        # Stop node #2 for future revert
+        self.stop_node(2)
+
+        # Get token ID
+        list_tokens = self.nodes[0].listtokens()
+        for idx, token in list_tokens.items():
+            if (token["symbol"] == "GOLD"):
+                token_a = idx
+
+        # Mint some tokens
+        self.nodes[0].minttokens(["300@" + token_a])
+        self.nodes[0].generate(1)
+
+        # Get node 0 results
+        results = self.nodes[0].listaccounthistory(collateral_a)
+
+        # Expect two sends, two receives and one mint tokens
+        assert_equal(len(results), 5)
+
+        # Account history from listaccounthistory and gettaccounthistory must be matched
+        for txs in results:
+            history = self.nodes[0].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
+            if ('owner' in history):
+                assert_equal(history['owner'], txs['owner'])
+                assert_equal(history['blockHeight'], txs['blockHeight'])
+                assert_equal(history['txn'], txs['txn'])
+                assert_equal(history['txid'], txs['txid'])
+            else:
+                self.log.error("nodes[0] history should not be empty")
+
+        # Get node 1 results
+        results = self.nodes[1].listaccounthistory(collateral_a)
+
+        # Expect one mint token TX
+        assert_equal(len(results), 1)
+
+        # Account history from listaccounthistory and gettaccounthistory must be matched
+        for txs in results:
+            history = self.nodes[1].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
+            if ('owner' in history):
+                assert_equal(history['owner'], txs['owner'])
+                assert_equal(history['blockHeight'], txs['blockHeight'])
+                assert_equal(history['txn'], txs['txn'])
+                assert_equal(history['txid'], txs['txid'])
+            else:
+                self.log.error("nodes[1] history should not be empty")
+
+if __name__ == '__main__':
+    TokensRPCGetAccountHistory().main ()

--- a/test/functional/rpc_getaccounthistory.py
+++ b/test/functional/rpc_getaccounthistory.py
@@ -60,14 +60,13 @@ class TokensRPCGetAccountHistory(DefiTestFramework):
 
         # Account history from listaccounthistory and gettaccounthistory must be matched
         for txs in results:
+            self.log.info("owner:%s blockHeight:%s txn:%s", txs['owner'], txs['blockHeight'], txs['txn'])
             history = self.nodes[0].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
-            if ('owner' in history):
-                assert_equal(history['owner'], txs['owner'])
-                assert_equal(history['blockHeight'], txs['blockHeight'])
-                assert_equal(history['txn'], txs['txn'])
-                assert_equal(history['txid'], txs['txid'])
-            else:
-                self.log.error("nodes[0] history should not be empty")
+            assert_equal('owner' in history, True)
+            assert_equal(history['owner'], txs['owner'])
+            assert_equal(history['blockHeight'], txs['blockHeight'])
+            assert_equal(history['txn'], txs['txn'])
+            assert_equal(history['txid'], txs['txid'])
 
         # Get node 1 results
         results = self.nodes[1].listaccounthistory(collateral_a)
@@ -77,14 +76,13 @@ class TokensRPCGetAccountHistory(DefiTestFramework):
 
         # Account history from listaccounthistory and gettaccounthistory must be matched
         for txs in results:
+            self.log.info("owner:%s blockHeight:%s txn:%s", txs['owner'], txs['blockHeight'], txs['txn'])
             history = self.nodes[1].getaccounthistory(txs['owner'], txs['blockHeight'], txs['txn'])
-            if ('owner' in history):
-                assert_equal(history['owner'], txs['owner'])
-                assert_equal(history['blockHeight'], txs['blockHeight'])
-                assert_equal(history['txn'], txs['txn'])
-                assert_equal(history['txid'], txs['txid'])
-            else:
-                self.log.error("nodes[1] history should not be empty")
+            assert_equal('owner' in history, True)
+            assert_equal(history['owner'], txs['owner'])
+            assert_equal(history['blockHeight'], txs['blockHeight'])
+            assert_equal(history['txn'], txs['txn'])
+            assert_equal(history['txid'], txs['txid'])
 
 if __name__ == '__main__':
     TokensRPCGetAccountHistory().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -248,6 +248,7 @@ BASE_SCRIPTS = [
     'feature_filelock.py',
     'p2p_unrequested_blocks.py',
     'rpc_listaccounthistory.py',
+    'rpc_getaccounthistory.py',
     'feature_includeconf.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:
<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->
/kind feature

#### What this PR does / why we need it:
Currently, we have listaccounthistory on DeFiCh/ain. However, there isn't a way to filter to get one AccountHistory and we need an RPC to get single account history to resolve balance transfer.

#### Which issue(s) does this PR fixes?:
https://github.com/DeFiCh/jellyfish/issues/1025
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:
