### PR TITLE
Fix creategovvoc argument parsing

### DIFF
--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -617,7 +617,7 @@ static const CRPCCommand commands[] =
 //  category        name                     actor (function)        params
 //  --------------- ----------------------   ---------------------   ----------
     {"proposals",   "creategovcfp",          &creategovcfp,          {"data", "inputs"} },
-    {"proposals",   "creategovvoc",          &creategovvoc,          {"title", "inputs"} },
+    {"proposals",   "creategovvoc",          &creategovvoc,          {"title", "context", "inputs"} },
     {"proposals",   "votegov",               &votegov,               {"proposalId", "masternodeId", "decision", "inputs"} },
     {"proposals",   "listgovvotes",          &listgovvotes,          {"proposalId", "masternode"} },
     {"proposals",   "getgovproposal",        &getgovproposal,        {"proposalId"} },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -351,7 +351,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
     { "creategovcfp", 0, "data" },
     { "creategovcfp", 1, "inputs" },
-    { "creategovvoc", 1, "inputs" },
+    { "creategovvoc", 2, "inputs" },
     { "votegov", 3, "inputs" },
 };
 // clang-format on


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Fixes creategovvoc argument parsing. Parses context argument as string