### PR TITLE
Simplify caches

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -101,7 +101,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize);
-    options.filter_policy = leveldb::NewBloomFilterPolicy(10);
+    options.filter_policy = leveldb::NewBloomFilterPolicy(24);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CDefiLevelDBLogger();
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {
@@ -120,7 +120,7 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
     readoptions.verify_checksums = true;
     iteroptions.verify_checksums = true;
     iteroptions.fill_cache = false;
-    syncoptions.sync = true;
+    syncoptions.sync = false;
     options = GetOptions(nCacheSize);
     options.create_if_missing = true;
     if (fMemory) {

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -101,7 +101,8 @@ static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize);
-    options.filter_policy = leveldb::NewBloomFilterPolicy(24);
+    options.write_buffer_size = nCacheSize / 2;
+    options.filter_policy = leveldb::NewBloomFilterPolicy(16);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CDefiLevelDBLogger();
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1576,7 +1576,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
     
     // Use the same dbcache for each
-    int64_t nCustomDefaultCacheSize = nTotalCache;
+    int64_t nCustomCacheSize = nTotalCache;
     int64_t nBlockTreeDBCache = nTotalCache;
     int64_t nTxIndexCache = nTotalCache;
     int64_t nCoinDBCache = nTotalCache;
@@ -1680,7 +1680,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                         "", CClientUIInterface::MSG_ERROR);
                 });
 
-                auto pcustomcsDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "enhancedcs", nCustomDefaultCacheSize, false, fReset || fReindexChainState));
+                auto pcustomcsDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "enhancedcs", nCustomCacheSize, false, fReset || fReindexChainState));
                 pcustomcsview.reset();
                 pcustomcsview = std::make_unique<CCustomCSView>(pcustomcsDB);
                 if (!fReset && !fReindexChainState) {
@@ -1696,27 +1696,27 @@ bool AppInitMain(InitInterfaces& interfaces)
                 // make account history db
                 paccountHistoryDB.reset();
                 if (gArgs.GetBoolArg("-acindex", DEFAULT_ACINDEX)) {
-                    paccountHistoryDB = std::make_unique<CAccountHistoryStorage>(GetDataDir() / "history",  nCustomDefaultCacheSize, false, fReset || fReindexChainState);
+                    paccountHistoryDB = std::make_unique<CAccountHistoryStorage>(GetDataDir() / "history",  nCustomCacheSize, false, fReset || fReindexChainState);
                     paccountHistoryDB->CreateMultiIndexIfNeeded();
                 }
 
                 pburnHistoryDB.reset();
-                pburnHistoryDB = std::make_unique<CBurnHistoryStorage>(GetDataDir() / "burn", nCustomDefaultCacheSize, false, fReset || fReindexChainState);
+                pburnHistoryDB = std::make_unique<CBurnHistoryStorage>(GetDataDir() / "burn", nCustomCacheSize, false, fReset || fReindexChainState);
                 pburnHistoryDB->CreateMultiIndexIfNeeded();
 
                 // Create vault history DB
                 pvaultHistoryDB.reset();
                 if (gArgs.GetBoolArg("-vaultindex", DEFAULT_VAULTINDEX)) {
-                    pvaultHistoryDB = std::make_unique<CVaultHistoryStorage>(GetDataDir() / "vault", nCustomDefaultCacheSize, false, fReset || fReindexChainState);
+                    pvaultHistoryDB = std::make_unique<CVaultHistoryStorage>(GetDataDir() / "vault", nCustomCacheSize, false, fReset || fReindexChainState);
                 }
 
                 // Create Future Swap DB
-                auto pfutureSwapDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "futureswap", nCustomDefaultCacheSize, false, fReset || fReindexChainState));
+                auto pfutureSwapDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "futureswap", nCustomCacheSize, false, fReset || fReindexChainState));
                 pfutureSwapView.reset();
                 pfutureSwapView = std::make_unique<CFutureSwapView>(pfutureSwapDB);
 
                 // Create Undos DB
-                auto pundosDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "undos", nCustomDefaultCacheSize, false, fReset || fReindexChainState));
+                auto pundosDB = std::make_shared<CStorageKV>(CStorageLevelDB(GetDataDir() / "undos", nCustomCacheSize, false, fReset || fReindexChainState));
                 pundosView.reset();
                 pundosView = std::make_unique<CUndosView>(pundosDB);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1581,7 +1581,6 @@ bool AppInitMain(InitInterfaces& interfaces)
     int64_t nTxIndexCache = nTotalCache;
     int64_t nCoinDBCache = nTotalCache;
     nCoinCacheUsage = nTotalCache;
-    nCustomMemUsage = std::max((nTotalCache >> 8), (nMinDbCache << 16));
     
     int64_t filter_index_cache = 0;
     if (!g_enabled_filter_types.empty()) {

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -558,7 +558,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
     mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -558,7 +558,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%d community=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
     mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -24,13 +24,13 @@ class uint256;
 //! No need to periodic flush if at least this much space still available.
 static constexpr int MAX_BLOCK_COINSDB_USAGE = 10;
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 256;
+static const int64_t nDefaultDbCache = 512;
 //! -dbbatchsize default (bytes)
 static const int64_t nDefaultDbBatchSize = 16 << 20;
 //! max. -dbcache (MiB)
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache (MiB)
-static const int64_t nMinDbCache = 8;
+static const int64_t nMinDbCache = 4;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
 static const int64_t nMaxBlockDBCache = 2;
 //! Max memory allocated to block tree DB specific cache, if -txindex (MiB)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2064,13 +2064,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 {
                     res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Unallocated), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 else
                 {
                     res = mnview.AddCommunityBalance(kv.first, subsidy);
                     if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
 
                 if (!res.ok)
@@ -2089,7 +2089,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 if (!res.ok) {
                     return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
                 } else {
-                    LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(kv.first), tx.GetHash().ToString(), (CBalances{{{{0}, subsidy}}}.ToString()));
+                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
                 nonUtxoTotal += subsidy;
             }
@@ -2646,7 +2646,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             else if (IsAnchorRewardTx(tx, metadata)) {
                 if (IsLegacyAnchorTx(chainparams.NetworkIDString(), tx.GetHash().ToString())) {
                     if (pindex->nHeight >= chainparams.GetConsensus().AMKHeight) {
-                        LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s txid=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::AnchorReward), tx.GetHash().ToString(), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
                         mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0);
                     } else {
                         mnview.SetFoundationsDebt(mnview.GetFoundationsDebt() + tx.GetValueOut());
@@ -2925,7 +2925,7 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
         LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
     } else {
         if (distributed.first != 0)
-            LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
+            LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessRewardEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
     }
 
     if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight) {
@@ -2934,7 +2934,7 @@ void CChainState::ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& 
             LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
         } else {
             if (distributed.second != 0)
-                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessRewardEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
+                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessRewardEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::Loan), (CBalances{{{{0}, -distributed.second}}}.ToString()));
         }
     }
 }
@@ -3661,7 +3661,7 @@ void CChainState::ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView
         if (prop.type == CPropType::CommunityFundProposal) {
             auto res = cache.SubCommunityBalance(CommunityAccountType::CommunityDevFunds, prop.nAmount);
             if (res) {
-                LogPrint(BCLog::ACCOUNTCHANGE, "CommunityBalanceChange: %s event=ProcessProposalEvents change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
+                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessProposalEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::CommunityDevFunds), (CBalances{{{{0}, -prop.nAmount}}}.ToString()));
                 cache.CalculateOwnerRewards(prop.address, pindex->nHeight);
                 cache.AddBalance(prop.address, {DCT_ID{0}, prop.nAmount});
             } else {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -136,7 +136,6 @@ bool fPruneMode = false;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
 size_t nCoinCacheUsage = 5000 * 300;
-size_t nCustomMemUsage = nDefaultDbCache << 10;
 uint64_t nPruneTarget = 0;
 bool fIsFakeNet = false;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;

--- a/src/validation.h
+++ b/src/validation.h
@@ -166,7 +166,6 @@ extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
-extern size_t nCustomMemUsage;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** If the tip is older than this (in seconds), the node is considered to be in initial block download. */


### PR DESCRIPTION
- Instead of scaled cache from dbcache, simplify caches to use the same value for all the DBs. 
- This has the implication of higher memory requirements, but provide better intuition on caching and simpler semantics.
- Make default writes to do `sync=false`. This should massively speed-up - this should offload the write to OS, while reducing the overall locked time in the application. sync=false moves the responsibility of rest of the write to the OS, so it is resistant to process crash. Only machine crash dynamics are changed. This should be an acceptable compromise for the benefits gained.
- Add additional bloom filter bits, since we do end up with very large set, eg. enhancedcs db. 