### PR TITLE
Add mocknet helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ src/univalue/gen
 # Only ignore unexpected patches
 *.patch
 !depends/patches/**/*.patch
+!contrib/devtools/*.patch
 
 #libtool object files
 *.lo

--- a/contrib/devtools/mocknet.patch
+++ b/contrib/devtools/mocknet.patch
@@ -1,0 +1,38 @@
+diff --git a/src/pos.cpp b/src/pos.cpp
+index 1ad8d066d..01b13b8aa 100644
+--- a/src/pos.cpp
++++ b/src/pos.cpp
+@@ -140,6 +140,11 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, int64_t blockTim
+ 
+     unsigned int nProofOfWorkLimit = UintToArith256(params.pos.diffLimit).GetCompact();
+ 
++    // Lower difficulty fork for mock network testing
++    if (fMockNetwork) {
++        return nProofOfWorkLimit;
++    }
++
+     int nHeight{pindexLast->nHeight + 1};
+     bool newDifficultyAdjust{nHeight > params.EunosHeight};
+ 
+diff --git a/src/version.h b/src/version.h
+index 3ab303d56..fb84cea92 100644
+--- a/src/version.h
++++ b/src/version.h
+@@ -9,7 +9,7 @@
+  * network protocol versioning
+  */
+ 
+-static const int PROTOCOL_VERSION = 70029;
++static const int PROTOCOL_VERSION = 100000;
+ 
+ //! initial proto version, to be increased after version/verack negotiation
+ static const int INIT_PROTO_VERSION = 209;
+@@ -18,7 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
+ static const int GETHEADERS_VERSION = 31800;
+ 
+ //! disconnect from peers older than this proto version
+-static const int MIN_PEER_PROTO_VERSION = 70023;
++static const int MIN_PEER_PROTO_VERSION = 100000;
+ 
+ //! nTime field added to CAddress, starting with this version;
+ //! if possible, avoid requesting addresses nodes older than this

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,7 +21,7 @@
 
 bool fMockNetwork = false;
 std::string sMockFoundationPubKey;
-uint64_t nMockBlockTimeSecs = 8;
+uint64_t nMockBlockTimeSecs = 0;
 
 std::vector<CTransactionRef> CChainParams::CreateGenesisMasternodes()
 {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -19,6 +19,10 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
+bool fMockNetwork = false;
+std::string sMockFoundationPubKey;
+uint64_t nMockBlockTimeSecs = 8;
+
 std::vector<CTransactionRef> CChainParams::CreateGenesisMasternodes()
 {
     std::vector<CTransactionRef> mnTxs;
@@ -325,6 +329,15 @@ public:
             /* nTxCount */ 1091894,
             /* dTxRate  */ 0.1841462153145931
         };
+
+        if (fMockNetwork) {
+            consensus.pos.nTargetSpacing = nMockBlockTimeSecs;
+            consensus.pos.nTargetTimespanV2 = 10 * consensus.pos.nTargetSpacing;
+            // Add additional foundation members here for testing
+            if (!sMockFoundationPubKey.empty()) {
+                consensus.foundationMembers.insert(GetScriptForDestination(DecodeDestination(sMockFoundationPubKey, *this)));
+            }
+        }
     }
 };
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -15,6 +15,12 @@
 #include <memory>
 #include <vector>
 
+
+/** Used for mocking network with low difficulty for testing */
+extern bool fMockNetwork;
+extern std::string sMockFoundationPubKey;
+extern uint64_t nMockBlockTimeSecs;
+
 struct SeedSpec6 {
     uint8_t addr[16];
     uint16_t port;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,7 +375,9 @@ void SetupServerArgs()
 
     // Hidden Options
     std::vector<std::string> hidden_args = {
-        "-dbcrashratio", "-forcecompactdb", "-interrupt-block=<hash|height>", "-stop-block=<hash|height>",
+        "-dbcrashratio", "-forcecompactdb", 
+        "-interrupt-block=<hash|height>", "-stop-block=<hash|height>",
+        "-mocknet", "-mocknet-blocktime=<secs>", "-mocknet-key=<pubkey>"
         // GUI args. These will be overwritten by SetupUIArgs for the GUI
         "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-splash"};
 
@@ -1218,6 +1220,11 @@ bool AppInitParameterInteraction()
     fIsFakeNet = Params().NetworkIDString() == "regtest" && gArgs.GetArg("-dummypos", false);
     CTxOut::SERIALIZE_FORCED_TO_OLD_IN_TESTS = Params().NetworkIDString() == "regtest" && gArgs.GetArg("-txnotokens", false);
 
+    fMockNetwork = gArgs.IsArgSet("-mocknet");
+    if (fMockNetwork) {
+        sMockFoundationPubKey = gArgs.GetArg("-mocknet-key", "");
+        nMockBlockTimeSecs = gArgs.GetArg("-mocknet-blocktime", 10);
+    }
     return true;
 }
 

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,7 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-interrupt-block', '-stop-block'])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-interrupt-block', '-stop-block', '-mocknet', '-mocknet-key', '-mocknet-blocktime'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
/kind feature

Adds the following undocumented flags:

- `-mocknet` - Enables mocked mainnet for testing. Useless without further patch.
- `-mocknet-blocktime=<secs>` - Block time option when mocknet is enabled
- `-mocknet-key=<pubkey>` - Adds an optional foundation key into mocknet for testing. 

Has the patch file: `contrib/devtools/mocknet.patch`. 

- The patch nullifies the difficulty of mocknet, so that it's easier to mine with any MNs that's carried over into mocknet. 
- The patch is technically not required and can just be a part of the main code, as it is gated. However, just to ensure there is no accidental or potential exploit that can utilize it, it is for now kept completely off the main code and carried as an optional patch. 

Procedure for mock testing mainnet:

- `git apply  contrib/devtools/mocknet.patch`
- Change the fork height as desired on chainparams. 
- Start with `-mocknet [-mocknet-blocktime=<secs>] [-mocknet-key="pubkey"]

This allows easier testing, and further automated mocked testing of mainnet. It is possible to fully bake in a MN into mocknet as well, but requires further work. For now, MNs need to carried over. 