### PR TITLE
Add -checkpoints-file flag to defid

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1073,7 +1073,7 @@ void ClearCheckpoints(CChainParams &params) {
 Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName) {
     std::ifstream file(fileName);
     if (!file.good()) {
-        return Res::Err("File \"%s\" does not exist.", fileName);
+        return Res::Err("Could not read %s. Ensure it exists and has read permissions", fileName);
     }
 
     ClearCheckpoints(params);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1091,10 +1091,8 @@ Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName)
             return Res::Err("Invalid hash: %s", hashStr);
         }
 
-        int height;
-        try {
-            height = std::stoi(heightStr);
-        } catch (...) {
+        int32_t height;
+        if (!ParseInt32(heightStr, &height)) {
             return Res::Err("Invalid height: %s", heightStr);
         }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1080,12 +1080,14 @@ Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName)
 
     std::string line;
     while (std::getline(file, line)) {
-        if (line.empty() || line.rfind('#', 0) == 0) continue;
+        auto trimmed = trim_ws(line);
+        if (trimmed.rfind('#', 0) == 0 || trimmed.find_first_not_of(" \n\r\t") == std::string::npos)
+            continue;
 
-        std::istringstream iss(line);
+        std::istringstream iss(trimmed);
         std::string hashStr, heightStr;
         if (!(iss >> heightStr >> hashStr)) {
-            return Res::Err("Error parsing line %s", line);
+            return Res::Err("Error parsing line %s", trimmed);
         }
 
         uint256 hash;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1080,6 +1080,8 @@ Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName)
 
     std::string line;
     while (std::getline(file, line)) {
+        if (line.empty() || line.rfind('#', 0) == 0) continue;
+
         std::istringstream iss(line);
         std::string hashStr, heightStr;
         if (!(iss >> heightStr >> hashStr)) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -123,6 +123,7 @@ protected:
     std::set<CKeyID> genesisTeam;
 
     friend void ClearCheckpoints(CChainParams &params);
+    friend Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName);
 };
 
 const auto SMART_CONTRACT_DFIP_2201 = "DFIP2201";

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -8,24 +8,13 @@
 #include <chainparams.h> // Params()
 #include <core_io.h>
 #include <primitives/transaction.h>
+#include <util/strencodings.h>
 
 #include <univalue.h>
 
 const DCT_ID CTokensView::DCT_ID_START = DCT_ID{128};
 
 extern const std::string CURRENCY_UNIT;
-
-std::string trim_ws(std::string const & str)
-{
-    std::string const ws = " \n\r\t";
-    size_t first = str.find_first_not_of(ws);
-    if (std::string::npos == first)
-    {
-        return str;
-    }
-    size_t last = str.find_last_not_of(ws);
-    return str.substr(first, (last - first + 1));
-}
 
 std::optional<CTokensView::CTokenImpl> CTokensView::GetToken(DCT_ID id) const
 {

--- a/src/masternodes/tokens.h
+++ b/src/masternodes/tokens.h
@@ -16,8 +16,6 @@
 class CTransaction;
 class UniValue;
 
-std::string trim_ws(std::string const & str);
-
 class CToken
 {
 public:

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -566,3 +566,15 @@ std::string Capitalize(std::string str)
     str[0] = ToUpper(str.front());
     return str;
 }
+
+std::string trim_ws(std::string const & str)
+{
+    std::string const ws = " \n\r\t";
+    size_t first = str.find_first_not_of(ws);
+    if (std::string::npos == first)
+    {
+        return str;
+    }
+    size_t last = str.find_last_not_of(ws);
+    return str.substr(first, (last - first + 1));
+}

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -39,6 +39,7 @@ std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);
+std::string trim_ws(std::string const & str);
 /* Returns true if each character in str is a hex character, and has an even
  * number of hex digits.*/
 bool IsHex(const std::string& str);

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,7 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-interrupt-block', '-stop-block', '-mocknet', '-mocknet-key', '-mocknet-blocktime'])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-interrupt-block', '-stop-block', '-mocknet', '-mocknet-key', '-mocknet-blocktime', '-checkpoints-file'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

Add -checkpoint-file=<file_path> flag to overwrite chainparams checkpoints.

To reduce defid datadir memory usage, the prune option is limited as it only prunes bitcoin related data.
Checkpoints are hardcoded in chainparams but some blocks segment are still reaching high memory usage. (50GiB around 800k blocks mark).
This PR let's a user add additional checkpoint to reduce resources usage.

The checkpoints file should be formatted as `height blockhash`
`checkpoints_file.txt` example :
```
50000 a45e6bf6ae858a287eb39021ea23880b4115c94e882e2b7c0fcfc98c317922cd
100000 3acd556dbd5e6e75bf463a15eeeeb54b6eab4a1f28039bdc343cc8c851cce45c
150000 46b231d42e5b002852708d48dec119bbc2d550fb67908f1e9f35102c1b45b94d
200000 414076e74894aaed3e1b52d64937f23289d59fe80e287c328a1281398bf9cb31
250000 d50a44503fa55cd01a78b98dea125e63b65aac720c96cca696857722e8149d77
300000 351c82cb8f77fba73e24223a9dd50954630560602c3a38f4d1c03dfa5cf1fd10
350000 ebc8737cb2caa77397f446e9a5aff72a2ca9e8305a6a6f8eb4b6c22f389bef08
400000 97c1014a66c9f327e04a59b3e1b4f551122d0698b6b1a98ec99555fffb474e9d
450000 03701a440b02d61b875ba2503bb53f1f1360cf66b4f0cf472e660a6809534379
500000 6a5b285bc68362deb66148069f55f82c02974056e73f5cc96971f7661ecd5880
550000 3f9aab70727d3cc76a3d406f520a71ccc6095aeea2d185e489f563320d429d5b
600000 79ddf4537e40cb59335a0551e5edc7bd396e6949aa2864c3200ca66f9c455405
650000 f18d64dd75c53590e833d3068132a65644963d5c5aebb4c73d42cbde8dc28d68
700000 0d0f779d7f43cc3fd9f01e71e136f7e9319d73791f8839720ab495327075e272
750000 d65c1f983b015ad665b2db9a206e2a7a0e8c51789918ea5bfda2f8121adc6f0f
800000 8d9ade23a54f16a0a5a6ce5d14788f93bfd7e703be8a3a07a85c935b47511f95
850000 2d7d58ae18a74f73b9836a8fffd3f65ce409536e654a6c644ce735215238a004
900000 02818c71fe7d8bcba7c778a73832a7e7b6603a8537bf61915ace497d2b0dec40
950000 51f243157205fb88f7cf5fe31cca7754f1b701c4482e9d43231cddcf931dc617
1000000 253d7137cfcda8d63e5f352ce1162c51a263dba6f9cad7a52f93308c91f04301
1050000 59df07db6d89dd1ea567dcbef1a605e434bdfb4008309c05843d482e7c04cc36
1100000 96d30c51e1617a12454a9ffa68a0e5746377063bdf09d1bf80bc5053ef8a392b
1150000 eeccab1fe80fe61498f6b264b56e6dc656e3d92bf1a1f6f544ff559df09306cd
1200000 0859876a88c08242c77a1deea7d01757e3c6c1b3155e73bff60e28c8f6e65911
1250000 cdbe56d09f344821b356f3d73862e8a8a6a939042e32d3e9b384da8228b9b5c4
1300000 be6dc303c212243899478b8908c1f7c54217bb735655cdef8d85ae2c3c548229
1350000 f8a18112409e689a55eeccb56ad0c7b18927ca8eda4b9f289dbaccc0685dcd2f
1400000 a222eb0930af41d1d5a6f367a9532ee319630fd72d72055fde5da6b57feabbc1
1450000 3a7e289cb3b0a3a460fb726f36e2bee4217492e8f8d996b8e342ab5082dc0462
1500000 c35a8a2fa6d076208dbb47e37b46b9da2da778bc06e2f224d5d5f370b8d71485
1550000 685a961abceadd38dbafafe0bdb528f6fb53cc9d3b4cbe2443446260f37e888c
1600000 213c49a84a8c01b412e13169ac0c1e070b828a73fa50b02e7ac18520155cb98a
1650000 7be36820df33d3a307d9b0c6c03f5e043fac3cf65d5fb19d111d52e31eda06ea
1700000 724af81603f524a0b54dea8348d8275e329b80e028982a706608099d68d01c9d
1750000 a787060561a8b2fced6aae34de52300b5a8721ce1a4e6ac6c37f995185441894
1800000 324cafa596501d4dda404727fc466eb493e072b669e00b007508fc1f69443991
1850000 1c9f6e6b7122f1d2e6ca0c6751453647e905e068ba8791e13c3722bbe5ff5987
1900000 65843174fc86bf26d65d3e10290c3e5f64fc946617ed0c9a391ecb17f55ecad5
1950000 70155c7089bffdf1f14745a4e5f819a40f590dc613bfda6d11502801ca9d657e
```
