### PR TITLE
Expand dex fee capability

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -33,6 +33,113 @@ static std::vector<std::string> KeyBreaker(const std::string& str){
     return strVec;
 }
 
+const std::map<std::string, uint8_t>& ATTRIBUTES::allowedVersions() {
+    static const std::map<std::string, uint8_t> versions{
+        {"v0",  VersionTypes::v0},
+    };
+    return versions;
+}
+
+const std::map<uint8_t, std::string>& ATTRIBUTES::displayVersions() {
+    static const std::map<uint8_t, std::string> versions{
+        {VersionTypes::v0,  "v0"},
+    };
+    return versions;
+}
+
+const std::map<std::string, uint8_t>& ATTRIBUTES::allowedTypes() {
+    static const std::map<std::string, uint8_t> types{
+        {"params",      AttributeTypes::Param},
+        {"poolpairs",   AttributeTypes::Poolpairs},
+        {"token",       AttributeTypes::Token},
+    };
+    return types;
+}
+
+const std::map<uint8_t, std::string>& ATTRIBUTES::displayTypes() {
+    static const std::map<uint8_t, std::string> types{
+        {AttributeTypes::Live,      "live"},
+        {AttributeTypes::Param,     "params"},
+        {AttributeTypes::Poolpairs, "poolpairs"},
+        {AttributeTypes::Token,     "token"},
+    };
+    return types;
+}
+
+const std::map<std::string, uint8_t>& ATTRIBUTES::allowedParamIDs() {
+    static const std::map<std::string, uint8_t> params{
+        {"dfip2201",    ParamIDs::DFIP2201}
+    };
+    return params;
+}
+
+const std::map<uint8_t, std::string>& ATTRIBUTES::displayParamsIDs() {
+    static const std::map<uint8_t, std::string> params{
+        {ParamIDs::DFIP2201,    "dfip2201"},
+        {ParamIDs::Economy,     "economy"},
+    };
+    return params;
+}
+
+const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys() {
+    static const std::map<uint8_t, std::map<std::string, uint8_t>> keys{
+        {
+            AttributeTypes::Token, {
+                {"payback_dfi",         TokenKeys::PaybackDFI},
+                {"payback_dfi_fee_pct", TokenKeys::PaybackDFIFeePCT},
+                {"dex_in_fee_pct",      TokenKeys::DexInFeePct},
+                {"dex_out_fee_pct",     TokenKeys::DexOutFeePct},
+            }
+        },
+        {
+            AttributeTypes::Poolpairs, {
+                {"token_a_fee_pct",     PoolKeys::TokenAFeePCT},
+                {"token_b_fee_pct",     PoolKeys::TokenBFeePCT},
+            }
+        },
+        {
+            AttributeTypes::Param, {
+                {"active",              DFIP2201Keys::Active},
+                {"minswap",             DFIP2201Keys::MinSwap},
+                {"premium",             DFIP2201Keys::Premium},
+            }
+        },
+    };
+    return keys;
+}
+
+const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys() {
+    static const std::map<uint8_t, std::map<uint8_t, std::string>> keys{
+        {
+            AttributeTypes::Token, {
+                {TokenKeys::PaybackDFI,       "payback_dfi"},
+                {TokenKeys::PaybackDFIFeePCT, "payback_dfi_fee_pct"},
+                {TokenKeys::DexInFeePct,      "dex_in_fee_pct"},
+                {TokenKeys::DexOutFeePct,     "dex_out_fee_pct"},
+            }
+        },
+        {
+            AttributeTypes::Poolpairs, {
+                {PoolKeys::TokenAFeePCT,      "token_a_fee_pct"},
+                {PoolKeys::TokenBFeePCT,      "token_b_fee_pct"},
+            }
+        },
+        {
+            AttributeTypes::Param, {
+                {DFIP2201Keys::Active,        "active"},
+                {DFIP2201Keys::Premium,       "premium"},
+                {DFIP2201Keys::MinSwap,       "minswap"},
+            }
+        },
+        {
+            AttributeTypes::Live, {
+                {EconomyKeys::PaybackDFITokens,  "dfi_payback_tokens"},
+            }
+        },
+    };
+    return keys;
+}
+
 static ResVal<int32_t> VerifyInt32(const std::string& str) {
     int32_t int32;
     if (!ParseInt32(str, &int32) || int32 < 0) {
@@ -41,7 +148,7 @@ static ResVal<int32_t> VerifyInt32(const std::string& str) {
     return {int32, Res::Ok()};
 }
 
-static ResVal<CAmount> VerifyFloat(const std::string& str) {
+static ResVal<CAttributeValue> VerifyFloat(const std::string& str) {
     CAmount amount = 0;
     if (!ParseFixedPoint(str, 8, &amount) || amount < 0) {
         return Res::Err("Amount must be a positive value");
@@ -49,15 +156,52 @@ static ResVal<CAmount> VerifyFloat(const std::string& str) {
     return {amount, Res::Ok()};
 }
 
-static ResVal<CAmount> VerifyPct(const std::string& str) {
+static ResVal<CAttributeValue> VerifyPct(const std::string& str) {
     auto resVal = VerifyFloat(str);
     if (!resVal) {
         return resVal;
     }
-    if (*resVal.val > COIN) {
+    if (CAttributeValue{COIN} < *resVal.val) {
         return Res::Err("Percentage exceeds 100%%");
     }
     return resVal;
+}
+
+static ResVal<CAttributeValue> VerifyBool(const std::string& str) {
+    if (str != "true" && str != "false") {
+        return Res::Err(R"(Boolean value must be either "true" or "false")");
+    }
+    return {str == "true", Res::Ok()};
+}
+
+const std::map<uint8_t, std::map<uint8_t,
+    std::function<ResVal<CAttributeValue>(const std::string&)>>>& ATTRIBUTES::parseValue() {
+
+    static const std::map<uint8_t, std::map<uint8_t,
+        std::function<ResVal<CAttributeValue>(const std::string&)>>> parsers{
+        {
+            AttributeTypes::Token, {
+                {TokenKeys::PaybackDFI,       VerifyBool},
+                {TokenKeys::PaybackDFIFeePCT, VerifyPct},
+                {TokenKeys::DexInFeePct,      VerifyPct},
+                {TokenKeys::DexOutFeePct,     VerifyPct},
+            }
+        },
+        {
+            AttributeTypes::Poolpairs, {
+                {PoolKeys::TokenAFeePCT,      VerifyPct},
+                {PoolKeys::TokenBFeePCT,      VerifyPct},
+            }
+        },
+        {
+            AttributeTypes::Param, {
+                {DFIP2201Keys::Active,       VerifyBool},
+                {DFIP2201Keys::Premium,      VerifyPct},
+                {DFIP2201Keys::MinSwap,      VerifyFloat},
+            }
+        },
+    };
+    return parsers;
 }
 
 static Res ShowError(const std::string& key, const std::map<std::string, uint8_t>& keys) {
@@ -84,8 +228,8 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         return Res::Err("Empty value");
     }
 
-    auto iver = allowedVersions.find(keys[0]);
-    if (iver == allowedVersions.end()) {
+    auto iver = allowedVersions().find(keys[0]);
+    if (iver == allowedVersions().end()) {
         return Res::Err("Unsupported version");
     }
 
@@ -98,9 +242,9 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         return Res::Err("Incorrect key for <type>. Object of ['<version>/<type>/ID/<key>','value'] expected");
     }
 
-    auto itype = allowedTypes.find(keys[1]);
-    if (itype == allowedTypes.end()) {
-        return ::ShowError("type", allowedTypes);
+    auto itype = allowedTypes().find(keys[1]);
+    if (itype == allowedTypes().end()) {
+        return ::ShowError("type", allowedTypes());
     }
 
     auto type = itype->second;
@@ -111,19 +255,17 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         if (!id) {
             return std::move(id);
         }
-
         typeId = *id.val;
     } else {
-        auto id = allowedParamIDs.find(keys[2]);
-        if (id == allowedParamIDs.end()) {
-            return ::ShowError("param", allowedParamIDs);
+        auto id = allowedParamIDs().find(keys[2]);
+        if (id == allowedParamIDs().end()) {
+            return ::ShowError("param", allowedParamIDs());
         }
-
         typeId = id->second;
     }
 
-    auto ikey = allowedKeys.find(type);
-    if (ikey == allowedKeys.end()) {
+    auto ikey = allowedKeys().find(type);
+    if (ikey == allowedKeys().end()) {
         return Res::Err("Unsupported type {%d}", type);
     }
 
@@ -132,68 +274,18 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         return ::ShowError("key", ikey->second);
     }
 
-    UniValue univalue;
     auto typeKey = itype->second;
-
-    CAttributeValue attribValue;
-
-    if (type == AttributeTypes::Token) {
-        if (typeKey == TokenKeys::PaybackDFI) {
-            if (value != "true" && value != "false") {
-                return Res::Err("Payback DFI value must be either \"true\" or \"false\"");
+    try {
+        if (auto parser = parseValue().at(type).at(typeKey)) {
+            auto attribValue = parser(value);
+            if (!attribValue) {
+                return std::move(attribValue);
             }
-            attribValue = value == "true";
-        } else if (typeKey == TokenKeys::PaybackDFIFeePCT) {
-            auto res = VerifyPct(value);
-            if (!res) {
-                return std::move(res);
-            }
-            attribValue = *res.val;
-        } else {
-            return Res::Err("Unrecognised key");
+            return applyVariable(CDataStructureV0{type, typeId, typeKey}, *attribValue.val);
         }
-    } else if (type == AttributeTypes::Poolpairs) {
-        if (typeKey == PoolKeys::TokenAFeePCT
-        ||  typeKey == PoolKeys::TokenBFeePCT) {
-            auto res = VerifyPct(value);
-            if (!res) {
-                return std::move(res);
-            }
-            attribValue = *res.val;
-        } else {
-            return Res::Err("Unrecognised key");
-        }
-    } else if (type == AttributeTypes::Param) {
-        if (typeId == ParamIDs::DFIP2201) {
-            if (typeKey == DFIP2201Keys::Active) {
-                if (value != "true" && value != "false") {
-                    return Res::Err("DFIP2201 actve value must be either \"true\" or \"false\"");
-                }
-                attribValue = value == "true";
-            } else if (typeKey == DFIP2201Keys::Premium) {
-                auto res = VerifyPct(value);
-                if (!res) {
-                    return std::move(res);
-                }
-                attribValue = *res.val;
-            } else if (typeKey == DFIP2201Keys::MinSwap) {
-                auto res = VerifyFloat(value);
-                if (!res) {
-                    return std::move(res);
-                }
-                attribValue = *res.val;
-            } else {
-                return Res::Err("Unrecognised key");
-            }
-        }
-    } else {
-        return Res::Err("Unrecognised type");
+    } catch (const std::out_of_range&) {
     }
-
-    if (applyVariable) {
-        return applyVariable(CDataStructureV0{type, typeId, typeKey}, attribValue);
-    }
-    return Res::Ok();
+    return Res::Err("No parse function {%d, %d}", type, typeKey);
 }
 
 Res ATTRIBUTES::Import(const UniValue & val) {
@@ -233,13 +325,13 @@ UniValue ATTRIBUTES::Export() const {
         try {
             const auto id = attrV0->type == AttributeTypes::Param
                          || attrV0->type == AttributeTypes::Live
-                            ? displayParamsIDs.at(attrV0->typeId)
+                            ? displayParamsIDs().at(attrV0->typeId)
                             : KeyBuilder(attrV0->typeId);
 
-            auto key = KeyBuilder(displayVersions.at(VersionTypes::v0),
-                                  displayTypes.at(attrV0->type),
+            auto key = KeyBuilder(displayVersions().at(VersionTypes::v0),
+                                  displayTypes().at(attrV0->type),
                                   id,
-                                  displayKeys.at(attrV0->type).at(attrV0->key));
+                                  displayKeys().at(attrV0->type).at(attrV0->key));
 
             if (auto bool_val = std::get_if<bool>(&attribute.second)) {
                 ret.pushKV(key, *bool_val ? "true" : "false");
@@ -267,40 +359,48 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
             return Res::Err("Unsupported version");
         }
         switch (attrV0->type) {
-            case AttributeTypes::Token: {
-                if (attrV0->key == TokenKeys::PaybackDFI
-                ||  attrV0->key == TokenKeys::PaybackDFIFeePCT) {
-                    uint32_t tokenId = attrV0->typeId;
-                    if (!view.GetLoanTokenByID(DCT_ID{tokenId})) {
-                        return Res::Err("No such loan token (%d)", tokenId);
-                    }
-                } else {
-                    return Res::Err("Unsupported key");
+            case AttributeTypes::Token:
+                switch (attrV0->key) {
+                    case TokenKeys::PaybackDFI:
+                    case TokenKeys::PaybackDFIFeePCT:
+                        if (!view.GetLoanTokenByID({attrV0->typeId})) {
+                            return Res::Err("No such loan token (%d)", attrV0->typeId);
+                        }
+                    break;
+                    case TokenKeys::DexInFeePct:
+                    case TokenKeys::DexOutFeePct:
+                        if (view.GetLastHeight() < Params().GetConsensus().GreatWorldHeight) {
+                            return Res::Err("Cannot be set before GreatWorld");
+                        }
+                        if (!view.GetToken(DCT_ID{attrV0->typeId})) {
+                            return Res::Err("No such token (%d)", attrV0->typeId);
+                        }
+                    break;
+                    default:
+                        return Res::Err("Unsupported key");
                 }
-            }
             break;
 
-            case AttributeTypes::Poolpairs: {
+            case AttributeTypes::Poolpairs:
                 if (!std::get_if<CAmount>(&attribute.second)) {
                     return Res::Err("Unsupported value");
                 }
-                if (attrV0->key == PoolKeys::TokenAFeePCT
-                ||  attrV0->key == PoolKeys::TokenBFeePCT) {
-                    uint32_t poolId = attrV0->typeId;
-                    if (!view.GetPoolPair(DCT_ID{poolId})) {
-                        return Res::Err("No such pool (%d)", poolId);
-                    }
-                } else {
-                    return Res::Err("Unsupported key");
+                switch (attrV0->key) {
+                    case PoolKeys::TokenAFeePCT:
+                    case PoolKeys::TokenBFeePCT:
+                        if (!view.GetPoolPair({attrV0->typeId})) {
+                            return Res::Err("No such pool (%d)", attrV0->typeId);
+                        }
+                    break;
+                    default:
+                        return Res::Err("Unsupported key");
                 }
-            }
             break;
 
-            case AttributeTypes::Param: {
+            case AttributeTypes::Param:
                 if (attrV0->typeId != ParamIDs::DFIP2201) {
                     return Res::Err("Unrecognised param id");
                 }
-            }
             break;
 
             // Live is set internally
@@ -319,19 +419,33 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
 {
     for (const auto& attribute : attributes) {
         auto attrV0 = std::get_if<CDataStructureV0>(&attribute.first);
-        if (attrV0 && attrV0->type == AttributeTypes::Poolpairs) {
-            uint32_t poolId = attrV0->typeId;
-            auto pool = mnview.GetPoolPair(DCT_ID{poolId});
+        if (!attrV0) {
+            continue;
+        }
+        if (attrV0->type == AttributeTypes::Poolpairs) {
+            auto poolId = DCT_ID{attrV0->typeId};
+            auto pool = mnview.GetPoolPair(poolId);
             if (!pool) {
-                return Res::Err("No such pool (%d)", poolId);
+                return Res::Err("No such pool (%d)", poolId.v);
             }
             auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ?
                                         pool->idTokenA : pool->idTokenB;
 
             auto valuePct = std::get<CAmount>(attribute.second);
-            auto res = mnview.SetDexFeePct(DCT_ID{poolId}, tokenId, valuePct);
-            if (!res) {
+            if (auto res = mnview.SetDexFeePct(poolId, tokenId, valuePct); !res) {
                 return res;
+            }
+        } else if (attrV0->type == AttributeTypes::Token) {
+            if (attrV0->key == TokenKeys::DexInFeePct
+            ||  attrV0->key == TokenKeys::DexOutFeePct) {
+                DCT_ID tokenA{attrV0->typeId}, tokenB{~0u};
+                if (attrV0->key == TokenKeys::DexOutFeePct) {
+                    std::swap(tokenA, tokenB);
+                }
+                auto valuePct = std::get<CAmount>(attribute.second);
+                if (auto res = mnview.SetDexFeePct(tokenA, tokenB, valuePct); !res) {
+                    return res;
+                }
             }
         }
     }

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -40,6 +40,8 @@ enum DFIP2201Keys : uint8_t  {
 enum TokenKeys : uint8_t  {
     PaybackDFI       = 'a',
     PaybackDFIFeePCT = 'b',
+    DexInFeePct      = 'c',
+    DexOutFeePct     = 'd',
 };
 
 enum PoolKeys : uint8_t {
@@ -119,88 +121,21 @@ public:
 
 private:
     // Defined allowed arguments
-    inline static const std::map<std::string, uint8_t> allowedVersions{
-        {"v0",          VersionTypes::v0},
-    };
-
-    inline static const std::map<std::string, uint8_t> allowedTypes{
-        {"params",      AttributeTypes::Param},
-        {"poolpairs",   AttributeTypes::Poolpairs},
-        {"token",       AttributeTypes::Token},
-    };
-
-    inline static const std::map<std::string, uint8_t> allowedParamIDs{
-        {"dfip2201",         ParamIDs::DFIP2201}
-    };
-
-    inline static const std::map<uint8_t, std::map<std::string, uint8_t>> allowedKeys{
-        {
-            AttributeTypes::Token, {
-                {"payback_dfi",         TokenKeys::PaybackDFI},
-                {"payback_dfi_fee_pct", TokenKeys::PaybackDFIFeePCT},
-            }
-        },
-        {
-            AttributeTypes::Poolpairs, {
-                {"token_a_fee_pct",     PoolKeys::TokenAFeePCT},
-                {"token_b_fee_pct",     PoolKeys::TokenBFeePCT},
-            }
-        },
-        {
-            AttributeTypes::Param, {
-                {"active",              DFIP2201Keys::Active},
-                {"minswap",             DFIP2201Keys::MinSwap},
-                {"premium",             DFIP2201Keys::Premium},
-            }
-        },
-    };
+    static const std::map<std::string, uint8_t>& allowedVersions();
+    static const std::map<std::string, uint8_t>& allowedTypes();
+    static const std::map<std::string, uint8_t>& allowedParamIDs();
+    static const std::map<uint8_t, std::map<std::string, uint8_t>>& allowedKeys();
+    static const std::map<uint8_t, std::map<uint8_t,
+            std::function<ResVal<CAttributeValue>(const std::string&)>>>& parseValue();
 
     // For formatting in export
-    inline static const std::map<uint8_t, std::string> displayVersions{
-        {VersionTypes::v0,          "v0"},
-    };
-
-    inline static const std::map<uint8_t, std::string> displayTypes{
-        {AttributeTypes::Live,      "live"},
-        {AttributeTypes::Param,     "params"},
-        {AttributeTypes::Poolpairs, "poolpairs"},
-        {AttributeTypes::Token,     "token"},
-    };
-
-    inline static const std::map<uint8_t, std::string> displayParamsIDs{
-        {ParamIDs::DFIP2201,       "dfip2201"},
-        {ParamIDs::Economy,        "economy"},
-    };
-
-    inline static const std::map<uint8_t, std::map<uint8_t, std::string>> displayKeys{
-        {
-            AttributeTypes::Token, {
-                {TokenKeys::PaybackDFI,       "payback_dfi"},
-                {TokenKeys::PaybackDFIFeePCT, "payback_dfi_fee_pct"},
-            }
-        },
-        {
-            AttributeTypes::Poolpairs, {
-                {PoolKeys::TokenAFeePCT,      "token_a_fee_pct"},
-                {PoolKeys::TokenBFeePCT,      "token_b_fee_pct"},
-            }
-        },
-        {
-            AttributeTypes::Param, {
-                {DFIP2201Keys::Active,       "active"},
-                {DFIP2201Keys::Premium,      "premium"},
-                {DFIP2201Keys::MinSwap,      "minswap"},
-            }
-        },
-        {
-            AttributeTypes::Live, {
-                {EconomyKeys::PaybackDFITokens,  "dfi_payback_tokens"},
-            }
-        },
-    };
+    static const std::map<uint8_t, std::string>& displayVersions();
+    static const std::map<uint8_t, std::string>& displayTypes();
+    static const std::map<uint8_t, std::string>& displayParamsIDs();
+    static const std::map<uint8_t, std::map<uint8_t, std::string>>& displayKeys();
 
     Res ProcessVariable(const std::string& key, const std::string& value,
-                        std::function<Res(const CAttributeType&, const CAttributeValue&)> applyVariable = {}) const;
+                        std::function<Res(const CAttributeType&, const CAttributeValue&)> applyVariable) const;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_ATTRIBUTES_H

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -778,7 +778,7 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
             }
         }
 
-        auto dexfeeInPct = view.GetDexFeePct(currentID, swapAmount.nTokenId);
+        auto dexfeeInPct = view.GetDexFeeInPct(currentID, swapAmount.nTokenId);
 
         // Perform swap
         poolResult = pool->Swap(swapAmount, dexfeeInPct, poolPrice, [&] (const CTokenAmount& dexfeeInAmount, const CTokenAmount& tokenAmount) {
@@ -787,11 +787,10 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
 
             CTokenAmount dexfeeOutAmount{tokenAmount.nTokenId, 0};
 
-            if (height >= Params().GetConsensus().FortCanningHillHeight) {
-                if (auto dexfeeOutPct = view.GetDexFeePct(currentID, tokenAmount.nTokenId)) {
-                    dexfeeOutAmount.nValue = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
-                    swapAmountResult.nValue -= dexfeeOutAmount.nValue;
-                }
+            auto dexfeeOutPct = view.GetDexFeeOutPct(currentID, tokenAmount.nTokenId);
+            if (dexfeeOutPct > 0) {
+                dexfeeOutAmount.nValue = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
+                swapAmountResult.nValue -= dexfeeOutAmount.nValue;
             }
 
             // If we're just testing, don't do any balance transfers.

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -262,7 +262,8 @@ public:
     bool HasPoolPair(DCT_ID const & poolId) const;
 
     Res SetDexFeePct(DCT_ID poolId, DCT_ID tokenId, CAmount feePct);
-    CAmount GetDexFeePct(DCT_ID poolId, DCT_ID tokenId) const;
+    CAmount GetDexFeeInPct(DCT_ID poolId, DCT_ID tokenId) const;
+    CAmount GetDexFeeOutPct(DCT_ID poolId, DCT_ID tokenId) const;
 
     std::pair<CAmount, CAmount> UpdatePoolRewards(std::function<CTokenAmount(CScript const &, DCT_ID)> onGetBalance, std::function<Res(CScript const &, CScript const &, CTokenAmount)> onTransfer, int nHeight = 0);
 

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -19,6 +19,7 @@ from test_framework.util import (
 )
 
 from decimal import Decimal
+from math import trunc
 
 class PoolPairTest (DefiTestFramework):
     def set_test_params(self):
@@ -28,10 +29,10 @@ class PoolPairTest (DefiTestFramework):
         # node2: Non Foundation
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-acindex=1'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-acindex=1'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170']]
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-greatworldheight=177', '-acindex=1'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-greatworldheight=177', '-acindex=1'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-greatworldheight=177'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-bayfrontgardensheight=0', '-dakotaheight=160', '-fortcanningheight=163', '-fortcanninghillheight=170', '-greatworldheight=177']]
 
 
     def run_test(self):
@@ -338,10 +339,11 @@ class PoolPairTest (DefiTestFramework):
 
         symbolBTC = "BTC#" + self.get_id_token("BTC")
         symbolLTC = "LTC#" + self.get_id_token("LTC")
-        idBitcoin = list(self.nodes[0].gettoken(symbolBTC).keys())[0]
+        idBTC = list(self.nodes[0].gettoken(symbolBTC).keys())[0]
+        idLTC = list(self.nodes[0].gettoken(symbolLTC).keys())[0]
 
         self.nodes[0].minttokens("1@" + symbolBTC)
-        self.nodes[0].minttokens("101@" + symbolLTC)
+        self.nodes[0].minttokens("111@" + symbolLTC)
         self.nodes[0].generate(1)
 
         self.nodes[0].createpoolpair({
@@ -372,7 +374,7 @@ class PoolPairTest (DefiTestFramework):
             })
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBitcoin], Decimal('0.00000001'))
+        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBTC], Decimal('0.00000001'))
 
         # Reset swap
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
@@ -388,7 +390,7 @@ class PoolPairTest (DefiTestFramework):
             })
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBitcoin], Decimal('0.00000002'))
+        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBTC], Decimal('0.00000002'))
 
         # Reset swap and move to Fort Canning Park Height and try swap again
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
@@ -405,7 +407,7 @@ class PoolPairTest (DefiTestFramework):
             })
         self.nodes[0].generate(1)
 
-        assert(idBitcoin not in self.nodes[0].getaccount(new_dest, {}, True))
+        assert(idBTC not in self.nodes[0].getaccount(new_dest, {}, True))
 
         # Reset swap
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
@@ -421,7 +423,7 @@ class PoolPairTest (DefiTestFramework):
             })
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBitcoin], Decimal('0.00000001'))
+        assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBTC], Decimal('0.00000001'))
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.05', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.08'}})
         self.nodes[0].generate(1)
@@ -487,10 +489,44 @@ class PoolPairTest (DefiTestFramework):
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/poolpairs/%s/token_a_fee_pct'%(idBL): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idBL): '0.01'}})
         self.nodes[0].generate(1)
 
-        print(self.nodes[0].getblockcount())
-        print(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'])
-
         assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'], {'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_a_fee_pct'%(idBL): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idBL): '0.01'})
+
+        self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
+        self.nodes[0].clearmempool()
+        self.nodes[0].generate(1)
+
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/%s/dex_in_fee_pct'%(idLTC): '0.02', 'v0/token/%s/dex_out_fee_pct'%(idBTC): '0.05'}})
+        self.nodes[0].generate(1)
+
+        result = self.nodes[0].getpoolpair(idBL)
+        assert_equal(result[idBL]['dexFeeInPctTokenB'], Decimal('0.02'))
+        assert_equal(result[idBL]['dexFeeOutPctTokenA'], Decimal('0.05'))
+
+        destBTC = self.nodes[0].getnewaddress("", "legacy")
+        swapltc = 10
+        self.nodes[0].poolswap({
+                "from": accountGN0,
+                "tokenFrom": symbolLTC,
+                "amountFrom": swapltc,
+                "to": destBTC,
+                "tokenTo": symbolBTC
+        })
+        commission = round((swapltc * 0.01), 8)
+        amountB = Decimal(swapltc - commission)
+        dexinfee = amountB * Decimal(0.02)
+        amountB = amountB - dexinfee
+        pool = self.nodes[0].getpoolpair("BTC-LTC")[idBL]
+        reserveA = pool['reserveA']
+        reserveB = pool['reserveB']
+
+        self.nodes[0].generate(1)
+
+        pool = self.nodes[0].getpoolpair("BTC-LTC")[idBL]
+        assert_equal(pool['reserveB'] - reserveB, round(amountB, 8))
+        swapped = self.nodes[0].getaccount(destBTC, {}, True)[idBTC]
+        amountA = reserveA - pool['reserveA']
+        dexoutfee = round(trunc(amountA * Decimal(0.05) * coin) / coin, 8)
+        assert_equal(round(amountA - Decimal(dexoutfee), 8), round(swapped, 8))
 
         # REVERTING:
         #========================

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -21,8 +21,8 @@ class GovsetTest (DefiTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-eunosheight=200', '-fortcanningheight=400', '-fortcanninghillheight=1110', '-subsidytest=1'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-eunosheight=200', '-fortcanningheight=400', '-fortcanninghillheight=1110', '-subsidytest=1']]
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-eunosheight=200', '-fortcanningheight=400', '-fortcanninghillheight=1110', '-greatworldheight=1141', '-subsidytest=1'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-eunosheight=200', '-fortcanningheight=400', '-fortcanninghillheight=1110', '-greatworldheight=1141', '-subsidytest=1']]
 
 
     def run_test(self):
@@ -445,14 +445,14 @@ class GovsetTest (DefiTestFramework):
         assert_raises_rpc_error(-5, "Empty value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/15/payback_dfi':''}})
         assert_raises_rpc_error(-5, "Incorrect key for <type>. Object of ['<version>/<type>/ID/<key>','value'] expected", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/payback_dfi':'true'}})
         assert_raises_rpc_error(-5, "Unrecognised type argument provided, valid types are: params, poolpairs, token,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/unrecognised/5/payback_dfi':'true'}})
-        assert_raises_rpc_error(-5, "Unrecognised key argument provided, valid keys are: payback_dfi, payback_dfi_fee_pct,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/unrecognised':'true'}})
+        assert_raises_rpc_error(-5, "Unrecognised key argument provided, valid keys are: dex_in_fee_pct, dex_out_fee_pct, payback_dfi, payback_dfi_fee_pct,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/unrecognised':'true'}})
         assert_raises_rpc_error(-5, "Identifier must be a positive integer", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/not_a_number/payback_dfi':'true'}})
-        assert_raises_rpc_error(-5, 'Payback DFI value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'not_a_number'}})
-        assert_raises_rpc_error(-5, 'Payback DFI value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'unrecognised'}})
+        assert_raises_rpc_error(-5, 'Boolean value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'not_a_number'}})
+        assert_raises_rpc_error(-5, 'Boolean value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'unrecognised'}})
         assert_raises_rpc_error(-5, "Amount must be a positive value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi_fee_pct':'not_a_number'}})
         assert_raises_rpc_error(-5, "Amount must be a positive value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi_fee_pct':'-1'}})
         assert_raises_rpc_error(-32600, "ATTRIBUTES: No such loan token (5)", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'true'}})
-        assert_raises_rpc_error(-5, "DFIP2201 actve value must be either \"true\" or \"false\"", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2201/active':'not_a_bool'}})
+        assert_raises_rpc_error(-5, "Boolean value must be either \"true\" or \"false\"", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2201/active':'not_a_bool'}})
         assert_raises_rpc_error(-5, "Amount must be a positive value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2201/minswap':'-1'}})
         assert_raises_rpc_error(-5, "Amount must be a positive value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2201/minswap':'not_a_number'}})
         assert_raises_rpc_error(-5, "Amount must be a positive value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2201/premium': 'not_a_number'}})
@@ -522,6 +522,17 @@ class GovsetTest (DefiTestFramework):
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'], {'v0/params/dfip2201/active': 'true', 'v0/params/dfip2201/premium': '0.025', 'v0/params/dfip2201/minswap': '0.001', 'v0/token/5/payback_dfi': 'true', 'v0/token/5/payback_dfi_fee_pct': '0.01'})
         assert_equal(self.nodes[0].listgovs()[8][0]['ATTRIBUTES'], {'v0/params/dfip2201/active': 'true', 'v0/params/dfip2201/premium': '0.025', 'v0/params/dfip2201/minswap': '0.001', 'v0/token/5/payback_dfi': 'true', 'v0/token/5/payback_dfi_fee_pct': '0.01'})
+
+        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/dex_in_fee_pct': '0.5'}})
+        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/dex_out_fee_pct': '0.5'}})
+        self.nodes[0].generate(1)
+
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/5/dex_in_fee_pct':'0.6','v0/token/5/dex_out_fee_pct':'0.12'}})
+        self.nodes[0].generate(1)
+
+        attriutes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attriutes['v0/token/5/dex_in_fee_pct'], '0.6')
+        assert_equal(attriutes['v0/token/5/dex_out_fee_pct'], '0.12')
 
 if __name__ == '__main__':
     GovsetTest ().main ()


### PR DESCRIPTION

/kind feature

#### What this PR does / why we need it:

```
Current:
/v0/poolpairs/<x>/token_a_fee_pct
/v0/poolpairs/<x>/token_b_fee_pct

new:
/v0/token/<x>/dex_in_fee_pct
/v0/token/<x>/dex_out_fee_pct
```

Aling with current dex fee variable via `poolpairs` adding new `token` variable to handle in/out dex fee
Priority is:

1. Get poolpair value
2. Fallback to token value

Fixes #1117 
