### PR TITLE
Simplify make.sh to use a single target instead of targets

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGETS="x86_64-pc-linux-gnu" ./make.sh docker-release-git
+      run: TARGET="x86_64-pc-linux-gnu" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-pc-linux-gnu
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGETS="x86_64-w64-mingw32" ./make.sh docker-release-git
+      run: TARGET="x86_64-w64-mingw32" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-w64-mingw32
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGETS="x86_64-apple-darwin18" ./make.sh docker-release-git
+      run: TARGET="x86_64-apple-darwin18" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-apple-darwin18
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571

--- a/.github/workflows/hotfix-builds.yaml
+++ b/.github/workflows/hotfix-builds.yaml
@@ -69,10 +69,10 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGET="x86_64-apple-darwin11" ./make.sh docker-release-git
+      run: TARGET="x86_64-apple-darwin18" ./make.sh docker-release-git
 
-    - name: Publish artifact - x86_64-apple-darwin11
+    - name: Publish artifact - x86_64-apple-darwin18
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
       with:
-        name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
+        name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz

--- a/.github/workflows/hotfix-builds.yaml
+++ b/.github/workflows/hotfix-builds.yaml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGETS="x86_64-w64-mingw32" ./make.sh docker-release-git
+      run: TARGET="x86_64-w64-mingw32" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-w64-mingw32
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
@@ -69,7 +69,7 @@ jobs:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
     - name: Build and package
-      run: TARGETS="x86_64-apple-darwin11" ./make.sh docker-release-git
+      run: TARGET="x86_64-apple-darwin11" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-apple-darwin11
       uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571

--- a/.github/workflows/jellyfish-tests.yml
+++ b/.github/workflows/jellyfish-tests.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Set build version
         run: |
           cd defichain
-          TARGETS="x86_64-pc-linux-gnu" ./make.sh git_version
+          TARGET="x86_64-pc-linux-gnu" ./make.sh git_version
               
       - name: Build and package
         run: |
           echo ">>> BUILD VERSION <<<"
           echo ${BUILD_VERSION}
           cd defichain
-          TARGETS="x86_64-pc-linux-gnu" ./make.sh docker-release-git
+          TARGET="x86_64-pc-linux-gnu" ./make.sh docker-release-git
           docker tag defichain-x86_64-pc-linux-gnu:$BUILD_VERSION defichain-x86_64-pc-linux-gnu:dockerhub-latest
           docker build -t test-build-container -f ./contrib/dockerfiles/dockerhub/x86_64-pc-linux-gnu.dockerfile .
       

--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -73,13 +73,13 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Build and package
-      run: TARGET="x86_64-apple-darwin11" ./make.sh docker-release-git
+      run: TARGET="x86_64-apple-darwin18" ./make.sh docker-release-git
 
-    - name: Publish artifact - x86_64-apple-darwin11
+    - name: Publish artifact - x86_64-apple-darwin18
       uses: actions/upload-artifact@v3
       with:
-        name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
+        name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz
 
   create-release:
     needs:
@@ -125,8 +125,8 @@ jobs:
         sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz > ./defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz.SHA256
         cd .. && cd ./defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip > ./defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip.SHA256
-        cd .. && cd ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
-        sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz > ././defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz.SHA256
+        cd .. && cd ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18
+        sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz > ././defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz.SHA256
 
     - name: Upload release asset - linux
       uses: actions/upload-release-asset@v1
@@ -174,8 +174,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
-        asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
-        asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz
+        asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz
         asset_content_type: application/gzip
 
     - name: Upload checksum asset - macos
@@ -184,6 +184,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
-        asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz.SHA256
-        asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz.SHA256
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz.SHA256
+        asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin18.tar.gz.SHA256
         asset_content_type: text/plain

--- a/.github/workflows/release-builds.yaml
+++ b/.github/workflows/release-builds.yaml
@@ -13,13 +13,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Build and package
       run: ./make.sh docker-release-git
 
     - name: Publish artifacts
-      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+      uses: actions/upload-artifact@v3
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
@@ -31,7 +33,7 @@ jobs:
         docker tag defichain-x86_64-pc-linux-gnu:${{ env.BUILD_VERSION }}
         defichain-x86_64-pc-linux-gnu:dockerhub-latest
 
-    - uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f
+    - uses: docker/build-push-action@v2
     # Make sure to only build on ain repo. Also add in additional restrictions here if needed to
     # make sure we don't push unnecessary images to docker
       if: ${{ github.repository == 'DeFiCh/ain' }}
@@ -50,13 +52,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v3
 
     - name: Build and package
-      run: TARGETS="x86_64-w64-mingw32" ./make.sh docker-release-git
+      run: TARGET="x86_64-w64-mingw32" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-w64-mingw32
-      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+      uses: actions/upload-artifact@v3
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
@@ -68,13 +70,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v3
 
     - name: Build and package
-      run: TARGETS="x86_64-apple-darwin11" ./make.sh docker-release-git
+      run: TARGET="x86_64-apple-darwin11" ./make.sh docker-release-git
 
     - name: Publish artifact - x86_64-apple-darwin11
-      uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571
+      uses: actions/upload-artifact@v3
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz
@@ -90,7 +92,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/checkout@v3
 
     - name: compute build version
       run: ./make.sh git-version
@@ -99,7 +101,7 @@ jobs:
       run: rm -rf *
 
     - name: get all build artifacts
-      uses: actions/download-artifact@4a7a711286f30c025902c28b541c10e147a9b843
+      uses: actions/download-artifact@v3
 
     - name: zip package for windows
       run: |
@@ -111,7 +113,7 @@ jobs:
 
     - name: Get Release by Tag
       id: get_release_by_tag
-      uses: jonfriesen/get-release-by-tag@77560d8bbb6096f823ca949d556a1e48c0a60cd0
+      uses: jonfriesen/get-release-by-tag@v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -127,7 +129,7 @@ jobs:
         sha256sum ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz > ././defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin11.tar.gz.SHA256
 
     - name: Upload release asset - linux
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -137,7 +139,7 @@ jobs:
         asset_content_type: application/gzip
 
     - name: Upload checksum - linux
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -147,7 +149,7 @@ jobs:
         asset_content_type: text/plain
 
     - name: Upload release asset - windows
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -157,7 +159,7 @@ jobs:
         asset_content_type: application/zip
 
     - name: Upload checksum asset - windows
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -167,7 +169,7 @@ jobs:
         asset_content_type: text/plain
 
     - name: Upload release asset - macos
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -177,7 +179,7 @@ jobs:
         asset_content_type: application/gzip
 
     - name: Upload checksum asset - macos
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/make.sh
+++ b/make.sh
@@ -16,8 +16,26 @@ setup_vars() {
     DOCKERFILES_DIR=${DOCKERFILES_DIR:-"./contrib/dockerfiles"}
     RELEASE_DIR=${RELEASE_DIR:-"./build"}
 
+    local default_target="x86_64-pc-linux-gnu"
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        default_target="x86_64-apple-darwin18"
+    elif [[ "${OSTYPE}" == "msys" ]]; then
+        default_target="x86_64-w64-mingw32"
+    fi
+
+    # shellcheck disable=SC2206
+    # This intentionally word-splits the array as env arg can only be strings.
+    # Other options available: x86_64-w64-mingw32 x86_64-apple-darwin11
+    TARGET=${TARGET:-"${default_target}"}
+
+    local default_compiler_flags=""
+    if [[ "${TARGET}" == "x86_64-pc-linux-gnu" || \
+        "${TARGET}" == "x86_64-apple-darwin11" ]]; then
+        default_compiler_flags="CC=clang-11 CXX=clang++-11"
+    fi
+
     MAKE_JOBS=${MAKE_JOBS:-$(nproc)}
-    MAKE_COMPILER=${MAKE_COMPILER:-"CC=clang-11 CXX=clang++-11"}
+    MAKE_COMPILER=${MAKE_COMPILER:-"${default_compiler_flags}"}
     MAKE_CONF_ARGS="${MAKE_COMPILER} ${MAKE_CONF_ARGS:-}"
     MAKE_ARGS=${MAKE_ARGS:-}
     MAKE_DEPS_ARGS=${MAKE_DEPS_ARGS:-}
@@ -25,11 +43,6 @@ setup_vars() {
     if [[ "${MAKE_DEBUG}" == "1" ]]; then
       MAKE_CONF_ARGS="${MAKE_CONF_ARGS} --enable-debug";
     fi
-
-    # shellcheck disable=SC2206
-    # This intentionally word-splits the array as env arg can only be strings.
-    # Other options available: x86_64-w64-mingw32 x86_64-apple-darwin18
-    TARGETS=(${TARGETS:-"x86_64-pc-linux-gnu"})
 }
 
 main() {
@@ -80,7 +93,7 @@ help() {
 # ----------- Direct builds ---------------
 
 build_deps() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
     local make_deps_args=${MAKE_DEPS_ARGS:-}
     local make_jobs=${MAKE_JOBS}
 
@@ -93,7 +106,7 @@ build_deps() {
 }
 
 build_conf() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
     local make_conf_opts=${MAKE_CONF_ARGS:-}
     local make_jobs=${MAKE_JOBS}
 
@@ -107,7 +120,7 @@ build_conf() {
 }
 
 build_make() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
     local make_args=${MAKE_ARGS:-}
     local make_jobs=${MAKE_JOBS}
 
@@ -123,7 +136,7 @@ build() {
 }
 
 deploy() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
     local img_prefix="${IMAGE_PREFIX}"
     local img_version="${IMAGE_VERSION}"
     local release_dir="${RELEASE_DIR}"
@@ -147,7 +160,7 @@ deploy() {
 }
 
 package() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
     local img_prefix="${IMAGE_PREFIX}"
     local img_version="${IMAGE_VERSION}"
     local release_dir="${RELEASE_DIR}"
@@ -174,17 +187,17 @@ package() {
 }
 
 release() {
-    local target=${1:-"x86_64-pc-linux-gnu"}
+    local target=${1:-${TARGET}}
 
     build "${target}"
     package "${target}"
-    sign
+    sign "${target}"
 }
 
 # -------------- Docker ---------------
 
 docker_build() {
-    local targets=("${TARGETS[@]}")
+    local target=${1:-${TARGET}}
     local img_prefix="${IMAGE_PREFIX}"
     local img_version="${IMAGE_VERSION}"
     local dockerfiles_dir="${DOCKERFILES_DIR}"
@@ -192,99 +205,93 @@ docker_build() {
 
     echo "> docker-build";
 
-    for target in "${targets[@]}"; do
-        if [[ "$target" == "x86_64-apple-darwin18" ]]; then
-            pkg_ensure_mac_sdk
-        fi
-        local img="${img_prefix}-${target}:${img_version}"
-        echo "> building: ${img}"
-        local docker_file="${dockerfiles_dir}/${target}.dockerfile"
-        echo "> docker build: ${img}"
-        docker build -f "${docker_file}" -t "${img}" "${docker_context}"
-    done
+    if [[ "$target" == "x86_64-apple-darwin"* ]]; then
+        pkg_ensure_mac_sdk
+    fi
+    local img="${img_prefix}-${target}:${img_version}"
+    echo "> building: ${img}"
+    local docker_file="${dockerfiles_dir}/${target}.dockerfile"
+    echo "> docker build: ${img}"
+    docker build -f "${docker_file}" -t "${img}" "${docker_context}"
 }
 
 docker_package() {
-    local targets=("${TARGETS[@]}")
+    local target=${1:-${TARGET}}
     local img_prefix="${IMAGE_PREFIX}"
     local img_version="${IMAGE_VERSION}"
     local release_dir="${RELEASE_DIR}"
 
     echo "> docker-package";
 
-    for target in "${targets[@]}"; do
-        local img="${img_prefix}-${target}:${img_version}"
-        echo "> packaging: ${img}"
+    local img="${img_prefix}-${target}:${img_version}"
+    echo "> packaging: ${img}"
 
-        # XREF: #pkg-name
-        local pkg_name="${img_prefix}-${img_version}-${target}"
-        local pkg_tar_file_name="${pkg_name}.tar.gz"
-        local pkg_rel_path="${release_dir}/${pkg_tar_file_name}"
-        local versioned_name="${img_prefix}-${img_version}"
+    # XREF: #pkg-name
+    local pkg_name="${img_prefix}-${img_version}-${target}"
+    local pkg_tar_file_name="${pkg_name}.tar.gz"
+    local pkg_rel_path="${release_dir}/${pkg_tar_file_name}"
+    local versioned_name="${img_prefix}-${img_version}"
 
-        mkdir -p "${release_dir}"
+    mkdir -p "${release_dir}"
 
-        docker run --rm "${img}" bash -c \
-            "tar --transform 's,^./,${versioned_name}/,' -czf - ./*" >"${pkg_rel_path}"
+    docker run --rm "${img}" bash -c \
+        "tar --transform 's,^./,${versioned_name}/,' -czf - ./*" >"${pkg_rel_path}"
 
-        echo "> package: ${pkg_rel_path}"
-    done
+    echo "> package: ${pkg_rel_path}"
 }
 
 docker_deploy() {
-    local targets=("${TARGETS[@]}")
+    local target=${1:-${TARGET}}
     local img_prefix="${IMAGE_PREFIX}"
     local img_version="${IMAGE_VERSION}"
     local release_dir="${RELEASE_DIR}"
 
     echo "> docker-deploy";
 
-    for target in "${targets[@]}"; do
-        local img="${img_prefix}-${target}:${img_version}"
-        echo "> deploy from: ${img}"
+    local img="${img_prefix}-${target}:${img_version}"
+    echo "> deploy from: ${img}"
 
-        # XREF: #pkg-name
-        local pkg_name="${img_prefix}-${img_version}-${target}"
-        local versioned_name="${img_prefix}-${img_version}"
-        local versioned_release_dir="${release_dir}/${versioned_name}"
+    # XREF: #pkg-name
+    local pkg_name="${img_prefix}-${img_version}-${target}"
+    local versioned_name="${img_prefix}-${img_version}"
+    local versioned_release_dir="${release_dir}/${versioned_name}"
 
-        rm -rf "${versioned_release_dir}" && mkdir -p "${versioned_release_dir}"
+    rm -rf "${versioned_release_dir}" && mkdir -p "${versioned_release_dir}"
 
-        local cid
-        cid=$(docker create "${img}")
-        local e=0
+    local cid
+    cid=$(docker create "${img}")
+    local e=0
 
-        { docker cp "${cid}:/app/." "${versioned_release_dir}" 2>/dev/null && e=1; } || true
-        docker rm "${cid}"
+    { docker cp "${cid}:/app/." "${versioned_release_dir}" 2>/dev/null && e=1; } || true
+    docker rm "${cid}"
 
-        if [[ "$e" == "1" ]]; then
-            echo "> deployed into: ${versioned_release_dir}"
-        else
-            echo "> failed: please sure package is built first"
-        fi
-    done
+    if [[ "$e" == "1" ]]; then
+        echo "> deployed into: ${versioned_release_dir}"
+    else
+        echo "> failed: please sure package is built first"
+    fi
 }
 
 docker_release() {
-    docker_build
-    docker_package
-    sign
+    docker_build "$@"
+    docker_package "$@"
+    sign "$@"
 }
 
 docker_package_git() {
     git_version
-    docker_package
+    docker_package "$@"
 }
 
 docker_release_git() {
     git_version
-    docker_release
+    docker_release "$@"
 }
 
 docker_build_deploy_git() {
-    git_version
-    docker_build
-    docker_deploy
+    git_version 
+    docker_build "$@"
+    docker_deploy "$@"
 }
 
 docker_clean() {
@@ -372,7 +379,7 @@ git_version() {
 pkg_install_deps() {
     apt update && apt install -y \
         software-properties-common build-essential libtool autotools-dev automake \
-        pkg-config bsdmainutils python3 libssl-dev libevent-dev libboost-system-dev \
+        pkg-config bsdmainutils python3 python3-pip libssl-dev libevent-dev libboost-system-dev \
         libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev \
         libminiupnpc-dev libzmq3-dev libqrencode-dev wget \
         curl cmake


### PR DESCRIPTION
/kind refactor

- Change `TARGETS` env var into `TARGET`. This brings consistency to how all the commands behave. Previously some commands looped over all, while some didn't. 
- Multi-targets can easily be involved by just calling the commands with different targets set (an use-case that's not seen a necessity so far, other than local, where it's easy to run separately)

Additionally: 
- This also uses major version numbering instead of hashes for GH Actions, which make it easier to maintain and comprehend, while also taking advantage of semver based fixes. Assumption: Rely on GitHub official actions to use major versions safely. The benefits outweigh the reproduciblity guarantee of hashes, when dealing with well known and relied on GH actions. 
- This also makes an attempt to fix the detached HEAD checkouts, that result in `-dirty` tags being added to release builds. 