### PR TITLE
Add legacy filtering mode

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -644,10 +644,10 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
         if (!attrV0) {
             continue;
         }
-        if (filter == GovVarsFilter::Version2Dot7 && 
+        if (filter == GovVarsFilter::Live && 
             attrV0->type != AttributeTypes::Live) {
                 continue;
-        } else if (filter == GovVarsFilter::) {
+        } else if (filter == GovVarsFilter::Version2Dot7) {
             if (attrV0->type == AttributeTypes::Token && 
             attrsVersion27TokenHiddenSet.find(attrV0->key) != attrsVersion27TokenHiddenSet.end()) 
                 continue;

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -626,7 +626,7 @@ Res ATTRIBUTES::Import(const UniValue & val) {
 // Keys to exclude when using the legacy filter mode, to keep things the 
 // same as pre 2.7.x versions, to reduce noise. Eventually, the APIs that 
 // cause too much noise can be deprecated and this code removed.
-std::set<uint32_t> legacyTokenKeysBlacklist = {
+std::set<uint32_t> attrsVersion27TokenHiddenSet = {
     TokenKeys::LoanCollateralEnabled,
     TokenKeys::LoanCollateralFactor,
     TokenKeys::LoanMintingEnabled,
@@ -644,12 +644,12 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
         if (!attrV0) {
             continue;
         }
-        if (filter == GovVarsFilter::LiveAttributes && 
+        if (filter == GovVarsFilter::Version2Dot7 && 
             attrV0->type != AttributeTypes::Live) {
                 continue;
-        } else if (filter == GovVarsFilter::Legacy) {
+        } else if (filter == GovVarsFilter::) {
             if (attrV0->type == AttributeTypes::Token && 
-            legacyTokenKeysBlacklist.find(attrV0->key) != legacyTokenKeysBlacklist.end()) 
+            attrsVersion27TokenHiddenSet.find(attrV0->key) != attrsVersion27TokenHiddenSet.end()) 
                 continue;
         }
         try {

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -644,7 +644,7 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
         if (!attrV0) {
             continue;
         }
-        if (filter == GovVarsFilter::Live && 
+        if (filter == GovVarsFilter::LiveAttributes && 
             attrV0->type != AttributeTypes::Live) {
                 continue;
         } else if (filter == GovVarsFilter::Version2Dot7) {

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -139,6 +139,7 @@ enum GovVarsFilter {
     Legacy,
     All,
     NoAttributes,
+    AttributesOnly,
     PrefixedAttributes,
     LiveAttributes,
 };

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -136,12 +136,12 @@ using CAttributeType = boost::variant<CDataStructureV0, CDataStructureV1>;
 using CAttributeValue = boost::variant<bool, CAmount, CBalances, CTokenPayback, CTokenCurrencyPair, OracleSplits, DescendantValue, AscendantValue>;
 
 enum GovVarsFilter {
-    Legacy,
     All,
     NoAttributes,
     AttributesOnly,
     PrefixedAttributes,
     LiveAttributes,
+    Version2Dot7,
 };
 
 class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES>

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -722,6 +722,9 @@ UniValue listgovs(const JSONRPCRequest& request) {
             mode = GovVarsFilter::All;
         } else if (prefix == "gov") {
             mode = GovVarsFilter::NoAttributes;
+        } else if (prefix == "attrs") {
+            mode = GovVarsFilter::AttributesOnly;
+
         } else if (prefix == "live") {
             mode = GovVarsFilter::LiveAttributes;
         } else {
@@ -759,7 +762,8 @@ UniValue listgovs(const JSONRPCRequest& request) {
                 }
             } else {
                 if (mode == GovVarsFilter::LiveAttributes || 
-                    mode == GovVarsFilter::PrefixedAttributes) {
+                    mode == GovVarsFilter::PrefixedAttributes ||
+                    mode == GovVarsFilter::AttributesOnly){
                     continue;
                 }
                 val = var->Export();

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -711,28 +711,24 @@ UniValue listgovs(const JSONRPCRequest& request) {
                },
     }.Check(request);
 
-    GovVarsFilter mode;
+    GovVarsFilter mode{GovVarsFilter::Legacy};
     std::string prefix;
     if (request.params.size() > 0) {
         prefix = request.params[0].getValStr();
     }
-    if (prefix.empty()) {
-        prefix = "legacy";
-    }
-
-    if (prefix == "all") {
-        mode = GovVarsFilter::All;
-    } else if (prefix == "legacy") {
-        mode = GovVarsFilter::Legacy;
-    } else if (prefix == "gov") {
-        mode = GovVarsFilter::NoAttributes;
-    } else if (prefix == "live") {
-        mode = GovVarsFilter::LiveAttributes;
-    } else {
-        mode = GovVarsFilter::PrefixedAttributes;
-        const std::regex versionRegex("v[0-9].*");
-        if (!std::regex_match(prefix.begin(), prefix.end(), versionRegex)) {
-            prefix = "v0/" + prefix;
+    if (!prefix.empty()) {
+        if (prefix == "all") {
+            mode = GovVarsFilter::All;
+        } else if (prefix == "gov") {
+            mode = GovVarsFilter::NoAttributes;
+        } else if (prefix == "live") {
+            mode = GovVarsFilter::LiveAttributes;
+        } else {
+            mode = GovVarsFilter::PrefixedAttributes;
+            const std::regex versionRegex("v[0-9].*");
+            if (!std::regex_match(prefix.begin(), prefix.end(), versionRegex)) {
+                prefix = "v0/" + prefix;
+            }
         }
     }
 

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -693,7 +693,7 @@ UniValue listgovs(const JSONRPCRequest& request) {
                "\nReturns information about all governance variables including pending changes\n",
                {
                    {"prefix", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                       "One of all, gov, live. Defaults to the legacy view. Any other string is treated as\n"
+                       "One of all, gov, attrs, live. Defaults to the all view. Any other string is treated as\n"
                        "a prefix of attributes to filter with. `v0/` is assumed if not explicitly provided."},
                },
                RPCResult{
@@ -712,7 +712,7 @@ UniValue listgovs(const JSONRPCRequest& request) {
                },
     }.Check(request);
 
-    GovVarsFilter mode{GovVarsFilter::Legacy};
+    GovVarsFilter mode{GovVarsFilter::All};
     std::string prefix;
     if (request.params.size() > 0) {
         prefix = request.params[0].getValStr();
@@ -724,12 +724,16 @@ UniValue listgovs(const JSONRPCRequest& request) {
             mode = GovVarsFilter::NoAttributes;
         } else if (prefix == "attrs") {
             mode = GovVarsFilter::AttributesOnly;
-
+        } else if (prefix == "v/2.7") {
+            // Undocumented. Make be removed or deprecated without notice. 
+            // Only here for unforeseen compatibility concern downstream
+            // for transitions.
+            mode = GovVarsFilter::Version2Dot7;
         } else if (prefix == "live") {
             mode = GovVarsFilter::LiveAttributes;
         } else {
             mode = GovVarsFilter::PrefixedAttributes;
-            const std::regex versionRegex("v[0-9].*");
+            const std::regex versionRegex("^v[0-9].*");
             if (!std::regex_match(prefix.begin(), prefix.end(), versionRegex)) {
                 prefix = "v0/" + prefix;
             }

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -693,7 +693,8 @@ UniValue listgovs(const JSONRPCRequest& request) {
                "\nReturns information about all governance variables including pending changes\n",
                {
                    {"prefix", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                       "One of all, legacy, gov, live. Any other string is treated as a prefix of attributes to filter with. `v0/` is assumed if not explicitly provided."},
+                       "One of all, gov, live. Defaults to the legacy view. Any other string is treated as\n"
+                       "a prefix of attributes to filter with. `v0/` is assumed if not explicitly provided."},
                },
                RPCResult{
                        "[[{id:{...}},{height:{...}},...], ...]     (array) Json array with JSON objects with variable information\n"

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -620,7 +620,7 @@ class GovsetTest (DefiTestFramework):
         assert_equal(self.nodes[0].listgovs("live"), [[{'ATTRIBUTES': {}}]])
 
         result_all = self.nodes[0].listgovs("all")
-        result_legacy = self.nodes[0].listgovs("legacy")
+        result_legacy = self.nodes[0].listgovs()
         result = self.nodes[0].listgovs()
 
         # For now it's all the same.

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -620,12 +620,13 @@ class GovsetTest (DefiTestFramework):
         assert_equal(self.nodes[0].listgovs("live"), [[{'ATTRIBUTES': {}}]])
 
         result_all = self.nodes[0].listgovs("all")
-        result_legacy = self.nodes[0].listgovs("legacy")
+        result_27 = self.nodes[0].listgovs("v/2.7")
         result = self.nodes[0].listgovs()
 
-        # For now it's all the same.
-        assert_equal(result, result_legacy)
-        # assert_equal(result, result_all)
+        # In this particular test, in the fork period, it's the same.
+        # TODO: Need to add more tests
+        assert_equal(result, result_27)
+        assert_equal(result, result_all)
 
         assert_equal(result, [[{'ICX_TAKERFEE_PER_BTC': Decimal('0.00200000')}], [{'LP_DAILY_LOAN_TOKEN_REWARD': Decimal('13020.86331792')}], [{'LP_LOAN_TOKEN_SPLITS': {'1': Decimal('0.10000000'), '2': Decimal('0.20000000'), '3': Decimal('0.70000000')}}], [{'LP_DAILY_DFI_REWARD': Decimal('13427.10581184')}], [{'LOAN_LIQUIDATION_PENALTY': Decimal('0.01000000')}], [{'LP_SPLITS': {'1': Decimal('0.70000000'), '2': Decimal('0.20000000'), '3': Decimal('0.10000000')}}], [{'ORACLE_BLOCK_INTERVAL': 30}], [{'ORACLE_DEVIATION': Decimal('0.07000000')}], [{'ATTRIBUTES': {'v0/params/dfip2201/active': 'true', 'v0/params/dfip2201/premium': '0.025', 'v0/params/dfip2201/minswap': '0.001', 'v0/params/dfip2203/active': 'true', 'v0/params/dfip2203/reward_pct': '0.05', 'v0/params/dfip2203/block_period': '20160', 'v0/token/5/payback_dfi': 'true', 'v0/token/5/payback_dfi_fee_pct': '0.33', 'v0/token/5/loan_payback/1': 'true', 'v0/token/5/loan_payback/2': 'true', 'v0/token/5/loan_payback_fee_pct/1': '0.25', 'v0/token/5/dex_in_fee_pct': '0.6', 'v0/token/5/dex_out_fee_pct': '0.12', 'v0/token/5/dfip2203': 'true'}}]])
 

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -619,7 +619,7 @@ class GovsetTest (DefiTestFramework):
         # live test. No live on this. For now, just ensure, no other attrs are listed
         assert_equal(self.nodes[0].listgovs("live"), [[{'ATTRIBUTES': {}}]])
 
-        result_all = self.nodes[0].listgovs("all")
+        result_all = self.nodes[0].listgovs("attrs")
         result_legacy = self.nodes[0].listgovs()
         result = self.nodes[0].listgovs()
 

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -619,13 +619,13 @@ class GovsetTest (DefiTestFramework):
         # live test. No live on this. For now, just ensure, no other attrs are listed
         assert_equal(self.nodes[0].listgovs("live"), [[{'ATTRIBUTES': {}}]])
 
-        result_all = self.nodes[0].listgovs("attrs")
-        result_legacy = self.nodes[0].listgovs()
+        result_all = self.nodes[0].listgovs("all")
+        result_legacy = self.nodes[0].listgovs("legacy")
         result = self.nodes[0].listgovs()
 
         # For now it's all the same.
         assert_equal(result, result_legacy)
-        assert_equal(result, result_all)
+        # assert_equal(result, result_all)
 
         assert_equal(result, [[{'ICX_TAKERFEE_PER_BTC': Decimal('0.00200000')}], [{'LP_DAILY_LOAN_TOKEN_REWARD': Decimal('13020.86331792')}], [{'LP_LOAN_TOKEN_SPLITS': {'1': Decimal('0.10000000'), '2': Decimal('0.20000000'), '3': Decimal('0.70000000')}}], [{'LP_DAILY_DFI_REWARD': Decimal('13427.10581184')}], [{'LOAN_LIQUIDATION_PENALTY': Decimal('0.01000000')}], [{'LP_SPLITS': {'1': Decimal('0.70000000'), '2': Decimal('0.20000000'), '3': Decimal('0.10000000')}}], [{'ORACLE_BLOCK_INTERVAL': 30}], [{'ORACLE_DEVIATION': Decimal('0.07000000')}], [{'ATTRIBUTES': {'v0/params/dfip2201/active': 'true', 'v0/params/dfip2201/premium': '0.025', 'v0/params/dfip2201/minswap': '0.001', 'v0/params/dfip2203/active': 'true', 'v0/params/dfip2203/reward_pct': '0.05', 'v0/params/dfip2203/block_period': '20160', 'v0/token/5/payback_dfi': 'true', 'v0/token/5/payback_dfi_fee_pct': '0.33', 'v0/token/5/loan_payback/1': 'true', 'v0/token/5/loan_payback/2': 'true', 'v0/token/5/loan_payback_fee_pct/1': '0.25', 'v0/token/5/dex_in_fee_pct': '0.6', 'v0/token/5/dex_out_fee_pct': '0.12', 'v0/token/5/dfip2203': 'true'}}]])
 

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -253,7 +253,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['destructionHeight'], self.nodes[0].getblockcount())
 
         # Check old token in Gov vars
-        result = self.nodes[0].listgovs()[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/token/{token_id}/fixed_interval_price_id' not in result)
         if collateral:
             assert(f'v0/token/{token_id}/loan_collateral_enabled' not in result)
@@ -316,7 +316,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['rewardLoanPct'], Decimal('0.00000000'))
 
         # Validate old Gov vars removed
-        result = self.nodes[0].listgovs()[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/poolpairs/{pool_id}/token_a_fee_pct' not in result)
         assert(f'v0/poolpairs/{pool_id}/token_b_fee_pct' not in result)
         assert(f'v0/token/{token_id}/dex_in_fee_pct' not in result)
@@ -617,7 +617,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check splits
-        result = self.nodes[0].listgovs()[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert_equal(result[f'v0/oracles/splits/{split_height}'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/500000'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idTSLA}/2,{self.idNVDA}/2,')
@@ -626,7 +626,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check TSLA entries removed
-        result = self.nodes[0].listgovs()[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/oracles/splits/{split_height}' not in result)
         assert(f'v0/oracles/splits/500000' not in result)
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idNVDA}/2,')

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -253,7 +253,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['destructionHeight'], self.nodes[0].getblockcount())
 
         # Check old token in Gov vars
-        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/token/{token_id}/fixed_interval_price_id' not in result)
         if collateral:
             assert(f'v0/token/{token_id}/loan_collateral_enabled' not in result)
@@ -316,7 +316,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['rewardLoanPct'], Decimal('0.00000000'))
 
         # Validate old Gov vars removed
-        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/poolpairs/{pool_id}/token_a_fee_pct' not in result)
         assert(f'v0/poolpairs/{pool_id}/token_b_fee_pct' not in result)
         assert(f'v0/token/{token_id}/dex_in_fee_pct' not in result)
@@ -617,7 +617,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check splits
-        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert_equal(result[f'v0/oracles/splits/{split_height}'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/500000'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idTSLA}/2,{self.idNVDA}/2,')
@@ -626,7 +626,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check TSLA entries removed
-        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
         assert(f'v0/oracles/splits/{split_height}' not in result)
         assert(f'v0/oracles/splits/500000' not in result)
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idNVDA}/2,')

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -253,7 +253,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['destructionHeight'], self.nodes[0].getblockcount())
 
         # Check old token in Gov vars
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
         assert(f'v0/token/{token_id}/fixed_interval_price_id' not in result)
         if collateral:
             assert(f'v0/token/{token_id}/loan_collateral_enabled' not in result)
@@ -316,7 +316,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['rewardLoanPct'], Decimal('0.00000000'))
 
         # Validate old Gov vars removed
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
         assert(f'v0/poolpairs/{pool_id}/token_a_fee_pct' not in result)
         assert(f'v0/poolpairs/{pool_id}/token_b_fee_pct' not in result)
         assert(f'v0/token/{token_id}/dex_in_fee_pct' not in result)
@@ -617,7 +617,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check splits
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
         assert_equal(result[f'v0/oracles/splits/{split_height}'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/500000'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idTSLA}/2,{self.idNVDA}/2,')
@@ -626,7 +626,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check TSLA entries removed
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[8][0]['ATTRIBUTES']
         assert(f'v0/oracles/splits/{split_height}' not in result)
         assert(f'v0/oracles/splits/500000' not in result)
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idNVDA}/2,')

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -253,7 +253,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['destructionHeight'], self.nodes[0].getblockcount())
 
         # Check old token in Gov vars
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[0][0]['ATTRIBUTES']
         assert(f'v0/token/{token_id}/fixed_interval_price_id' not in result)
         if collateral:
             assert(f'v0/token/{token_id}/loan_collateral_enabled' not in result)
@@ -316,7 +316,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['rewardLoanPct'], Decimal('0.00000000'))
 
         # Validate old Gov vars removed
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[0][0]['ATTRIBUTES']
         assert(f'v0/poolpairs/{pool_id}/token_a_fee_pct' not in result)
         assert(f'v0/poolpairs/{pool_id}/token_b_fee_pct' not in result)
         assert(f'v0/token/{token_id}/dex_in_fee_pct' not in result)
@@ -617,7 +617,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check splits
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[0][0]['ATTRIBUTES']
         assert_equal(result[f'v0/oracles/splits/{split_height}'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/500000'], f'{self.idTSLA}/2,')
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idTSLA}/2,{self.idNVDA}/2,')
@@ -626,7 +626,7 @@ class TokenSplitTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check TSLA entries removed
-        result = self.nodes[0].listgovs("all")[8][0]['ATTRIBUTES']
+        result = self.nodes[0].listgovs("attrs")[0][0]['ATTRIBUTES']
         assert(f'v0/oracles/splits/{split_height}' not in result)
         assert(f'v0/oracles/splits/500000' not in result)
         assert_equal(result[f'v0/oracles/splits/1000000'], f'{self.idNVDA}/2,')


### PR DESCRIPTION
/kind feature

- This completes the missing legacy filtering impl to make sure the default output is compatible with previous versions. 
- all / live / gov / <prefix> can be used for the rest. 