### PR TITLE
Log fd limits, minor cleanup

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -51,14 +51,6 @@ void CScheduler::serviceQueue()
 
             // Wait until either there is a new task, or until
             // the time of the first item on the queue:
-
-// wait_until needs boost 1.50 or later; older versions have timed_wait:
-#if BOOST_VERSION < 105000
-            while (!shouldStop() && !taskQueue.empty() &&
-                   newTaskScheduled.timed_wait(lock, toPosixTime(taskQueue.begin()->first))) {
-                // Keep waiting until timeout
-            }
-#else
             // Some boost versions have a conflicting overload of wait_until that returns void.
             // Explicitly use a template here to avoid hitting that overload.
             while (!shouldStop() && !taskQueue.empty()) {
@@ -66,7 +58,6 @@ void CScheduler::serviceQueue()
                 if (newTaskScheduled.wait_until<>(lock, timeToWaitFor) == boost::cv_status::timeout)
                     break; // Exit loop after timeout, it means we reached the time of the event
             }
-#endif
             // If there are multiple threads, the queue can empty while we're waiting (another
             // thread may service the task we were waiting on).
             if (shouldStop() || taskQueue.empty())

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1058,8 +1058,11 @@ int RaiseFileDescriptorLimit(int nMinFD) {
             setrlimit(RLIMIT_NOFILE, &limitFD);
             getrlimit(RLIMIT_NOFILE, &limitFD);
         }
+        LogPrintf("conf: fd limit: req: %d, set %d, max: %d\n",
+            nMinFD, limitFD.rlim_cur, limitFD.rlim_max);
         return limitFD.rlim_cur;
     }
+    LogPrintf("conf: fd limit: %d, max: unknown\n", nMinFD);
     return nMinFD; // getrlimit failed, assume it's fine
 #endif
 }

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -57,6 +57,6 @@ static void SetInternalName(std::string name) { }
 
 void util::ThreadRename(std::string&& name)
 {
-    SetThreadName(("defi-" + name).c_str());
+    SetThreadName(("defid-" + name).c_str());
     SetInternalName(std::move(name));
 }


### PR DESCRIPTION
/kind chore

- Log fd limits. This could be a key reason for the IO failures. Would be helpful to have these in the logs to corelate investigations. 
- Remove old boost code branch
- Use thread rename prefix as `defid` so process search matches for defid still succeeds (eg: ps without -af doesn't search exe path and will result in failure for defid)
