### PR TITLE
Introduce immutable view type

### DIFF
--- a/src/flushablestorage.h
+++ b/src/flushablestorage.h
@@ -389,7 +389,7 @@ public:
     bool IsEmpty() const;
     CStorageKV& GetStorage();
     size_t SizeEstimate() const;
-    bool Flush(bool sync = false);
+    virtual bool Flush(bool sync = false);
     void Compact(const TBytes& begin, const TBytes& end);
 
 protected:

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -147,12 +147,12 @@ Res CAccountsHistoryWriter::SubBalance(CScript const & owner, CTokenAmount amoun
     return res;
 }
 
-bool CAccountsHistoryWriter::Flush()
+bool CAccountsHistoryWriter::Flush(bool sync)
 {
     if (writers) {
         writers->Flush(height, txid, txn, type);
     }
-    return CCustomCSView::Flush();
+    return CCustomCSView::Flush(sync);
 }
 
 CHistoryWriters::CHistoryWriters(CAccountHistoryStorage* historyView, CBurnHistoryStorage* burnView, CVaultHistoryStorage* vaultView)

--- a/src/masternodes/accountshistory.h
+++ b/src/masternodes/accountshistory.h
@@ -112,7 +112,7 @@ public:
 
     Res AddBalance(CScript const & owner, CTokenAmount amount) override;
     Res SubBalance(CScript const & owner, CTokenAmount amount) override;
-    bool Flush();
+    bool Flush(bool sync = false) override;
 };
 
 template<typename T, typename... Args>

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -14,7 +14,7 @@ CAccounts GetAllMineAccounts(CWallet * const pwallet) {
 
     CAccounts walletAccounts;
 
-    CCustomCSView mnview(*pcustomcsview);
+    CImmutableCSView mnview(*pcustomcsview);
     auto targetHeight = mnview.GetLastHeight() + 1;
 
     mnview.ForEachAccount([&](CScript const & account) {
@@ -420,7 +420,7 @@ void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuth
     auto res = CustomMetadataParse(height, Params().GetConsensus(), metadata, txMessage);
     if (res) {
         LOCK(cs_main);
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
         CCoinsViewCache coins(&::ChainstateActive().CoinsTip());
         if (optAuthTx)
             AddCoins(coins, *optAuthTx, height);

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -48,6 +48,17 @@ public:
     void AddLockedCoin(const COutPoint& coin);
 };
 
+// immutable type preventing accident data flush to parent view
+class CImmutableCSView : public CCustomCSView {
+public:
+    CImmutableCSView(CImmutableCSView&&) = delete;
+    CImmutableCSView(const CImmutableCSView&) = delete;
+    CImmutableCSView(CCustomCSView& o) : CStorageView(o), CCustomCSView(o) {}
+    CImmutableCSView(CImmutableCSView& o) : CStorageView(o), CCustomCSView(o) {}
+private:
+    bool Flush(bool = false) final { return false; }
+};
+
 // common functions
 bool IsSkippedTx(const uint256& hash);
 CMutableTransaction fund(CMutableTransaction& mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx, CCoinControl* coin_control = nullptr);

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -95,8 +95,8 @@ UniValue outputEntryToJSON(COutputEntry const & entry, CBlockIndex const * index
     return obj;
 }
 
-static void onPoolRewards(CCustomCSView & view, CScript const & owner, uint32_t begin, uint32_t end, std::function<void(uint32_t, DCT_ID, RewardType, CTokenAmount)> onReward) {
-    CCustomCSView mnview(view);
+static void onPoolRewards(CImmutableCSView & view, CScript const & owner, uint32_t begin, uint32_t end, std::function<void(uint32_t, DCT_ID, RewardType, CTokenAmount)> onReward) {
+    CImmutableCSView mnview(view);
     static const uint32_t eunosHeight = Params().GetConsensus().EunosHeight;
     view.ForEachPoolId([&] (DCT_ID const & poolId) {
         auto height = view.GetShare(poolId, owner);
@@ -320,7 +320,7 @@ UniValue listaccounts(const JSONRPCRequest& request) {
 
     UniValue ret(UniValue::VARR);
 
-    CCustomCSView mnview(*pcustomcsview);
+    CImmutableCSView mnview(*pcustomcsview);
     auto targetHeight = mnview.GetLastHeight() + 1;
 
     mnview.ForEachAccount([&](CScript const & account) {
@@ -414,7 +414,7 @@ UniValue getaccount(const JSONRPCRequest& request) {
         ret.setObject();
     }
 
-    CCustomCSView mnview(*pcustomcsview);
+    CImmutableCSView mnview(*pcustomcsview);
     auto targetHeight = mnview.GetLastHeight() + 1;
 
     mnview.CalculateOwnerRewards(reqOwner, targetHeight);
@@ -507,7 +507,7 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     }
 
     CBalances totalBalances;
-    CCustomCSView mnview(*pcustomcsview);
+    CImmutableCSView mnview(*pcustomcsview);
     for (const auto& account : GetAllMineAccounts(pwallet)) {
         totalBalances.AddBalances(account.second.balances);
     }
@@ -892,7 +892,7 @@ UniValue accounttoutxos(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-void RevertOwnerBalances(CCustomCSView & view, CScript const & owner, TAmounts const & balances) {
+void RevertOwnerBalances(CImmutableCSView & view, CScript const & owner, TAmounts const & balances) {
     for (const auto& balance : balances) {
         auto amount = -balance.second;
         auto token = view.GetToken(balance.first);
@@ -1040,7 +1040,7 @@ UniValue listaccounthistory(const JSONRPCRequest& request) {
     std::set<uint256> txs;
     const bool shouldSearchInWallet = (tokenFilter.empty() || tokenFilter == "DFI") && CustomTxType::None == txType;
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto hasToken = [&](TAmounts const & diffs) {
         for (auto const & diff : diffs) {
@@ -1295,7 +1295,7 @@ UniValue listburnhistory(const JSONRPCRequest& request) {
     pwallet->BlockUntilSyncedToCurrentChain();
 
     std::set<uint256> txs;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto hasToken = [&](TAmounts const & diffs) {
         for (auto const & diff : diffs) {
@@ -1442,7 +1442,7 @@ UniValue accounthistorycount(const JSONRPCRequest& request) {
     }
 
     std::set<uint256> txs;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     const bool shouldSearchInWallet = (tokenFilter.empty() || tokenFilter == "DFI") && CustomTxType::None == txType;
 
     auto hasToken = [&](TAmounts const & diffs) {
@@ -1544,7 +1544,7 @@ UniValue listcommunitybalances(const JSONRPCRequest& request) {
     UniValue ret(UniValue::VOBJ);
 
     CAmount burnt{0};
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto height = view.GetLastHeight();
     auto postFortCanningHeight = height >= Params().GetConsensus().FortCanningHeight;
@@ -1733,7 +1733,7 @@ UniValue getburninfo(const JSONRPCRequest& request) {
     CBalances dexfeeburn;
     UniValue dfipaybacktokens{UniValue::VARR};
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto calcBurn = [&](AccountHistoryKey const & key, AccountHistoryValue const & value) -> bool
     {

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -3,6 +3,7 @@
 #include <key_io.h>
 #include <masternodes/res.h>
 #include <masternodes/mn_checks.h>
+#include <masternodes/mn_rpc.h>
 #include <primitives/transaction.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
@@ -14,7 +15,7 @@ class CCustomTxRpcVisitor
 {
     uint32_t height;
     UniValue& rpcInfo;
-    CCustomCSView& mnview;
+    CImmutableCSView& mnview;
     const CTransaction& tx;
 
     void tokenInfo(const CToken& token) const {
@@ -58,7 +59,7 @@ class CCustomTxRpcVisitor
     }
 
 public:
-    CCustomTxRpcVisitor(const CTransaction& tx, uint32_t height, CCustomCSView& mnview, UniValue& rpcInfo)
+    CCustomTxRpcVisitor(const CTransaction& tx, uint32_t height, CImmutableCSView& mnview, UniValue& rpcInfo)
         : height(height), rpcInfo(rpcInfo), mnview(mnview), tx(tx) {
     }
 
@@ -451,7 +452,7 @@ Res RpcInfo(const CTransaction& tx, uint32_t height, CustomTxType& txType, UniVa
     auto txMessage = customTypeToMessage(txType);
     auto res = CustomMetadataParse(height, Params().GetConsensus(), metadata, txMessage);
     if (res) {
-        CCustomCSView mnview(*pcustomcsview);
+        CImmutableCSView mnview(*pcustomcsview);
         std::visit(CCustomTxRpcVisitor(tx, height, mnview, results), txMessage);
     }
     return res;

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -1,6 +1,6 @@
 #include <masternodes/mn_rpc.h>
 
-UniValue icxOrderToJSON(CCustomCSView& view, CICXOrderImplemetation const& order, uint8_t const status, int currentHeight) {
+UniValue icxOrderToJSON(CImmutableCSView& view, CICXOrderImplemetation const& order, uint8_t const status, int currentHeight) {
     UniValue orderObj(UniValue::VOBJ);
 
     auto token = view.GetToken(order.idToken);
@@ -54,7 +54,7 @@ UniValue icxOrderToJSON(CCustomCSView& view, CICXOrderImplemetation const& order
     return (ret);
 }
 
-UniValue icxMakeOfferToJSON(CCustomCSView& view, CICXMakeOfferImplemetation const& makeoffer, uint8_t const status) {
+UniValue icxMakeOfferToJSON(CImmutableCSView& view, CICXMakeOfferImplemetation const& makeoffer, uint8_t const status) {
     UniValue orderObj(UniValue::VOBJ);
 
     auto order = view.GetICXOrderByCreationTx(makeoffer.orderTx);
@@ -76,7 +76,7 @@ UniValue icxMakeOfferToJSON(CCustomCSView& view, CICXMakeOfferImplemetation cons
     return (ret);
 }
 
-UniValue icxSubmitDFCHTLCToJSON(CCustomCSView& view, CICXSubmitDFCHTLCImplemetation const& dfchtlc, uint8_t const status) {
+UniValue icxSubmitDFCHTLCToJSON(CImmutableCSView& view, CICXSubmitDFCHTLCImplemetation const& dfchtlc, uint8_t const status) {
     auto offer = view.GetICXMakeOfferByCreationTx(dfchtlc.offerTx);
     if (!offer)
         return (UniValue::VNULL);
@@ -119,7 +119,7 @@ UniValue icxSubmitDFCHTLCToJSON(CCustomCSView& view, CICXSubmitDFCHTLCImplemetat
     return (ret);
 }
 
-UniValue icxSubmitEXTHTLCToJSON(CCustomCSView& view, CICXSubmitEXTHTLCImplemetation const& exthtlc, uint8_t const status) {
+UniValue icxSubmitEXTHTLCToJSON(CImmutableCSView& view, CICXSubmitEXTHTLCImplemetation const& exthtlc, uint8_t const status) {
     auto offer = view.GetICXMakeOfferByCreationTx(exthtlc.offerTx);
     if (!offer)
         return (UniValue::VNULL);
@@ -282,7 +282,7 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
     int targetHeight;
     {
         DCT_ID idToken;
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         if (order.orderType == CICXOrder::TYPE_INTERNAL)
         {
@@ -427,7 +427,7 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
 
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto order = view.GetICXOrderByCreationTx(makeoffer.orderTx);
         if (!order)
@@ -563,7 +563,7 @@ UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
     int targetHeight;
     CScript authScript;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto offer = view.GetICXMakeOfferByCreationTx(submitdfchtlc.offerTx);
         if (!offer)
@@ -720,7 +720,7 @@ UniValue icxsubmitexthtlc(const JSONRPCRequest& request) {
     int targetHeight;
     CScript authScript;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto offer = view.GetICXMakeOfferByCreationTx(submitexthtlc.offerTx);
         if (!offer)
@@ -924,7 +924,7 @@ UniValue icxcloseorder(const JSONRPCRequest& request) {
     int targetHeight;
     CScript authScript;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto order = view.GetICXOrderByCreationTx(closeorder.orderTx);
         if (!order)
@@ -1021,7 +1021,7 @@ UniValue icxcloseoffer(const JSONRPCRequest& request) {
     int targetHeight;
     CScript authScript;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto offer = view.GetICXMakeOfferByCreationTx(closeoffer.offerTx);
         if (!offer)
@@ -1094,7 +1094,7 @@ UniValue icxgetorder(const JSONRPCRequest& request) {
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("EXPERIMENTAL warning:", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto currentHeight = view.GetLastHeight();
     uint256 orderTxid = uint256S(request.params[0].getValStr());
@@ -1164,7 +1164,7 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
         if (!byObj["closed"].isNull()) closed = byObj["closed"].get_bool();
     }
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto currentHeight = view.GetLastHeight();
     DCT_ID idToken = {std::numeric_limits<uint32_t>::max()};
@@ -1291,7 +1291,7 @@ UniValue icxlisthtlcs(const JSONRPCRequest& request) {
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto dfchtlclambda = [&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
         if (key.first != offerTxid || !limit)

--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -2,11 +2,11 @@
 
 #include <masternodes/govvariables/attributes.h>
 
-extern UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose);
+extern UniValue tokenToJSON(CImmutableCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose);
 extern UniValue listauctions(const JSONRPCRequest& request);
-extern std::pair<int, int> GetFixedIntervalPriceBlocks(int currentHeight, const CCustomCSView &mnview);
+extern std::pair<int, int> GetFixedIntervalPriceBlocks(int currentHeight, const CImmutableCSView &mnview);
 
-UniValue setCollateralTokenToJSON(CCustomCSView& view, CLoanSetCollateralTokenImplementation const& collToken)
+UniValue setCollateralTokenToJSON(CImmutableCSView& view, CLoanSetCollateralTokenImplementation const& collToken)
 {
     UniValue collTokenObj(UniValue::VOBJ);
 
@@ -24,7 +24,7 @@ UniValue setCollateralTokenToJSON(CCustomCSView& view, CLoanSetCollateralTokenIm
     return (collTokenObj);
 }
 
-UniValue setLoanTokenToJSON(CCustomCSView& view, CLoanSetLoanTokenImplementation const& loanToken, DCT_ID tokenId)
+UniValue setLoanTokenToJSON(CImmutableCSView& view, CLoanSetLoanTokenImplementation const& loanToken, DCT_ID tokenId)
 {
     UniValue loanTokenObj(UniValue::VOBJ);
 
@@ -201,7 +201,7 @@ UniValue getcollateraltoken(const JSONRPCRequest& request) {
     std::string tokenSymbol = request.params[0].get_str();
     DCT_ID idToken;
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto token = view.GetTokenGuessId(trim_ws(tokenSymbol), idToken);
     if (!token)
@@ -234,7 +234,7 @@ UniValue listcollateraltokens(const JSONRPCRequest& request) {
      }.Check(request);
 
     UniValue ret(UniValue::VARR);
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     view.ForEachLoanCollateralToken([&](CollateralTokenKey const & key, uint256 const & collTokenTx) {
         auto collToken = view.GetLoanCollateralToken(collTokenTx);
@@ -427,7 +427,7 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
     int targetHeight;
     {
         DCT_ID id;
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto token = view.GetTokenGuessId(tokenStr, id);
         if (!token)
@@ -508,7 +508,7 @@ UniValue listloantokens(const JSONRPCRequest& request) {
 
     UniValue ret(UniValue::VARR);
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     view.ForEachLoanToken([&](DCT_ID const & key, CLoanView::CLoanSetLoanTokenImpl loanToken) {
         ret.push_back(setLoanTokenToJSON(view, loanToken,key));
@@ -564,7 +564,7 @@ UniValue getloantoken(const JSONRPCRequest& request)
     std::string tokenSymbol = request.params[0].get_str();
     DCT_ID idToken;
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto token = view.GetTokenGuessId(trim_ws(tokenSymbol), idToken);
     if (!token)
@@ -909,7 +909,7 @@ UniValue listloanschemes(const JSONRPCRequest& request) {
     };
     std::set<CLoanScheme, decltype(cmp)> loans(cmp);
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     view.ForEachLoanScheme([&loans](const std::string& identifier, const CLoanSchemeData& data){
         CLoanScheme loanScheme;
@@ -967,7 +967,7 @@ UniValue getloanscheme(const JSONRPCRequest& request) {
     if (loanSchemeId.empty() || loanSchemeId.length() > 8)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "id cannot be empty or more than 8 chars long");
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto loanScheme = view.GetLoanScheme(loanSchemeId);
     if (!loanScheme)
@@ -1054,7 +1054,7 @@ UniValue takeloan(const JSONRPCRequest& request) {
     int targetHeight;
     CScript ownerAddress;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto vault = view.GetVault(takeLoan.vaultId);
         if (!vault)
@@ -1192,7 +1192,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
 
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         // Get vault if exists, vault owner used as auth.
         auto vault = view.GetVault(loanPayback.vaultId);
@@ -1249,7 +1249,7 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
 
     UniValue ret{UniValue::VOBJ};
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     auto height = view.GetLastHeight();
     auto blockTime = WITH_LOCK(cs_main, return ::ChainActive()[height]->GetBlockTime());
 
@@ -1340,7 +1340,7 @@ UniValue getinterest(const JSONRPCRequest& request) {
     if (loanSchemeId.empty() || loanSchemeId.length() > 8)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "id cannot be empty or more than 8 chars long");
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     if (!view.GetLoanScheme(loanSchemeId))
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot find existing loan scheme with id " + loanSchemeId);

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -3,7 +3,7 @@
 #include <pos_kernel.h>
 
 // Here (but not a class method) just by similarity with other '..ToJSON'
-UniValue mnToJSON(CCustomCSView& view, uint256 const & nodeId, CMasternode const& node, bool verbose, const std::set<std::pair<CKeyID, uint256>>& mnIds, const CWallet* pwallet)
+UniValue mnToJSON(CImmutableCSView& view, uint256 const & nodeId, CMasternode const& node, bool verbose, const std::set<std::pair<CKeyID, uint256>>& mnIds, const CWallet* pwallet)
 {
     UniValue ret(UniValue::VOBJ);
     auto currentHeight = view.GetLastHeight();
@@ -242,7 +242,7 @@ UniValue setforcedrewardaddress(const JSONRPCRequest& request)
     CTxDestination ownerDest;
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto nodePtr = view.GetMasternode(nodeId);
         if (!nodePtr) {
@@ -350,7 +350,7 @@ UniValue remforcedrewardaddress(const JSONRPCRequest& request)
     CTxDestination ownerDest;
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto nodePtr = view.GetMasternode(nodeId);
         if (!nodePtr) {
@@ -444,7 +444,7 @@ UniValue resignmasternode(const JSONRPCRequest& request)
     CTxDestination ownerDest;
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto nodePtr = view.GetMasternode(nodeId);
         if (!nodePtr) {
@@ -539,7 +539,7 @@ UniValue updatemasternode(const JSONRPCRequest& request)
 
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto nodePtr = view.GetMasternode(nodeId);
         if (!nodePtr) {
@@ -650,7 +650,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VOBJ);
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     const auto mnIds = view.GetOperatorsMulti();
     view.ForEachMasternode([&](uint256 const& nodeId, CMasternode node) {
         if (!including_start)
@@ -685,7 +685,7 @@ UniValue getmasternode(const JSONRPCRequest& request)
 
     uint256 id = ParseHashV(request.params[0], "masternode id");
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     const auto mnIds = view.GetOperatorsMulti();
     auto node = view.GetMasternode(id);
     if (node) {
@@ -725,7 +725,7 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
         ++idCount;
     }
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     if (!identifier["ownerAddress"].isNull()) {
         CKeyID ownerAddressID;
@@ -850,7 +850,7 @@ UniValue getanchorteams(const JSONRPCRequest& request)
     }.Check(request);
 
     int blockHeight;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     if (!request.params[0].isNull()) {
         blockHeight = request.params[0].get_int();
     } else {
@@ -919,7 +919,7 @@ UniValue getactivemasternodecount(const JSONRPCRequest& request)
     }
 
     std::set<uint256> masternodes;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     auto pindex = WITH_LOCK(cs_main, return ::ChainActive().Tip());
     // Get active MNs from last week's worth of blocks
@@ -947,7 +947,7 @@ UniValue listanchors(const JSONRPCRequest& request)
                },
     }.Check(request);
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     auto confirms = view.CAnchorConfirmsView::GetAnchorConfirmData();
 
     std::sort(confirms.begin(), confirms.end(), [](CAnchorConfirmData a, CAnchorConfirmData b) {

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -1,6 +1,6 @@
 #include <masternodes/mn_rpc.h>
 
-UniValue poolToJSON(CCustomCSView& view, DCT_ID const& id, CPoolPair const& pool, CToken const& token, bool verbose) {
+UniValue poolToJSON(CImmutableCSView& view, DCT_ID const& id, CPoolPair const& pool, CToken const& token, bool verbose) {
     UniValue poolObj(UniValue::VOBJ);
     poolObj.pushKV("symbol", token.symbol);
     poolObj.pushKV("name", token.name);
@@ -131,7 +131,7 @@ void CheckAndFillPoolSwapMessage(const JSONRPCRequest& request, CPoolSwapMessage
         tokenTo = metadataObj["tokenTo"].getValStr();
     }
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto token = view.GetTokenGuessId(tokenFrom, poolSwapMsg.idTokenFrom);
         if (!token)
@@ -212,7 +212,7 @@ UniValue listpoolpairs(const JSONRPCRequest& request) {
     }
 
     UniValue ret(UniValue::VOBJ);
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     view.ForEachPoolPair([&](DCT_ID const & id, CPoolPair pool) {
         const auto token = view.GetToken(id);
         if (token) {
@@ -250,7 +250,7 @@ UniValue getpoolpair(const JSONRPCRequest& request) {
     }
 
     DCT_ID id;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     auto token = view.GetTokenGuessId(request.params[0].getValStr(), id);
     if (token) {
         auto pool = view.GetPoolPair(id);
@@ -556,7 +556,7 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     int targetHeight;
     DCT_ID idtokenA, idtokenB;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto token = view.GetTokenGuessId(tokenA, idtokenA);
         if (!token)
@@ -678,7 +678,7 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     DCT_ID poolId;
     int targetHeight;
     {
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         auto token = view.GetTokenGuessId(poolStr, poolId);
         if (!token) {
@@ -929,7 +929,7 @@ UniValue compositeswap(const JSONRPCRequest& request) {
 
     {
         // If no direct swap found search for composite swap
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
         if (!view.GetPoolPair(poolSwapMsg.idTokenFrom, poolSwapMsg.idTokenTo)) {
 
             auto compositeSwap = CPoolSwap(poolSwapMsg, targetHeight);
@@ -1060,7 +1060,7 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
     // test execution and get amount
     Res res = Res::Ok();
     {
-        CCustomCSView mnview_dummy(*pcustomcsview); // create dummy cache for test state writing
+        CImmutableCSView mnview_dummy(*pcustomcsview); // create dummy cache for test state writing
 
         int targetHeight = mnview_dummy.GetLastHeight() + 1;
 
@@ -1222,7 +1222,7 @@ UniValue listpoolshares(const JSONRPCRequest& request) {
     PoolShareKey startKey{ start, CScript{} };
 
     UniValue ret(UniValue::VOBJ);
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     view.ForEachPoolShare([&](DCT_ID const & poolId, CScript const & provider, uint32_t) {
         const CTokenAmount tokenAmount = view.GetBalance(provider, poolId);
         if(tokenAmount.nValue) {

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -214,7 +214,7 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     int targetHeight;
     {
         DCT_ID id;
-        CCustomCSView view(*pcustomcsview);
+        CImmutableCSView view(*pcustomcsview);
 
         token = view.GetTokenGuessId(tokenStr, id);
         if (id == DCT_ID{0}) {
@@ -323,7 +323,7 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose) {
+UniValue tokenToJSON(CImmutableCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose) {
     UniValue tokenObj(UniValue::VOBJ);
     tokenObj.pushKV("symbol", token.symbol);
     tokenObj.pushKV("symbolKey", token.CreateSymbolKey(id));
@@ -425,7 +425,7 @@ UniValue listtokens(const JSONRPCRequest& request) {
     }
 
     UniValue ret(UniValue::VOBJ);
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     view.ForEachToken([&](DCT_ID const& id, CTokenImplementation token) {
         ret.pushKVs(tokenToJSON(view, id, token, verbose));
         return --limit != 0;
@@ -451,7 +451,7 @@ UniValue gettoken(const JSONRPCRequest& request) {
     }.Check(request);
 
     DCT_ID id;
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
     auto token = view.GetTokenGuessId(request.params[0].getValStr(), id);
     if (token) {
         return tokenToJSON(view, id, *token, true);
@@ -585,7 +585,7 @@ UniValue getcustomtx(const JSONRPCRequest& request)
     if (!actualHeight) {
 
         LOCK(cs_main);
-        CCustomCSView mnview(*pcustomcsview);
+        CImmutableCSView mnview(*pcustomcsview);
         CCoinsViewCache view(&::ChainstateActive().CoinsTip());
 
         auto res = ApplyCustomTx(mnview, view, *tx, Params().GetConsensus(), nHeight);
@@ -661,7 +661,7 @@ UniValue minttokens(const JSONRPCRequest& request) {
     const CBalances minted = DecodeAmounts(pwallet->chain(), request.params[0], "");
     UniValue const & txInputs = request.params[1];
 
-    CCustomCSView view(*pcustomcsview);
+    CImmutableCSView view(*pcustomcsview);
 
     int targetHeight = view.GetLastHeight() + 1;
 

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -4,6 +4,7 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <masternodes/masternodes.h>
+#include <masternodes/mn_rpc.h>
 #include <rpc/rawtransaction_util.h>
 #include <test/setup_common.h>
 
@@ -582,6 +583,17 @@ BOOST_AUTO_TEST_CASE(SnapshotParallel)
         for (int i = 0; i < num_threads; i++)
             threads[i].join();
     }
+}
+
+BOOST_AUTO_TEST_CASE(CImmutableType)
+{
+    CImmutableCSView view(*pcustomcsview);
+    CTokenAmount amount{{}, 100000};
+    BOOST_REQUIRE(view.AddBalance({}, amount).ok);
+    BOOST_CHECK_EQUAL(view.GetBalance({}, DCT_ID{}), amount);
+    CCustomCSView& mnview = view;
+    BOOST_REQUIRE(!mnview.Flush());
+    BOOST_CHECK_EQUAL(pcustomcsview->GetBalance({}, DCT_ID{}), CTokenAmount{});
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

/kind feature

Views at rpc level aims to cache data during execution but they shouldn't propagate changes to its parent (in most cases the main level db view). `CImmutableCSView` can keep changes over the parent view, but cannot, direct or indirect, to pass through the data.