### PR TITLE
Fix loan token flag for old token on split

### DIFF
--- a/src/masternodes/tokens.h
+++ b/src/masternodes/tokens.h
@@ -151,7 +151,7 @@ public:
     Res CreateDFIToken();
     ResVal<DCT_ID> CreateToken(CTokenImpl const & token, bool isPreBayfront = false);
     Res RevertCreateToken(uint256 const & txid);
-    Res UpdateToken(CTokenImpl const & newToken, bool isPreBayfront = false, const bool skipNameValidation = false);
+    Res UpdateToken(CTokenImpl const & newToken, bool isPreBayfront = false, const bool tokenSplitUpdatea = false);
 
     Res BayfrontFlagsCleanup();
     Res AddMintedTokens(DCT_ID const & id, CAmount const & amount);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4141,7 +4141,7 @@ void CChainState::ProcessTokenSplits(const CBlock& block, const CBlockIndex* pin
         token->symbol += newTokenSuffix;
         token->destructionHeight = pindex->nHeight;
         token->destructionTx = pindex->GetBlockHash();
-        token->flags &= ~static_cast<uint8_t>(CToken::TokenFlags::Default);
+        token->flags &= ~(static_cast<uint8_t>(CToken::TokenFlags::Default) | static_cast<uint8_t>(CToken::TokenFlags::LoanToken));
         token->flags |= static_cast<uint8_t>(CToken::TokenFlags::Finalized);
 
         res = view.SubMintedTokens(oldTokenId, token->minted);

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -249,6 +249,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['mintable'], False)
         assert_equal(result['tradeable'], False)
         assert_equal(result['finalized'], True)
+        assert_equal(result['isLoanToken'], False)
         assert_equal(result['destructionTx'], self.nodes[0].getbestblockhash())
         assert_equal(result['destructionHeight'], self.nodes[0].getblockcount())
 
@@ -287,6 +288,7 @@ class TokenSplitTest(DefiTestFramework):
         assert_equal(result['mintable'], True)
         assert_equal(result['tradeable'], True)
         assert_equal(result['finalized'], False)
+        assert_equal(result['isLoanToken'], True)
         assert_equal(result['creationTx'], self.nodes[0].getblock(self.nodes[0].getbestblockhash())['tx'][1])
         assert_equal(result['creationHeight'], self.nodes[0].getblockcount())
         assert_equal(result['destructionTx'], '0000000000000000000000000000000000000000000000000000000000000000')


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
After the token split, the old token was still having the loan token flag set. This fix will unset it.
