### PR TITLE
Improve mocknet simulation params

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -998,10 +998,10 @@ void CMainParams::UpdateActivationParametersFromArgs() {
             consensus.foundationMembers.insert(GetScriptForDestination(DecodeDestination(sMockFoundationPubKey, *this)));
             LogPrintf("mocknet: key: %s\n", sMockFoundationPubKey);
         }
-    }
 
-    // Do this at the end, to ensure simualte mainnet overrides are in place.
-    SetupCommonArgActivationParams(consensus);
+        // Do this at the end, to ensure simualte mainnet overrides are in place.
+        SetupCommonArgActivationParams(consensus);
+    }
 }
 
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -968,6 +968,8 @@ void SetupCommonArgActivationParams(Consensus::Params &consensus) {
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
         consensus.pos.nTargetSpacing = 30; // seconds
         consensus.pos.nTargetTimespanV2 = 1008 * consensus.pos.nTargetSpacing; // 1008 blocks
+        LogPrintf("conf: simulatemainnet: true (Re-adjusted: blocktime=%ds, difficultytimespan=%ds)\n",
+            consensus.pos.nTargetSpacing, consensus.pos.nTargetTimespanV2);
     }
 }
 
@@ -979,7 +981,7 @@ void CMainParams::UpdateActivationParametersFromArgs() {
         LogPrintf("WARNING: MOCKNET ACTIVE. THIS IS NOT MAINNET\n");
         LogPrintf("============================================\n");
         auto sMockFoundationPubKey = gArgs.GetArg("-mocknet-key", "");
-        auto nMockBlockTimeSecs = gArgs.GetArg("-mocknet-blocktime", 10);
+        auto nMockBlockTimeSecs = gArgs.GetArg("-mocknet-blocktime", 30);
         if (!gArgs.IsArgSet("-maxtipage")) {
             gArgs.ForceSetArg("-maxtipage", "2207520000"); // 10 years
         }
@@ -989,8 +991,6 @@ void CMainParams::UpdateActivationParametersFromArgs() {
         consensus.pos.nTargetTimespanV2 = 10 * consensus.pos.nTargetSpacing;
         consensus.pos.allowMintingWithoutPeers = true;
 
-        SetupCommonArgActivationParams(consensus);
-
         LogPrintf("mocknet: block-time: %s secs\n", consensus.pos.nTargetSpacing);
 
         // Add additional foundation members here for testing
@@ -999,6 +999,9 @@ void CMainParams::UpdateActivationParametersFromArgs() {
             LogPrintf("mocknet: key: %s\n", sMockFoundationPubKey);
         }
     }
+
+    // Do this at the end, to ensure simualte mainnet overrides are in place.
+    SetupCommonArgActivationParams(consensus);
 }
 
 


### PR DESCRIPTION
/kind chore

- Improvement mocknet parameters, and to better simulate mainnet. 
- This avoids things like interest rate changing in mocknet when proper simulation parameters are applied.  