### PR TITLE
Live dex statistics

### DIFF
--- a/src/masternodes/consensus/loans.cpp
+++ b/src/masternodes/consensus/loans.cpp
@@ -579,7 +579,7 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message& obj) const {
 
                     balances.Add(CTokenAmount{loanTokenId, subAmount});
                     balances.Add(CTokenAmount{paybackTokenId, penalty});
-                    attributes->attributes[liveKey] = balances;
+                    attributes->SetValue(liveKey, std::move(balances));
 
                     LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Burning interest and loan in %s directly - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
 
@@ -592,7 +592,7 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message& obj) const {
 
                     balances.tokensPayback.Add(CTokenAmount{loanTokenId, subAmount});
                     balances.tokensFee.Add(CTokenAmount{paybackTokenId, penalty});
-                    attributes->attributes[liveKey] = balances;
+                    attributes->SetValue(liveKey, balances);
 
                     LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Swapping %s to DFI and burning it - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
 

--- a/src/masternodes/consensus/smartcontracts.cpp
+++ b/src/masternodes/consensus/smartcontracts.cpp
@@ -178,7 +178,7 @@ Res CSmartContractsConsensus::operator()(const CFutureSwapMessage& obj) const {
         balances.Add(obj.source);
     }
 
-    attributes->attributes[liveKey] = balances;
+    attributes->SetValue(liveKey, std::move(balances));
     return mnview.SetVariable(*attributes);
 }
 

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -37,6 +37,7 @@ enum EconomyKeys : uint8_t {
     DFIP2203Current  = 'c',
     DFIP2203Burned   = 'd',
     DFIP2203Minted   = 'e',
+    DexTokens        = 'f',
 };
 
 enum DFIPKeys : uint8_t  {
@@ -111,8 +112,38 @@ struct CTokenPayback {
     }
 };
 
+struct CDexTokenInfo {
+
+    struct CTokenInfo {
+        uint64_t swaps;
+        uint64_t feeburn;
+        uint64_t commissions;
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action) {
+            READWRITE(swaps);
+            READWRITE(feeburn);
+            READWRITE(commissions);
+        }
+    };
+
+    CTokenInfo totalTokenA;
+    CTokenInfo totalTokenB;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(totalTokenA);
+        READWRITE(totalTokenB);
+    }
+};
+
+using CDexBalances = std::map<DCT_ID, CDexTokenInfo>;
 using CAttributeType = std::variant<CDataStructureV0>;
-using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CTokenCurrencyPair>;
+using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CDexBalances, CTokenCurrencyPair>;
 
 class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES>
 {
@@ -150,6 +181,21 @@ public:
         return value;
     }
 
+    template<typename K, typename T>
+    void SetValue(const K& key, T&& value) {
+        static_assert(std::is_convertible_v<K, CAttributeType>);
+        static_assert(std::is_convertible_v<T, CAttributeValue>);
+        changed.insert(key);
+        attributes[key] = std::forward<T>(value);
+    }
+
+    template<typename K>
+    void EraseKey(const K& key) {
+        static_assert(std::is_convertible_v<K, CAttributeType>);
+        changed.insert(key);
+        attributes.erase(key);
+    }
+
     template<typename K>
     [[nodiscard]] bool CheckKey(const K& key) const {
         static_assert(std::is_convertible_v<K, CAttributeType>);
@@ -177,16 +223,17 @@ public:
         READWRITE(attributes);
     }
 
-    std::map<CAttributeType, CAttributeValue> attributes;
     uint32_t time{0};
-
     // For formatting in export
     static const std::map<uint8_t, std::string>& displayVersions();
     static const std::map<uint8_t, std::string>& displayTypes();
     static const std::map<uint8_t, std::string>& displayParamsIDs();
     static const std::map<uint8_t, std::map<uint8_t, std::string>>& displayKeys();
 private:
+    friend class CGovView;
     bool futureBlockUpdated{};
+    std::set<CAttributeType> changed;
+    std::map<CAttributeType, CAttributeValue> attributes;
 
     // Defined allowed arguments
     static const std::map<std::string, uint8_t>& allowedVersions();

--- a/src/masternodes/gv.cpp
+++ b/src/masternodes/gv.cpp
@@ -15,7 +15,29 @@
 
 Res CGovView::SetVariable(GovVariable const & var)
 {
-    return WriteBy<ByName>(var.GetName(), var) ? Res::Ok() : Res::Err("can't write to DB");
+    auto WriteVar = [this](GovVariable const & var) {
+        return WriteBy<ByName>(var.GetName(), var) ? Res::Ok() : Res::Err("can't write to DB");
+    };
+    if (var.GetName() != "ATTRIBUTES") {
+        return WriteVar(var);
+    }
+    auto attributes = GetAttributes();
+    if (!attributes) {
+        return WriteVar(var);
+    }
+    auto& current = dynamic_cast<const ATTRIBUTES&>(var);
+    if (current.changed.empty()) {
+        return Res::Ok();
+    }
+    for (auto& key : current.changed) {
+        auto it = current.attributes.find(key);
+        if (it == current.attributes.end()) {
+            attributes->attributes.erase(key);
+        } else {
+            attributes->attributes[key] = it->second;
+        }
+    }
+    return WriteVar(*attributes);
 }
 
 std::shared_ptr<GovVariable> CGovView::GetVariable(std::string const & name) const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3403,11 +3403,11 @@ void CChainState::ProcessFutures(const CBlockIndex* pindex, CCustomCSView& cache
         cache.EraseFuturesUserValues(key);
     }
 
-    attributes->attributes[burnKey] = burned;
-    attributes->attributes[mintedKey] = minted;
+    attributes->SetValue(burnKey, std::move(burned));
+    attributes->SetValue(mintedKey, std::move(minted));
 
     if (!unpaidContracts.empty()) {
-        attributes->attributes[liveKey] = balances;
+        attributes->SetValue(liveKey, std::move(balances));
     }
 
     cache.SetVariable(*attributes);

--- a/test/functional/feature_loan_vault.py
+++ b/test/functional/feature_loan_vault.py
@@ -744,7 +744,9 @@ class VaultTest (DefiTestFramework):
 
         # Invalidate fork block
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
-        assert_equal(len(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']), 0)
+        result = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        for key in result.keys():
+            assert key.startswith('v0/live')
 
         # Move to hard fork again
         self.move_to_gw_fork()

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -196,6 +196,11 @@ class PoolPairTest (DefiTestFramework):
         # 7 Sync
         self.sync_blocks([self.nodes[0], self.nodes[2]])
 
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        # silver is tokenB
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_b'%(idGS)], Decimal('9.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_b'%(idGS)], Decimal('1.0'))
+
         # 8 Checking that poolswap is correct
         goldCheckN0 = self.nodes[2].getaccount(accountGN0, {}, True)[idGold]
         silverCheckN0 = self.nodes[2].getaccount(accountGN0, {}, True)[idSilver]
@@ -253,6 +258,10 @@ class PoolPairTest (DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_b'%(idGS)], Decimal('189.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_b'%(idGS)], Decimal('21.0'))
+
         maxPrice = self.nodes[0].listpoolpairs()['1']['reserveB/reserveA']
         # exchange tokens each other should work
         self.nodes[0].poolswap({
@@ -273,6 +282,12 @@ class PoolPairTest (DefiTestFramework):
             "maxPrice": maxPrice,
         })
         self.nodes[0].generate(1)
+
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_a'%(idGS)], Decimal('180.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_a'%(idGS)], Decimal('20.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_b'%(idGS)], Decimal('369.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_b'%(idGS)], Decimal('41.0'))
 
         # Test fort canning max price change
         disconnect_nodes(self.nodes[0], 1)
@@ -390,6 +405,12 @@ class PoolPairTest (DefiTestFramework):
             })
         self.nodes[0].generate(1)
 
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_a'%(idBL)], Decimal('0.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_a'%(idBL)], Decimal('0.0'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_swap_b'%(idBL)], Decimal('0.00000189'))
+        assert_equal(attributes['v0/live/economy/dex/%s/total_commission_b'%(idBL)], Decimal('1E-8'))
+
         assert_equal(self.nodes[0].getaccount(new_dest, {}, True)[idBTC], Decimal('0.00000002'))
 
         # Reset swap and move to Fort Canning Park Height and try swap again
@@ -428,7 +449,9 @@ class PoolPairTest (DefiTestFramework):
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.05', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.08'}})
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'], {'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.05', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.08'})
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/poolpairs/%s/token_a_fee_pct'%(idGS)], '0.05')
+        assert_equal(attributes['v0/poolpairs/%s/token_b_fee_pct'%(idGS)], '0.08')
 
         result = self.nodes[0].getpoolpair(idGS)
         assert_equal(result[idGS]['dexFeePctTokenA'], Decimal('0.05'))
@@ -461,11 +484,17 @@ class PoolPairTest (DefiTestFramework):
 
         assert_equal(self.nodes[0].getburninfo()['dexfeetokens'].sort(), ['%.8f'%(dexinfee)+symbolGOLD, '%.8f'%(dexoutfee)+symbolSILVER].sort())
 
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_a'%(idGS)], dexinfee)
+        assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_b'%(idGS)], dexoutfee)
+
         # set 1% token dex fee and commission
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.01'}})
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'], {'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.01'})
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/poolpairs/%s/token_a_fee_pct'%(idGS)], '0.01')
+        assert_equal(attributes['v0/poolpairs/%s/token_b_fee_pct'%(idGS)], '0.01')
 
         self.nodes[0].updatepoolpair({"pool": "GS", "commission": 0.01})
         self.nodes[0].generate(1)
@@ -489,7 +518,11 @@ class PoolPairTest (DefiTestFramework):
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/poolpairs/%s/token_a_fee_pct'%(idBL): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idBL): '0.01'}})
         self.nodes[0].generate(1)
 
-        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES'], {'v0/poolpairs/%s/token_a_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idGS): '0.01', 'v0/poolpairs/%s/token_a_fee_pct'%(idBL): '0.01', 'v0/poolpairs/%s/token_b_fee_pct'%(idBL): '0.01'})
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/poolpairs/%s/token_a_fee_pct'%(idGS)], '0.01')
+        assert_equal(attributes['v0/poolpairs/%s/token_b_fee_pct'%(idGS)], '0.01')
+        assert_equal(attributes['v0/poolpairs/%s/token_a_fee_pct'%(idBL)], '0.01')
+        assert_equal(attributes['v0/poolpairs/%s/token_b_fee_pct'%(idBL)], '0.01')
 
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
         self.nodes[0].clearmempool()
@@ -527,6 +560,10 @@ class PoolPairTest (DefiTestFramework):
         amountA = reserveA - pool['reserveA']
         dexoutfee = round(trunc(amountA * Decimal(0.05) * coin) / coin, 8)
         assert_equal(round(amountA - Decimal(dexoutfee), 8), round(swapped, 8))
+
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_b'%(idBL)], round(dexinfee, 8))
+        assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_a'%(idBL)], Decimal(str(round(dexoutfee, 8))))
 
         # REVERTING:
         #========================

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -51,6 +51,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "masternodes/govvariables/attributes -> masternodes/gv -> masternodes/govvariables/attributes"
     "masternodes/govvariables/attributes -> masternodes/masternodes -> masternodes/govvariables/attributes"
     "masternodes/govvariables/attributes -> masternodes/masternodes -> validation -> masternodes/govvariables/attributes"
+    "masternodes/govvariables/attributes -> masternodes/mn_checks -> masternodes/govvariables/attributes"
     "masternodes/govvariables/icx_takerfee_per_btc -> masternodes/gv -> masternodes/govvariables/icx_takerfee_per_btc"
     "masternodes/govvariables/loan_daily_reward -> masternodes/gv -> masternodes/govvariables/loan_daily_reward"
     "masternodes/govvariables/loan_daily_reward -> masternodes/masternodes -> validation -> masternodes/govvariables/loan_daily_reward"


### PR DESCRIPTION
/kind feature

Live statistics of every swap including intermediates swaps in composite one (the reason is: dex fees)

```
/v0/live/economy/dex/{poolId}/total_swap_{a/b} - total amount of all swap
/v0/live/economy/dex/{poolId}/total_commission_{a/b} - total commission of all swaps
/v0/live/economy/dex/{poolId}/fee_burn_{a/b} - total amount of burned fees
```