### PR TITLE
Refactor mocknet and add more params

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -18,8 +18,6 @@
 
 /** Used for mocking network with low difficulty for testing */
 extern bool fMockNetwork;
-extern std::string sMockFoundationPubKey;
-extern uint64_t nMockBlockTimeSecs;
 
 struct SeedSpec6 {
     uint8_t addr[16];


### PR DESCRIPTION
/kind feature

- Better defaults like `maxtipage` and `allowMintingWithoutPeers` for mocknet to ensure it works as expected by default.
- Refactor regtest like fork height validations and utilize it for mocknet. 
- Can now use `-fortcanningcrunchheight=<>`, `-greatworldheight=<>`, etc with mocknet