### PR TITLE
Move consortium to separate key in attributes instead under token key.

### DIFF
--- a/src/masternodes/consensus/tokens.cpp
+++ b/src/masternodes/consensus/tokens.cpp
@@ -123,7 +123,7 @@ Res CTokensConsensus::operator()(const CMintTokensMessage& obj) const {
             if (!attributes)
                return Res::Err("Cannot read from attributes gov variable!");
 
-            CDataStructureV0 membersKey{AttributeTypes::Token, tokenId.v, TokenKeys::ConsortiumMembers};
+            CDataStructureV0 membersKey{AttributeTypes::Consortium, tokenId.v, ConsortiumKeys::Members};
             auto members = attributes->GetValue(membersKey, CConsortiumMembers{});
 
             CDataStructureV0 membersMintedKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::ConsortiumMembersMinted};
@@ -155,7 +155,7 @@ Res CTokensConsensus::operator()(const CMintTokensMessage& obj) const {
             if (!mintable)
                 return Res::Err("You are not a foundation or consortium member and cannot mint this token!");
 
-            CDataStructureV0 maxLimitKey{AttributeTypes::Token, tokenId.v, TokenKeys::ConsortiumMintLimit};
+            CDataStructureV0 maxLimitKey{AttributeTypes::Consortium, tokenId.v, ConsortiumKeys::MintLimit};
             auto maxLimit = attributes->GetValue(maxLimitKey, CAmount{0});
 
             CDataStructureV0 consortiumMintedKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::ConsortiumMinted};
@@ -218,7 +218,7 @@ Res CTokensConsensus::operator()(const CBurnTokensMessage& obj) const {
             if (!attributes)
                return Res::Err("Cannot read from attributes gov variable!");
 
-            CDataStructureV0 membersKey{AttributeTypes::Token, tokenId.v, TokenKeys::ConsortiumMembers};
+            CDataStructureV0 membersKey{AttributeTypes::Consortium, tokenId.v, ConsortiumKeys::Members};
             auto members = attributes->GetValue(membersKey, CConsortiumMembers{});
             CDataStructureV0 membersMintedKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::ConsortiumMembersMinted};
             auto membersBalances = attributes->GetValue(membersMintedKey, CConsortiumMembersMinted{});

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -228,7 +228,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {EconomyKeys::DFIP2203Burned,           "dfip2203_burned"},
                 {EconomyKeys::DFIP2203Minted,           "dfip2203_minted"},
                 {EconomyKeys::DexTokens,                "dex"},
-                {EconomyKeys::ConsortiumMinted,         "consortium_global"},
+                {EconomyKeys::ConsortiumMinted,         "consortium"},
                 {EconomyKeys::ConsortiumMembersMinted,  "consortium_members"},
             }
         },

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -189,8 +189,8 @@ struct CConsortiumMember
 
 struct CConsortiumMinted
 {
-    CBalances minted;
-    CBalances burnt;
+    CAmount minted;
+    CAmount burnt;
 
     ADD_SERIALIZE_METHODS;
 
@@ -206,11 +206,12 @@ using OracleSplits = std::map<uint32_t, int32_t>;
 using DescendantValue = std::pair<uint32_t, int32_t>;
 using AscendantValue = std::pair<uint32_t, std::string>;
 using CConsortiumMembers = std::map<std::string, CConsortiumMember>;
-using CConsortiumMembersMinted = std::map<std::string, CConsortiumMinted>;
+using CConsortiumMembersMinted = std::map<DCT_ID, std::map<std::string, CConsortiumMinted>>;
+using CConsortiumGlobalMinted = std::map<DCT_ID, CConsortiumMinted>;
 
 using CAttributeType = std::variant<CDataStructureV0>;
 using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CDexBalances, CTokenCurrencyPair, OracleSplits, DescendantValue, AscendantValue,
-                                        CConsortiumMembers, CConsortiumMinted, CConsortiumMembersMinted>;
+                                        CConsortiumMembers, CConsortiumMembersMinted, CConsortiumGlobalMinted>;
 
 class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES>
 {

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -19,12 +19,13 @@ enum VersionTypes : uint8_t {
 };
 
 enum AttributeTypes : uint8_t {
-    Live      = 'l',
-    Oracles   = 'o',
-    Param     = 'a',
-    Token     = 't',
-    Poolpairs = 'p',
-    Locks     = 'L',
+    Live       = 'l',
+    Oracles    = 'o',
+    Param      = 'a',
+    Token      = 't',
+    Poolpairs  = 'p',
+    Locks      = 'L',
+    Consortium = 'c',
 };
 
 enum ParamIDs : uint8_t  {
@@ -74,15 +75,11 @@ enum TokenKeys : uint8_t  {
     Ascendant             = 'm',
     Descendant            = 'n',
     Epitaph               = 'o',
-    ConsortiumMembers     = 'p',
-    ConsortiumMintLimit   = 'q',
 };
 
 enum ConsortiumKeys : uint8_t  {
     Members               = 'a',
     MintLimit             = 'b',
-    MintLimitPerInterval  = 'c',
-
 };
 
 enum PoolKeys : uint8_t {

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -690,7 +690,7 @@ UniValue minttokens(const JSONRPCRequest& request) {
             auto attributes = pcustomcsview->GetAttributes();
             if (attributes)
             {
-                CDataStructureV0 membersKey{AttributeTypes::Token, kv.first.v, TokenKeys::ConsortiumMembers};
+                CDataStructureV0 membersKey{AttributeTypes::Consortium, kv.first.v, ConsortiumKeys::Members};
                 auto members = attributes->GetValue(membersKey, CConsortiumMembers{});
                 for (auto const& member : members)
                     if (IsMineCached(*pwallet, member.second.ownerAddress))

--- a/test/functional/feature_consortium.py
+++ b/test/functional/feature_consortium.py
@@ -99,9 +99,9 @@ class ConsortiumTest (DefiTestFramework):
 
         assert_equal(self.nodes[2].getaccount(account2)[0], '1.00000000@' + symbolBTC)
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('1.00000000'))
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/members' : '{"01":{"name":"test", \
                                                                                                    "ownerAddress":"' + account2 +'", \
@@ -125,12 +125,12 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[2].getaccount(account2), ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE])
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/supply'], Decimal('2.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
@@ -151,12 +151,12 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[2].getaccount(account2), ['1.00000000@' + symbolBTC, '1.00000000@' + symbolDOGE])
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/burnt'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/supply'], Decimal('1.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
@@ -181,12 +181,12 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(account0), ['0.50000000@' + symbolDOGE])
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/supply'], Decimal('0.50000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
@@ -205,12 +205,12 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(account0), [])
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/supply'], Decimal('0.50000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
@@ -254,12 +254,12 @@ class ConsortiumTest (DefiTestFramework):
         self.sync_blocks()
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('9.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('6.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('3.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
-        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/minted'], Decimal('9.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/burnt'], Decimal('6.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/1/supply'], Decimal('3.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium/2/supply'], Decimal('0.50000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('7.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('6.00000000'))
         assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))

--- a/test/functional/feature_consortium.py
+++ b/test/functional/feature_consortium.py
@@ -69,7 +69,7 @@ class ConsortiumTest (DefiTestFramework):
         assert_raises_rpc_error(-5, "Need foundation or consortium member authorization", self.nodes[2].minttokens, ["1@" + symbolBTC])
         assert_raises_rpc_error(-5, "Need foundation or consortium member authorization", self.nodes[2].minttokens, ["1@" + symbolDOGE])
 
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + idBTC + '/consortium_members' : '{"01":{"name":"test", \
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idBTC + '/members' : '{"01":{"name":"test", \
                                                                                                   "ownerAddress":"' + account2 + '", \
                                                                                                   "backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf", \
                                                                                                   "mintLimit":10.00000000}, \
@@ -78,18 +78,18 @@ class ConsortiumTest (DefiTestFramework):
                                                                                                   "backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5", \
                                                                                                   "mintLimit":4.00000000}}'}})
 
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + idBTC + '/consortium_mint_limit' : '1000000000'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idBTC + '/mint_limit' : '1000000000'}})
         self.nodes[0].generate(1)
         self.sync_blocks()
 
-        assert_raises_rpc_error(-32600, "Cannot add a member with an owner address of a existing consortium member", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/' + idBTC + '/consortium_members' : '{"03":{"name":"test", \
+        assert_raises_rpc_error(-32600, "Cannot add a member with an owner address of a existing consortium member", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/' + idBTC + '/members' : '{"03":{"name":"test", \
                                                                                                                                                                 "ownerAddress":"' + account2 +'", \
                                                                                                                                                                 "backingId":"7cb2f6954291d81d2270c9a6a52442b3f8c637b1ec793c731cb5f5a8f7fb9b9d", \
                                                                                                                                                                 "mintLimit":10.00000000}}'}})
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/token/' + idBTC + '/consortium_members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":10.00000000,"status":0},"02":{"name":"test123","ownerAddress":"' + account3 +'","backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5","mintLimit":4.00000000,"status":0}}')
-        assert_equal(attribs['v0/token/' + idBTC + '/consortium_mint_limit'], '1000000000')
+        assert_equal(attribs['v0/consortium/' + idBTC + '/members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":10.00000000,"status":0},"02":{"name":"test123","ownerAddress":"' + account3 +'","backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5","mintLimit":4.00000000,"status":0}}')
+        assert_equal(attribs['v0/consortium/' + idBTC + '/mint_limit'], '1000000000')
 
         assert_raises_rpc_error(-5, "Need foundation or consortium member authorization", self.nodes[2].minttokens, ["1@" + symbolDOGE])
 
@@ -101,20 +101,20 @@ class ConsortiumTest (DefiTestFramework):
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
         assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC'], 'burnt': [], 'supply': ['1.00000000@BTC']})
 
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + idDOGE + '/consortium_members' : '{"01":{"name":"test", \
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/members' : '{"01":{"name":"test", \
                                                                                                    "ownerAddress":"' + account2 +'", \
                                                                                                    "backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf", \
                                                                                                    "mintLimit":5.00000000}}'}})
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + idDOGE + '/consortium_mint_limit' : '600000000'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/mint_limit' : '600000000'}})
         self.nodes[0].generate(1)
         self.sync_blocks()
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/token/' + idBTC + '/consortium_members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":10.00000000,"status":0},"02":{"name":"test123","ownerAddress":"' + account3 +'","backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5","mintLimit":4.00000000,"status":0}}')
-        assert_equal(attribs['v0/token/' + idBTC + '/consortium_mint_limit'], '1000000000')
+        assert_equal(attribs['v0/consortium/' + idBTC + '/members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":10.00000000,"status":0},"02":{"name":"test123","ownerAddress":"' + account3 +'","backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5","mintLimit":4.00000000,"status":0}}')
+        assert_equal(attribs['v0/consortium/' + idBTC + '/mint_limit'], '1000000000')
 
-        assert_equal(attribs['v0/token/' + idDOGE + '/consortium_members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":5.00000000,"status":0}}')
-        assert_equal(attribs['v0/token/' + idDOGE + '/consortium_mint_limit'], '600000000')
+        assert_equal(attribs['v0/consortium/' + idDOGE + '/members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":5.00000000,"status":0}}')
+        assert_equal(attribs['v0/consortium/' + idDOGE + '/mint_limit'], '600000000')
 
         self.nodes[2].minttokens(["2@" + symbolDOGE])
         self.nodes[2].generate(1)
@@ -176,7 +176,7 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC', '2.00000000@DOGE'], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@BTC', '0.50000000@DOGE']})
         assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@' + symbolBTC, '0.50000000@' + symbolDOGE]}})
 
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + idDOGE + '/consortium_members' : '{"01":{"name":"test", \
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/members' : '{"01":{"name":"test", \
                                                                                                    "ownerAddress":"' + account2 +'", \
                                                                                                    "backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf", \
                                                                                                    "mintLimit":5.00000000, \
@@ -185,7 +185,7 @@ class ConsortiumTest (DefiTestFramework):
         self.sync_blocks()
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/token/' + idDOGE + '/consortium_members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":5.00000000,"status":1}}')
+        assert_equal(attribs['v0/consortium/' + idDOGE + '/members'], '{"01":{"name":"test","ownerAddress":"' + account2 +'","backingId":"ebf634ef7143bc5466995a385b842649b2037ea89d04d469bfa5ec29daf7d1cf","mintLimit":5.00000000,"status":1}}')
         assert_equal(self.nodes[0].getburninfo(), {'address': 'mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG', 'amount': Decimal('0E-8'), 'tokens': [], 'consortiumtokens': ['2.00000000@DOGE'], 'feeburn': Decimal('2.00000000'), 'auctionburn': Decimal('0E-8'), 'paybackburn': Decimal('0E-8'), 'dexfeetokens': [], 'dfipaybackfee': Decimal('0E-8'), 'dfipaybacktokens': [], 'paybackfees': [], 'paybacktokens': [], 'emissionburn': Decimal('4831.15500000'), 'dfip2203': []})
 
         assert_raises_rpc_error(-32600, "Cannot mint token, not an active member of consortium for DOGE!", self.nodes[2].minttokens, ["1@" + symbolDOGE])
@@ -218,6 +218,18 @@ class ConsortiumTest (DefiTestFramework):
 
         assert_raises_rpc_error(-32600, "You will exceed your maximum mint limit for " + symbolBTC + " token by minting this amount!", self.nodes[3].minttokens, ["2.00000001@" + symbolBTC])
         assert_raises_rpc_error(-32600, "You will exceed global maximum consortium mint limit for " + symbolBTC + " token by minting this amount!", self.nodes[3].minttokens, ["1.00000001@" + symbolBTC])
+
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idBTC + '/members' : '{"02":{"name":"test123", \
+                                                                                                  "ownerAddress":"' + account3 + '", \
+                                                                                                  "backingId":"6c67fe93cad3d6a4982469a9b6708cdde2364f183d3698d3745f86eeb8ba99d5", \
+                                                                                                  "mintLimit":6.00000000}}'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idBTC + '/mint_limit' : '2000000000'}})
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        self.nodes[3].minttokens(["2@" + symbolBTC])
+        self.nodes[3].generate(1)
+        self.sync_blocks()
 
 if __name__ == '__main__':
     ConsortiumTest().main()

--- a/test/functional/feature_consortium.py
+++ b/test/functional/feature_consortium.py
@@ -99,7 +99,9 @@ class ConsortiumTest (DefiTestFramework):
 
         assert_equal(self.nodes[2].getaccount(account2)[0], '1.00000000@' + symbolBTC)
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC'], 'burnt': [], 'supply': ['1.00000000@BTC']})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/members' : '{"01":{"name":"test", \
                                                                                                    "ownerAddress":"' + account2 +'", \
@@ -123,8 +125,18 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[2].getaccount(account2), ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE])
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC', '2.00000000@DOGE'], 'burnt': [], 'supply': ['1.00000000@BTC', '2.00000000@DOGE']})
-        assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': [], 'supply': ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE]}})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/supply'], Decimal('2.00000000'))
 
         assert_raises_rpc_error(-32600, "You will exceed your maximum mint limit for " + symbolDOGE + " token by minting this amount!", self.nodes[2].minttokens, ["3.00000001@" + symbolDOGE])
 
@@ -139,8 +151,18 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[2].getaccount(account2), ['1.00000000@' + symbolBTC, '1.00000000@' + symbolDOGE])
 
         attribs = self.nodes[2].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC', '2.00000000@DOGE'], 'burnt': ['1.00000000@DOGE'], 'supply': ['1.00000000@BTC', '1.00000000@DOGE']})
-        assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': ['1.00000000@DOGE'], 'supply': ['1.00000000@' + symbolBTC, '1.00000000@' + symbolDOGE]}})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/burnt'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/supply'], Decimal('1.00000000'))
 
         self.nodes[2].accounttoaccount(account2, {account0: "1@" + symbolDOGE})
         self.nodes[2].generate(1)
@@ -159,8 +181,18 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(account0), ['0.50000000@' + symbolDOGE])
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC', '2.00000000@DOGE'], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@BTC', '0.50000000@DOGE']})
-        assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@' + symbolBTC, '0.50000000@' + symbolDOGE]}})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/supply'], Decimal('0.50000000'))
 
         self.nodes[0].burntokens({
             'amounts': "0.5@" + symbolDOGE,
@@ -173,8 +205,18 @@ class ConsortiumTest (DefiTestFramework):
         assert_equal(self.nodes[0].getaccount(account0), [])
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['1.00000000@BTC', '2.00000000@DOGE'], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@BTC', '0.50000000@DOGE']})
-        assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['1.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': ['1.50000000@DOGE'], 'supply': ['1.00000000@' + symbolBTC, '0.50000000@' + symbolDOGE]}})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/supply'], Decimal('0.50000000'))
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/consortium/' + idDOGE + '/members' : '{"01":{"name":"test", \
                                                                                                    "ownerAddress":"' + account2 +'", \
@@ -212,9 +254,21 @@ class ConsortiumTest (DefiTestFramework):
         self.sync_blocks()
 
         attribs = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
-        assert_equal(attribs['v0/live/economy/consortium_minted'], {'minted': ['9.00000000@BTC', '2.00000000@DOGE'], 'burnt': ['6.00000000@BTC', '1.50000000@DOGE'], 'supply': ['3.00000000@BTC', '0.50000000@DOGE']})
-        assert_equal(attribs['v0/live/economy/consortium_members_minted'], {'01': {'minted' : ['7.00000000@' + symbolBTC, '2.00000000@' + symbolDOGE], 'burnt': ['6.00000000@BTC', '1.50000000@DOGE'], 'supply': ['1.00000000@' + symbolBTC, '0.50000000@' + symbolDOGE]},
-                                                                            '02': {'minted' : ['2.00000000@' + symbolBTC], 'burnt': [], 'supply': ['2.00000000@' + symbolBTC]}})
+        assert_equal(attribs['v0/live/economy/consortium_global/1/minted'], Decimal('9.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/burnt'], Decimal('6.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/1/supply'], Decimal('3.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_global/2/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/minted'], Decimal('7.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/burnt'], Decimal('6.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/01/supply'], Decimal('1.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/burnt'], Decimal('1.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/2/01/supply'], Decimal('0.50000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/02/minted'], Decimal('2.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/02/burnt'], Decimal('0.00000000'))
+        assert_equal(attribs['v0/live/economy/consortium_members/1/02/supply'], Decimal('2.00000000'))
 
         assert_raises_rpc_error(-32600, "You will exceed your maximum mint limit for " + symbolBTC + " token by minting this amount!", self.nodes[3].minttokens, ["2.00000001@" + symbolBTC])
         assert_raises_rpc_error(-32600, "You will exceed global maximum consortium mint limit for " + symbolBTC + " token by minting this amount!", self.nodes[3].minttokens, ["1.00000001@" + symbolBTC])

--- a/test/functional/feature_loan_payback_dfi.py
+++ b/test/functional/feature_loan_payback_dfi.py
@@ -144,9 +144,6 @@ class PaybackDFILoanTest (DefiTestFramework):
             'amounts': "1@DFI"
         })
 
-        assert_raises_rpc_error(-5, 'Unrecognised type argument provided, valid types are: locks, oracles, params, poolpairs, token,',
-                                self.nodes[0].setgov, {"ATTRIBUTES":{'v0/live/economy/dfi_payback_tokens':'1'}})
-
         # Disable loan payback
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + iddUSD + '/payback_dfi':'false'}})
         self.nodes[0].generate(1)

--- a/test/functional/feature_loan_payback_dfi_v2.py
+++ b/test/functional/feature_loan_payback_dfi_v2.py
@@ -289,9 +289,6 @@ class PaybackDFILoanTest (DefiTestFramework):
         assert("Payback of loan via DFI token is not currently active" in errorString)
 
     def setgov_attribute_to_false_and_payback(self):
-        assert_raises_rpc_error(-5, 'Unrecognised type argument provided, valid types are: locks, oracles, params, poolpairs, token,',
-                                self.nodes[0].setgov, {"ATTRIBUTES":{'v0/live/economy/dfi_payback_tokens':'1'}})
-
         # Disable loan payback
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/token/' + self.iddUSD + '/payback_dfi':'false'}})
         self.nodes[0].generate(1)

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -444,8 +444,9 @@ class GovsetTest (DefiTestFramework):
         assert_raises_rpc_error(-5, "Unsupported version", self.nodes[0].setgov, {"ATTRIBUTES":{'1/token/15/payback_dfi':'true'}})
         assert_raises_rpc_error(-5, "Empty value", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/15/payback_dfi':''}})
         assert_raises_rpc_error(-5, "Incorrect key for <type>. Object of ['<version>/<type>/ID/<key>','value'] expected", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/payback_dfi':'true'}})
-        assert_raises_rpc_error(-5, "Unrecognised type argument provided, valid types are: locks, oracles, params, poolpairs, token,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/unrecognised/5/payback_dfi':'true'}})
-        assert_raises_rpc_error(-5, "Unrecognised key argument provided, valid keys are: consortium_members, consortium_mint_limit, dex_in_fee_pct, dex_out_fee_pct, dfip2203, fixed_interval_price_id, loan_collateral_enabled, loan_collateral_factor, loan_minting_enabled, loan_minting_interest, loan_payback, loan_payback_fee_pct, payback_dfi, payback_dfi_fee_pct,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/unrecognised':'true'}})
+        assert_raises_rpc_error(-5, "Unrecognised type argument provided, valid types are: consortium, locks, oracles, params, poolpairs, token,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/unrecognised/5/payback_dfi':'true'}})
+        assert_raises_rpc_error(-5, "Unrecognised key argument provided, valid keys are: dex_in_fee_pct, dex_out_fee_pct, dfip2203, fixed_interval_price_id, loan_collateral_enabled, loan_collateral_factor, loan_minting_enabled, loan_minting_interest, loan_payback, loan_payback_fee_pct, payback_dfi, payback_dfi_fee_pct,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/unrecognised':'true'}})
+        assert_raises_rpc_error(-5, "Unrecognised key argument provided, valid keys are: members, mint_limit,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/5/unrecognised':'true'}})
         assert_raises_rpc_error(-5, "Value must be an integer", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/not_a_number/payback_dfi':'true'}})
         assert_raises_rpc_error(-5, 'Boolean value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'not_a_number'}})
         assert_raises_rpc_error(-5, 'Boolean value must be either "true" or "false"', self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/payback_dfi':'unrecognised'}})
@@ -597,11 +598,11 @@ class GovsetTest (DefiTestFramework):
         assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/loan_minting_enabled':'true'}})
         assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/loan_minting_interest':'5.00000000'}})
         assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/locks/token/5':'true'}})
-        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_members' : '{"01":{"name":"test", \
+        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/members' : '{"01":{"name":"test", \
                                                                                                                                                                 "ownerAddress":"' + owner +'", \
                                                                                                                                                                 "backingId":"blablabla", \
                                                                                                                                                                 "mintLimit":10.00000000}}'}})
-        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_mint_limit':'1000000000'}})
+        assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/mint_limit':'1000000000'}})
         assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/oracles/splits/4000': '1/50'}})
         assert_raises_rpc_error(-32600, "ATTRIBUTES: Cannot be set before GreatWorld", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/dfip2203/start_block':'0'}})
 
@@ -633,20 +634,24 @@ class GovsetTest (DefiTestFramework):
         assert_raises_rpc_error(-32600, "Fixed interval price currency pair must be set first", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/loan_minting_interest':'1'}})
         assert_raises_rpc_error(-5, "Unrecognised locks argument provided, valid lockss are: token,", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/locks/oracle/5':'true'}})
         assert_raises_rpc_error(-32600, "No loan token with id (4)", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/locks/token/4':'true'}})
-        assert_raises_rpc_error(-5, "recipient () does not refer to any valid address", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_members' : '{"01":{"name":"test", \
+        assert_raises_rpc_error(-5, "recipient () does not refer to any valid address", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/members' : '{"01":{"name":"test", \
                                                                                                                                                                        "ownerAddress":"", \
                                                                                                                                                                        "backingId":"blablabla", \
                                                                                                                                                                        "mintLimit":10.00000000}}'}})
-        assert_raises_rpc_error(-5, "Not a valid consortium member object", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_members' : '{"01":{"name":"test",} \
+        assert_raises_rpc_error(-3, "Amount out of range", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/members' : '{"01":{"name":"test", \
+                                                                                                                                                       "ownerAddress":"' + owner +'", \
+                                                                                                                                                       "backingId":"blablabla", \
+                                                                                                                                                       "mintLimit":-10.00000000}}'}})
+        assert_raises_rpc_error(-5, "Not a valid consortium member object", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/members' : '{"01":{"name":"test",} \
                                                                                                                                                            "ownerAddress":"' + owner +'", \
                                                                                                                                                            "backingId":"blablabla", \
                                                                                                                                                            "mintLimit":10.00000000}}'}})
-        assert_raises_rpc_error(-5, "Status must be a positive number", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_members' : '{"01":{"name":"test", \
+        assert_raises_rpc_error(-5, "Status must be a positive number", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/members' : '{"01":{"name":"test", \
                                                                                                                                                        "ownerAddress":"' + owner +'", \
                                                                                                                                                        "backingId":"blablabla", \
                                                                                                                                                        "mintLimit":10.00000000, \
                                                                                                                                                        "status":-1}}'}})
-        assert_raises_rpc_error(-5, "Value must be a positive integer", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/4/consortium_mint_limit':'-1'}})
+        assert_raises_rpc_error(-5, "Value must be a positive integer", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/consortium/4/mint_limit':'-1'}})
         assert_raises_rpc_error(-5, "Unrecognised key argument provided", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/ascendant': '1'}})
         assert_raises_rpc_error(-5, "Unrecognised key argument provided", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/descendant': '1'}})
         assert_raises_rpc_error(-5, "Unrecognised key argument provided", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/token/5/epitaph': '1'}})


### PR DESCRIPTION
#### What kind of PR is this?:

/kind refactor

#### What this PR does / why we need it:
Put consortium members in `v0/consortium/<token_id>/...` instead of `v0/token/<token_id>/consortium_members/...`
Also made live economy consortium accounting to be per token: `v0/live/economy/consortium_global/1/minted`
