### PR TITLE
Fix interest rate string on logs, minor refactor

### DIFF
--- a/src/masternodes/loan.cpp
+++ b/src/masternodes/loan.cpp
@@ -476,7 +476,7 @@ CAmount CLoanView::GetLoanLiquidationPenalty()
     return 5 * COIN / 100;
 }
 
-boost::optional<std::string> GetInterestPerBlockHighPrecisionString(const base_uint<128>& value) {
+boost::optional<std::string> TryGetInterestPerBlockHighPrecisionString(const base_uint<128>& value) {
     struct HighPrecisionInterestValue {
         typedef boost::multiprecision::int128_t int128;
         typedef int64_t int64;
@@ -518,4 +518,13 @@ boost::optional<std::string> GetInterestPerBlockHighPrecisionString(const base_u
         }
     };
     return HighPrecisionInterestValue(value).GetInterestPerBlockString();
+}
+
+std::string GetInterestPerBlockHighPrecisionString(const base_uint<128>& value) {
+    auto res = TryGetInterestPerBlockHighPrecisionString(value);
+    if (!res) {
+        LogPrintf("WARNING: High precision interest string conversion failure. Falling back to hex.\n");
+        return value.ToString();
+    }
+    return *res;
 }

--- a/src/masternodes/loan.h
+++ b/src/masternodes/loan.h
@@ -266,7 +266,9 @@ CAmount TotalInterest(const CInterestRateV2& rate, uint32_t height);
 CAmount InterestPerBlock(const CInterestRateV2& rate, uint32_t height);
 base_uint<128> TotalInterestCalculation(const CInterestRateV2& rate, uint32_t height);
 CAmount CeilInterest(const base_uint<128>& value, uint32_t height);
-boost::optional<std::string> GetInterestPerBlockHighPrecisionString(const base_uint<128>& value);
+
+std::string GetInterestPerBlockHighPrecisionString(const base_uint<128>& value);
+boost::optional<std::string> TryGetInterestPerBlockHighPrecisionString(const base_uint<128>& value);
 
 base_uint<128> InterestPerBlockCalculationV2(CAmount amount, CAmount tokenInterest, CAmount schemeInterest);
 

--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -1462,13 +1462,7 @@ UniValue getinterest(const JSONRPCRequest& request) {
         obj.pushKV("interestPerBlock", ValueFromAmount(CeilInterest(interestPerBlock, height)));
         if (height >= Params().GetConsensus().FortCanningHillHeight)
         {
-            auto realizedInterestStr = GetInterestPerBlockHighPrecisionString(interestPerBlock);
-            // Ideally would be better to have a universal graceful shutdown methodology to force the node to
-            // stop for these unexpected state errors that violate operating params but still not enough
-            // memory inconsistency to crash risking wallet and data corruption.
-            if (!realizedInterestStr)
-                throw JSONRPCError(RPC_MISC_ERROR, "Invalid GetInterestPerBlockHighPrecisionString.");
-            obj.pushKV("realizedInterestPerBlock", UniValue(UniValue::VNUM, *realizedInterestStr));
+            obj.pushKV("realizedInterestPerBlock", UniValue(UniValue::VNUM, GetInterestPerBlockHighPrecisionString(interestPerBlock)));
         }
         ret.push_back(obj);
     }

--- a/src/test/loan_tests.cpp
+++ b/src/test/loan_tests.cpp
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(high_precision_interest_rate_to_string_tests)
         else if (typeKind == 1) input = base_uint<128>(boost::get<std::string>(key));
         else BOOST_TEST_FAIL("unknown type");
 
-        auto res = GetInterestPerBlockHighPrecisionString(input);
+        auto res = TryGetInterestPerBlockHighPrecisionString(input);
         if (!res) BOOST_TEST_FAIL("negatives detected");
         BOOST_CHECK_EQUAL(*res, expectedResult);
     }
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(high_precision_interest_rate_to_string_tests)
     // for (auto n = 0; n < 128; n++) {
     //     nums.push_back(i);
     //     std::cout << " { \"" << i.GetHex() << "\", \"";
-    //     std::cout << GetInterestPerBlockHighPrecisionString(i);
+    //     std::cout << TryGetInterestPerBlockHighPrecisionString(i);
     //     std::cout << "\" }," << std::endl;
     //     i = i >> 1;
     // }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4294,22 +4294,12 @@ static Res VaultSplits(CCustomCSView& view, ATTRIBUTES& attributes, const DCT_ID
         }
 
         if (LogAcceptCategory(BCLog::TOKEN_SPLIT)) {
-            auto s1 = GetInterestPerBlockHighPrecisionString(oldInterestPerBlock);
-            auto s2 = GetInterestPerBlockHighPrecisionString(newInterestRatePerBlock);
-            std::string s1Str;
-            std::string s2Str;
-            if (s1 && s2) {
-                s1Str = *s1;
-                s2Str = *s2;
-            }
-            else {
-                s1Str = oldInterestPerBlock.ToString();
-                s2Str = newInterestRatePerBlock.ToString();
-                LogPrint(BCLog::TOKEN_SPLIT, "WARNING: TokenSplit GetInterestPerBlockHighPrecisionString failed\n");
-            }
             LogPrint(BCLog::TOKEN_SPLIT, "TokenSplit: V Interest (%s: %s => %s, %s => %s)\n",
-                vaultId.ToString(), oldRateToHeight.ToString(), newRateToHeight.ToString(),
-                s1Str, s2Str);
+                vaultId.ToString(),
+                GetInterestPerBlockHighPrecisionString(oldRateToHeight),
+                GetInterestPerBlockHighPrecisionString(newRateToHeight),
+                GetInterestPerBlockHighPrecisionString(oldInterestPerBlock),
+                GetInterestPerBlockHighPrecisionString(newInterestRatePerBlock));
         }
 
         view.WriteInterestRate(std::make_pair(vaultId, newTokenId), rate, rate.height);


### PR DESCRIPTION
/kind fix

- Break `GetInterestPerBlockHighPrecisionString` into a fallible `TryGetInterestPerBlockHighPrecisionString` and infallible method, with a fallback string to Hex. 
- Infallible ones are preferred in the consensus path. 