### PR TITLE
Refactor community balance logs

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3837,7 +3837,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
     }
     mnview.SetTeam(finMsg.nextTeam);
     if (height >= consensusParams.AMKHeight) {
-        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%d community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
         mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     }
     else {
@@ -3914,7 +3914,7 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction con
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%d community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
     mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2051,13 +2051,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 {
                     res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Unallocated), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 else
                 {
                     res = mnview.AddCommunityBalance(kv.first, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
 
                 if (!res.ok)
@@ -2076,7 +2076,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 if (!res.ok) {
                     return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
                 } else {
-                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 nonUtxoTotal += subsidy;
             }
@@ -2749,7 +2749,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (!res.ok) {
             LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, block.GetHash().ToString());
         } else {
-            LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: ProcessRewardEvents community=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
+            if (distributed.first != 0)
+                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
         }
 
         if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight) {
@@ -2757,7 +2758,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             if (!res.ok) {
                 LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, block.GetHash().ToString());
             } else {
-                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: ProcessRewardEvents community=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
+                if (distributed.second != 0)
+                    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
             }
         }
 


### PR DESCRIPTION
- Add a new prefix "CommunityBalanceChange" so it doesn't interfere with the slightly different format of AccountChange.
- Additionally, remove 0 value change from logs to reduce noise.