### PR TITLE
Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,3 @@
-.github
-contrib/dockerfiles
-
 # depends
 
 depends/built
@@ -31,7 +28,6 @@ src/defi-tx
 src/defi-wallet
 src/test/test_defi
 src/test/test_defi_fuzzy
-src/qt/test/test_defi-qt
 
 # autoreconf
 Makefile.in
@@ -59,21 +55,6 @@ src/config/defi-config.h.in
 src/config/stamp-h1
 src/obj
 share/setup.nsi
-share/qt/Info.plist
-
-src/univalue/gen
-
-src/qt/*.moc
-src/qt/moc_*.cpp
-src/qt/forms/ui_*.h
-
-src/qt/test/moc*.cpp
-
-src/qt/defi-qt.config
-src/qt/defi-qt.creator
-src/qt/defi-qt.creator.user
-src/qt/defi-qt.files
-src/qt/defi-qt.includes
 
 .deps
 .dirstamp
@@ -106,20 +87,15 @@ src/qt/defi-qt.includes
 *.lo
 *.la
 
-# Compilation and Qt preprocessor part
+# Compilation
 *.qm
 Makefile
 !depends/Makefile
-defi-qt
-Defi-Qt.app
 background.tiff*
-
-# Qt Creator
 Makefile.am.user
 
 # Unit-tests
 Makefile.test
-defi-qt_test
 
 # Resources cpp
 qrc_*.cpp


### PR DESCRIPTION
/kind chore

- Update docker ignore to remove qt and also make it more in line with the repo to avoid unexpected pitfalls. 
- Also attempts to fix #1166. 