### PR TITLE
Cache and reuse attributes

### DIFF
--- a/src/masternodes/consensus/governance.cpp
+++ b/src/masternodes/consensus/governance.cpp
@@ -42,17 +42,13 @@ Res CGovernanceConsensus::operator()(const CGovernanceMessage& obj) const {
 
         if (var->GetName() == "ATTRIBUTES") {
             // Add to existing ATTRIBUTES instead of overwriting.
-            auto govVar = mnview.GetVariable(var->GetName());
+            auto govVar = mnview.GetAttributes();
 
             if (!govVar) {
                 return Res::Err("%s: %s", var->GetName(), "Failed to get existing ATTRIBUTES");
             }
 
-            if (auto attrs = dynamic_cast<ATTRIBUTES*>(govVar.get())) {
-                attrs->time = time;
-            } else {
-                return Res::Err("%s: %s", var->GetName(), "Failed to cast to ATTRIBUTES");
-            }
+            govVar->time = time;
 
             // Validate as complete set. Check for future conflicts between key pairs.
             if (!(res = govVar->Import(var->Export()))

--- a/src/masternodes/consensus/smartcontracts.cpp
+++ b/src/masternodes/consensus/smartcontracts.cpp
@@ -11,7 +11,7 @@
 #include <masternodes/tokens.h>
 
 Res CSmartContractsConsensus::HandleDFIP2201Contract(const CSmartContractMessage& obj) const {
-    const auto attributes = mnview.GetAttributes();
+    auto attributes = mnview.GetAttributesCached();
     if (!attributes)
         return Res::Err("Attributes unavailable");
 

--- a/src/masternodes/consensus/vaults.cpp
+++ b/src/masternodes/consensus/vaults.cpp
@@ -152,7 +152,7 @@ Res CVaultsConsensus::operator()(const CDepositToVaultMessage& obj) const {
     // If collateral token exist make sure it is enabled.
     if (mnview.GetCollateralTokenFromAttributes(obj.amount.nTokenId)) {
         CDataStructureV0 collateralKey{AttributeTypes::Token, obj.amount.nTokenId.v, TokenKeys::LoanCollateralEnabled};
-        if (const auto attributes = mnview.GetAttributes(); !attributes->GetValue(collateralKey, false)) {
+        if (auto attributes = mnview.GetAttributesCached(); !attributes->GetValue(collateralKey, false)) {
             return Res::Err("Collateral token (%d) is disabled", obj.amount.nTokenId.v);
         }
     }

--- a/src/masternodes/gv.h
+++ b/src/masternodes/gv.h
@@ -77,7 +77,7 @@ struct CGovernanceHeightMessage {
 class CGovView : public virtual CStorageView
 {
 public:
-    Res SetVariable(GovVariable const & var);
+    virtual Res SetVariable(GovVariable const & var);
     std::shared_ptr<GovVariable> GetVariable(std::string const &govKey) const;
 
     Res SetStoredVariables(const std::set<std::shared_ptr<GovVariable>>& govVars, const uint32_t height);

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -29,6 +29,7 @@
 #include <set>
 #include <stdint.h>
 
+class ATTRIBUTES;
 class CBlockIndex;
 class CTransaction;
 
@@ -432,6 +433,7 @@ class CCustomCSView
     Res PopulateLoansData(CCollateralLoans& result, CVaultId const& vaultId, uint32_t height, int64_t blockTime, bool useNextPrice, bool requireLivePrice);
     Res PopulateCollateralData(CCollateralLoans& result, CVaultId const& vaultId, CBalances const& collaterals, uint32_t height, int64_t blockTime, bool useNextPrice, bool requireLivePrice);
 
+    mutable std::shared_ptr<const ATTRIBUTES> attributes;
 public:
     // Increase version when underlaying tables are changed
     static constexpr const int DbVersion = 1;
@@ -451,7 +453,7 @@ public:
     }
 
     // cache-upon-a-cache (not a copy!) constructor
-    CCustomCSView(CCustomCSView & other) : CStorageView(other)
+    CCustomCSView(CCustomCSView & other) : CStorageView(other), attributes(other.attributes)
     {
         CheckPrefixes();
     }
@@ -478,6 +480,9 @@ public:
     ResVal<CCollateralLoans> GetLoanCollaterals(CVaultId const & vaultId, CBalances const & collaterals, uint32_t height, int64_t blockTime, bool useNextPrice = false, bool requireLivePrice = true);
 
     ResVal<CAmount> GetValidatedIntervalPrice(CTokenCurrencyPair priceFeedId, bool useNextPrice, bool requireLivePrice);
+
+    Res SetVariable(GovVariable const & var) override;
+    std::shared_ptr<const ATTRIBUTES> GetAttributesCached() const;
 
     [[nodiscard]] std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(const DCT_ID& id) const override;
     [[nodiscard]] std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(const DCT_ID& id) const override;

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1808,7 +1808,7 @@ UniValue getburninfo(const JSONRPCRequest& request) {
 
     CAmount burnt{0};
 
-    if (auto attributes = view.GetAttributes()) {
+    if (auto attributes = view.GetAttributesCached()) {
         CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackDFITokens};
         auto tokenBalances = attributes->GetValue(liveKey, CBalances{});
         for (const auto& balance : tokenBalances.balances) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2197,18 +2197,16 @@ std::vector<CAuctionBatch> CollectAuctionBatches(const CCollateralLoans& collLoa
 }
 
 bool ApplyGovVars(CCustomCSView& cache, const CBlockIndex& pindex, const std::map<std::string, std::string>& attrs){
-    if (auto govVar = cache.GetVariable("ATTRIBUTES")) {
-        if (auto var = dynamic_cast<ATTRIBUTES*>(govVar.get())) {
-            var->time = pindex.nTime;
+    if (auto var = cache.GetAttributes()) {
+        var->time = pindex.nTime;
 
-            UniValue obj(UniValue::VOBJ);
-            for (const auto& [key, value] : attrs) {
-                obj.pushKV(key, value);
-            }
+        UniValue obj(UniValue::VOBJ);
+        for (const auto& [key, value] : attrs) {
+            obj.pushKV(key, value);
+        }
 
-            if (var->Import(obj) && var->Validate(cache) && var->Apply(cache, pindex.nHeight) && cache.SetVariable(*var)) {
-                return true;
-            }
+        if (var->Import(obj) && var->Validate(cache) && var->Apply(cache, pindex.nHeight) && cache.SetVariable(*var)) {
+            return true;
         }
     }
 


### PR DESCRIPTION

/kind refactor

#### What this PR does / why we need it:
Attributes are serialized as a single record to db, by increasing its size it might open a performance issue.
Introduce `GetAttributeCached` to keep a read only accessor
