### PR TITLE
Refactor community balance logs

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -563,7 +563,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%d community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
     mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -563,7 +563,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
     mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2066,13 +2066,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 {
                     res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Unallocated), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 else
                 {
                     res = mnview.AddCommunityBalance(kv.first, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
 
                 if (!res.ok)
@@ -2091,7 +2091,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 if (!res.ok) {
                     return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
                 } else {
-                    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 nonUtxoTotal += subsidy;
             }
@@ -2638,7 +2638,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             else if (IsAnchorRewardTx(tx, metadata)) {
                 if (IsLegacyAnchorTx(chainparams.NetworkIDString(), tx.GetHash().ToString())) {
                     if (pindex->nHeight >= chainparams.GetConsensus().AMKHeight) {
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
                         mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0);
                     } else {
                         mnview.SetFoundationsDebt(mnview.GetFoundationsDebt() + tx.GetValueOut());
@@ -2921,7 +2921,7 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
         LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
     } else {
         if (distributed.first != 0)
-            LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
+            LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessRewardEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
     }
 
     if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight) {
@@ -2930,7 +2930,7 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
             LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
         } else {
             if (distributed.second != 0)
-                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
+                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessRewardEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
         }
     }
 }
@@ -3657,7 +3657,7 @@ void CChainState::ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView
         if (prop.type == CPropType::CommunityFundProposal) {
             auto res = cache.SubCommunityBalance(CommunityAccountType::CommunityDevFunds, prop.nAmount);
             if (res) {
-                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessProposalEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
+                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessProposalEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
                 cache.CalculateOwnerRewards(prop.address, pindex->nHeight);
                 cache.AddBalance(prop.address, {DCT_ID{0}, prop.nAmount});
             } else {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2066,14 +2066,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 {
                     res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
-
+                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Unallocated), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 else
                 {
                     res = mnview.AddCommunityBalance(kv.first, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
 
                 if (!res.ok)
@@ -2092,7 +2091,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 if (!res.ok) {
                     return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
                 } else {
-                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 nonUtxoTotal += subsidy;
             }
@@ -2639,7 +2638,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             else if (IsAnchorRewardTx(tx, metadata)) {
                 if (IsLegacyAnchorTx(chainparams.NetworkIDString(), tx.GetHash().ToString())) {
                     if (pindex->nHeight >= chainparams.GetConsensus().AMKHeight) {
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%d community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
                         mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0);
                     } else {
                         mnview.SetFoundationsDebt(mnview.GetFoundationsDebt() + tx.GetValueOut());
@@ -2921,7 +2920,8 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
     if (!res) {
         LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
     } else {
-        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: ProcessRewardEvents community=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
+        if (distributed.first != 0)
+            LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
     }
 
     if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight) {
@@ -2929,7 +2929,8 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
         if (!res) {
             LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
         } else {
-            LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: ProcessRewardEvents community=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
+            if (distributed.second != 0)
+                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
         }
     }
 }
@@ -3656,7 +3657,7 @@ void CChainState::ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView
         if (prop.type == CPropType::CommunityFundProposal) {
             auto res = cache.SubCommunityBalance(CommunityAccountType::CommunityDevFunds, prop.nAmount);
             if (res) {
-                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: ProcessProposalEvents community=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
+                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessProposalEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
                 cache.CalculateOwnerRewards(prop.address, pindex->nHeight);
                 cache.AddBalance(prop.address, {DCT_ID{0}, prop.nAmount});
             } else {


### PR DESCRIPTION
- Add a new prefix "CommunityBalanceChange" so it doesn't interfere with the slightly different format of AccountChange.
- Additionally, remove 0 value change from logs to reduce noise.