### PR TITLE
Unset governance variable

### DIFF
--- a/src/masternodes/consensus/governance.cpp
+++ b/src/masternodes/consensus/governance.cpp
@@ -88,6 +88,26 @@ Res CGovernanceConsensus::operator()(const CGovernanceMessage& obj) const {
     return Res::Ok();
 }
 
+Res CGovernanceConsensus::operator()(const CGovernanceUnsetMessage& obj) const {
+    //check foundation auth
+    if (!HasFoundationAuth())
+        return Res::Err("tx not from foundation member");
+
+    for(const auto& gov : obj.govs) {
+        auto var = mnview.GetVariable(gov.first);
+        if (!var)
+            return Res::Err("'%s': variable does not registered", gov.first);
+
+        auto res = var->Erase(mnview, height, gov.second);
+        if (!res)
+            return Res::Err("%s: %s", var->GetName(), res.msg);
+
+        if (!(res = mnview.SetVariable(*var)))
+            return Res::Err("%s: %s", var->GetName(), res.msg);
+    }
+    return Res::Ok();
+}
+
 Res CGovernanceConsensus::operator()(const CGovernanceHeightMessage& obj) const {
     //check foundation auth
     if (!HasFoundationAuth())

--- a/src/masternodes/consensus/governance.h
+++ b/src/masternodes/consensus/governance.h
@@ -8,12 +8,14 @@
 #include <masternodes/consensus/txvisitor.h>
 
 struct CGovernanceMessage;
+struct CGovernanceUnsetMessage;
 struct CGovernanceHeightMessage;
 
 class CGovernanceConsensus : public CCustomTxVisitor {
 public:
     using CCustomTxVisitor::CCustomTxVisitor;
     Res operator()(const CGovernanceMessage& obj) const;
+    Res operator()(const CGovernanceUnsetMessage& obj) const;
     Res operator()(const CGovernanceHeightMessage& obj) const;
 
     static Res storeGovVars(const CGovernanceHeightMessage& obj, CCustomCSView& view);

--- a/src/masternodes/customtx.cpp
+++ b/src/masternodes/customtx.cpp
@@ -35,6 +35,7 @@ CustomTxType CustomTxCodeToType(uint8_t ch) {
         case CustomTxType::FutureSwapExecution:
         case CustomTxType::FutureSwapRefund:
         case CustomTxType::SetGovVariable:
+        case CustomTxType::UnsetGovVariable:
         case CustomTxType::SetGovVariableHeight:
         case CustomTxType::AutoAuthPrep:
         case CustomTxType::AppointOracle:
@@ -101,6 +102,7 @@ std::string ToString(CustomTxType type) {
         CustomTxTypeString(FutureSwapExecution);
         CustomTxTypeString(FutureSwapRefund);
         CustomTxTypeString(SetGovVariable);
+        CustomTxTypeString(UnsetGovVariable);
         CustomTxTypeString(SetGovVariableHeight);
         CustomTxTypeString(AppointOracle);
         CustomTxTypeString(RemoveOracleAppoint);

--- a/src/masternodes/customtx.h
+++ b/src/masternodes/customtx.h
@@ -55,6 +55,7 @@ enum struct CustomTxType : uint8_t
 
     // governance
     SetGovVariable          = 'G',
+    UnsetGovVariable        = 'W',
     SetGovVariableHeight    = 'j',
 
     // Auto auth

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -372,7 +372,7 @@ static Res ShowError(const std::string& key, const std::map<std::string, uint8_t
     return Res::Err(error);
 }
 
-Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value,
+Res ATTRIBUTES::ProcessVariable(const std::string& key, std::optional<std::string> value,
                                 const std::function<Res(const CAttributeType&, const CAttributeValue&)>& applyVariable) {
 
     if (key.size() > 128) {
@@ -384,7 +384,7 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         return Res::Err("Empty version");
     }
 
-    if (value.empty()) {
+    if (value && value->empty()) {
         return Res::Err("Empty value");
     }
 
@@ -501,9 +501,13 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         }
     }
 
+    if (!value) {
+        return applyVariable(attrV0, {});
+    }
+
     try {
         if (auto parser = parseValue().at(type).at(typeKey)) {
-            auto attribValue = parser(value);
+            auto attribValue = parser(*value);
             if (!attribValue) {
                 return std::move(attribValue);
             }
@@ -512,6 +516,11 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
     } catch (const std::out_of_range&) {
     }
     return Res::Err("No parse function {%d, %d}", type, typeKey);
+}
+
+bool ATTRIBUTES::IsEmpty() const
+{
+    return attributes.empty();
 }
 
 ResVal<CScript> GetFutureSwapContractAddress()
@@ -834,9 +843,6 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                 break;
 
             case AttributeTypes::Poolpairs:
-                if (!std::get_if<CAmount>(&value)) {
-                    return Res::Err("Unsupported value");
-                }
                 switch (attrV0->key) {
                     case PoolKeys::TokenAFeePCT:
                     case PoolKeys::TokenBFeePCT:
@@ -888,7 +894,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res ATTRIBUTES::Apply(CCustomCSView& mnview, CFutureSwapView& futureSwapView, const uint32_t height)
+Res ATTRIBUTES::Apply(CCustomCSView& mnview, CFutureSwapView& futureSwapView, uint32_t height)
 {
     for (const auto& attribute : attributes) {
         auto attrV0 = std::get_if<CDataStructureV0>(&attribute.first);
@@ -1039,6 +1045,51 @@ Res ATTRIBUTES::Apply(CCustomCSView& mnview, CFutureSwapView& futureSwapView, co
                     return Res::Err("Cannot be set at or below current height");
                 }
             }
+        }
+    }
+    return Res::Ok();
+}
+
+Res ATTRIBUTES::Erase(CCustomCSView & mnview, uint32_t, std::vector<std::string> const & keys)
+{
+    for (const auto& key : keys) {
+        auto res = ProcessVariable(key, {},
+            [&](const CAttributeType& attribute, const CAttributeValue&) {
+                auto attrV0 = std::get_if<CDataStructureV0>(&attribute);
+                if (!attrV0) {
+                    return Res::Ok();
+                }
+                if (attrV0->type == AttributeTypes::Live) {
+                    return Res::Err("Live attribute cannot be deleted");
+                }
+                if (!EraseKey(attribute)) {
+                    return Res::Err("Attribute {%d} not exists", attrV0->type);
+                }
+                if (attrV0->type == AttributeTypes::Poolpairs) {
+                    auto poolId = DCT_ID{attrV0->typeId};
+                    auto pool = mnview.GetPoolPair(poolId);
+                    if (!pool) {
+                        return Res::Err("No such pool (%d)", poolId.v);
+                    }
+                    auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ?
+                                                pool->idTokenA : pool->idTokenB;
+
+                    return mnview.EraseDexFeePct(poolId, tokenId);
+                } else if (attrV0->type == AttributeTypes::Token) {
+                    if (attrV0->key == TokenKeys::DexInFeePct
+                    ||  attrV0->key == TokenKeys::DexOutFeePct) {
+                        DCT_ID tokenA{attrV0->typeId}, tokenB{~0u};
+                        if (attrV0->key == TokenKeys::DexOutFeePct) {
+                            std::swap(tokenA, tokenB);
+                        }
+                        return mnview.EraseDexFeePct(tokenA, tokenB);
+                    }
+                }
+                return Res::Ok();
+            }
+        );
+        if (!res) {
+            return res;
         }
     }
 

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -162,11 +162,13 @@ using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CD
 class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
-    Res Apply(CCustomCSView& mnview, const uint32_t height) override { return Res::Err("Calling the wrong Apply"); };
-    Res Apply(CCustomCSView& mnview, CFutureSwapView& futureSwapView, const uint32_t height);
+    Res Apply(CCustomCSView& mnview, uint32_t height) override { return Res::Err("Calling the wrong Apply"); };
+    Res Apply(CCustomCSView& mnview, CFutureSwapView& futureSwapView, uint32_t height);
+    Res Erase(CCustomCSView& mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "ATTRIBUTES"; }
@@ -205,10 +207,13 @@ public:
     }
 
     template<typename K>
-    void EraseKey(const K& key) {
+    bool EraseKey(const K& key) {
         static_assert(std::is_convertible_v<K, CAttributeType>);
-        changed.insert(key);
-        attributes.erase(key);
+        if (attributes.erase(key)) {
+            changed.insert(key);
+            return true;
+        }
+        return false;
     }
 
     template<typename K>
@@ -264,7 +269,7 @@ private:
     static const std::map<uint8_t, std::map<uint8_t,
             std::function<ResVal<CAttributeValue>(const std::string&)>>>& parseValue();
 
-    Res ProcessVariable(const std::string& key, const std::string& value,
+    Res ProcessVariable(const std::string& key, std::optional<std::string> value,
                         const std::function<Res(const CAttributeType&, const CAttributeValue&)>& applyVariable);
     Res RefundFuturesContracts(CCustomCSView &mnview, CFutureSwapView& futureSwapView, const uint32_t height, const uint32_t tokenID = std::numeric_limits<uint32_t>::max());
 };

--- a/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
+++ b/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
@@ -7,6 +7,11 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool ICX_TAKERFEE_PER_BTC::IsEmpty() const
+{
+    return !takerFeePerBTC.has_value();
+}
+
 Res ICX_TAKERFEE_PER_BTC::Import(const UniValue & val)
 {
     takerFeePerBTC = AmountFromValue(val);
@@ -15,7 +20,7 @@ Res ICX_TAKERFEE_PER_BTC::Import(const UniValue & val)
 
 UniValue ICX_TAKERFEE_PER_BTC::Export() const
 {
-    return ValueFromAmount(takerFeePerBTC);
+    return ValueFromAmount(takerFeePerBTC.value_or(0));
 }
 
 Res ICX_TAKERFEE_PER_BTC::Validate(const CCustomCSView &mnview) const
@@ -28,5 +33,11 @@ Res ICX_TAKERFEE_PER_BTC::Validate(const CCustomCSView &mnview) const
 
 Res ICX_TAKERFEE_PER_BTC::Apply(CCustomCSView & mnview, uint32_t)
 {
-    return mnview.ICXSetTakerFeePerBTC(takerFeePerBTC);
+    return mnview.ICXSetTakerFeePerBTC(takerFeePerBTC.value_or(0));
+}
+
+Res ICX_TAKERFEE_PER_BTC::Erase(CCustomCSView & mnview, uint32_t, std::vector<std::string> const &)
+{
+    takerFeePerBTC.reset();
+    return mnview.ICXEraseTakerFeePerBTC();
 }

--- a/src/masternodes/govvariables/icx_takerfee_per_btc.h
+++ b/src/masternodes/govvariables/icx_takerfee_per_btc.h
@@ -7,10 +7,12 @@
 class ICX_TAKERFEE_PER_BTC : public GovVariable, public AutoRegistrator<GovVariable, ICX_TAKERFEE_PER_BTC>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "ICX_TAKERFEE_PER_BTC"; }
@@ -23,8 +25,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(takerFeePerBTC);
     }
-    
-    CAmount takerFeePerBTC;
+
+    GvOptional<CAmount> takerFeePerBTC;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_ICX_TAKERFEE_PER_BTC_H

--- a/src/masternodes/govvariables/loan_daily_reward.cpp
+++ b/src/masternodes/govvariables/loan_daily_reward.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool LP_DAILY_LOAN_TOKEN_REWARD::IsEmpty() const
+{
+    return !dailyReward.has_value();
+}
 
 Res LP_DAILY_LOAN_TOKEN_REWARD::Import(const UniValue & val)
 {
@@ -17,7 +21,7 @@ Res LP_DAILY_LOAN_TOKEN_REWARD::Import(const UniValue & val)
 
 UniValue LP_DAILY_LOAN_TOKEN_REWARD::Export() const
 {
-    return ValueFromAmount(dailyReward);
+    return ValueFromAmount(dailyReward.value_or(0));
 }
 
 Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView & view) const
@@ -30,5 +34,11 @@ Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView & view) const
 
 Res LP_DAILY_LOAN_TOKEN_REWARD::Apply(CCustomCSView & mnview, uint32_t height)
 {
-    return mnview.SetLoanDailyReward(height, dailyReward);
+    return mnview.SetLoanDailyReward(height, dailyReward.value_or(0));
+}
+
+Res LP_DAILY_LOAN_TOKEN_REWARD::Erase(CCustomCSView & mnview, uint32_t height, std::vector<std::string> const &)
+{
+    dailyReward.reset();
+    return mnview.SetLoanDailyReward(height, 0);
 }

--- a/src/masternodes/govvariables/loan_daily_reward.h
+++ b/src/masternodes/govvariables/loan_daily_reward.h
@@ -11,10 +11,12 @@
 class LP_DAILY_LOAN_TOKEN_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_LOAN_TOKEN_REWARD>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "LP_DAILY_LOAN_TOKEN_REWARD"; }
@@ -27,7 +29,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(dailyReward);
     }
-    CAmount dailyReward;
+
+    GvOptional<CAmount> dailyReward;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_LOAN_DAILY_REWARD_H

--- a/src/masternodes/govvariables/loan_liquidation_penalty.cpp
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool LOAN_LIQUIDATION_PENALTY::IsEmpty() const
+{
+    return !penalty.has_value();
+}
 
 Res LOAN_LIQUIDATION_PENALTY::Import(const UniValue & val)
 {
@@ -17,7 +21,7 @@ Res LOAN_LIQUIDATION_PENALTY::Import(const UniValue & val)
 
 UniValue LOAN_LIQUIDATION_PENALTY::Export() const
 {
-    return ValueFromAmount(penalty);
+    return ValueFromAmount(penalty.value_or(0));
 }
 
 Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView & view) const
@@ -33,5 +37,11 @@ Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView & view) const
 
 Res LOAN_LIQUIDATION_PENALTY::Apply(CCustomCSView & mnview, uint32_t height)
 {
-    return mnview.SetLoanLiquidationPenalty(penalty);
+    return mnview.SetLoanLiquidationPenalty(penalty.value_or(0));
+}
+
+Res LOAN_LIQUIDATION_PENALTY::Erase(CCustomCSView & mnview, uint32_t, std::vector<std::string> const &)
+{
+    penalty.reset();
+    return mnview.EraseLoanLiquidationPenalty();
 }

--- a/src/masternodes/govvariables/loan_liquidation_penalty.h
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.h
@@ -11,10 +11,12 @@
 class LOAN_LIQUIDATION_PENALTY : public GovVariable, public AutoRegistrator<GovVariable, LOAN_LIQUIDATION_PENALTY>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "LOAN_LIQUIDATION_PENALTY"; }
@@ -27,7 +29,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(penalty);
     }
-    CAmount penalty;
+
+    GvOptional<CAmount> penalty;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_LOAN_LIQUIDATION_PENALTY_H

--- a/src/masternodes/govvariables/loan_splits.cpp
+++ b/src/masternodes/govvariables/loan_splits.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool LP_LOAN_TOKEN_SPLITS::IsEmpty() const
+{
+    return splits.empty();
+}
 
 Res LP_LOAN_TOKEN_SPLITS::Import(const UniValue & val)
 {
@@ -66,5 +70,21 @@ Res LP_LOAN_TOKEN_SPLITS::Apply(CCustomCSView & mnview, uint32_t height)
         return true;
     });
 
+    return Res::Ok();
+}
+
+Res LP_LOAN_TOKEN_SPLITS::Erase(CCustomCSView & mnview, uint32_t height, std::vector<std::string> const & keys)
+{
+    for (const auto& key : keys) {
+        auto res = DCT_ID::FromString(key);
+        if (!res)
+            return std::move(res);
+
+        auto id = *res.val;
+        if (!splits.erase(id))
+            return Res::Err("id {%d} does not exists", id.v);
+
+        mnview.SetRewardLoanPct(id, height, 0);
+    }
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/loan_splits.h
+++ b/src/masternodes/govvariables/loan_splits.h
@@ -11,10 +11,12 @@
 class LP_LOAN_TOKEN_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_LOAN_TOKEN_SPLITS>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "LP_LOAN_TOKEN_SPLITS"; }

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool LP_DAILY_DFI_REWARD::IsEmpty() const
+{
+    return !dailyReward.has_value();
+}
 
 Res LP_DAILY_DFI_REWARD::Import(const UniValue & val)
 {
@@ -17,7 +21,7 @@ Res LP_DAILY_DFI_REWARD::Import(const UniValue & val)
 
 UniValue LP_DAILY_DFI_REWARD::Export() const
 {
-    return ValueFromAmount(dailyReward);
+    return ValueFromAmount(dailyReward.value_or(0));
 }
 
 Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView & view) const
@@ -31,5 +35,11 @@ Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView & view) const
 
 Res LP_DAILY_DFI_REWARD::Apply(CCustomCSView & mnview, uint32_t height)
 {
-    return mnview.SetDailyReward(height, dailyReward);
+    return mnview.SetDailyReward(height, dailyReward.value_or(0));
+}
+
+Res LP_DAILY_DFI_REWARD::Erase(CCustomCSView & mnview, uint32_t height, std::vector<std::string> const &)
+{
+    dailyReward.reset();
+    return mnview.SetDailyReward(height, 0);
 }

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.h
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.h
@@ -11,10 +11,12 @@
 class LP_DAILY_DFI_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_DFI_REWARD>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const&) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "LP_DAILY_DFI_REWARD"; }
@@ -27,7 +29,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(dailyReward);
     }
-    CAmount dailyReward;
+
+    GvOptional<CAmount> dailyReward;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_LP_DAILY_DFI_REWARD_H

--- a/src/masternodes/govvariables/lp_splits.cpp
+++ b/src/masternodes/govvariables/lp_splits.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool LP_SPLITS::IsEmpty() const
+{
+    return splits.empty();
+}
 
 Res LP_SPLITS::Import(const UniValue & val)
 {
@@ -62,5 +66,21 @@ Res LP_SPLITS::Apply(CCustomCSView & mnview, uint32_t height)
         mnview.SetRewardPct(poolId, height, rewardPct);
         return true;
     });
+    return Res::Ok();
+}
+
+Res LP_SPLITS::Erase(CCustomCSView & mnview, uint32_t height, std::vector<std::string> const & keys)
+{
+    for (const auto& key : keys) {
+        auto res = DCT_ID::FromString(key);
+        if (!res)
+            return std::move(res);
+
+        auto id = *res.val;
+        if (!splits.erase(id))
+            return Res::Err("id {%d} does not exists", id.v);
+
+        mnview.SetRewardPct(id, height, 0);
+    }
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/lp_splits.h
+++ b/src/masternodes/govvariables/lp_splits.h
@@ -11,10 +11,12 @@
 class LP_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_SPLITS>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "LP_SPLITS"; }

--- a/src/masternodes/govvariables/oracle_block_interval.cpp
+++ b/src/masternodes/govvariables/oracle_block_interval.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool ORACLE_BLOCK_INTERVAL::IsEmpty() const
+{
+    return !blockInterval.has_value();
+}
 
 Res ORACLE_BLOCK_INTERVAL::Import(const UniValue & val)
 {
@@ -20,7 +24,7 @@ Res ORACLE_BLOCK_INTERVAL::Import(const UniValue & val)
 
 UniValue ORACLE_BLOCK_INTERVAL::Export() const
 {
-    return static_cast<uint64_t>(blockInterval);
+    return static_cast<uint64_t>(blockInterval.value_or(0));
 }
 
 Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView & view) const
@@ -34,7 +38,13 @@ Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res ORACLE_BLOCK_INTERVAL::Apply(CCustomCSView & mnview, const uint32_t height)
+Res ORACLE_BLOCK_INTERVAL::Apply(CCustomCSView & mnview, uint32_t height)
 {
-    return mnview.SetIntervalBlock(blockInterval);
+    return mnview.SetIntervalBlock(blockInterval.value_or(0));
+}
+
+Res ORACLE_BLOCK_INTERVAL::Erase(CCustomCSView & mnview, uint32_t, std::vector<std::string> const &)
+{
+    blockInterval.reset();
+    return mnview.EraseIntervalBlock();
 }

--- a/src/masternodes/govvariables/oracle_block_interval.h
+++ b/src/masternodes/govvariables/oracle_block_interval.h
@@ -11,10 +11,12 @@
 class ORACLE_BLOCK_INTERVAL : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_BLOCK_INTERVAL>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
-    Res Apply(CCustomCSView &mnview, const uint32_t height) override;
+    Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const&) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "ORACLE_BLOCK_INTERVAL"; }
@@ -27,7 +29,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(blockInterval);
     }
-    uint32_t blockInterval;
+
+    GvOptional<uint32_t> blockInterval;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_BLOCK_INTERVAL_H

--- a/src/masternodes/govvariables/oracle_deviation.cpp
+++ b/src/masternodes/govvariables/oracle_deviation.cpp
@@ -8,6 +8,10 @@
 #include <masternodes/masternodes.h> /// CCustomCSView
 #include <rpc/util.h> /// AmountFromValue
 
+bool ORACLE_DEVIATION::IsEmpty() const
+{
+    return !deviation.has_value();
+}
 
 Res ORACLE_DEVIATION::Import(const UniValue & val)
 {
@@ -17,7 +21,7 @@ Res ORACLE_DEVIATION::Import(const UniValue & val)
 
 UniValue ORACLE_DEVIATION::Export() const
 {
-    return ValueFromAmount(deviation);
+    return ValueFromAmount(deviation.value_or(0));
 }
 
 Res ORACLE_DEVIATION::Validate(const CCustomCSView & view) const
@@ -33,5 +37,11 @@ Res ORACLE_DEVIATION::Validate(const CCustomCSView & view) const
 
 Res ORACLE_DEVIATION::Apply(CCustomCSView & mnview, uint32_t height)
 {
-    return mnview.SetPriceDeviation(deviation);
+    return mnview.SetPriceDeviation(deviation.value_or(0));
+}
+
+Res ORACLE_DEVIATION::Erase(CCustomCSView & mnview, uint32_t, std::vector<std::string> const &)
+{
+    deviation.reset();
+    return mnview.ErasePriceDeviation();
 }

--- a/src/masternodes/govvariables/oracle_deviation.h
+++ b/src/masternodes/govvariables/oracle_deviation.h
@@ -11,10 +11,12 @@
 class ORACLE_DEVIATION : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_DEVIATION>
 {
 public:
+    bool IsEmpty() const override;
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
+    Res Erase(CCustomCSView &mnview, uint32_t height, std::vector<std::string> const &) override;
 
     std::string GetName() const override { return TypeName(); }
     static constexpr char const * TypeName() { return "ORACLE_DEVIATION"; }
@@ -27,7 +29,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(deviation);
     }
-    CAmount deviation;
+
+    GvOptional<CAmount> deviation;
 };
 
 #endif // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_DEVIATION_H

--- a/src/masternodes/gv.h
+++ b/src/masternodes/gv.h
@@ -10,6 +10,7 @@
 #include <masternodes/res.h>
 #include <univalue/include/univalue.h>
 
+#include <optional>
 #include <unordered_map>
 
 class ATTRIBUTES;
@@ -25,17 +26,38 @@ public:
 
     virtual std::string GetName() const = 0;
 
+    virtual bool IsEmpty() const = 0;
     virtual Res Import(UniValue const &) = 0;
     virtual UniValue Export() const = 0;
     /// @todo it looks like Validate+Apply may be redundant. refactor for one?
     virtual Res Validate(CCustomCSView const &) const = 0;
     virtual Res Apply(CCustomCSView &, uint32_t) = 0;
+    virtual Res Erase(CCustomCSView &, uint32_t, std::vector<std::string> const &) = 0;
 
     virtual void Serialize(CVectorWriter& s) const = 0;
     virtual void Unserialize(VectorReader& s) = 0;
 
     virtual void Serialize(CDataStream& s) const = 0;
     virtual void Unserialize(CDataStream& s) = 0;
+};
+
+template<typename T>
+class GvOptional : public std::optional<T>
+{
+public:
+    using std::optional<T>::optional;
+    using std::optional<T>::operator bool;
+
+    template<typename Stream>
+    inline void Serialize(Stream& s) const {
+        assert(this->has_value());
+        ::Serialize(s, this->value());
+    }
+
+    template<typename Stream>
+    inline void Unserialize(Stream& s) {
+        ::Unserialize(s, *this ? this->value() : this->emplace());
+    }
 };
 
 struct CGovernanceMessage {
@@ -71,6 +93,16 @@ struct CGovernanceHeightMessage {
                 s >> startHeight;
             }
         }
+    }
+};
+
+struct CGovernanceUnsetMessage {
+    std::map<std::string, std::vector<std::string>> govs;
+
+    ADD_SERIALIZE_METHODS;
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(govs);
     }
 };
 

--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -377,6 +377,13 @@ Res CICXOrderView::ICXSetTakerFeePerBTC(CAmount amount)
     return Res::Ok();
 }
 
+Res CICXOrderView::ICXEraseTakerFeePerBTC()
+{
+    EraseBy<ICXVariables>('A');
+
+    return Res::Ok();
+}
+
 CAmount CICXOrderView::ICXGetTakerFeePerBTC()
 {
     CAmount takerFeePerBTC = CICXMakeOffer::DEFAULT_TAKER_FEE_PER_BTC;

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -447,6 +447,7 @@ public:
 
     // ICX_TAKERFEE_PER_BTC
     Res ICXSetTakerFeePerBTC(CAmount amount);
+    Res ICXEraseTakerFeePerBTC();
     CAmount ICXGetTakerFeePerBTC();
 
     struct ICXOrderCreationTx         { static constexpr uint8_t prefix() { return '1'; } };

--- a/src/masternodes/loan.cpp
+++ b/src/masternodes/loan.cpp
@@ -472,6 +472,12 @@ Res CLoanView::SetLoanLiquidationPenalty(CAmount penalty)
     return Res::Ok();
 }
 
+Res CLoanView::EraseLoanLiquidationPenalty()
+{
+    Erase(LoanLiquidationPenalty::prefix());
+    return Res::Ok();
+}
+
 CAmount CLoanView::GetLoanLiquidationPenalty()
 {
     CAmount penalty;

--- a/src/masternodes/loan.h
+++ b/src/masternodes/loan.h
@@ -361,6 +361,7 @@ public:
     void ForEachLoanTokenAmount(std::function<bool (const CVaultId&,  const CBalances&)> callback);
 
     Res SetLoanLiquidationPenalty(CAmount penalty);
+    Res EraseLoanLiquidationPenalty();
     CAmount GetLoanLiquidationPenalty();
 
     [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(const DCT_ID& id) const = 0;

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -56,6 +56,7 @@ CCustomTxMessage customTypeToMessage(CustomTxType txType) {
         case CustomTxType::SmartContract:           return CSmartContractMessage{};
         case CustomTxType::DFIP2203:                return CFutureSwapMessage{};
         case CustomTxType::SetGovVariable:          return CGovernanceMessage{};
+        case CustomTxType::UnsetGovVariable:        return CGovernanceUnsetMessage{};
         case CustomTxType::SetGovVariableHeight:    return CGovernanceHeightMessage{};
         case CustomTxType::AppointOracle:           return CAppointOracleMessage{};
         case CustomTxType::RemoveOracleAppoint:     return CRemoveOracleAppointMessage{};
@@ -200,6 +201,9 @@ public:
         else
         if constexpr (IsOneOf<T, CSmartContractMessage>())
             return IsHardforkEnabled(consensus.FortCanningHillHeight);
+        else
+        if constexpr (IsOneOf<T, CGovernanceUnsetMessage>())
+            return IsHardforkEnabled(consensus.GreatWorldHeight);
         else
         if constexpr (IsOneOf<T, CLoanPaybackLoanV2Message,
                                  CFutureSwapMessage>())

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -50,6 +50,7 @@ using CCustomTxMessage = std::variant<
     CSmartContractMessage,
     CFutureSwapMessage,
     CGovernanceMessage,
+    CGovernanceUnsetMessage,
     CGovernanceHeightMessage,
     CAppointOracleMessage,
     CRemoveOracleAppointMessage,

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -565,6 +565,96 @@ UniValue setgov(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
+UniValue unsetgov(const JSONRPCRequest& request) {
+    auto pwallet = GetWallet(request);
+
+    RPCHelpMan{"unsetgov",
+               "\nUnset special 'governance' variables:: ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_LOAN_TOKEN_SPLITS, LP_SPLITS, ORACLE_BLOCK_INTERVAL, ORACLE_DEVIATION\n",
+               {
+                    {"variables", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Object with variables",
+                        {
+                            {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "Variable's name is the key."},
+                        },
+                    },
+                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
+                        {
+                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                                {
+                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                                },
+                            },
+                        },
+                    },
+               },
+               RPCResult{
+                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
+               },
+               RPCExamples{
+                       HelpExampleCli("unsetgov", "'{\"LP_SPLITS\": [\"2\",\"3\"]'")
+                       + HelpExampleRpc("unsetgov", "'{\"ICX_TAKERFEE_PER_BTC\"}'")
+               },
+    }.Check(request);
+
+    if (pwallet->chain().isInitialBlockDownload()) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+    }
+    pwallet->BlockUntilSyncedToCurrentChain();
+
+    RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, true);
+
+    std::map<std::string, std::vector<std::string>> govs;
+    if (request.params.size() > 0 && request.params[0].isObject()) {
+        for (const std::string& name : request.params[0].getKeys()) {
+            auto gv = GovVariable::Create(name);
+            if (!gv) {
+                throw JSONRPCError(RPC_INVALID_REQUEST, "Variable " + name + " not registered");
+            }
+            auto& keys = govs[name];
+            const auto& value = request.params[0][name];
+            if (value.isArray()) {
+                for (const auto& key : value.getValues()) {
+                    keys.push_back(key.get_str());
+                }
+            }
+        }
+    }
+
+    CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
+    metadata << static_cast<unsigned char>(CustomTxType::UnsetGovVariable)
+             << govs;
+
+    CScript scriptMeta;
+    scriptMeta << OP_RETURN << ToByteVector(metadata);
+
+    int targetHeight = pcustomcsview->GetLastHeight() + 1;
+
+    const auto txVersion = GetTransactionVersion(targetHeight);
+    CMutableTransaction rawTx(txVersion);
+    rawTx.vout.push_back(CTxOut(0, scriptMeta));
+
+    UniValue const & txInputs = request.params[1];
+    CTransactionRef optAuthTx;
+    std::set<CScript> auths;
+    rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, true /*needFoundersAuth*/, optAuthTx, txInputs);
+
+    CCoinControl coinControl;
+
+    // Set change to selected foundation address
+    CTxDestination dest;
+    ExtractDestination(*auths.cbegin(), dest);
+    if (IsValidDestination(dest)) {
+        coinControl.destChange = dest;
+    }
+
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
+
+    // check execution
+    execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
+
+    return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
+}
+
 UniValue setgovheight(const JSONRPCRequest& request) {
     auto pwallet = GetWallet(request);
 
@@ -889,6 +979,7 @@ static const CRPCCommand commands[] =
 //  category        name                     actor (function)        params
 //  --------------  ----------------------   --------------------    ----------,
     {"blockchain",  "setgov",                &setgov,                {"variables", "inputs"}},
+    {"blockchain",  "unsetgov",              &unsetgov,              {"variables", "inputs"}},
     {"blockchain",  "setgovheight",          &setgovheight,          {"variables", "height", "inputs"}},
     {"blockchain",  "getgov",                &getgov,                {"name"}},
     {"blockchain",  "listgovs",              &listgovs,              {""}},

--- a/src/masternodes/oracles.cpp
+++ b/src/masternodes/oracles.cpp
@@ -191,6 +191,12 @@ Res COracleView::SetPriceDeviation(const uint32_t deviation)
     return Res::Ok();
 }
 
+Res COracleView::ErasePriceDeviation()
+{
+    Erase(PriceDeviation::prefix());
+    return Res::Ok();
+}
+
 CAmount COracleView::GetPriceDeviation() const
 {
     uint32_t deviation;
@@ -205,6 +211,12 @@ CAmount COracleView::GetPriceDeviation() const
 Res COracleView::SetIntervalBlock(const uint32_t blockInterval)
 {
     Write(FixedIntervalBlockKey::prefix(), blockInterval);
+    return Res::Ok();
+}
+
+Res COracleView::EraseIntervalBlock()
+{
+    Erase(FixedIntervalBlockKey::prefix());
     return Res::Ok();
 }
 

--- a/src/masternodes/oracles.h
+++ b/src/masternodes/oracles.h
@@ -152,9 +152,11 @@ public:
     void ForEachFixedIntervalPrice(std::function<bool(const CTokenCurrencyPair&, CLazySerialize<CFixedIntervalPrice>)> callback, const CTokenCurrencyPair& start = {});
 
     Res SetPriceDeviation(const uint32_t deviation);
+    Res ErasePriceDeviation();
     CAmount GetPriceDeviation() const;
 
     Res SetIntervalBlock(const uint32_t blockInterval);
+    Res EraseIntervalBlock();
     uint32_t GetIntervalBlock() const;
 
     [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t>& tokenIds) const = 0;

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -727,8 +727,9 @@ Res CPoolPairView::SetDexFeePct(DCT_ID poolId, DCT_ID tokenId, CAmount feePct) {
     return Res::Ok();
 }
 
-void CPoolPairView::EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId) {
+Res CPoolPairView::EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId) {
     EraseBy<ByTokenDexFeePct>(std::make_pair(poolId, tokenId));
+    return Res::Ok();
 }
 
 CAmount CPoolPairView::GetDexFeeInPct(DCT_ID poolId, DCT_ID tokenId) const {

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -255,7 +255,7 @@ public:
     bool HasPoolPair(DCT_ID const & poolId) const;
 
     Res SetDexFeePct(DCT_ID poolId, DCT_ID tokenId, CAmount feePct);
-    void EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId);
+    Res EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId);
     CAmount GetDexFeeInPct(DCT_ID poolId, DCT_ID tokenId) const;
     CAmount GetDexFeeOutPct(DCT_ID poolId, DCT_ID tokenId) const;
 

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -242,6 +242,16 @@ public:
         }
     }
 
+    void operator()(const CGovernanceUnsetMessage& obj) const {
+        for (const auto& gov : obj.govs) {
+            UniValue keys(UniValue::VARR);
+            for (const auto& key : gov.second)
+                keys.push_back(key);
+
+            rpcInfo.pushKV(gov.first, keys);
+        }
+    }
+
     void operator()(const CGovernanceHeightMessage& obj) const {
         rpcInfo.pushKV(obj.govVar->GetName(), obj.govVar->Export());
         rpcInfo.pushKV("startHeight", static_cast<uint64_t>(obj.startHeight));

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -311,6 +311,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setgov", 0, "variables" },
     { "setgov", 1, "inputs" },
 
+    { "unsetgov", 0, "variables" },
+    { "unsetgov", 1, "inputs" },
+
     { "setgovheight", 0, "variables" },
     { "setgovheight", 1, "height" },
     { "setgovheight", 2, "inputs" },

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -693,5 +693,46 @@ class GovsetTest (DefiTestFramework):
         attriutes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
         assert_equal(attriutes['v0/oracles/splits/4000'], '4/50,5/10,')
 
+        result = self.nodes[0].getgov('ORACLE_DEVIATION')
+        assert_equal(result['ORACLE_DEVIATION'], Decimal('0.07000000'))
+
+        result = self.nodes[0].getgov('LP_SPLITS')
+        assert_equal(result['LP_SPLITS'], {'1': Decimal('0.70000000'), '2': Decimal('0.20000000'), '3': Decimal('0.10000000')})
+
+        self.nodes[0].unsetgov({'ATTRIBUTES': ['v0/token/5/fixed_interval_price_id', 'v0/token/5/loan_minting_enabled', 'v0/token/5/loan_minting_interest', 'v0/token/5/loan_payback/1', 'v0/token/5/loan_payback/2', 'v0/token/5/loan_payback_fee_pct/1']})
+        self.nodes[0].generate(1)
+
+        result = self.nodes[0].getgov('ATTRIBUTES')
+        attributes = result['ATTRIBUTES']
+        assert 'v0/token/5/fixed_interval_price_id' not in attributes
+        assert 'v0/token/5/loan_minting_enabled' not in attributes
+        assert 'v0/token/5/loan_minting_interest' not in attributes
+        assert 'v0/token/5/loan_payback/1' not in attributes
+        assert 'v0/token/5/loan_payback/2' not in attributes
+        assert 'v0/token/5/loan_payback_fee_pct/1' not in attributes
+
+        self.nodes[0].unsetgov({'ATTRIBUTES': ['v0/params/dfip2203/active', 'v0/params/dfip2203/reward_pct', 'v0/params/dfip2203/block_period', 'v0/token/5/dfip2203']})
+        self.nodes[0].generate(1)
+
+        result = self.nodes[0].getgov('ATTRIBUTES')
+        attributes = result['ATTRIBUTES']
+        assert 'v0/params/dfip2203/active' not in attributes
+        assert 'v0/params/dfip2203/reward_pct' not in attributes
+        assert 'v0/params/dfip2203/block_period' not in attributes
+        assert 'v0/token/5/dfip2203' not in attributes
+
+        self.nodes[0].unsetgov({'ORACLE_DEVIATION':'', 'LP_SPLITS':['1', '2'], 'ATTRIBUTES':['v0/params/dfip2201/active', 'v0/params/dfip2201/premium', 'v0/params/dfip2201/minswap', 'v0/token/5/payback_dfi_fee_pct', 'v0/token/5/dex_in_fee_pct', 'v0/token/5/dex_out_fee_pct']})
+        self.nodes[0].generate(1)
+
+        result = self.nodes[0].getgov('ORACLE_DEVIATION')
+        assert_equal(result['ORACLE_DEVIATION'], Decimal('0E-8'))
+
+        result = self.nodes[0].getgov('LP_SPLITS')
+        assert_equal(result['LP_SPLITS'], {'3': Decimal('0.10000000')})
+
+        result = self.nodes[0].getgov('ATTRIBUTES')
+        attributes = result['ATTRIBUTES']
+        assert_equal(attributes['v0/token/5/payback_dfi'], 'true')
+
 if __name__ == '__main__':
     GovsetTest ().main ()


### PR DESCRIPTION
/kind feature

```
unsetgov({'ORACLE_DEVIATION':[], 'LP_SPLITS':['1', '2'], 'ATTRIBUTES':['v0/params/dfip2201/active']})
```
The new command deletes a gov variable itself including other related db indices, a cleanup command