### PR TITLE
Fix accounting of payback burn and swap to DFI if payback token is different than native loan token or DFI.

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -76,7 +76,7 @@ std::string ToString(CustomTxType type) {
         case CustomTxType::WithdrawFromVault:   return "WithdrawFromVault";
         case CustomTxType::TakeLoan:            return "TakeLoan";
         case CustomTxType::PaybackLoan:         return "PaybackLoan";
-        case CustomTxType::PaybackLoanV2:       return "PaybackLoanV2";
+        case CustomTxType::PaybackLoanV2:       return "PaybackLoan";
         case CustomTxType::AuctionBid:          return "AuctionBid";
         case CustomTxType::Reject:              return "Reject";
         case CustomTxType::None:                return "None";

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3023,6 +3023,8 @@ public:
                         subInToken = kv.second;
                     }
 
+                    shouldSetVariable = true;
+
                     auto penalty = MultiplyAmounts(subInToken, COIN - penaltyPct);
 
                     if (paybackTokenId == DCT_ID{0})
@@ -3033,6 +3035,10 @@ public:
                         balances.Add(CTokenAmount{loanTokenId, subAmount});
                         balances.Add(CTokenAmount{paybackTokenId, penalty});
                         attributes->attributes[liveKey] = balances;
+
+                        LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Burning interest and loan in %s directly - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
+
+                        res = TransferTokenBalance(paybackTokenId, subInToken, obj.from, consensus.burnAddress);
                     }
                     else
                     {
@@ -3042,12 +3048,11 @@ public:
                         balances.tokensPayback.Add(CTokenAmount{loanTokenId, subAmount});
                         balances.tokensFee.Add(CTokenAmount{paybackTokenId, penalty});
                         attributes->attributes[liveKey] = balances;
+
+                        LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Swapping %s to DFI and burning it - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
+
+                        res = SwapToDFIOverUSD(mnview, paybackTokenId, subInToken, obj.from, consensus.burnAddress, height);
                     }
-
-                    shouldSetVariable = true;
-
-                    LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Burning interest and loan in %s directly - %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
-                    res = TransferTokenBalance(paybackTokenId, subInToken, obj.from, consensus.burnAddress);
                 }
 
                 if (!res)

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1802,7 +1802,8 @@ UniValue getburninfo(const JSONRPCRequest& request) {
         }
 
         // withdraw burn
-        if (value.category == uint8_t(CustomTxType::PaybackLoan)) {
+        if (value.category == uint8_t(CustomTxType::PaybackLoan)
+        || value.category == uint8_t(CustomTxType::PaybackLoanV2)) {
             for (auto const & diff : value.diff) {
                 paybackFee += diff.second;
             }
@@ -1885,7 +1886,7 @@ UniValue getburninfo(const JSONRPCRequest& request) {
     return result;
 }
 
-UniValue HandleSendDFIP2201DFIInput(const JSONRPCRequest& request, CWalletCoinsUnlocker pwallet, 
+UniValue HandleSendDFIP2201DFIInput(const JSONRPCRequest& request, CWalletCoinsUnlocker pwallet,
         const std::pair<std::string, CScript>& contractPair, CTokenAmount amount) {
     CUtxosToAccountMessage msg{};
     msg.to = {{contractPair.second, {{{{0}, amount.nValue}}}}};

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -448,7 +448,7 @@ public:
             if (auto dtoken = mnview.GetToken(idx.first)) {
                 auto dtokenImpl = static_cast<CTokenImplementation const&>(*dtoken);
                 if (auto dtokenPair = mnview.GetTokenByCreationTx(dtokenImpl.creationTx)) {
-                    loan.pushKV("dToken",dtokenPair->first.ToString());
+                    loan.pushKV("dTokens",dtokenPair->first.ToString());
                 }
             }
             for (auto const & kv : idx.second.balances) {

--- a/test/functional/feature_loan_payback_dfi_v2.py
+++ b/test/functional/feature_loan_payback_dfi_v2.py
@@ -311,6 +311,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         vaultBefore = self.nodes[0].getvault(self.vaultId1)
         [amountBefore, _] = vaultBefore['loanAmounts'][0].split('@')
 
+        old_info = self.nodes[0].getburninfo()
+
         # Partial loan payback in DFI
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId1,
@@ -322,6 +324,7 @@ class PaybackDFILoanTest (DefiTestFramework):
         info = self.nodes[0].getburninfo()
         assert_equal(info['dfipaybackfee'], Decimal('0.01000000')) # paybackfee defaults to 1% of total payback -> 0.01 DFI
         assert_equal(info['dfipaybacktokens'], ['3.96000000@DUSD']) # 4 - penalty (0.01DFI->0.04USD)
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('1'))
 
         vaultAfter = self.nodes[0].getvault(self.vaultId1)
         [amountAfter, _] = vaultAfter['loanAmounts'][0].split('@')
@@ -336,6 +339,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         vaultBefore = self.nodes[0].getvault(self.vaultId1)
         [amountBefore, _] = vaultBefore['loanAmounts'][0].split('@')
 
+        old_info = self.nodes[0].getburninfo()
+
         # Partial loan payback in DFI
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId1,
@@ -347,6 +352,7 @@ class PaybackDFILoanTest (DefiTestFramework):
         info = self.nodes[0].getburninfo()
         assert_equal(info['dfipaybackfee'], Decimal('0.06000000'))
         assert_equal(info['dfipaybacktokens'], ['7.76000000@DUSD'])
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('1'))
 
         vaultAfter = self.nodes[0].getvault(self.vaultId1)
         [amountAfter, _] = vaultAfter['loanAmounts'][0].split('@')
@@ -359,6 +365,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         [amountBefore, _] = vaultBefore['loanAmounts'][0].split('@')
         [balanceDFIBefore, _] = self.nodes[0].getaccount(self.addr_DFI)[0].split('@')
 
+        old_info = self.nodes[0].getburninfo()
+
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId1,
             'from': self.addr_DFI,
@@ -369,6 +377,7 @@ class PaybackDFILoanTest (DefiTestFramework):
         info = self.nodes[0].getburninfo()
         assert_equal(info['dfipaybackfee'],  Decimal('1.27368435'))
         assert_equal(info['dfipaybacktokens'], ['100.00001113@DUSD']) # Total loan in vault1 + previous dfipaybacktokens
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('24.27368714'))
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
         assert_equal(attribs['v0/live/economy/dfi_payback_tokens'], ['1.27368435@DFI', '100.00001113@DUSD'])
@@ -387,6 +396,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         })
         self.nodes[0].generate(10)
 
+        old_info = self.nodes[0].getburninfo()
+
         [balanceDFIBefore, _] = self.nodes[0].getaccount(self.addr_DFI)[0].split('@')
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId1,
@@ -398,6 +409,7 @@ class PaybackDFILoanTest (DefiTestFramework):
         info = self.nodes[0].getburninfo()
         assert_equal(info['dfipaybackfee'], Decimal('2.58947407'))
         assert_equal(info['dfipaybacktokens'], ['200.00003016@DUSD'])
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('26.31579449'))
 
         vaultAfter = self.nodes[0].getvault(self.vaultId1)
         [balanceDFIAfter, _] = self.nodes[0].getaccount(self.addr_DFI)[0].split('@')
@@ -588,6 +600,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         vaultBefore = self.nodes[0].getvault(self.vaultId3)
         [amountBefore, _] = vaultBefore['loanAmounts'][0].split('@')
 
+        old_info = self.nodes[0].getburninfo()
+
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId3,
             'from': self.addr_BTC,
@@ -605,6 +619,11 @@ class PaybackDFILoanTest (DefiTestFramework):
 
         [balanceBTCAfter, _] = self.nodes[0].getaccount(self.addr_BTC)[0].split('@')
         assert_equal(Decimal(balanceBTCBefore) - Decimal(balanceBTCAfter), Decimal('0.5'))
+
+        info = self.nodes[0].getburninfo()
+        assert_equal(info['paybackfees'], ['0.12500000@BTC'])
+        assert_equal(info['paybacktokens'], ['3750000.00000000@TSLA'])
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('6209.54767138'))
 
     def payback_dUSD_with_dUSD(self):
         self.nodes[0].takeloan({
@@ -651,6 +670,8 @@ class PaybackDFILoanTest (DefiTestFramework):
         })
         self.nodes[0].generate(1)
 
+        old_info = self.nodes[0].getburninfo()
+
         self.nodes[0].paybackloan({
             'vaultId': self.vaultId4,
             'from': self.addr_BTC,
@@ -667,6 +688,11 @@ class PaybackDFILoanTest (DefiTestFramework):
 
         [balanceBTCAfter, _] = self.nodes[0].getaccount(self.addr_BTC)[0].split('@')
         assert_equal(Decimal(balanceBTCBefore) - Decimal(balanceBTCAfter), Decimal('0.00000001'))
+
+        info = self.nodes[0].getburninfo()
+        assert_equal(info['paybackfees'], ['0.12500000@BTC'])
+        assert_equal(info['paybacktokens'], ['3750000.00000002@TSLA'])
+        assert_equal(info['paybackburn'], old_info['paybackburn'] + Decimal('0.00012413'))
 
     def run_test(self):
         self.setup()


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Add accounting of PaybackLoanV2 in `getburninfo`.

When doing payback of loan, if payback token is not native loan token or DFI, then swap it to DFI over DUSD.