### PR TITLE
Interest per block value and amounts on getvault

### DIFF
--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -158,6 +158,7 @@ namespace {
             TAmounts totalBalances{};
             TAmounts interestBalances{};
             CAmount totalInterests{0};
+            CAmount totalInterestsPerBlock{0};
             TAmounts interestsPerBlock{};
 
             for (const auto& loan : loanTokens->balances) {

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -187,7 +187,7 @@ namespace {
             interestValue = ValueFromAmount(totalInterests);
             loanBalances = AmountsToJSON(totalBalances);
             interestAmounts = AmountsToJSON(interestBalances);
-            if(verbose) {
+            if (verbose) {
                 interestsPerBlockBalances = AmountsToJSON(interestsPerBlock);
                 totalInterestsPerBlockValue = ValueFromAmount(totalInterestsPerBlock);
             }

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -123,7 +123,7 @@ namespace {
             return result;
         }
 
-        UniValue ratioValue{0}, collValue{0}, loanValue{0}, interestValue{0}, collateralRatio{0}, nextCollateralRatio{0};
+        UniValue ratioValue{0}, collValue{0}, loanValue{0}, interestValue{0}, collateralRatio{0}, nextCollateralRatio{0}, totalInterestsPerBlockValue{0};
 
         auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
         if (!collaterals)
@@ -152,11 +152,13 @@ namespace {
 
         UniValue loanBalances{UniValue::VARR};
         UniValue interestAmounts{UniValue::VARR};
+        UniValue interestsPerBlockBalances{UniValue::VARR};
 
         if (auto loanTokens = pcustomcsview->GetLoanTokens(vaultId)) {
             TAmounts totalBalances{};
             TAmounts interestBalances{};
             CAmount totalInterests{0};
+            TAmounts interestsPerBlock{};
 
             for (const auto& loan : loanTokens->balances) {
                 auto token = pcustomcsview->GetLoanTokenByID(loan.first);
@@ -169,7 +171,13 @@ namespace {
                 if (auto priceFeed = pcustomcsview->GetFixedIntervalPrice(token->fixedIntervalPriceId)) {
                     auto price = priceFeed.val->priceRecord[0];
                     totalInterests += MultiplyAmounts(price, totalInterest);
+                    if (verbose) {
+                        auto interestPerBlock = rate->interestPerBlock.GetLow64();
+                        interestsPerBlock.insert({loan.first, interestPerBlock});
+                        totalInterestsPerBlock += MultiplyAmounts(price, static_cast<CAmount>(interestPerBlock));
+                    }
                 }
+
                 totalBalances.insert({loan.first, value});
                 interestBalances.insert({loan.first, totalInterest});
                 if (pcustomcsview->AreTokensLocked({loan.first.v})){
@@ -179,6 +187,10 @@ namespace {
             interestValue = ValueFromAmount(totalInterests);
             loanBalances = AmountsToJSON(totalBalances);
             interestAmounts = AmountsToJSON(interestBalances);
+            if(verbose) {
+                interestsPerBlockBalances = AmountsToJSON(interestsPerBlock);
+                totalInterestsPerBlockValue = ValueFromAmount(totalInterestsPerBlock);
+            }
         }
 
         result.pushKV("vaultId", vaultId.GetHex());
@@ -194,6 +206,7 @@ namespace {
             interestValue = -1;
             ratioValue = -1;
             collateralRatio = -1;
+            totalInterestsPerBlockValue = -1;
         }
         result.pushKV("collateralValue", collValue);
         result.pushKV("loanValue", loanValue);
@@ -207,6 +220,8 @@ namespace {
                 nextCollateralRatio = int(rate.val->ratio());
                 result.pushKV("nextCollateralRatio", nextCollateralRatio);
             }
+            result.pushKV("totalInterestPerBlockValue", totalInterestsPerBlockValue);
+            result.pushKV("interestPerBlock", interestsPerBlockBalances);
         }
         return result;
     }

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -221,8 +221,8 @@ namespace {
                 nextCollateralRatio = int(rate.val->ratio());
                 result.pushKV("nextCollateralRatio", nextCollateralRatio);
             }
-            result.pushKV("totalInterestPerBlockValue", totalInterestsPerBlockValue);
-            result.pushKV("interestPerBlock", interestsPerBlockBalances);
+            result.pushKV("interestPerBlockValue", totalInterestsPerBlockValue);
+            result.pushKV("interestsPerBlock", interestsPerBlockBalances);
         }
         return result;
     }

--- a/test/functional/feature_loan_priceupdate.py
+++ b/test/functional/feature_loan_priceupdate.py
@@ -325,7 +325,7 @@ class PriceUpdateTest (DefiTestFramework):
         vaultBeforeUpdate = self.nodes[0].getvault(vaultId1, True)
         assert_equal(vaultBeforeUpdate["collateralRatio"], 2375)
         assert_equal(vaultBeforeUpdate["nextCollateralRatio"], 3213)
-        interestPerBlockTSLA = vaultBeforeUpdate["interestPerBlock"][0].split('@')[0]
+        interestPerBlockTSLA = vaultBeforeUpdate["interestsPerBlock"][0].split('@')[0]
         amountInterestTSLA = vaultBeforeUpdate["interestAmounts"][0].split('@')[0]
         self.nodes[0].generate(1)
         vaultBeforeUpdate = self.nodes[0].getvault(vaultId1, True)
@@ -338,7 +338,7 @@ class PriceUpdateTest (DefiTestFramework):
         vaultAfterUpdate = self.nodes[0].getvault(vaultId1, True)
         assert_equal(vaultAfterUpdate["collateralRatio"], vaultBeforeUpdate["nextCollateralRatio"])
         assert_equal(vaultAfterUpdate["nextCollateralRatio"], 3213)
-        interestPerBlockTSLA = vaultAfterUpdate["interestPerBlock"][0].split('@')[0]
+        interestPerBlockTSLA = vaultAfterUpdate["interestsPerBlock"][0].split('@')[0]
         amountInterestTSLA = vaultAfterUpdate["interestAmounts"][0].split('@')[0]
         self.nodes[0].generate(1)
         vaultAfterUpdate = self.nodes[0].getvault(vaultId1, True)

--- a/test/functional/feature_loan_priceupdate.py
+++ b/test/functional/feature_loan_priceupdate.py
@@ -325,13 +325,26 @@ class PriceUpdateTest (DefiTestFramework):
         vaultBeforeUpdate = self.nodes[0].getvault(vaultId1, True)
         assert_equal(vaultBeforeUpdate["collateralRatio"], 2375)
         assert_equal(vaultBeforeUpdate["nextCollateralRatio"], 3213)
-
+        interestPerBlockTSLA = vaultBeforeUpdate["interestPerBlock"][0].split('@')[0]
+        amountInterestTSLA = vaultBeforeUpdate["interestAmounts"][0].split('@')[0]
+        self.nodes[0].generate(1)
+        vaultBeforeUpdate = self.nodes[0].getvault(vaultId1, True)
+        expectedInterestAfterOneBlock = Decimal(amountInterestTSLA) + Decimal(interestPerBlockTSLA)
+        realInteresAfterOneBlock = Decimal(vaultBeforeUpdate["interestAmounts"][0].split('@')[0])
+        assert_equal(realInteresAfterOneBlock, expectedInterestAfterOneBlock)
         # Let price update and check vault again
-        self.nodes[0].generate(6)
+        self.nodes[0].generate(5)
 
         vaultAfterUpdate = self.nodes[0].getvault(vaultId1, True)
         assert_equal(vaultAfterUpdate["collateralRatio"], vaultBeforeUpdate["nextCollateralRatio"])
         assert_equal(vaultAfterUpdate["nextCollateralRatio"], 3213)
+        interestPerBlockTSLA = vaultAfterUpdate["interestPerBlock"][0].split('@')[0]
+        amountInterestTSLA = vaultAfterUpdate["interestAmounts"][0].split('@')[0]
+        self.nodes[0].generate(1)
+        vaultAfterUpdate = self.nodes[0].getvault(vaultId1, True)
+        expectedInterestAfterOneBlock = Decimal(amountInterestTSLA) + Decimal(interestPerBlockTSLA)
+        realInteresAfterOneBlock = Decimal(vaultAfterUpdate["interestAmounts"][0].split('@')[0])
+        assert_equal(realInteresAfterOneBlock, expectedInterestAfterOneBlock)
 
 if __name__ == '__main__':
     PriceUpdateTest().main()

--- a/test/functional/feature_token_lock.py
+++ b/test/functional/feature_token_lock.py
@@ -279,8 +279,8 @@ class TokenLockTest(DefiTestFramework):
         assert_equal(result['interestValue'], -1)
         assert_equal(result['informativeRatio'], -1)
         assert_equal(result['collateralRatio'], -1)
-        assert_equal(result['totalInterestPerBlockValue'], -1)
-        assert_equal(result['interestPerBlock'], [])
+        assert_equal(result['interestPerBlockValue'], -1)
+        assert_equal(result['interestsPerBlock'], [])
 
         # Deposit to vault should fail
         assert_raises_rpc_error(-32600, "Fixed interval price currently disabled due to locked token", self.nodes[0].deposittovault, self.vault, self.address, f'100000@{self.symbolDUSD}')

--- a/test/functional/feature_token_lock.py
+++ b/test/functional/feature_token_lock.py
@@ -273,6 +273,14 @@ class TokenLockTest(DefiTestFramework):
         assert_equal(result['interestValue'], -1)
         assert_equal(result['informativeRatio'], -1)
         assert_equal(result['collateralRatio'], -1)
+        result = self.nodes[0].getvault(self.vault, True)
+        assert_equal(result['collateralValue'], -1)
+        assert_equal(result['loanValue'], -1)
+        assert_equal(result['interestValue'], -1)
+        assert_equal(result['informativeRatio'], -1)
+        assert_equal(result['collateralRatio'], -1)
+        assert_equal(result['totalInterestPerBlockValue'], -1)
+        assert_equal(result['interestPerBlock'], [])
 
         # Deposit to vault should fail
         assert_raises_rpc_error(-32600, "Fixed interval price currently disabled due to locked token", self.nodes[0].deposittovault, self.vault, self.address, f'100000@{self.symbolDUSD}')


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind feature

#### What this PR does / why we need it:
Add interest per block amounts for `getvault` and total value of interests per block in usd.

Tests added.