### PR TITLE
Return -1 value on getvault when tokens are locked

### DIFF
--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -1,4 +1,3 @@
-#include "masternodes/masternodes.h"
 #include <masternodes/accountshistory.h>
 #include <masternodes/auctionhistory.h>
 #include <masternodes/mn_rpc.h>

--- a/test/functional/feature_token_lock.py
+++ b/test/functional/feature_token_lock.py
@@ -266,13 +266,13 @@ class TokenLockTest(DefiTestFramework):
         assert_raises_rpc_error(-32600, "Cannot take loan while any of the asset's price in the vault is not live", self.nodes[0].takeloan, {'vaultId': self.vault, 'amounts': f'1@{self.symbolTSLA}'})
         assert_raises_rpc_error(-32600, "Cannot take loan while any of the asset's price in the vault is not live", self.nodes[0].takeloan, {'vaultId': self.vault, 'amounts': f'1@{self.symbolGOOGL}'})
 
-        # Vault amounts should be zero while token locked
+        # Vault amounts should be -1 while token locked
         result = self.nodes[0].getvault(self.vault)
-        assert_equal(result['collateralValue'], 0)
-        assert_equal(result['loanValue'], 0)
-        assert_equal(result['interestValue'], Decimal('0.00000000'))
-        assert_equal(result['informativeRatio'], 0)
-        assert_equal(result['collateralRatio'], 0)
+        assert_equal(result['collateralValue'], -1)
+        assert_equal(result['loanValue'], -1)
+        assert_equal(result['interestValue'], -1)
+        assert_equal(result['informativeRatio'], -1)
+        assert_equal(result['collateralRatio'], -1)
 
         # Deposit to vault should fail
         assert_raises_rpc_error(-32600, "Fixed interval price currently disabled due to locked token", self.nodes[0].deposittovault, self.vault, self.address, f'100000@{self.symbolDUSD}')

--- a/test/functional/feature_token_split_usd_value.py
+++ b/test/functional/feature_token_split_usd_value.py
@@ -167,7 +167,6 @@ class TokenSplitUSDValueTest(DefiTestFramework):
         self.nodes[0].generate(10)
 
     def split(self, tokenId, keepLocked=False, oracleSplit=False, multiplier=2):
-        tokenSymbol = self.get_token_symbol_from_id(tokenId)
         self.nodes[0].setgov({"ATTRIBUTES":{f'v0/locks/token/{tokenId}':'true'}})
         self.nodes[0].generate(1)
 


### PR DESCRIPTION
#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:

Make `getvault` return -1 values instead of 0 when any of the tokens in the vault is frozen.

Added functional tests.
