### PR TITLE
Verbose flag to getvault to get nextCollateralRatio

### DIFF
--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -184,8 +184,10 @@ namespace {
         if (verbose) {
             useNextPrice = true;
             auto rate = pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height + 1, blockTime, useNextPrice, requireLivePrice);
-            nextCollateralRatio = int(rate.val->ratio());
-            result.pushKV("nextCollateralRatio", nextCollateralRatio);
+            if (rate) {
+                nextCollateralRatio = int(rate.val->ratio());
+                result.pushKV("nextCollateralRatio", nextCollateralRatio);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Add tests for nextCollateralRatio

<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind feature

#### What this PR does / why we need it:

Add optional verbose flag to `getvault` rpc to retrieve nextCollateralRatio.

Add tests.