### PR TITLE
Simplify attribute key uint32 migration

### DIFF
--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -79,18 +79,7 @@ struct CDataStructureV0 {
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(type);
         READWRITE(typeId);
-        if (ser_action.ForRead()) {
-            // Check if next key is 8bit or extended size 8bit + 32bit
-            if (s.size() == sizeof(uint8_t) || s.size() == sizeof(uint8_t) + sizeof(uint32_t)) {
-                uint8_t key8;
-                READWRITE(key8);
-                key = key8;
-            } else {
-                READWRITE(key);
-            }
-        } else {
-            READWRITE(key);
-        }
+        READWRITE(VARINT(key));
         if (IsExtendedSize()) {
             READWRITE(keyId);
         } else {


### PR DESCRIPTION

/kind fix

`CDataStructureV0::key` is uint8 < 0x7F (a printable character) switching to uint32 is seamless via `VARINT` which writes such characters as one byte representation.