### PR TITLE
format: clang-format masternodes

### DIFF
--- a/src/masternodes/.clang-format
+++ b/src/masternodes/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Chromium
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/src/masternodes/accounts.cpp
+++ b/src/masternodes/accounts.cpp
@@ -4,15 +4,16 @@
 
 #include <masternodes/accounts.h>
 
-void CAccountsView::ForEachBalance(std::function<bool(CScript const &, CTokenAmount const &)> callback, BalanceKey const & start)
-{
-    ForEach<ByBalanceKey, BalanceKey, CAmount>([&callback] (BalanceKey const & key, CAmount val) {
-        return callback(key.owner, CTokenAmount{key.tokenID, val});
-    }, start);
+void CAccountsView::ForEachBalance(std::function<bool(CScript const &, CTokenAmount const &)> callback,
+                                   BalanceKey const &start) {
+    ForEach<ByBalanceKey, BalanceKey, CAmount>(
+        [&callback](BalanceKey const &key, CAmount val) {
+            return callback(key.owner, CTokenAmount{key.tokenID, val});
+        },
+        start);
 }
 
-CTokenAmount CAccountsView::GetBalance(CScript const & owner, DCT_ID tokenID) const
-{
+CTokenAmount CAccountsView::GetBalance(CScript const &owner, DCT_ID tokenID) const {
     CAmount val;
     bool ok = ReadBy<ByBalanceKey>(BalanceKey{owner, tokenID}, val);
     if (ok) {
@@ -21,8 +22,7 @@ CTokenAmount CAccountsView::GetBalance(CScript const & owner, DCT_ID tokenID) co
     return CTokenAmount{tokenID, 0};
 }
 
-Res CAccountsView::SetBalance(CScript const & owner, CTokenAmount amount)
-{
+Res CAccountsView::SetBalance(CScript const &owner, CTokenAmount amount) {
     if (amount.nValue != 0) {
         WriteBy<ByBalanceKey>(BalanceKey{owner, amount.nTokenId}, amount.nValue);
     } else {
@@ -31,8 +31,7 @@ Res CAccountsView::SetBalance(CScript const & owner, CTokenAmount amount)
     return Res::Ok();
 }
 
-Res CAccountsView::AddBalance(CScript const & owner, CTokenAmount amount)
-{
+Res CAccountsView::AddBalance(CScript const &owner, CTokenAmount amount) {
     if (amount.nValue == 0) {
         return Res::Ok();
     }
@@ -44,8 +43,7 @@ Res CAccountsView::AddBalance(CScript const & owner, CTokenAmount amount)
     return SetBalance(owner, balance);
 }
 
-Res CAccountsView::SubBalance(CScript const & owner, CTokenAmount amount)
-{
+Res CAccountsView::SubBalance(CScript const &owner, CTokenAmount amount) {
     if (amount.nValue == 0) {
         return Res::Ok();
     }
@@ -57,9 +55,8 @@ Res CAccountsView::SubBalance(CScript const & owner, CTokenAmount amount)
     return SetBalance(owner, balance);
 }
 
-Res CAccountsView::AddBalances(CScript const & owner, CBalances const & balances)
-{
-    for (const auto& kv : balances.balances) {
+Res CAccountsView::AddBalances(CScript const &owner, CBalances const &balances) {
+    for (const auto &kv : balances.balances) {
         auto res = AddBalance(owner, CTokenAmount{kv.first, kv.second});
         if (!res.ok) {
             return res;
@@ -68,9 +65,8 @@ Res CAccountsView::AddBalances(CScript const & owner, CBalances const & balances
     return Res::Ok();
 }
 
-Res CAccountsView::SubBalances(CScript const & owner, CBalances const & balances)
-{
-    for (const auto& kv : balances.balances) {
+Res CAccountsView::SubBalances(CScript const &owner, CBalances const &balances) {
+    for (const auto &kv : balances.balances) {
         auto res = SubBalance(owner, CTokenAmount{kv.first, kv.second});
         if (!res.ok) {
             return res;
@@ -79,28 +75,23 @@ Res CAccountsView::SubBalances(CScript const & owner, CBalances const & balances
     return Res::Ok();
 }
 
-void CAccountsView::ForEachAccount(std::function<bool(CScript const &)> callback, CScript const & start)
-{
-    ForEach<ByHeightKey, CScript, uint32_t>([&callback] (CScript const & owner, CLazySerialize<uint32_t>) {
-        return callback(owner);
-    }, start);
+void CAccountsView::ForEachAccount(std::function<bool(CScript const &)> callback, CScript const &start) {
+    ForEach<ByHeightKey, CScript, uint32_t>(
+        [&callback](CScript const &owner, CLazySerialize<uint32_t>) { return callback(owner); }, start);
 }
 
-Res CAccountsView::UpdateBalancesHeight(CScript const & owner, uint32_t height)
-{
+Res CAccountsView::UpdateBalancesHeight(CScript const &owner, uint32_t height) {
     WriteBy<ByHeightKey>(owner, height);
     return Res::Ok();
 }
 
-uint32_t CAccountsView::GetBalancesHeight(CScript const & owner)
-{
+uint32_t CAccountsView::GetBalancesHeight(CScript const &owner) {
     uint32_t height;
     bool ok = ReadBy<ByHeightKey>(owner, height);
     return ok ? height : 0;
 }
 
-Res CAccountsView::StoreFuturesUserValues(const CFuturesUserKey& key, const CFuturesUserValue& futures)
-{
+Res CAccountsView::StoreFuturesUserValues(const CFuturesUserKey &key, const CFuturesUserValue &futures) {
     if (!WriteBy<ByFuturesSwapKey>(key, futures)) {
         return Res::Err("Failed to store futures");
     }
@@ -108,13 +99,13 @@ Res CAccountsView::StoreFuturesUserValues(const CFuturesUserKey& key, const CFut
     return Res::Ok();
 }
 
-void CAccountsView::ForEachFuturesUserValues(std::function<bool(const CFuturesUserKey&, const CFuturesUserValue&)> callback, const CFuturesUserKey& start)
-{
+void CAccountsView::ForEachFuturesUserValues(
+    std::function<bool(const CFuturesUserKey &, const CFuturesUserValue &)> callback,
+    const CFuturesUserKey &start) {
     ForEach<ByFuturesSwapKey, CFuturesUserKey, CFuturesUserValue>(callback, start);
 }
 
-Res CAccountsView::EraseFuturesUserValues(const CFuturesUserKey& key)
-{
+Res CAccountsView::EraseFuturesUserValues(const CFuturesUserKey &key) {
     if (!EraseBy<ByFuturesSwapKey>(key)) {
         return Res::Err("Failed to erase futures");
     }
@@ -122,8 +113,7 @@ Res CAccountsView::EraseFuturesUserValues(const CFuturesUserKey& key)
     return Res::Ok();
 }
 
-Res CAccountsView::StoreFuturesDUSD(const CFuturesUserKey& key, const CAmount& amount)
-{
+Res CAccountsView::StoreFuturesDUSD(const CFuturesUserKey &key, const CAmount &amount) {
     if (!WriteBy<ByFuturesDUSDKey>(key, amount)) {
         return Res::Err("Failed to store futures");
     }
@@ -131,13 +121,12 @@ Res CAccountsView::StoreFuturesDUSD(const CFuturesUserKey& key, const CAmount& a
     return Res::Ok();
 }
 
-void CAccountsView::ForEachFuturesDUSD(std::function<bool(const CFuturesUserKey&, const CAmount&)> callback, const CFuturesUserKey& start)
-{
+void CAccountsView::ForEachFuturesDUSD(std::function<bool(const CFuturesUserKey &, const CAmount &)> callback,
+                                       const CFuturesUserKey &start) {
     ForEach<ByFuturesDUSDKey, CFuturesUserKey, CAmount>(callback, start);
 }
 
-Res CAccountsView::EraseFuturesDUSD(const CFuturesUserKey& key)
-{
+Res CAccountsView::EraseFuturesDUSD(const CFuturesUserKey &key) {
     if (!EraseBy<ByFuturesDUSDKey>(key)) {
         return Res::Err("Failed to erase futures");
     }

--- a/src/masternodes/accounts.h
+++ b/src/masternodes/accounts.h
@@ -5,10 +5,10 @@
 #ifndef DEFI_MASTERNODES_ACCOUNTS_H
 #define DEFI_MASTERNODES_ACCOUNTS_H
 
-#include <flushablestorage.h>
-#include <masternodes/res.h>
-#include <masternodes/balances.h>
 #include <amount.h>
+#include <flushablestorage.h>
+#include <masternodes/balances.h>
+#include <masternodes/res.h>
 #include <script/script.h>
 
 struct CFuturesUserKey {
@@ -19,7 +19,7 @@ struct CFuturesUserKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(height));
             height = ~height;
@@ -35,7 +35,7 @@ struct CFuturesUserKey {
         }
     }
 
-    bool operator<(const CFuturesUserKey& o) const {
+    bool operator<(const CFuturesUserKey &o) const {
         return std::tie(height, owner, txn) < std::tie(o.height, o.owner, o.txn);
     }
 };
@@ -47,46 +47,58 @@ struct CFuturesUserValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(source);
         READWRITE(destination);
     }
 };
 
-class CAccountsView : public virtual CStorageView
-{
-public:
-    void ForEachAccount(std::function<bool(CScript const &)> callback, CScript const & start = {});
-    void ForEachBalance(std::function<bool(CScript const &, CTokenAmount const &)> callback, BalanceKey const & start = {});
-    CTokenAmount GetBalance(CScript const & owner, DCT_ID tokenID) const;
+class CAccountsView : public virtual CStorageView {
+   public:
+    void ForEachAccount(std::function<bool(CScript const &)> callback, CScript const &start = {});
+    void ForEachBalance(std::function<bool(CScript const &, CTokenAmount const &)> callback,
+                        BalanceKey const &start = {});
+    CTokenAmount GetBalance(CScript const &owner, DCT_ID tokenID) const;
 
-    virtual Res AddBalance(CScript const & owner, CTokenAmount amount);
-    virtual Res SubBalance(CScript const & owner, CTokenAmount amount);
+    virtual Res AddBalance(CScript const &owner, CTokenAmount amount);
+    virtual Res SubBalance(CScript const &owner, CTokenAmount amount);
 
-    Res AddBalances(CScript const & owner, CBalances const & balances);
-    Res SubBalances(CScript const & owner, CBalances const & balances);
+    Res AddBalances(CScript const &owner, CBalances const &balances);
+    Res SubBalances(CScript const &owner, CBalances const &balances);
 
-    uint32_t GetBalancesHeight(CScript const & owner);
-    Res UpdateBalancesHeight(CScript const & owner, uint32_t height);
+    uint32_t GetBalancesHeight(CScript const &owner);
+    Res UpdateBalancesHeight(CScript const &owner, uint32_t height);
 
-    Res StoreFuturesUserValues(const CFuturesUserKey& key, const CFuturesUserValue& futures);
-    Res EraseFuturesUserValues(const CFuturesUserKey& key);
-    void ForEachFuturesUserValues(std::function<bool(const CFuturesUserKey&, const CFuturesUserValue&)> callback, const CFuturesUserKey& start =
-            {std::numeric_limits<uint32_t>::max(), {}, std::numeric_limits<uint32_t>::max()});
+    Res StoreFuturesUserValues(const CFuturesUserKey &key, const CFuturesUserValue &futures);
+    Res EraseFuturesUserValues(const CFuturesUserKey &key);
+    void ForEachFuturesUserValues(std::function<bool(const CFuturesUserKey &, const CFuturesUserValue &)> callback,
+                                  const CFuturesUserKey &start = {std::numeric_limits<uint32_t>::max(),
+                                                                  {},
+                                                                  std::numeric_limits<uint32_t>::max()});
 
-    Res StoreFuturesDUSD(const CFuturesUserKey& key, const CAmount& amount);
-    Res EraseFuturesDUSD(const CFuturesUserKey& key);
-    void ForEachFuturesDUSD(std::function<bool(const CFuturesUserKey&, const CAmount&)> callback, const CFuturesUserKey& start =
-            {std::numeric_limits<uint32_t>::max(), {}, std::numeric_limits<uint32_t>::max()});
+    Res StoreFuturesDUSD(const CFuturesUserKey &key, const CAmount &amount);
+    Res EraseFuturesDUSD(const CFuturesUserKey &key);
+    void ForEachFuturesDUSD(std::function<bool(const CFuturesUserKey &, const CAmount &)> callback,
+                            const CFuturesUserKey &start = {std::numeric_limits<uint32_t>::max(),
+                                                            {},
+                                                            std::numeric_limits<uint32_t>::max()});
 
     // tags
-    struct ByBalanceKey { static constexpr uint8_t prefix() { return 'a'; } };
-    struct ByHeightKey  { static constexpr uint8_t prefix() { return 'b'; } };
-    struct ByFuturesSwapKey  { static constexpr uint8_t prefix() { return 'J'; } };
-    struct ByFuturesDUSDKey  { static constexpr uint8_t prefix() { return 'm'; } };
+    struct ByBalanceKey {
+        static constexpr uint8_t prefix() { return 'a'; }
+    };
+    struct ByHeightKey {
+        static constexpr uint8_t prefix() { return 'b'; }
+    };
+    struct ByFuturesSwapKey {
+        static constexpr uint8_t prefix() { return 'J'; }
+    };
+    struct ByFuturesDUSDKey {
+        static constexpr uint8_t prefix() { return 'm'; }
+    };
 
-private:
-    Res SetBalance(CScript const & owner, CTokenAmount amount);
+   private:
+    Res SetBalance(CScript const &owner, CTokenAmount amount);
 };
 
-#endif //DEFI_MASTERNODES_ACCOUNTS_H
+#endif  // DEFI_MASTERNODES_ACCOUNTS_H

--- a/src/masternodes/accountshistory.cpp
+++ b/src/masternodes/accountshistory.cpp
@@ -2,21 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#include <masternodes/accountshistory.h>
+#include <key_io.h>
 #include <masternodes/accounts.h>
+#include <masternodes/accountshistory.h>
 #include <masternodes/masternodes.h>
 #include <masternodes/vaulthistory.h>
-#include <key_io.h>
 
 struct AccountHistoryKeyNew {
     uint32_t blockHeight;
     CScript owner;
-    uint32_t txn; // for order in block
+    uint32_t txn;  // for order in block
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(blockHeight));
             blockHeight = ~blockHeight;
@@ -37,16 +37,15 @@ struct AccountHistoryKeyNew {
     }
 };
 
-static AccountHistoryKeyNew Convert(AccountHistoryKey const & key) {
+static AccountHistoryKeyNew Convert(AccountHistoryKey const &key) {
     return {key.blockHeight, key.owner, key.txn};
 }
 
-static AccountHistoryKey Convert(AccountHistoryKeyNew const & key) {
+static AccountHistoryKey Convert(AccountHistoryKeyNew const &key) {
     return {key.owner, key.blockHeight, key.txn};
 }
 
-void CAccountsHistoryView::CreateMultiIndexIfNeeded()
-{
+void CAccountsHistoryView::CreateMultiIndexIfNeeded() {
     AccountHistoryKeyNew anyNewKey{~0u, {}, ~0u};
     if (auto it = LowerBound<ByAccountHistoryKeyNew>(anyNewKey); it.Valid()) {
         return;
@@ -67,43 +66,43 @@ void CAccountsHistoryView::CreateMultiIndexIfNeeded()
     LogPrint(BCLog::BENCH, "    - Multi index took: %dms\n", GetTimeMillis() - startTime);
 }
 
-void CAccountsHistoryView::ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, AccountHistoryValue)> callback,
-                                                 const CScript & owner, uint32_t height, uint32_t txn)
-{
+void CAccountsHistoryView::ForEachAccountHistory(
+    std::function<bool(AccountHistoryKey const &, AccountHistoryValue)> callback,
+    const CScript &owner,
+    uint32_t height,
+    uint32_t txn) {
     if (!owner.empty()) {
         ForEach<ByAccountHistoryKey, AccountHistoryKey, AccountHistoryValue>(callback, {owner, height, txn});
         return;
     }
 
-    ForEach<ByAccountHistoryKeyNew, AccountHistoryKeyNew, char>([&](AccountHistoryKeyNew const & newKey, char) {
-        auto key = Convert(newKey);
-        auto value = ReadAccountHistory(key);
-        assert(value);
-        return callback(key, *value);
-    }, {height, owner, txn});
+    ForEach<ByAccountHistoryKeyNew, AccountHistoryKeyNew, char>(
+        [&](AccountHistoryKeyNew const &newKey, char) {
+            auto key = Convert(newKey);
+            auto value = ReadAccountHistory(key);
+            assert(value);
+            return callback(key, *value);
+        },
+        {height, owner, txn});
 }
 
-std::optional<AccountHistoryValue> CAccountsHistoryView::ReadAccountHistory(AccountHistoryKey const & key) const
-{
+std::optional<AccountHistoryValue> CAccountsHistoryView::ReadAccountHistory(AccountHistoryKey const &key) const {
     return ReadBy<ByAccountHistoryKey, AccountHistoryValue>(key);
 }
 
-Res CAccountsHistoryView::WriteAccountHistory(const AccountHistoryKey& key, const AccountHistoryValue& value)
-{
+Res CAccountsHistoryView::WriteAccountHistory(const AccountHistoryKey &key, const AccountHistoryValue &value) {
     WriteBy<ByAccountHistoryKey>(key, value);
     WriteBy<ByAccountHistoryKeyNew>(Convert(key), '\0');
     return Res::Ok();
 }
 
-Res CAccountsHistoryView::EraseAccountHistory(const AccountHistoryKey& key)
-{
+Res CAccountsHistoryView::EraseAccountHistory(const AccountHistoryKey &key) {
     EraseBy<ByAccountHistoryKey>(key);
     EraseBy<ByAccountHistoryKeyNew>(Convert(key));
     return Res::Ok();
 }
 
-Res CAccountsHistoryView::EraseAccountHistoryHeight(uint32_t height)
-{
+Res CAccountsHistoryView::EraseAccountHistoryHeight(uint32_t height) {
     std::vector<AccountHistoryKey> keysToDelete;
 
     auto it = LowerBound<ByAccountHistoryKeyNew>(AccountHistoryKeyNew{height, {}, ~0u});
@@ -111,31 +110,32 @@ Res CAccountsHistoryView::EraseAccountHistoryHeight(uint32_t height)
         keysToDelete.push_back(Convert(it.Key()));
     }
 
-    for (const auto& key : keysToDelete) {
+    for (const auto &key : keysToDelete) {
         EraseAccountHistory(key);
     }
     return Res::Ok();
 }
 
-CAccountHistoryStorage::CAccountHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
-    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe))
-{
-}
+CAccountHistoryStorage::CAccountHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
+    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe)) {}
 
-CBurnHistoryStorage::CBurnHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
-    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe))
-{
-}
+CBurnHistoryStorage::CBurnHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
+    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe)) {}
 
-CAccountsHistoryWriter::CAccountsHistoryWriter(CCustomCSView & storage, uint32_t height, uint32_t txn, const uint256& txid, uint8_t type,
-                                               CHistoryWriters* writers)
-    : CStorageView(new CFlushableStorageKV(static_cast<CStorageKV&>(storage.GetStorage()))), height(height), txn(txn),
-    txid(txid), type(type), writers(writers)
-{
-}
+CAccountsHistoryWriter::CAccountsHistoryWriter(CCustomCSView &storage,
+                                               uint32_t height,
+                                               uint32_t txn,
+                                               const uint256 &txid,
+                                               uint8_t type,
+                                               CHistoryWriters *writers)
+    : CStorageView(new CFlushableStorageKV(static_cast<CStorageKV &>(storage.GetStorage()))),
+      height(height),
+      txn(txn),
+      txid(txid),
+      type(type),
+      writers(writers) {}
 
-Res CAccountsHistoryWriter::AddBalance(CScript const & owner, CTokenAmount amount)
-{
+Res CAccountsHistoryWriter::AddBalance(CScript const &owner, CTokenAmount amount) {
     auto res = CCustomCSView::AddBalance(owner, amount);
     if (writers && amount.nValue != 0 && res.ok) {
         writers->AddBalance(owner, amount, vaultID);
@@ -144,8 +144,7 @@ Res CAccountsHistoryWriter::AddBalance(CScript const & owner, CTokenAmount amoun
     return res;
 }
 
-Res CAccountsHistoryWriter::SubBalance(CScript const & owner, CTokenAmount amount)
-{
+Res CAccountsHistoryWriter::SubBalance(CScript const &owner, CTokenAmount amount) {
     auto res = CCustomCSView::SubBalance(owner, amount);
     if (writers && res.ok && amount.nValue != 0) {
         writers->SubBalance(owner, amount, vaultID);
@@ -154,25 +153,25 @@ Res CAccountsHistoryWriter::SubBalance(CScript const & owner, CTokenAmount amoun
     return res;
 }
 
-bool CAccountsHistoryWriter::Flush()
-{
+bool CAccountsHistoryWriter::Flush() {
     if (writers) {
         writers->Flush(height, txid, txn, type, vaultID);
     }
     return CCustomCSView::Flush();
 }
 
-CAccountHistoryStorage* CAccountsHistoryWriter::GetAccountHistoryStore() {
+CAccountHistoryStorage *CAccountsHistoryWriter::GetAccountHistoryStore() {
     return writers ? writers->GetAccountHistoryStore() : nullptr;
 };
 
-CHistoryWriters::CHistoryWriters(CAccountHistoryStorage* historyView, CBurnHistoryStorage* burnView, CVaultHistoryStorage* vaultView)
+CHistoryWriters::CHistoryWriters(CAccountHistoryStorage *historyView,
+                                 CBurnHistoryStorage *burnView,
+                                 CVaultHistoryStorage *vaultView)
     : historyView(historyView), burnView(burnView), vaultView(vaultView) {}
 
-extern std::string ScriptToString(CScript const& script);
+extern std::string ScriptToString(CScript const &script);
 
-void CHistoryWriters::AddBalance(const CScript& owner, const CTokenAmount amount, const uint256& vaultID)
-{
+void CHistoryWriters::AddBalance(const CScript &owner, const CTokenAmount amount, const uint256 &vaultID) {
     if (historyView) {
         diffs[owner][amount.nTokenId] += amount.nValue;
     }
@@ -184,15 +183,13 @@ void CHistoryWriters::AddBalance(const CScript& owner, const CTokenAmount amount
     }
 }
 
-void CHistoryWriters::AddFeeBurn(const CScript& owner, const CAmount amount)
-{
+void CHistoryWriters::AddFeeBurn(const CScript &owner, const CAmount amount) {
     if (burnView && amount != 0) {
         burnDiffs[owner][DCT_ID{0}] += amount;
     }
 }
 
-void CHistoryWriters::SubBalance(const CScript& owner, const CTokenAmount amount, const uint256& vaultID)
-{
+void CHistoryWriters::SubBalance(const CScript &owner, const CTokenAmount amount, const uint256 &vaultID) {
     if (historyView) {
         diffs[owner][amount.nTokenId] -= amount.nValue;
     }
@@ -204,30 +201,39 @@ void CHistoryWriters::SubBalance(const CScript& owner, const CTokenAmount amount
     }
 }
 
-void CHistoryWriters::Flush(const uint32_t height, const uint256& txid, const uint32_t txn, const uint8_t type, const uint256& vaultID)
-{
+void CHistoryWriters::Flush(const uint32_t height,
+                            const uint256 &txid,
+                            const uint32_t txn,
+                            const uint8_t type,
+                            const uint256 &vaultID) {
     if (historyView) {
-        for (const auto& diff : diffs) {
-            LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s addr=%s change=%s\n", txid.GetHex(), ScriptToString(diff.first), (CBalances{diff.second}.ToString()));
+        for (const auto &diff : diffs) {
+            LogPrint(BCLog::ACCOUNTCHANGE,
+                     "AccountChange: txid=%s addr=%s change=%s\n",
+                     txid.GetHex(),
+                     ScriptToString(diff.first),
+                     (CBalances{diff.second}.ToString()));
             historyView->WriteAccountHistory({diff.first, height, txn}, {txid, type, diff.second});
         }
     }
     if (burnView) {
-        for (const auto& diff : burnDiffs) {
+        for (const auto &diff : burnDiffs) {
             burnView->WriteAccountHistory({diff.first, height, txn}, {txid, type, diff.second});
         }
     }
     if (vaultView) {
-        for (const auto& diff : vaultDiffs) {
-            for (const auto& addresses : diff.second) {
-                vaultView->WriteVaultHistory({height, diff.first, txn, addresses.first}, {txid, type, addresses.second});
+        for (const auto &diff : vaultDiffs) {
+            for (const auto &addresses : diff.second) {
+                vaultView->WriteVaultHistory({height, diff.first, txn, addresses.first},
+                                             {txid, type, addresses.second});
             }
         }
         if (!schemeID.empty()) {
             vaultView->WriteVaultScheme({vaultID, height}, {type, txid, schemeID, txn});
         }
         if (!globalLoanScheme.identifier.empty()) {
-            vaultView->WriteGlobalScheme({height, txn, globalLoanScheme.schemeCreationTxid}, {globalLoanScheme, type, txid});
+            vaultView->WriteGlobalScheme({height, txn, globalLoanScheme.schemeCreationTxid},
+                                         {globalLoanScheme, type, txid});
         }
     }
 }

--- a/src/masternodes/accountshistory.h
+++ b/src/masternodes/accountshistory.h
@@ -18,12 +18,12 @@ class CVaultHistoryStorage;
 struct AccountHistoryKey {
     CScript owner;
     uint32_t blockHeight;
-    uint32_t txn; // for order in block
+    uint32_t txn;  // for order in block
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(owner);
 
         if (ser_action.ForRead()) {
@@ -31,8 +31,7 @@ struct AccountHistoryKey {
             blockHeight = ~blockHeight;
             READWRITE(WrapBigEndian(txn));
             txn = ~txn;
-        }
-        else {
+        } else {
             uint32_t blockHeight_ = ~blockHeight;
             READWRITE(WrapBigEndian(blockHeight_));
             uint32_t txn_ = ~txn;
@@ -49,82 +48,95 @@ struct AccountHistoryValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(txid);
         READWRITE(category);
         READWRITE(diff);
     }
 };
 
-class CAccountsHistoryView : public virtual CStorageView
-{
-public:
+class CAccountsHistoryView : public virtual CStorageView {
+   public:
     void CreateMultiIndexIfNeeded();
     Res EraseAccountHistoryHeight(uint32_t height);
-    [[nodiscard]] std::optional<AccountHistoryValue> ReadAccountHistory(AccountHistoryKey const & key) const;
-    Res WriteAccountHistory(AccountHistoryKey const & key, AccountHistoryValue const & value);
-    Res EraseAccountHistory(AccountHistoryKey const & key);
+    [[nodiscard]] std::optional<AccountHistoryValue> ReadAccountHistory(AccountHistoryKey const &key) const;
+    Res WriteAccountHistory(AccountHistoryKey const &key, AccountHistoryValue const &value);
+    Res EraseAccountHistory(AccountHistoryKey const &key);
     void ForEachAccountHistory(std::function<bool(AccountHistoryKey const &, AccountHistoryValue)> callback,
-                               const CScript& owner = {}, uint32_t height = std::numeric_limits<uint32_t>::max(), uint32_t txn = std::numeric_limits<uint32_t>::max());
+                               const CScript &owner = {},
+                               uint32_t height = std::numeric_limits<uint32_t>::max(),
+                               uint32_t txn = std::numeric_limits<uint32_t>::max());
 
     // tags
-    struct ByAccountHistoryKey    { static constexpr uint8_t prefix() { return 'h'; } };
-    struct ByAccountHistoryKeyNew { static constexpr uint8_t prefix() { return 'H'; } };
+    struct ByAccountHistoryKey {
+        static constexpr uint8_t prefix() { return 'h'; }
+    };
+    struct ByAccountHistoryKeyNew {
+        static constexpr uint8_t prefix() { return 'H'; }
+    };
 };
 
-class CAccountHistoryStorage : public CAccountsHistoryView
-                             , public CAuctionHistoryView
-{
-public:
-    CAccountHistoryStorage(CAccountHistoryStorage& accountHistory) : CStorageView(new CFlushableStorageKV(accountHistory.DB())) {}
-    CAccountHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
+class CAccountHistoryStorage : public CAccountsHistoryView, public CAuctionHistoryView {
+   public:
+    CAccountHistoryStorage(CAccountHistoryStorage &accountHistory)
+        : CStorageView(new CFlushableStorageKV(accountHistory.DB())) {}
+    CAccountHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
 };
 
-class CBurnHistoryStorage : public CAccountsHistoryView
-{
-public:
-    CBurnHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
+class CBurnHistoryStorage : public CAccountsHistoryView {
+   public:
+    CBurnHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
 };
 
 class CHistoryWriters {
-    CAccountHistoryStorage* historyView{};
-    CBurnHistoryStorage* burnView{};
+    CAccountHistoryStorage *historyView{};
+    CBurnHistoryStorage *burnView{};
     std::map<CScript, TAmounts> diffs;
     std::map<CScript, TAmounts> burnDiffs;
-    std::map<uint256, std::map<CScript,TAmounts>> vaultDiffs;
+    std::map<uint256, std::map<CScript, TAmounts>> vaultDiffs;
 
-public:
-    CVaultHistoryStorage* vaultView{};
+   public:
+    CVaultHistoryStorage *vaultView{};
     CLoanSchemeCreation globalLoanScheme;
     std::string schemeID;
 
-    CHistoryWriters(CAccountHistoryStorage* historyView, CBurnHistoryStorage* burnView, CVaultHistoryStorage* vaultView);
+    CHistoryWriters(CAccountHistoryStorage *historyView,
+                    CBurnHistoryStorage *burnView,
+                    CVaultHistoryStorage *vaultView);
 
-    CAccountHistoryStorage* GetAccountHistoryStore() { return historyView; };
+    CAccountHistoryStorage *GetAccountHistoryStore() { return historyView; };
 
-    void AddBalance(const CScript& owner, const CTokenAmount amount, const uint256& vaultID);
-    void AddFeeBurn(const CScript& owner, const CAmount amount);
-    void SubBalance(const CScript& owner, const CTokenAmount amount, const uint256& vaultID);
-    void Flush(const uint32_t height, const uint256& txid, const uint32_t txn, const uint8_t type, const uint256& vaultID);
+    void AddBalance(const CScript &owner, const CTokenAmount amount, const uint256 &vaultID);
+    void AddFeeBurn(const CScript &owner, const CAmount amount);
+    void SubBalance(const CScript &owner, const CTokenAmount amount, const uint256 &vaultID);
+    void Flush(const uint32_t height,
+               const uint256 &txid,
+               const uint32_t txn,
+               const uint8_t type,
+               const uint256 &vaultID);
 };
 
-class CAccountsHistoryWriter : public CCustomCSView
-{
+class CAccountsHistoryWriter : public CCustomCSView {
     const uint32_t height;
     const uint32_t txn;
     const uint256 txid;
     const uint8_t type;
-    CHistoryWriters* writers{};
+    CHistoryWriters *writers{};
 
-public:
+   public:
     uint256 vaultID;
 
-    CAccountsHistoryWriter(CCustomCSView & storage, uint32_t height, uint32_t txn, const uint256& txid, uint8_t type, CHistoryWriters* writers);
-    Res AddBalance(CScript const & owner, CTokenAmount amount) override;
-    Res SubBalance(CScript const & owner, CTokenAmount amount) override;
+    CAccountsHistoryWriter(CCustomCSView &storage,
+                           uint32_t height,
+                           uint32_t txn,
+                           const uint256 &txid,
+                           uint8_t type,
+                           CHistoryWriters *writers);
+    Res AddBalance(CScript const &owner, CTokenAmount amount) override;
+    Res SubBalance(CScript const &owner, CTokenAmount amount) override;
     bool Flush() override;
 
-    CAccountHistoryStorage* GetAccountHistoryStore() override;
+    CAccountHistoryStorage *GetAccountHistoryStore() override;
 };
 
 extern std::unique_ptr<CAccountHistoryStorage> paccountHistoryDB;
@@ -132,4 +144,4 @@ extern std::unique_ptr<CBurnHistoryStorage> pburnHistoryDB;
 
 static constexpr bool DEFAULT_ACINDEX = true;
 
-#endif //DEFI_MASTERNODES_ACCOUNTSHISTORY_H
+#endif  // DEFI_MASTERNODES_ACCOUNTSHISTORY_H

--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -9,9 +9,9 @@
 #include <key.h>
 #include <logging.h>
 #include <masternodes/masternodes.h>
-#include <streams.h>
 #include <script/standard.h>
 #include <spv/spv_wrapper.h>
+#include <streams.h>
 #include <timedata.h>
 #include <util/system.h>
 #include <util/validation.h>
@@ -29,99 +29,95 @@ static const char DB_ANCHORS = 'A';
 static const char DB_PENDING = 'p';
 static const char DB_BITCOININDEX = 'Z';  // Bitcoin height to blockhash table
 
-uint256 CAnchorData::GetSignHash() const
-{
+uint256 CAnchorData::GetSignHash() const {
     CDataStream ss{SER_GETHASH, PROTOCOL_VERSION};
-    ss << previousAnchor << height << blockHash << nextTeam; // << salt_;
+    ss << previousAnchor << height << blockHash << nextTeam;  // << salt_;
     return Hash(ss.begin(), ss.end());
 }
 
-CAnchorAuthMessage::Signature CAnchorAuthMessage::GetSignature() const
-{
+CAnchorAuthMessage::Signature CAnchorAuthMessage::GetSignature() const {
     return signature;
 }
 
-uint256 CAnchorAuthMessage::GetHash() const
-{
+uint256 CAnchorAuthMessage::GetHash() const {
     CDataStream ss{SER_NETWORK, PROTOCOL_VERSION};
     ss << *this;
     return Hash(ss.begin(), ss.end());
 }
 
-bool CAnchorAuthMessage::SignWithKey(const CKey& key)
-{
+bool CAnchorAuthMessage::SignWithKey(const CKey &key) {
     if (!key.SignCompact(GetSignHash(), signature)) {
         signature.clear();
     }
     return !signature.empty();
 }
 
-bool CAnchorAuthMessage::GetPubKey(CPubKey& pubKey) const
-{
+bool CAnchorAuthMessage::GetPubKey(CPubKey &pubKey) const {
     return !signature.empty() && pubKey.RecoverCompact(GetSignHash(), signature);
 }
 
-CKeyID CAnchorAuthMessage::GetSigner() const
-{
+CKeyID CAnchorAuthMessage::GetSigner() const {
     CPubKey pubKey;
     return (!signature.empty() && pubKey.RecoverCompact(GetSignHash(), signature)) ? pubKey.GetID() : CKeyID{};
 }
 
-CAnchor CAnchor::Create(const std::vector<CAnchorAuthMessage> & auths, CTxDestination const & rewardDest)
-{
+CAnchor CAnchor::Create(const std::vector<CAnchorAuthMessage> &auths, CTxDestination const &rewardDest) {
     // assumed here that all of the auths are uniform, were checked for sigs and consensus has been reached!
     assert(rewardDest.index() == PKHashType || rewardDest.index() == WitV0KeyHashType);
 
     if (auths.size() > 0) {
-        CAnchor anchor(static_cast<CAnchorData const &> (auths.at(0)));
+        CAnchor anchor(static_cast<CAnchorData const &>(auths.at(0)));
 
         for (size_t i = 0; i < auths.size(); ++i) {
             anchor.sigs.push_back(auths[i].GetSignature());
         }
-        anchor.rewardKeyID = rewardDest.index() == PKHashType ? CKeyID(std::get<PKHash>(rewardDest)) : CKeyID(std::get<WitnessV0KeyHash>(rewardDest));
+        anchor.rewardKeyID = rewardDest.index() == PKHashType ? CKeyID(std::get<PKHash>(rewardDest))
+                                                              : CKeyID(std::get<WitnessV0KeyHash>(rewardDest));
         anchor.rewardKeyType = rewardDest.index();
         return anchor;
     }
     return {};
 }
 
-bool CAnchor::CheckAuthSigs(CTeam const & team) const
-{
+bool CAnchor::CheckAuthSigs(CTeam const &team) const {
     // Sigs must meet quorum size.
     const auto quorum = GetMinAnchorQuorum(team);
     if (sigs.size() < quorum) {
-        return error("%s: Anchor auth team quorum not met. Min quorum: %d sigs size %d", __func__, GetMinAnchorQuorum(team), sigs.size());
+        return error("%s: Anchor auth team quorum not met. Min quorum: %d sigs size %d",
+                     __func__,
+                     GetMinAnchorQuorum(team),
+                     sigs.size());
     }
 
     // Number of unique sigs must meet the required quorum.
     const auto uniqueKeys = CheckSigs(GetSignHash(), sigs, team);
     if (uniqueKeys < quorum) {
-        return error("%s: Anchor auth team unique key quorum not met. Min quorum: %d keys size %d", __func__, quorum, uniqueKeys);
+        return error("%s: Anchor auth team unique key quorum not met. Min quorum: %d keys size %d",
+                     __func__,
+                     quorum,
+                     uniqueKeys);
     }
 
     return true;
 }
 
-const CAnchorAuthIndex::Auth * CAnchorAuthIndex::GetAuth(uint256 const & msgHash) const
-{
+const CAnchorAuthIndex::Auth *CAnchorAuthIndex::GetAuth(uint256 const &msgHash) const {
     AssertLockHeld(cs_main);
 
-    auto const & list = auths.get<Auth::ByMsgHash>();
+    auto const &list = auths.get<Auth::ByMsgHash>();
     auto const it = list.find(msgHash);
     return it != list.end() ? &(*it) : nullptr;
 }
 
-const CAnchorAuthIndex::Auth * CAnchorAuthIndex::GetVote(const uint256 & signHash, const CKeyID & signer) const
-{
+const CAnchorAuthIndex::Auth *CAnchorAuthIndex::GetVote(const uint256 &signHash, const CKeyID &signer) const {
     AssertLockHeld(cs_main);
 
-    auto const & list = auths.get<Auth::ByVote>();
+    auto const &list = auths.get<Auth::ByVote>();
     auto const it = list.find(std::make_tuple(signHash, signer));
     return it != list.end() ? &(*it) : nullptr;
 }
 
-bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth & auth) const
-{
+bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth &auth) const {
     AssertLockHeld(cs_main);
 
     // 1. Prev and top checks
@@ -132,20 +128,33 @@ bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth & auth) const
             auto prev = panchors->GetAnchorByTx(auth.previousAnchor);
 
             if (!prev) {
-                LogPrint(BCLog::ANCHORING, "%s: Got anchor auth, hash %s, blockheight: %d, but can't find previousAnchor %s\n", __func__, auth.GetHash().ToString(), auth.height, auth.previousAnchor.ToString());
+                LogPrint(BCLog::ANCHORING,
+                         "%s: Got anchor auth, hash %s, blockheight: %d, but can't find previousAnchor %s\n",
+                         __func__,
+                         auth.GetHash().ToString(),
+                         auth.height,
+                         auth.previousAnchor.ToString());
                 return false;
             }
 
             if (auth.height <= prev->anchor.height) {
-                LogPrint(BCLog::ANCHORING, "%s: Auth blockHeight should be higher than previousAnchor height! %d > %d\n", __func__, auth.height, prev->anchor.height);
+                LogPrint(BCLog::ANCHORING,
+                         "%s: Auth blockHeight should be higher than previousAnchor height! %d > %d\n",
+                         __func__,
+                         auth.height,
+                         prev->anchor.height);
                 return false;
             }
         }
 
-        auto const * topAnchor = panchors->GetActiveAnchor();
+        auto const *topAnchor = panchors->GetActiveAnchor();
         if (topAnchor) {
             if (auth.height <= topAnchor->anchor.height) {
-                LogPrint(BCLog::ANCHORING, "%s: Auth blockHeight should be higher than top anchor height! %d > %d\n", __func__, auth.height, topAnchor->anchor.height);
+                LogPrint(BCLog::ANCHORING,
+                         "%s: Auth blockHeight should be higher than top anchor height! %d > %d\n",
+                         __func__,
+                         auth.height,
+                         topAnchor->anchor.height);
                 return false;
             }
 
@@ -164,7 +173,7 @@ bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth & auth) const
     }
 
     // 2. chain context:
-    CBlockIndex* block = ::ChainActive()[auth.height];
+    CBlockIndex *block = ::ChainActive()[auth.height];
     if (block == nullptr) {
         LogPrint(BCLog::ANCHORING, "%s: Can't get block from anchor height: %d\n", __func__, auth.height);
         return false;
@@ -185,7 +194,10 @@ bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth & auth) const
     }
 
     if (team.empty()) {
-        LogPrint(BCLog::ANCHORING, "%s: Can't get team for previousAnchor tx %s\n", __func__, auth.previousAnchor.ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Can't get team for previousAnchor tx %s\n",
+                 __func__,
+                 auth.previousAnchor.ToString());
         return false;
     }
 
@@ -193,51 +205,53 @@ bool CAnchorAuthIndex::ValidateAuth(const CAnchorAuthIndex::Auth & auth) const
 
     CPubKey pubKey;
     if (!auth.GetPubKey(pubKey)) {
-        LogPrint(BCLog::ANCHORING, "%s: Can't recover pubkey from sig, auth: %s\n", __func__, auth.GetHash().ToString());
-        return false;;
+        LogPrint(
+            BCLog::ANCHORING, "%s: Can't recover pubkey from sig, auth: %s\n", __func__, auth.GetHash().ToString());
+        return false;
+        ;
     }
     const CKeyID masternodeKey{pubKey.GetID()};
     if (team.find(masternodeKey) == team.end()) {
-        LogPrint(BCLog::ANCHORING, "%s: Recovered keyID %s is not a current team member\n", __func__, masternodeKey.ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Recovered keyID %s is not a current team member\n",
+                 __func__,
+                 masternodeKey.ToString());
         return false;
     }
 
     return true;
 }
 
-bool CAnchorAuthIndex::AddAuth(const CAnchorAuthIndex::Auth & auth)
-{
+bool CAnchorAuthIndex::AddAuth(const CAnchorAuthIndex::Auth &auth) {
     AssertLockHeld(cs_main);
     return auths.insert(auth).second;
 }
 
-uint32_t GetMinAnchorQuorum(const CAnchorData::CTeam &team)
-{
+uint32_t GetMinAnchorQuorum(const CAnchorData::CTeam &team) {
     if (Params().NetworkIDString() == "regtest") {
         return gArgs.GetArg("-anchorquorum", 1);
     }
-    return  static_cast<uint32_t>(1 + (team.size() * 2) / 3); // 66% + 1
+    return static_cast<uint32_t>(1 + (team.size() * 2) / 3);  // 66% + 1
 }
 
-CAmount GetAnchorSubsidy(int anchorHeight, int prevAnchorHeight, const Consensus::Params& consensusParams)
-{
+CAmount GetAnchorSubsidy(int anchorHeight, int prevAnchorHeight, const Consensus::Params &consensusParams) {
     if (anchorHeight < prevAnchorHeight) {
         return 0;
     }
 
     int period = anchorHeight - prevAnchorHeight;
-    return consensusParams.spv.anchorSubsidy + (period / consensusParams.spv.subsidyIncreasePeriod) * consensusParams.spv.subsidyIncreaseValue;
+    return consensusParams.spv.anchorSubsidy +
+           (period / consensusParams.spv.subsidyIncreasePeriod) * consensusParams.spv.subsidyIncreaseValue;
 }
 
 /*
  * Choose best (high) anchor auth group with
  */
-CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) const
-{
+CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const &rewardDest) const {
     AssertLockHeld(cs_main);
     // KList is sorted by defi height + signHash (all except sign)
     typedef Auths::index<Auth::ByKey>::type KList;
-    KList const & list = auths.get<Auth::ByKey>();
+    KList const &list = auths.get<Auth::ByKey>();
 
     auto const topAnchor = panchors->GetActiveAnchor();
     uint32_t quorum = 1 + (Params().GetConsensus().mn.anchoringTeamSize * 2) / 3;
@@ -250,7 +264,13 @@ CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) co
 
     // get freshest consensus:
     for (auto it = list.rbegin(); it != list.rend() && it->height > topHeight; ++it) {
-        LogPrint(BCLog::ANCHORING, "%s: height %d, blockHash %s, signHash %s, msg %s\n", __func__, it->height, it->blockHash.ToString(), it->GetSignHash().ToString(), it->GetHash().ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: height %d, blockHash %s, signHash %s, msg %s\n",
+                 __func__,
+                 it->height,
+                 it->blockHash.ToString(),
+                 it->GetSignHash().ToString(),
+                 it->GetHash().ToString());
         if (topAnchor && topAnchor->txHash != it->previousAnchor)
             continue;
 
@@ -259,17 +279,15 @@ CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) co
             curHeight = it->height;
             curSignHash = it->GetSignHash();
 
-            if (it->nextTeam.size() == 1)
-            {
+            if (it->nextTeam.size() == 1) {
                 // Team data reference
-                const CKeyID& teamData = *it->nextTeam.begin();
+                const CKeyID &teamData = *it->nextTeam.begin();
 
                 uint64_t anchorCreationHeight;
                 std::shared_ptr<std::vector<unsigned char>> prefix;
 
                 // Check this is post-fork anchor auth
-                if (GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix))
-                {
+                if (GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix)) {
                     // Get anchor team at time of creating this auth
                     auto team = pcustomcsview->GetAuthTeam(anchorCreationHeight);
                     if (team) {
@@ -284,11 +302,12 @@ CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) co
 
             if (count >= quorum) {
                 KList::iterator it0, it0Copy, it1;
-                std::tie(it0,it1) = list.equal_range(std::make_tuple(curHeight, curSignHash));
+                std::tie(it0, it1) = list.equal_range(std::make_tuple(curHeight, curSignHash));
 
                 // Fix to avoid "Anchor too new" error until F hard fork
                 auto anchorIndex = ::ChainActive()[it0->height];
-                if (!anchorIndex || anchorIndex->nTime + Params().GetConsensus().mn.anchoringTimeDepth > GetAdjustedTime()) {
+                if (!anchorIndex ||
+                    anchorIndex->nTime + Params().GetConsensus().mn.anchoringTimeDepth > GetAdjustedTime()) {
                     continue;
                 }
 
@@ -303,7 +322,11 @@ CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) co
 
                 if (validCount >= quorum) {
                     for (uint32_t i = 0; i < quorum && it0 != it1; ++i, ++it0) {
-                        LogPrint(BCLog::ANCHORING, "auths: pick up %d, %s, %s\n", it0->height, it0->blockHash.ToString(), it0->GetHash().ToString());
+                        LogPrint(BCLog::ANCHORING,
+                                 "auths: pick up %d, %s, %s\n",
+                                 it0->height,
+                                 it0->blockHash.ToString(),
+                                 it0->GetHash().ToString());
 
                         freshestConsensus.push_back(*it0);
                     }
@@ -316,41 +339,41 @@ CAnchor CAnchorAuthIndex::CreateBestAnchor(CTxDestination const & rewardDest) co
     return CAnchor::Create(freshestConsensus, rewardDest);
 }
 
-void CAnchorAuthIndex::ForEachAnchorAuthByHeight(std::function<bool (const CAnchorAuthIndex::Auth &)> callback) const
-{
+void CAnchorAuthIndex::ForEachAnchorAuthByHeight(std::function<bool(const CAnchorAuthIndex::Auth &)> callback) const {
     AssertLockHeld(cs_main);
 
     typedef Auths::index<Auth::ByKey>::type KList;
-    KList const & list = auths.get<Auth::ByKey>();
+    KList const &list = auths.get<Auth::ByKey>();
     for (auto it = list.rbegin(); it != list.rend(); ++it)
-        if (!callback(*it)) break;
+        if (!callback(*it))
+            break;
 }
 
-void CAnchorAuthIndex::PruneOlderThan(THeight height)
-{
+void CAnchorAuthIndex::PruneOlderThan(THeight height) {
     AssertLockHeld(cs_main);
     // KList is sorted by defi height + signHash (all except sign)
     typedef Auths::index<Auth::ByKey>::type KList;
-    KList & list = auths.get<Auth::ByKey>();
+    KList &list = auths.get<Auth::ByKey>();
 
     auto it = list.upper_bound(std::make_tuple(height, uint256{}));
     list.erase(list.begin(), it);
 }
 
 CAnchorIndex::CAnchorIndex(size_t nCacheSize, bool fMemory, bool fWipe)
-    : db(new CDBWrapper(GetDataDir() / "anchors", nCacheSize, fMemory, fWipe))
-{
-}
+    : db(new CDBWrapper(GetDataDir() / "anchors", nCacheSize, fMemory, fWipe)) {}
 
-bool CAnchorIndex::Load()
-{
+bool CAnchorIndex::Load() {
     AssertLockHeld(cs_main);
 
     AnchorIndexImpl().swap(anchors);
 
-    std::function<void (uint256 const &, AnchorRec &)> onLoad = [this] (uint256 const &, AnchorRec & rec) {
+    std::function<void(uint256 const &, AnchorRec &)> onLoad = [this](uint256 const &, AnchorRec &rec) {
         // just for debug
-        LogPrint(BCLog::ANCHORING, "anchor load: blockHash: %s, height %d, btc height: %d\n", rec.anchor.blockHash.ToString(), rec.anchor.height, rec.btcHeight);
+        LogPrint(BCLog::ANCHORING,
+                 "anchor load: blockHash: %s, height %d, btc height: %d\n",
+                 rec.anchor.blockHash.ToString(),
+                 rec.anchor.height,
+                 rec.btcHeight);
 
         anchors.insert(std::move(rec));
     };
@@ -365,34 +388,31 @@ bool CAnchorIndex::Load()
     return result;
 }
 
-void CAnchorIndex::ForEachAnchorByBtcHeight(std::function<bool(const CAnchorIndex::AnchorRec &)> callback) const
-{
+void CAnchorIndex::ForEachAnchorByBtcHeight(std::function<bool(const CAnchorIndex::AnchorRec &)> callback) const {
     typedef AnchorIndexImpl::index<AnchorRec::ByBtcHeight>::type KList;
-    KList const & list = anchors.get<AnchorRec::ByBtcHeight>();
+    KList const &list = anchors.get<AnchorRec::ByBtcHeight>();
     for (auto it = list.rbegin(); it != list.rend(); ++it)
-        if (!callback(*it)) break;
+        if (!callback(*it))
+            break;
 }
 
-const CAnchorIndex::AnchorRec * CAnchorIndex::GetActiveAnchor() const
-{
+const CAnchorIndex::AnchorRec *CAnchorIndex::GetActiveAnchor() const {
     return top;
 }
 
-const CAnchorIndex::AnchorRec * CAnchorIndex::GetAnchorByTx(const uint256 & hash) const
-{
+const CAnchorIndex::AnchorRec *CAnchorIndex::GetAnchorByTx(const uint256 &hash) const {
     AssertLockHeld(cs_main);
 
-    AnchorIndexImpl const & index = anchors;
-    auto & list = index.get<AnchorRec::ByBtcTxHash>();
+    AnchorIndexImpl const &index = anchors;
+    auto &list = index.get<AnchorRec::ByBtcTxHash>();
     auto it = list.find(hash);
     return it != list.end() ? &(*it) : nullptr;
 }
 
-bool CAnchorIndex::AddAnchor(CAnchor const & anchor, uint256 const & btcTxHash, THeight btcBlockHeight, bool overwrite)
-{
+bool CAnchorIndex::AddAnchor(CAnchor const &anchor, uint256 const &btcTxHash, THeight btcBlockHeight, bool overwrite) {
     AssertLockHeld(cs_main);
 
-    AnchorRec rec{ anchor, btcTxHash, btcBlockHeight };
+    AnchorRec rec{anchor, btcTxHash, btcBlockHeight};
     if (overwrite) {
         DeleteAnchorByBtcTx(btcTxHash);
     }
@@ -405,15 +425,15 @@ bool CAnchorIndex::AddAnchor(CAnchor const & anchor, uint256 const & btcTxHash, 
     return result;
 }
 
-bool CAnchorIndex::DeleteAnchorByBtcTx(const uint256 & btcTxHash)
-{
+bool CAnchorIndex::DeleteAnchorByBtcTx(const uint256 &btcTxHash) {
     AssertLockHeld(cs_main);
 
     auto anchor = GetAnchorByBtcTx(btcTxHash);
 
     if (anchor) {
         // revert top if deleted anchor was in active chain (one of current top parents)
-        for (auto it = top; it && it->btcHeight >= anchor->btcHeight; it = GetAnchorByBtcTx(it->anchor.previousAnchor)) {
+        for (auto it = top; it && it->btcHeight >= anchor->btcHeight;
+             it = GetAnchorByBtcTx(it->anchor.previousAnchor)) {
             if (anchor == it) {
                 top = GetAnchorByBtcTx(anchor->anchor.previousAnchor);
                 possibleReActivation = true;
@@ -428,35 +448,32 @@ bool CAnchorIndex::DeleteAnchorByBtcTx(const uint256 & btcTxHash)
     return false;
 }
 
-CAnchorData::CTeam CAnchorIndex::GetNextTeam(const uint256 & btcPrevTx) const
-{
+CAnchorData::CTeam CAnchorIndex::GetNextTeam(const uint256 &btcPrevTx) const {
     AssertLockHeld(cs_main);
 
     if (btcPrevTx.IsNull())
         return Params().GetGenesisTeam();
 
-    AnchorRec const * prev = GetAnchorByTx(btcPrevTx);
+    AnchorRec const *prev = GetAnchorByTx(btcPrevTx);
     if (!prev) {
-        LogPrintf("Can't get previous anchor with btc hash %s\n",  btcPrevTx.ToString());
+        LogPrintf("Can't get previous anchor with btc hash %s\n", btcPrevTx.ToString());
         return CAnchorData::CTeam{};
     }
     return prev->anchor.nextTeam;
 }
 
-CAnchorIndex::AnchorRec const * CAnchorIndex::GetAnchorByBtcTx(uint256 const & txHash) const
-{
+CAnchorIndex::AnchorRec const *CAnchorIndex::GetAnchorByBtcTx(uint256 const &txHash) const {
     AssertLockHeld(cs_main);
 
     typedef AnchorIndexImpl::index<AnchorRec::ByBtcTxHash>::type KList;
-    KList const & list = anchors.get<AnchorRec::ByBtcTxHash>();
+    KList const &list = anchors.get<AnchorRec::ByBtcTxHash>();
 
     auto const it = list.find(txHash);
     return it != list.end() ? &*it : nullptr;
 }
 
 /// Get all UNREWARDED and ACTIVE anchors (resided on chain with anchor's top).
-CAnchorIndex::UnrewardedResult CAnchorIndex::GetUnrewarded() const
-{
+CAnchorIndex::UnrewardedResult CAnchorIndex::GetUnrewarded() const {
     AssertLockHeld(cs_main);
 
     auto it = panchors->GetActiveAnchor();
@@ -465,12 +482,12 @@ CAnchorIndex::UnrewardedResult CAnchorIndex::GetUnrewarded() const
         ;
     // create confirmed set
     UnrewardedResult confirmed;
-    for (; it ; it = panchors->GetAnchorByBtcTx(it->anchor.previousAnchor)) {
+    for (; it; it = panchors->GetAnchorByBtcTx(it->anchor.previousAnchor)) {
         confirmed.insert(it->txHash);
     }
 
     // find unrewarded
-    for (auto && it = confirmed.begin(); it != confirmed.end(); /* no advance */) {
+    for (auto &&it = confirmed.begin(); it != confirmed.end(); /* no advance */) {
         if (pcustomcsview->GetRewardForAnchor(*it))
             it = confirmed.erase(it);
         else
@@ -480,40 +497,34 @@ CAnchorIndex::UnrewardedResult CAnchorIndex::GetUnrewarded() const
     return confirmed;
 }
 
-int CAnchorIndex::GetAnchorConfirmations(uint256 const & txHash) const
-{
+int CAnchorIndex::GetAnchorConfirmations(uint256 const &txHash) const {
     AssertLockHeld(cs_main);
     return GetAnchorConfirmations(GetAnchorByBtcTx(txHash));
 }
 
-int CAnchorIndex::GetAnchorConfirmations(const CAnchorIndex::AnchorRec * rec) const
-{
+int CAnchorIndex::GetAnchorConfirmations(const CAnchorIndex::AnchorRec *rec) const {
     AssertLockHeld(cs_main);
     if (!rec) {
         return -1;
     }
-    // for cases when tx->blockHeight == TX_UNCONFIRMED _or_ GetLastBlockHeight() less than already _confirmed_ tx (rescan in progress)
+    // for cases when tx->blockHeight == TX_UNCONFIRMED _or_ GetLastBlockHeight() less than already _confirmed_ tx
+    // (rescan in progress)
     return spvLastHeight < rec->btcHeight ? 0 : spvLastHeight - rec->btcHeight + 1;
 }
 
-void CAnchorIndex::CheckPendingAnchors()
-{
+void CAnchorIndex::CheckPendingAnchors() {
     uint32_t height = spv::pspv ? spv::pspv->GetLastBlockHeight() : 0;
 
     LOCK(cs_main);
 
     spv::PendingSet anchorsPending(spv::PendingOrder);
-    ForEachPending([&anchorsPending](uint256 const &, AnchorRec & rec) {
-        anchorsPending.insert(rec);
-    });
+    ForEachPending([&anchorsPending](uint256 const &, AnchorRec &rec) { anchorsPending.insert(rec); });
 
     std::set<uint256> deletePending;
-    for (const auto& rec : anchorsPending) {
-
+    for (const auto &rec : anchorsPending) {
         CBlockIndex anchorBlock;
         uint64_t anchorCreationHeight;
         if (!ContextualValidateAnchor(rec.anchor, anchorBlock, anchorCreationHeight)) {
-
             // Height used to ignore failure if due to not being in main chain yet.
             if (anchorCreationHeight != std::numeric_limits<uint64_t>::max()) {
                 deletePending.insert(rec.txHash);
@@ -533,7 +544,11 @@ void CAnchorIndex::CheckPendingAnchors()
 
         // Here we can check new rule that Bitcoin blocktime is three hours more than DeFi anchored block
         if (anchorBlock.nTime > timestamp - Params().GetConsensus().mn.anchoringTimeDepth) {
-            LogPrint(BCLog::ANCHORING, "Anchor too new. DeFi: %d Bitcoin: %d Anchor: %s\n", anchorBlock.nTime, timestamp, rec.txHash.ToString());
+            LogPrint(BCLog::ANCHORING,
+                     "Anchor too new. DeFi: %d Bitcoin: %d Anchor: %s\n",
+                     anchorBlock.nTime,
+                     timestamp,
+                     rec.txHash.ToString());
             deletePending.insert(rec.txHash);
             continue;
         }
@@ -542,14 +557,18 @@ void CAnchorIndex::CheckPendingAnchors()
         CTeam team;
         auto anchorTeam = pcustomcsview->GetAuthTeam(anchorCreationHeight);
         if (!anchorTeam || anchorTeam->empty()) {
-            LogPrint(BCLog::ANCHORING, "No team found at height %ld. Deleting anchor txHash %s\n", anchorCreationHeight, rec.txHash.ToString());
+            LogPrint(BCLog::ANCHORING,
+                     "No team found at height %ld. Deleting anchor txHash %s\n",
+                     anchorCreationHeight,
+                     rec.txHash.ToString());
             deletePending.insert(rec.txHash);
             continue;
         }
 
         // Validate the anchor sigs
         if (!rec.anchor.CheckAuthSigs(*anchorTeam)) {
-            LogPrint(BCLog::ANCHORING, "Signature validation fails. Deleting anchor txHash %s\n", rec.txHash.ToString());
+            LogPrint(
+                BCLog::ANCHORING, "Signature validation fails. Deleting anchor txHash %s\n", rec.txHash.ToString());
             deletePending.insert(rec.txHash);
             continue;
         }
@@ -564,15 +583,15 @@ void CAnchorIndex::CheckPendingAnchors()
         CheckActiveAnchor(height);
     }
 
-    for (const auto& hash : deletePending) {
+    for (const auto &hash : deletePending) {
         DeletePendingByBtcTx(hash);
     }
 }
 
-void CAnchorIndex::CheckActiveAnchor(uint32_t height, bool forced)
-{
+void CAnchorIndex::CheckActiveAnchor(uint32_t height, bool forced) {
     // Only continue with context of chain
-    if (ShutdownRequested()) return;
+    if (ShutdownRequested())
+        return;
 
     {
         LOCK(cs_main);
@@ -580,12 +599,13 @@ void CAnchorIndex::CheckActiveAnchor(uint32_t height, bool forced)
 
         panchors->ActivateBestAnchor(forced);
 
-        // prune auths older than anchor with 6 confirmations. Warning! This constant are using for start confirming reward too!
+        // prune auths older than anchor with 6 confirmations. Warning! This constant are using for start confirming
+        // reward too!
         auto it = panchors->GetActiveAnchor();
         for (; it && GetAnchorConfirmations(it) < 6; it = panchors->GetAnchorByBtcTx(it->anchor.previousAnchor))
             ;
         if (it)
-            panchorauths->PruneOlderThan(it->anchor.height+1);
+            panchorauths->PruneOlderThan(it->anchor.height + 1);
 
         /// @todo panchorAwaitingConfirms - optimize?
         /// @attention - 'it' depends on previous loop conditions (>=6).
@@ -595,15 +615,13 @@ void CAnchorIndex::CheckActiveAnchor(uint32_t height, bool forced)
     }
 }
 
-void CAnchorIndex::UpdateLastHeight(uint32_t height)
-{
+void CAnchorIndex::UpdateLastHeight(uint32_t height) {
     AssertLockHeld(cs_main);
     spvLastHeight = height;
 }
 
 // selects "best" of two anchors at the equal btc height (prevs must be checked before)
-CAnchorIndex::AnchorRec const * BestOfTwo(CAnchorIndex::AnchorRec const * a1, CAnchorIndex::AnchorRec const * a2)
-{
+CAnchorIndex::AnchorRec const *BestOfTwo(CAnchorIndex::AnchorRec const *a1, CAnchorIndex::AnchorRec const *a2) {
     if (a1 == nullptr)
         return a2;
     if (a2 == nullptr)
@@ -613,8 +631,7 @@ CAnchorIndex::AnchorRec const * BestOfTwo(CAnchorIndex::AnchorRec const * a1, CA
 }
 
 /// @returns true if top active anchor has been changed
-bool CAnchorIndex::ActivateBestAnchor(bool forced)
-{
+bool CAnchorIndex::ActivateBestAnchor(bool forced) {
     AssertLockHeld(cs_main);
 
     if (!possibleReActivation && !forced)
@@ -624,7 +641,8 @@ bool CAnchorIndex::ActivateBestAnchor(bool forced)
 
     int const minConfirmations{Params().GetConsensus().spv.minConfirmations};
     auto oldTop = top;
-    // rollback if necessary. this should not happen in prod (w/o anchor tx deletion), but possible in test when manually reduce height in btc chain
+    // rollback if necessary. this should not happen in prod (w/o anchor tx deletion), but possible in test when
+    // manually reduce height in btc chain
     for (; top && GetAnchorConfirmations(top) < minConfirmations; top = GetAnchorByBtcTx(top->anchor.previousAnchor))
         ;
 
@@ -633,14 +651,13 @@ bool CAnchorIndex::ActivateBestAnchor(bool forced)
     uint256 prev = top ? top->anchor.previousAnchor : uint256{};
 
     // start running from top anchor height
-    // (yes, it can re-select different best anchor on the "current" top anchor level - for the cases if spv not feed txs of one block "at once")
+    // (yes, it can re-select different best anchor on the "current" top anchor level - for the cases if spv not feed
+    // txs of one block "at once")
     typedef AnchorIndexImpl::index<AnchorRec::ByBtcHeight>::type KList;
-    KList const & list = anchors.get<AnchorRec::ByBtcHeight>();
-    for (auto it = (topHeight == 0 ? list.begin() : list.find(topHeight)); it != list.end(); ) {
-
+    KList const &list = anchors.get<AnchorRec::ByBtcHeight>();
+    for (auto it = (topHeight == 0 ? list.begin() : list.find(topHeight)); it != list.end();) {
         int const confs = GetAnchorConfirmations(&*it);
-        if (confs < minConfirmations)
-        {
+        if (confs < minConfirmations) {
             // still pending - check it again on next event
             /// @todo may be additional check for confs > 0 (for possibleReActivation)
             possibleReActivation = true;
@@ -648,12 +665,11 @@ bool CAnchorIndex::ActivateBestAnchor(bool forced)
         }
 
         KList::iterator it0, it1;
-        std::tie(it0,it1) = list.equal_range(it->btcHeight);
-        CAnchorIndex::AnchorRec const * choosenOne = nullptr;
+        std::tie(it0, it1) = list.equal_range(it->btcHeight);
+        CAnchorIndex::AnchorRec const *choosenOne = nullptr;
         // at least one iteration here
         for (; it0 != it1; ++it0) {
-            if (it0->anchor.previousAnchor == prev)
-            {
+            if (it0->anchor.previousAnchor == prev) {
                 // candidate
                 choosenOne = BestOfTwo(choosenOne, &*it0);
             }
@@ -669,11 +685,13 @@ bool CAnchorIndex::ActivateBestAnchor(bool forced)
     return top != oldTop;
 }
 
-bool CAnchorIndex::AddToAnchorPending(CAnchor const & anchor, uint256 const & btcTxHash, THeight btcBlockHeight, bool overwrite)
-{
+bool CAnchorIndex::AddToAnchorPending(CAnchor const &anchor,
+                                      uint256 const &btcTxHash,
+                                      THeight btcBlockHeight,
+                                      bool overwrite) {
     AssertLockHeld(cs_main);
 
-    AnchorRec rec{ anchor, btcTxHash, btcBlockHeight };
+    AnchorRec rec{anchor, btcTxHash, btcBlockHeight};
     if (overwrite) {
         DeletePendingByBtcTx(btcTxHash);
     }
@@ -681,15 +699,13 @@ bool CAnchorIndex::AddToAnchorPending(CAnchor const & anchor, uint256 const & bt
     return db->Write(std::make_pair(DB_PENDING, rec.txHash), rec);
 }
 
-bool CAnchorIndex::GetPendingByBtcTx(uint256 const & txHash, AnchorRec & rec) const
-{
+bool CAnchorIndex::GetPendingByBtcTx(uint256 const &txHash, AnchorRec &rec) const {
     AssertLockHeld(cs_main);
 
     return db->Read(std::make_pair(DB_PENDING, txHash), rec);
 }
 
-bool CAnchorIndex::DeletePendingByBtcTx(uint256 const & btcTxHash)
-{
+bool CAnchorIndex::DeletePendingByBtcTx(uint256 const &btcTxHash) {
     AssertLockHeld(cs_main);
 
     AnchorRec pending;
@@ -704,83 +720,74 @@ bool CAnchorIndex::DeletePendingByBtcTx(uint256 const & btcTxHash)
     return false;
 }
 
-bool CAnchorIndex::WriteBlock(const uint32_t height, const uint256& blockHash)
-{
+bool CAnchorIndex::WriteBlock(const uint32_t height, const uint256 &blockHash) {
     // Store Bitcoin block index
     return db->Write(std::make_pair(DB_BITCOININDEX, height), blockHash);
 }
 
-uint256 CAnchorIndex::ReadBlockHash(const uint32_t& height)
-{
+uint256 CAnchorIndex::ReadBlockHash(const uint32_t &height) {
     uint256 blockHash;
     db->Read(std::make_pair(DB_BITCOININDEX, height), blockHash);
     return blockHash;
 }
 
-void CAnchorIndex::ForEachPending(std::function<void (uint256 const &, AnchorRec &)> callback)
-{
+void CAnchorIndex::ForEachPending(std::function<void(uint256 const &, AnchorRec &)> callback) {
     AssertLockHeld(cs_main);
 
     IterateTable(DB_PENDING, callback);
 }
 
-bool CAnchorIndex::DbExists(const uint256 & hash) const
-{
+bool CAnchorIndex::DbExists(const uint256 &hash) const {
     return db->Exists(std::make_pair(DB_ANCHORS, hash));
 }
 
-bool CAnchorIndex::DbRead(uint256 const & hash, AnchorRec & rec) const
-{
+bool CAnchorIndex::DbRead(uint256 const &hash, AnchorRec &rec) const {
     return db->Read(std::make_pair(DB_ANCHORS, hash), rec);
 }
 
-bool CAnchorIndex::DbWrite(AnchorRec const & rec)
-{
+bool CAnchorIndex::DbWrite(AnchorRec const &rec) {
     return db->Write(std::make_pair(DB_ANCHORS, rec.txHash), rec);
 }
 
-bool CAnchorIndex::DbErase(uint256 const & hash)
-{
+bool CAnchorIndex::DbErase(uint256 const &hash) {
     return db->Erase(std::make_pair(DB_ANCHORS, hash));
 }
 
-const CAnchorIndex::AnchorRec* CAnchorIndex::GetLatestAnchorUpToDeFiHeight(THeight blockHeightDeFi) const
-{
+const CAnchorIndex::AnchorRec *CAnchorIndex::GetLatestAnchorUpToDeFiHeight(THeight blockHeightDeFi) const {
     AssertLockHeld(cs_main);
 
-    auto & index = anchors.get<AnchorRec::ByDeFiHeight>();
+    auto &index = anchors.get<AnchorRec::ByDeFiHeight>();
     auto it = index.lower_bound(blockHeightDeFi);
     return (it != index.begin()) ? &(*(--it)) : nullptr;
 }
 
 /// Validates all except tx confirmations
-bool ValidateAnchor(const CAnchor & anchor)
-{
+bool ValidateAnchor(const CAnchor &anchor) {
     AssertLockHeld(cs_main);
 
     // Check sig size to avoid storing bogus anchors with large number of sigs
     if (anchor.nextTeam.size() != 1) {
-        return error("%s: Incorrect anchor team size. Found: %d",
-                     __func__, anchor.nextTeam.size());
+        return error("%s: Incorrect anchor team size. Found: %d", __func__, anchor.nextTeam.size());
     }
 
-    if (anchor.sigs.size() <= static_cast<size_t>(Params().GetConsensus().mn.anchoringTeamSize))
-    {
+    if (anchor.sigs.size() <= static_cast<size_t>(Params().GetConsensus().mn.anchoringTeamSize)) {
         // Team entry
-        const CKeyID& teamData = *anchor.nextTeam.begin();
+        const CKeyID &teamData = *anchor.nextTeam.begin();
 
         uint64_t anchorCreationHeight;
         std::shared_ptr<std::vector<unsigned char>> prefix;
 
         // Post-fork anchor, will be added to pending anchors to validate in chain context
-        if (GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix))
-        {
+        if (GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix)) {
             // Make sure anchor created after fork.
             if (anchorCreationHeight >= static_cast<uint64_t>(Params().GetConsensus().DakotaHeight)) {
                 return true;
             } else {
-                LogPrint(BCLog::ANCHORING, "%s: Post fork anchor created before fork height. Anchor %ld fork %d\n",
-                         __func__, anchorCreationHeight, Params().GetConsensus().DakotaHeight);
+                LogPrint(BCLog::ANCHORING,
+                         "%s: Post fork anchor created before fork height. Anchor %ld fork %d\n",
+                         __func__,
+                         anchorCreationHeight,
+                         Params().GetConsensus().DakotaHeight);
                 return false;
             }
         }
@@ -789,33 +796,32 @@ bool ValidateAnchor(const CAnchor & anchor)
     return false;
 }
 
-bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBlock, uint64_t &anchorCreationHeight)
-{
+bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex &anchorBlock, uint64_t &anchorCreationHeight) {
     AssertLockHeld(cs_main);
 
     // Validate previous anchor. Set spv::pspv to allow anchor auth relay on non-SPV nodes.
-    if (spv::pspv && !anchor.previousAnchor.IsNull())
-    {
+    if (spv::pspv && !anchor.previousAnchor.IsNull()) {
         auto prev = panchors->GetAnchorByTx(anchor.previousAnchor);
         CAnchorIndex::AnchorRec pending;
-        if (!prev)
-        {
+        if (!prev) {
             // Check pending anchors
-            if (!panchors->GetPendingByBtcTx(anchor.previousAnchor, pending))
-            {
+            if (!panchors->GetPendingByBtcTx(anchor.previousAnchor, pending)) {
                 return error("%s: Previous anchor %s specified, but does not exist.",
-                             __func__, anchor.previousAnchor.ToString());
+                             __func__,
+                             anchor.previousAnchor.ToString());
             }
-        }
-        else if ((prev && anchor.height <= prev->anchor.height) || // Check height in accepted anchor
-                 (!pending.txHash.IsNull() && anchor.height <= pending.anchor.height)) // Check height in pending anchor
+        } else if ((prev && anchor.height <= prev->anchor.height) ||  // Check height in accepted anchor
+                   (!pending.txHash.IsNull() &&
+                    anchor.height <= pending.anchor.height))  // Check height in pending anchor
         {
             return error("%s: Anchor blockHeight should be higher than previousAnchor height! %d > %d",
-                         __func__, anchor.height, prev->anchor.height);
+                         __func__,
+                         anchor.height,
+                         prev->anchor.height);
         }
     }
 
-    CBlockIndex* anchorIndex = ::ChainActive()[anchor.height];
+    CBlockIndex *anchorIndex = ::ChainActive()[anchor.height];
     if (!anchorIndex) {
         // Set to max to be used to avoid deleting pending anchor.
         anchorCreationHeight = std::numeric_limits<uint64_t>::max();
@@ -825,7 +831,10 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
 
     if (anchorIndex->GetBlockHash() != anchor.blockHash) {
         return error("%s: Anchor and blockchain mismatch at height %d. Expected %s found %s",
-                     __func__, anchor.height, anchorIndex->GetBlockHash().ToString(), anchor.blockHash.ToString());
+                     __func__,
+                     anchor.height,
+                     anchorIndex->GetBlockHash().ToString(),
+                     anchor.blockHash.ToString());
     }
 
     // Should already be checked before adding to pending, double check here.
@@ -834,7 +843,7 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
     }
 
     // Team entry
-    const CKeyID& teamData = *anchor.nextTeam.begin();
+    const CKeyID &teamData = *anchor.nextTeam.begin();
 
     std::shared_ptr<std::vector<unsigned char>> prefix;
 
@@ -846,13 +855,18 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
     // Only anchor by specified frequency
     if (anchorCreationHeight % Params().GetConsensus().mn.anchoringFrequency != 0) {
         return error("%s: Anchor height does not meet frequency rule. Height %ld, frequency %d",
-                     __func__, anchorCreationHeight, Params().GetConsensus().mn.anchoringFrequency);
+                     __func__,
+                     anchorCreationHeight,
+                     Params().GetConsensus().mn.anchoringFrequency);
     }
 
     // Make sure height exist
     const auto anchorCreationBlock = ::ChainActive()[anchorCreationHeight];
     if (anchorCreationBlock == nullptr) {
-        LogPrint(BCLog::ANCHORING, "%s: Cannot get block from anchor team data: height %ld\n", __func__, anchorCreationHeight);
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Cannot get block from anchor team data: height %ld\n",
+                 __func__,
+                 anchorCreationHeight);
 
         // Set to max to be used to avoid deleting pending anchor.
         anchorCreationHeight = std::numeric_limits<uint64_t>::max();
@@ -862,10 +876,14 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
 
     // Then match the hash prefix from anchor and active chain
     size_t prefixLength{CKeyID().size() - (spv::BtcAnchorMarker.size() * sizeof(uint8_t)) - sizeof(uint64_t)};
-    std::vector<unsigned char> hashPrefix{anchorCreationBlock->GetBlockHash().begin(), anchorCreationBlock->GetBlockHash().begin() + prefixLength};
+    std::vector<unsigned char> hashPrefix{anchorCreationBlock->GetBlockHash().begin(),
+                                          anchorCreationBlock->GetBlockHash().begin() + prefixLength};
     if (hashPrefix != *prefix) {
         return error("%s: Anchor prefix and active chain do not match. anchor %s active %s height %ld",
-                     __func__, HexStr(*prefix), HexStr(hashPrefix), anchorCreationHeight);
+                     __func__,
+                     HexStr(*prefix),
+                     HexStr(hashPrefix),
+                     anchorCreationHeight);
     }
 
     // Get start anchor height
@@ -892,7 +910,8 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
 
     // Check heights match
     if (static_cast<int>(anchor.height) != anchorHeight) {
-        return error("%s: Anchor height mismatch. Anchor height %d calculated height %d", __func__, anchor.height, anchorHeight);
+        return error(
+            "%s: Anchor height mismatch. Anchor height %d calculated height %d", __func__, anchor.height, anchorHeight);
     }
 
     anchorBlock = *::ChainActive()[anchorHeight];
@@ -900,28 +919,27 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex& anchorBloc
     return true;
 }
 
-uint256 CAnchorConfirmData::GetSignHash() const
-{
+uint256 CAnchorConfirmData::GetSignHash() const {
     CDataStream ss{SER_GETHASH, 0};
     ss << btcTxHash << anchorHeight << prevAnchorHeight << rewardKeyID << rewardKeyType;
     return Hash(ss.begin(), ss.end());
 }
 
-uint256 CAnchorConfirmDataPlus::GetSignHash() const
-{
+uint256 CAnchorConfirmDataPlus::GetSignHash() const {
     CDataStream ss{SER_GETHASH, 0};
     ss << btcTxHash << anchorHeight << prevAnchorHeight << rewardKeyID << rewardKeyType << dfiBlockHash << btcTxHeight;
     return Hash(ss.begin(), ss.end());
 }
 
-std::optional<CAnchorConfirmMessage> CAnchorConfirmMessage::CreateSigned(const CAnchor& anchor, const THeight prevAnchorHeight,
-                                                                           const uint256 &btcTxHash, CKey const & key, const THeight btcTxHeight)
-{
+std::optional<CAnchorConfirmMessage> CAnchorConfirmMessage::CreateSigned(const CAnchor &anchor,
+                                                                         const THeight prevAnchorHeight,
+                                                                         const uint256 &btcTxHash,
+                                                                         CKey const &key,
+                                                                         const THeight btcTxHeight) {
     // Potential post-fork unrewarded anchor
-    if (anchor.nextTeam.size() == 1)
-    {
+    if (anchor.nextTeam.size() == 1) {
         // Team data reference
-        const CKeyID& teamData = *anchor.nextTeam.begin();
+        const CKeyID &teamData = *anchor.nextTeam.begin();
 
         uint64_t anchorCreationHeight;
         std::shared_ptr<std::vector<unsigned char>> prefix;
@@ -930,8 +948,13 @@ std::optional<CAnchorConfirmMessage> CAnchorConfirmMessage::CreateSigned(const C
         GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix);
     }
 
-    CAnchorConfirmMessage message(CAnchorConfirmDataPlus{btcTxHash, anchor.height, prevAnchorHeight, anchor.rewardKeyID,
-                                                         anchor.rewardKeyType, anchor.blockHash, btcTxHeight});
+    CAnchorConfirmMessage message(CAnchorConfirmDataPlus{btcTxHash,
+                                                         anchor.height,
+                                                         prevAnchorHeight,
+                                                         anchor.rewardKeyID,
+                                                         anchor.rewardKeyType,
+                                                         anchor.blockHash,
+                                                         btcTxHeight});
 
     if (!key.SignCompact(message.GetSignHash(), message.signature)) {
         message.signature.clear();
@@ -940,26 +963,22 @@ std::optional<CAnchorConfirmMessage> CAnchorConfirmMessage::CreateSigned(const C
     return message;
 }
 
-uint256 CAnchorConfirmMessage::GetHash() const
-{
+uint256 CAnchorConfirmMessage::GetHash() const {
     CDataStream ss{SER_NETWORK, PROTOCOL_VERSION};
     ss << *this;
     return Hash(ss.begin(), ss.end());
 }
 
-CKeyID CAnchorConfirmMessage::GetSigner() const
-{
+CKeyID CAnchorConfirmMessage::GetSigner() const {
     CPubKey pubKey;
     return (!signature.empty() && pubKey.RecoverCompact(GetSignHash(), signature)) ? pubKey.GetID() : CKeyID{};
 }
 
-bool CAnchorFinalizationMessage::CheckConfirmSigs()
-{
+bool CAnchorFinalizationMessage::CheckConfirmSigs() {
     return CheckSigs(GetSignHash(), sigs, currentTeam);
 }
 
-size_t CAnchorFinalizationMessagePlus::CheckConfirmSigs(const uint32_t height)
-{
+size_t CAnchorFinalizationMessagePlus::CheckConfirmSigs(const uint32_t height) {
     auto team = pcustomcsview->GetConfirmTeam(height);
     if (!team) {
         return false;
@@ -967,34 +986,36 @@ size_t CAnchorFinalizationMessagePlus::CheckConfirmSigs(const uint32_t height)
     return CheckSigs(GetSignHash(), sigs, *team);
 }
 
-bool CAnchorAwaitingConfirms::EraseAnchor(AnchorTxHash const &txHash)
-{
+bool CAnchorAwaitingConfirms::EraseAnchor(AnchorTxHash const &txHash) {
     AssertLockHeld(cs_main);
 
-    auto & list = confirms.get<Confirm::ByAnchor>();
-    auto count = list.erase(txHash); // should erase ALL with that key. Check it!
-    LogPrint(BCLog::ANCHORING, "AnchorConfirms::EraseAnchor: erase %d confirms for anchor %s\n", count, txHash.ToString());
+    auto &list = confirms.get<Confirm::ByAnchor>();
+    auto count = list.erase(txHash);  // should erase ALL with that key. Check it!
+    LogPrint(
+        BCLog::ANCHORING, "AnchorConfirms::EraseAnchor: erase %d confirms for anchor %s\n", count, txHash.ToString());
 
     return count > 0;
 }
 
-const CAnchorConfirmMessage *CAnchorAwaitingConfirms::GetConfirm(ConfirmMessageHash const &msgHash) const
-{
+const CAnchorConfirmMessage *CAnchorAwaitingConfirms::GetConfirm(ConfirmMessageHash const &msgHash) const {
     AssertLockHeld(cs_main);
 
-    auto const & list = confirms.get<Confirm::ByMsgHash>();
+    auto const &list = confirms.get<Confirm::ByMsgHash>();
     auto it = list.find(msgHash);
     return it != list.end() ? &(*it) : nullptr;
 }
 
-bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessage) const
-{
+bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessage) const {
     AssertLockHeld(cs_main);
 
     CKeyID signer = confirmMessage.GetSigner();
     if (signer.IsNull()) {
-        LogPrint(BCLog::ANCHORING, "%s: Warning! Signature incorrect. btcTxHash: %s confirmMessageHash: %s Key: %s\n",
-                 __func__, confirmMessage.btcTxHash.ToString(), confirmMessage.GetHash().ToString(), signer.ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Warning! Signature incorrect. btcTxHash: %s confirmMessageHash: %s Key: %s\n",
+                 __func__,
+                 confirmMessage.btcTxHash.ToString(),
+                 confirmMessage.GetHash().ToString(),
+                 signer.ToString());
         return false;
     }
 
@@ -1012,19 +1033,29 @@ bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessa
 
     auto it = pcustomcsview->GetMasternodeIdByOperator(signer);
     if (!it || !pcustomcsview->GetMasternode(*it)->IsActive(height)) {
-        LogPrint(BCLog::ANCHORING, "%s: Warning! Masternode with operator key %s does not exist or not active!\n", __func__, signer.ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Warning! Masternode with operator key %s does not exist or not active!\n",
+                 __func__,
+                 signer.ToString());
         return false;
     }
 
-    CBlockIndex* anchorIndex = ::ChainActive()[confirmMessage.anchorHeight];
+    CBlockIndex *anchorIndex = ::ChainActive()[confirmMessage.anchorHeight];
     if (!anchorIndex) {
-        LogPrint(BCLog::ANCHORING, "%s: Active chain does not contain block height %d\n", __func__, confirmMessage.anchorHeight);
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Active chain does not contain block height %d\n",
+                 __func__,
+                 confirmMessage.anchorHeight);
         return false;
     }
 
     if (anchorIndex->GetBlockHash() != confirmMessage.dfiBlockHash) {
-        LogPrint(BCLog::ANCHORING, "%s: Anchor and blockchain mismatch at height %d. Expected %s found %s\n",
-                 __func__, confirmMessage.anchorHeight, anchorIndex->GetBlockHash().ToString(), confirmMessage.dfiBlockHash.ToString());
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Anchor and blockchain mismatch at height %d. Expected %s found %s\n",
+                 __func__,
+                 confirmMessage.anchorHeight,
+                 anchorIndex->GetBlockHash().ToString(),
+                 confirmMessage.dfiBlockHash.ToString());
         return false;
     }
 
@@ -1036,20 +1067,17 @@ bool CAnchorAwaitingConfirms::Validate(CAnchorConfirmMessage const &confirmMessa
     return true;
 }
 
-bool CAnchorAwaitingConfirms::Add(CAnchorConfirmMessage const &newConfirmMessage)
-{
+bool CAnchorAwaitingConfirms::Add(CAnchorConfirmMessage const &newConfirmMessage) {
     AssertLockHeld(cs_main);
     return confirms.insert(newConfirmMessage).second;
 }
 
-void CAnchorAwaitingConfirms::Clear()
-{
+void CAnchorAwaitingConfirms::Clear() {
     AssertLockHeld(cs_main);
     Confirms().swap(confirms);
 }
 
-void CAnchorAwaitingConfirms::ReVote()
-{
+void CAnchorAwaitingConfirms::ReVote() {
     AssertLockHeld(cs_main);
 
     const auto height = ::ChainActive().Height();
@@ -1064,22 +1092,21 @@ void CAnchorAwaitingConfirms::ReVote()
 
     const auto operatorDetails = AmISignerNow(height, currentTeam);
 
-    for (const auto& keys : operatorDetails) {
+    for (const auto &keys : operatorDetails) {
         CAnchorIndex::UnrewardedResult unrewarded = panchors->GetUnrewarded();
-        for (auto const & btcTxHash : unrewarded) {
-            pcustomcsview->CreateAndRelayConfirmMessageIfNeed(panchors->GetAnchorByTx(btcTxHash), btcTxHash, keys.second);
+        for (auto const &btcTxHash : unrewarded) {
+            pcustomcsview->CreateAndRelayConfirmMessageIfNeed(
+                panchors->GetAnchorByTx(btcTxHash), btcTxHash, keys.second);
         }
     }
-
 }
 
 // for MINERS only!
-std::vector<CAnchorConfirmMessage> CAnchorAwaitingConfirms::GetQuorumFor(const CAnchorData::CTeam & team) const
-{
+std::vector<CAnchorConfirmMessage> CAnchorAwaitingConfirms::GetQuorumFor(const CAnchorData::CTeam &team) const {
     AssertLockHeld(cs_main);
 
     typedef Confirms::index<Confirm::ByKey>::type KList;
-    KList const & list = confirms.get<Confirm::ByKey>();
+    KList const &list = confirms.get<Confirm::ByKey>();
     uint32_t quorum = GetMinAnchorQuorum(team);
 
     std::vector<CAnchorConfirmMessage> result;
@@ -1087,8 +1114,8 @@ std::vector<CAnchorConfirmMessage> CAnchorAwaitingConfirms::GetQuorumFor(const C
     for (auto it = list.begin(); it != list.end(); /* w/o advance! */) {
         // get next group of confirms
         KList::iterator it0, it1;
-        std::tie(it0,it1) = list.equal_range(std::make_tuple(it->btcTxHeight, it->btcTxHash));
-        if (std::distance(it0,it1) >= quorum) {
+        std::tie(it0, it1) = list.equal_range(std::make_tuple(it->btcTxHeight, it->btcTxHash));
+        if (std::distance(it0, it1) >= quorum) {
             result.clear();
             for (; result.size() < quorum && it0 != it1; ++it0) {
                 if (team.find(it0->GetSigner()) != team.end()) {
@@ -1099,21 +1126,22 @@ std::vector<CAnchorConfirmMessage> CAnchorAwaitingConfirms::GetQuorumFor(const C
                 return result;
             }
         }
-        it = it1; // next group!
+        it = it1;  // next group!
     }
     return {};
 }
 
-void CAnchorAwaitingConfirms::ForEachConfirm(std::function<void (const CAnchorAwaitingConfirms::Confirm &)> callback) const
-{
+void CAnchorAwaitingConfirms::ForEachConfirm(
+    std::function<void(const CAnchorAwaitingConfirms::Confirm &)> callback) const {
     AssertLockHeld(cs_main);
-    auto const & list = confirms.get<Confirm::ByKey>();
+    auto const &list = confirms.get<Confirm::ByKey>();
     for (auto it = list.begin(); it != list.end(); ++it)
         callback(*it);
 }
 
-bool GetAnchorEmbeddedData(const CKeyID& data, uint64_t& anchorCreationHeight, std::shared_ptr<std::vector<unsigned char>>& prefix)
-{
+bool GetAnchorEmbeddedData(const CKeyID &data,
+                           uint64_t &anchorCreationHeight,
+                           std::shared_ptr<std::vector<unsigned char>> &prefix) {
     // Blockhash prefix length
     size_t prefixLength{CKeyID().size() - (spv::BtcAnchorMarker.size() * sizeof(uint8_t)) - sizeof(uint64_t)};
 
@@ -1135,29 +1163,25 @@ bool GetAnchorEmbeddedData(const CKeyID& data, uint64_t& anchorCreationHeight, s
     return true;
 }
 
-namespace spv
-{
-const PendingOrderType PendingOrder = PendingOrderType([](const CAnchorIndex::AnchorRec& a, const CAnchorIndex::AnchorRec& b)
-{
-    if (a.btcHeight == b.btcHeight)
-    {
-        if (a.anchor.height == b.anchor.height)
-        {
-            if (a.anchor.height >= static_cast<THeight>(Params().GetConsensus().EunosHeight))
-            {
-                const auto blockHash = panchors->ReadBlockHash(a.btcHeight);
-                auto aHash = Hash(a.txHash.begin(), a.txHash.end(), blockHash.begin(), blockHash.end());
-                auto bHash = Hash(b.txHash.begin(), b.txHash.end(), blockHash.begin(), blockHash.end());
-                return aHash < bHash;
+namespace spv {
+const PendingOrderType PendingOrder =
+    PendingOrderType([](const CAnchorIndex::AnchorRec &a, const CAnchorIndex::AnchorRec &b) {
+        if (a.btcHeight == b.btcHeight) {
+            if (a.anchor.height == b.anchor.height) {
+                if (a.anchor.height >= static_cast<THeight>(Params().GetConsensus().EunosHeight)) {
+                    const auto blockHash = panchors->ReadBlockHash(a.btcHeight);
+                    auto aHash = Hash(a.txHash.begin(), a.txHash.end(), blockHash.begin(), blockHash.end());
+                    auto bHash = Hash(b.txHash.begin(), b.txHash.end(), blockHash.begin(), blockHash.end());
+                    return aHash < bHash;
+                }
+
+                return a.txHash < b.txHash;
             }
 
-            return a.txHash < b.txHash;
+            // Higher DeFi comes first
+            return a.anchor.height > b.anchor.height;
         }
 
-        // Higher DeFi comes first
-        return a.anchor.height > b.anchor.height;
-    }
-
-    return a.btcHeight < b.btcHeight;
-});
+        return a.btcHeight < b.btcHeight;
+    });
 }

--- a/src/masternodes/anchors.h
+++ b/src/masternodes/anchors.h
@@ -14,13 +14,13 @@
 #include <functional>
 #include <vector>
 
-#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/member.hpp>
-#include <boost/multi_index/tag.hpp>
-#include <boost/multi_index/indexed_by.hpp>
-#include <boost/multi_index/composite_key.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <boost/multi_index_container.hpp>
 
 #include <boost/thread.hpp>
 
@@ -30,99 +30,86 @@ class CBlockIndex;
 class CKey;
 class CPubkey;
 
-namespace spv
-{
-    class CSpvWrapper;
-    struct BtcAnchorTx;
+namespace spv {
+class CSpvWrapper;
+struct BtcAnchorTx;
+}  // namespace spv
+
+namespace Consensus {
+struct Params;
 }
 
-namespace Consensus
-{
-    struct Params;
-}
+typedef uint32_t THeight;  // cause not decided yet which type to use for heights
 
-typedef uint32_t THeight; // cause not decided yet which type to use for heights
-
-struct CAnchorData
-{
+struct CAnchorData {
     using CTeam = std::set<CKeyID>;
 
-    uint256 previousAnchor;         ///< Previous tx-AnchorAnnouncement on BTC chain
-    THeight height;                 ///< Height of the anchor block (DeFi)
-    uint256 blockHash;              ///< Hash of the anchor block (DeFi)
-    CTeam nextTeam;                 ///< Calculated based on stake modifier at {blockHash}
+    uint256 previousAnchor;  ///< Previous tx-AnchorAnnouncement on BTC chain
+    THeight height;          ///< Height of the anchor block (DeFi)
+    uint256 blockHash;       ///< Hash of the anchor block (DeFi)
+    CTeam nextTeam;          ///< Calculated based on stake modifier at {blockHash}
 
     uint256 GetSignHash() const;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-         READWRITE(previousAnchor);
-         READWRITE(height);
-         READWRITE(blockHash);
-         READWRITE(nextTeam);
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(previousAnchor);
+        READWRITE(height);
+        READWRITE(blockHash);
+        READWRITE(nextTeam);
     }
 };
 
-class CAnchorAuthMessage : public CAnchorData
-{
+class CAnchorAuthMessage : public CAnchorData {
     using Signature = std::vector<unsigned char>;
-public:
 
-    CAnchorAuthMessage(CAnchorData const & base = CAnchorData())
-        : CAnchorData(base)
-        , signature()
-    {}
+   public:
+    CAnchorAuthMessage(CAnchorData const &base = CAnchorData()) : CAnchorData(base), signature() {}
 
     Signature GetSignature() const;
     uint256 GetHash() const;
-    bool SignWithKey(const CKey& key);
-    bool GetPubKey(CPubKey& pubKey) const;
+    bool SignWithKey(const CKey &key);
+    bool GetPubKey(CPubKey &pubKey) const;
     CKeyID GetSigner() const;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-         READWRITEAS(CAnchorData, *this);
-         READWRITE(signature);
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITEAS(CAnchorData, *this);
+        READWRITE(signature);
     }
 
     // tags for multiindex
-    struct ByMsgHash{};     // by message hash (for inv)
-    struct ByBlockHash{};   // by blockhash (for locator/GETANCHORAUTHS)
-    struct ByKey{};         // composite, by height and GetSignHash for anchor creation
-    struct ByVote{};        // composite, by GetSignHash and signer, helps detect doublesigning
+    struct ByMsgHash {};    // by message hash (for inv)
+    struct ByBlockHash {};  // by blockhash (for locator/GETANCHORAUTHS)
+    struct ByKey {};        // composite, by height and GetSignHash for anchor creation
+    struct ByVote {};       // composite, by GetSignHash and signer, helps detect doublesigning
 
-private:
+   private:
     Signature signature;
 };
 
-class CAnchor : public CAnchorData
-{
+class CAnchor : public CAnchorData {
     using Signature = std::vector<unsigned char>;
     using CTeam = CAnchorData::CTeam;
 
-public:
+   public:
     std::vector<Signature> sigs;
     CKeyID rewardKeyID;
     char rewardKeyType;
 
-    CAnchor(CAnchorData const & base = CAnchorData())
-        : CAnchorData(base)
-        , sigs()
-        , rewardKeyID()
-        , rewardKeyType(0)
-    {}
+    CAnchor(CAnchorData const &base = CAnchorData()) : CAnchorData(base), sigs(), rewardKeyID(), rewardKeyType(0) {}
 
-    static CAnchor Create(std::vector<CAnchorAuthMessage> const & auths, CTxDestination const & rewardDest);
-    bool CheckAuthSigs(CTeam const & team) const;
+    static CAnchor Create(std::vector<CAnchorAuthMessage> const &auths, CTxDestination const &rewardDest);
+    bool CheckAuthSigs(CTeam const &team) const;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAnchorData, *this);
         READWRITE(sigs);
         READWRITE(rewardKeyID);
@@ -130,65 +117,56 @@ public:
     }
 };
 
-
 using namespace boost::multi_index;
 
-class CAnchorAuthIndex
-{
+class CAnchorAuthIndex {
     using CTeam = CAnchorData::CTeam;
 
-public:
+   public:
     using Auth = CAnchorAuthMessage;
 
-    typedef boost::multi_index_container<Auth,
+    typedef boost::multi_index_container<
+        Auth,
         indexed_by<
             // index for p2p messaging (inv/getdata)
-            ordered_unique<
-                tag<Auth::ByMsgHash>, const_mem_fun<Auth, uint256, &Auth::GetHash>
-            >,
+            ordered_unique<tag<Auth::ByMsgHash>, const_mem_fun<Auth, uint256, &Auth::GetHash>>,
             // index for locator/GETANCHORAUTHS
-            ordered_non_unique<
-                tag<Auth::ByBlockHash>, member<CAnchorData, uint256, &CAnchorData::blockHash>
-            >,
+            ordered_non_unique<tag<Auth::ByBlockHash>, member<CAnchorData, uint256, &CAnchorData::blockHash>>,
             // index for quorum selection (CreateBestAnchor())
             // just to remember that there may be auths with equal blockHash, but with different prevs and teams!
-            ordered_non_unique<
-                tag<Auth::ByKey>, composite_key<Auth,
-                    member<CAnchorData, THeight, &CAnchorData::height>,
-                    const_mem_fun<CAnchorData, uint256, &CAnchorData::GetSignHash>
-                >
-            >,
+            ordered_non_unique<tag<Auth::ByKey>,
+                               composite_key<Auth,
+                                             member<CAnchorData, THeight, &CAnchorData::height>,
+                                             const_mem_fun<CAnchorData, uint256, &CAnchorData::GetSignHash>>>,
             // restriction index that helps detect doublesigning
             // it may by quite expensive to index by GetSigner on the fly, but it should happen only on insertion
-            ordered_unique<
-                tag<Auth::ByVote>, composite_key<Auth,
-                    const_mem_fun<CAnchorData, uint256, &CAnchorData::GetSignHash>,
-                    const_mem_fun<Auth, CKeyID, &Auth::GetSigner>
-                >
-            >
+            ordered_unique<tag<Auth::ByVote>,
+                           composite_key<Auth,
+                                         const_mem_fun<CAnchorData, uint256, &CAnchorData::GetSignHash>,
+                                         const_mem_fun<Auth, CKeyID, &Auth::GetSigner>>>
 
-        >
-    > Auths;
+            >>
+        Auths;
 
-    Auth const * GetAuth(uint256 const & msgHash) const;
-    Auth const * GetVote(uint256 const & signHash, CKeyID const & signer) const;
-    bool ValidateAuth(Auth const & auth) const;
-    bool AddAuth(Auth const & auth);
+    Auth const *GetAuth(uint256 const &msgHash) const;
+    Auth const *GetVote(uint256 const &signHash, CKeyID const &signer) const;
+    bool ValidateAuth(Auth const &auth) const;
+    bool AddAuth(Auth const &auth);
 
-    CAnchor CreateBestAnchor(CTxDestination const & rewardDest) const;
+    CAnchor CreateBestAnchor(CTxDestination const &rewardDest) const;
     void ForEachAnchorAuthByHeight(std::function<bool(const CAnchorAuthIndex::Auth &)> callback) const;
     void PruneOlderThan(THeight height);
 
-private:
+   private:
     Auths auths;
 };
 
-class CAnchorIndex
-{
-private:
+class CAnchorIndex {
+   private:
     std::shared_ptr<CDBWrapper> db;
     std::unique_ptr<CDBBatch> batch;
-public:
+
+   public:
     using Signature = std::vector<unsigned char>;
     using CTeam = CAnchorData::CTeam;
 
@@ -200,90 +178,89 @@ public:
         ADD_SERIALIZE_METHODS;
 
         template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action) {
+        inline void SerializationOp(Stream &s, Operation ser_action) {
             READWRITE(anchor);
             READWRITE(txHash);
             READWRITE(btcHeight);
         }
 
         // tags for multiindex
-        struct ByBtcTxHash{};
-        struct ByBtcHeight{};
-        struct ByDeFiHeight{};
+        struct ByBtcTxHash {};
+        struct ByBtcHeight {};
+        struct ByDeFiHeight {};
 
-        THeight DeFiBlockHeight() const {return anchor.height;}
+        THeight DeFiBlockHeight() const { return anchor.height; }
     };
 
-    typedef boost::multi_index_container<AnchorRec,
-        indexed_by<
-            ordered_unique    < tag<AnchorRec::ByBtcTxHash>,  member<AnchorRec, uint256,  &AnchorRec::txHash> >,
-            ordered_non_unique< tag<AnchorRec::ByBtcHeight>,  member<AnchorRec, THeight,  &AnchorRec::btcHeight> >,
-            ordered_non_unique< tag<AnchorRec::ByDeFiHeight>, const_mem_fun<AnchorRec, THeight, &AnchorRec::DeFiBlockHeight> >
-        >
-    > AnchorIndexImpl;
+    typedef boost::multi_index_container<
+        AnchorRec,
+        indexed_by<ordered_unique<tag<AnchorRec::ByBtcTxHash>, member<AnchorRec, uint256, &AnchorRec::txHash>>,
+                   ordered_non_unique<tag<AnchorRec::ByBtcHeight>, member<AnchorRec, THeight, &AnchorRec::btcHeight>>,
+                   ordered_non_unique<tag<AnchorRec::ByDeFiHeight>,
+                                      const_mem_fun<AnchorRec, THeight, &AnchorRec::DeFiBlockHeight>>>>
+        AnchorIndexImpl;
 
     CAnchorIndex(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
     bool Load();
 
     void ForEachAnchorByBtcHeight(std::function<bool(const CAnchorIndex::AnchorRec &)> callback) const;
-    AnchorRec const * GetActiveAnchor() const;
-    bool ActivateBestAnchor(bool forced = false); // rescan anchors
+    AnchorRec const *GetActiveAnchor() const;
+    bool ActivateBestAnchor(bool forced = false);  // rescan anchors
 
-    AnchorRec const * GetAnchorByTx(uint256 const & hash) const;
+    AnchorRec const *GetAnchorByTx(uint256 const &hash) const;
 
-    bool AddAnchor(CAnchor const & anchor, uint256 const & btcTxHash, THeight btcBlockHeight, bool overwrite = true);
-    bool DeleteAnchorByBtcTx(uint256 const & btcTxHash);
+    bool AddAnchor(CAnchor const &anchor, uint256 const &btcTxHash, THeight btcBlockHeight, bool overwrite = true);
+    bool DeleteAnchorByBtcTx(uint256 const &btcTxHash);
 
-    CAnchorData::CTeam GetNextTeam(uint256 const & btcPrevTx) const;
+    CAnchorData::CTeam GetNextTeam(uint256 const &btcPrevTx) const;
 
-    AnchorRec const * GetAnchorByBtcTx(uint256 const & txHash) const;
+    AnchorRec const *GetAnchorByBtcTx(uint256 const &txHash) const;
 
     using UnrewardedResult = std::set<uint256>;
     UnrewardedResult GetUnrewarded() const;
 
-    int GetAnchorConfirmations(uint256 const & txHash) const;
-    int GetAnchorConfirmations(AnchorRec const * rec) const;
+    int GetAnchorConfirmations(uint256 const &txHash) const;
+    int GetAnchorConfirmations(AnchorRec const *rec) const;
 
     void CheckActiveAnchor(uint32_t height, bool forced = false);
     void UpdateLastHeight(uint32_t height);
 
     // Post-fork anchor pending, requires chain context to validate. Some pending may be bogus, intentional or not.
-    bool AddToAnchorPending(CAnchor const & anchor, uint256 const & btcTxHash, THeight btcBlockHeight, bool overwrite = false);
-    bool GetPendingByBtcTx(uint256 const & txHash, AnchorRec & rec) const;
-    bool DeletePendingByBtcTx(uint256 const & btcTxHash);
-    void ForEachPending(std::function<void (const uint256 &, AnchorRec &)> callback);
+    bool AddToAnchorPending(CAnchor const &anchor,
+                            uint256 const &btcTxHash,
+                            THeight btcBlockHeight,
+                            bool overwrite = false);
+    bool GetPendingByBtcTx(uint256 const &txHash, AnchorRec &rec) const;
+    bool DeletePendingByBtcTx(uint256 const &btcTxHash);
+    void ForEachPending(std::function<void(const uint256 &, AnchorRec &)> callback);
 
     // Used to apply chain context to post-fork anchors which get added to pending.
     void CheckPendingAnchors();
 
     // Store and read Bitcoin block hash by height, used in BestOfTwo calculation.
-    bool WriteBlock(const uint32_t height, const uint256& blockHash);
-    uint256 ReadBlockHash(const uint32_t& height);
+    bool WriteBlock(const uint32_t height, const uint256 &blockHash);
+    uint256 ReadBlockHash(const uint32_t &height);
 
-    AnchorRec const * GetLatestAnchorUpToDeFiHeight(THeight blockHeightDeFi) const;
+    AnchorRec const *GetLatestAnchorUpToDeFiHeight(THeight blockHeightDeFi) const;
 
-private:
+   private:
     AnchorIndexImpl anchors;
-    AnchorRec const * top = nullptr;
+    AnchorRec const *top = nullptr;
     bool possibleReActivation = false;
     uint32_t spvLastHeight = 0;
 
-private:
+   private:
     template <typename Key, typename Value>
-    bool IterateTable(char prefix, std::function<void(Key const &, Value &)> callback)
-    {
-        std::unique_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&*db)->NewIterator());
+    bool IterateTable(char prefix, std::function<void(Key const &, Value &)> callback) {
+        std::unique_ptr<CDBIterator> pcursor(const_cast<CDBWrapper *>(&*db)->NewIterator());
         pcursor->Seek(prefix);
 
-        while (pcursor->Valid())
-        {
+        while (pcursor->Valid()) {
             boost::this_thread::interruption_point();
             std::pair<char, Key> key;
-            if (pcursor->GetKey(key) && key.first == prefix)
-            {
+            if (pcursor->GetKey(key) && key.first == prefix) {
                 Value value;
-                if (pcursor->GetValue(value))
-                {
+                if (pcursor->GetValue(value)) {
                     callback(key.second, value);
                 } else {
                     return error("Anchors::Load() : unable to read value");
@@ -296,14 +273,13 @@ private:
         return true;
     }
 
-    bool DbExists(uint256 const & hash) const;
-    bool DbRead(uint256 const & hash, AnchorRec & anchor) const;
-    bool DbWrite(AnchorRec const & anchor);
-    bool DbErase(uint256 const & hash);
+    bool DbExists(uint256 const &hash) const;
+    bool DbRead(uint256 const &hash, AnchorRec &anchor) const;
+    bool DbWrite(AnchorRec const &anchor);
+    bool DbErase(uint256 const &hash);
 };
 
-struct CAnchorConfirmData
-{
+struct CAnchorConfirmData {
     uint256 btcTxHash;
     THeight anchorHeight;
     THeight prevAnchorHeight;
@@ -315,7 +291,7 @@ struct CAnchorConfirmData
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(btcTxHash);
         READWRITE(anchorHeight);
         READWRITE(prevAnchorHeight);
@@ -324,10 +300,8 @@ struct CAnchorConfirmData
     }
 };
 
-
 // derived from common struct at list to avoid serialization mistakes
-struct CAnchorFinalizationMessage : public CAnchorConfirmData
-{
+struct CAnchorFinalizationMessage : public CAnchorConfirmData {
     using Signature = std::vector<unsigned char>;
 
     // (base data + teams + all signs)
@@ -335,19 +309,15 @@ struct CAnchorFinalizationMessage : public CAnchorConfirmData
     CAnchorData::CTeam currentTeam;
     std::vector<Signature> sigs;
 
-    CAnchorFinalizationMessage(CAnchorConfirmData const & base = CAnchorConfirmData())
-        : CAnchorConfirmData(base)
-        , nextTeam()
-        , currentTeam()
-        , sigs()
-    {}
+    CAnchorFinalizationMessage(CAnchorConfirmData const &base = CAnchorConfirmData())
+        : CAnchorConfirmData(base), nextTeam(), currentTeam(), sigs() {}
 
     bool CheckConfirmSigs();
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAnchorConfirmData, *this);
         READWRITE(nextTeam);
         READWRITE(currentTeam);
@@ -355,22 +325,22 @@ struct CAnchorFinalizationMessage : public CAnchorConfirmData
     }
 };
 
-
-struct CAnchorConfirmDataPlus : public CAnchorConfirmData
-{
+struct CAnchorConfirmDataPlus : public CAnchorConfirmData {
     uint256 dfiBlockHash;
     THeight btcTxHeight{0};
 
-    CAnchorConfirmDataPlus(const uint256& btcTxHash, const THeight anchorHeight, const THeight prevAnchorHeight, const CKeyID& rewardKeyID,
-                           const char rewardKeyType, const uint256& dfiBlockHash, const THeight btcTxHeight)
+    CAnchorConfirmDataPlus(const uint256 &btcTxHash,
+                           const THeight anchorHeight,
+                           const THeight prevAnchorHeight,
+                           const CKeyID &rewardKeyID,
+                           const char rewardKeyType,
+                           const uint256 &dfiBlockHash,
+                           const THeight btcTxHeight)
         : CAnchorConfirmData{btcTxHash, anchorHeight, prevAnchorHeight, rewardKeyID, rewardKeyType},
           dfiBlockHash{dfiBlockHash},
-          btcTxHeight{btcTxHeight}
-    {}
+          btcTxHeight{btcTxHeight} {}
 
-    explicit CAnchorConfirmDataPlus(const CAnchorFinalizationMessage& base)
-        : CAnchorConfirmData(base)
-    {}
+    explicit CAnchorConfirmDataPlus(const CAnchorFinalizationMessage &base) : CAnchorConfirmData(base) {}
 
     CAnchorConfirmDataPlus() = default;
 
@@ -379,7 +349,7 @@ struct CAnchorConfirmDataPlus : public CAnchorConfirmData
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAnchorConfirmData, *this);
         READWRITE(dfiBlockHash);
         READWRITE(btcTxHeight);
@@ -387,117 +357,106 @@ struct CAnchorConfirmDataPlus : public CAnchorConfirmData
 };
 
 // single confirmation message
-class CAnchorConfirmMessage : public CAnchorConfirmDataPlus
-{
-public:
+class CAnchorConfirmMessage : public CAnchorConfirmDataPlus {
+   public:
     using Signature = std::vector<unsigned char>;
 
     // (base data + single sign)
     Signature signature;
 
-    CAnchorConfirmMessage(CAnchorConfirmDataPlus const & base = CAnchorConfirmDataPlus())
-        : CAnchorConfirmDataPlus(base)
-        , signature()
-    {}
+    CAnchorConfirmMessage(CAnchorConfirmDataPlus const &base = CAnchorConfirmDataPlus())
+        : CAnchorConfirmDataPlus(base), signature() {}
 
-    static std::optional<CAnchorConfirmMessage> CreateSigned(const CAnchor &anchor, const THeight prevAnchorHeight,
-                                                               const uint256 &btcTxHash, CKey const & key, const THeight btcTxHeight);
+    static std::optional<CAnchorConfirmMessage> CreateSigned(const CAnchor &anchor,
+                                                             const THeight prevAnchorHeight,
+                                                             const uint256 &btcTxHash,
+                                                             CKey const &key,
+                                                             const THeight btcTxHeight);
     uint256 GetHash() const;
     CKeyID GetSigner() const;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAnchorConfirmDataPlus, *this);
         READWRITE(signature);
     }
 
     // tags for multiindex
-    struct ByMsgHash{};     // by message hash (for inv)
-    struct ByAnchor{};      // by btctxhash
-    struct ByKey{};         // composite, by btctxhash and GetSignHash for miner/reward creation
-    struct ByVote{};        // composite, by GetSignHash and signer, helps detect doublesigning
+    struct ByMsgHash {};  // by message hash (for inv)
+    struct ByAnchor {};   // by btctxhash
+    struct ByKey {};      // composite, by btctxhash and GetSignHash for miner/reward creation
+    struct ByVote {};     // composite, by GetSignHash and signer, helps detect doublesigning
 };
 
 // derived from common struct at list to avoid serialization mistakes
-struct CAnchorFinalizationMessagePlus : public CAnchorConfirmDataPlus
-{
+struct CAnchorFinalizationMessagePlus : public CAnchorConfirmDataPlus {
     std::vector<CAnchorConfirmMessage::Signature> sigs;
 
-    CAnchorFinalizationMessagePlus(CAnchorConfirmDataPlus const & base = CAnchorConfirmDataPlus())
-        : CAnchorConfirmDataPlus(base)
-        , sigs()
-    {}
+    CAnchorFinalizationMessagePlus(CAnchorConfirmDataPlus const &base = CAnchorConfirmDataPlus())
+        : CAnchorConfirmDataPlus(base), sigs() {}
 
     size_t CheckConfirmSigs(const uint32_t height);
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAnchorConfirmDataPlus, *this);
         READWRITE(sigs);
     }
 };
 
-class CAnchorAwaitingConfirms
-{
+class CAnchorAwaitingConfirms {
     using ConfirmMessageHash = uint256;
     using AnchorTxHash = uint256;
 
-private:
+   private:
     using Confirm = CAnchorConfirmMessage;
 
-    typedef boost::multi_index_container<Confirm,
+    typedef boost::multi_index_container<
+        Confirm,
         indexed_by<
             // index for p2p messaging (inv/getdata)
-            ordered_unique<
-                tag<Confirm::ByMsgHash>, const_mem_fun<Confirm, uint256, &Confirm::GetHash>
-            >,
+            ordered_unique<tag<Confirm::ByMsgHash>, const_mem_fun<Confirm, uint256, &Confirm::GetHash>>,
             // index for group confirms deletion
-            ordered_non_unique<
-                tag<Confirm::ByAnchor>, member<CAnchorConfirmData, uint256, &CAnchorConfirmData::btcTxHash>
-            >,
+            ordered_non_unique<tag<Confirm::ByAnchor>,
+                               member<CAnchorConfirmData, uint256, &CAnchorConfirmData::btcTxHash>>,
             // index for quorum selection (miner affected) Protected against double signing.
             // just to remember that there may be confirms with equal btcTxHeight, but with different teams!
-            ordered_unique<
-                tag<Confirm::ByKey>, composite_key<Confirm,
-                    member<CAnchorConfirmDataPlus, THeight, &CAnchorConfirmDataPlus::btcTxHeight>,
-                    member<CAnchorConfirmData, uint256, &CAnchorConfirmData::btcTxHash>,
-                    const_mem_fun<Confirm, CKeyID, &Confirm::GetSigner>
-                >
-            >,
+            ordered_unique<tag<Confirm::ByKey>,
+                           composite_key<Confirm,
+                                         member<CAnchorConfirmDataPlus, THeight, &CAnchorConfirmDataPlus::btcTxHeight>,
+                                         member<CAnchorConfirmData, uint256, &CAnchorConfirmData::btcTxHash>,
+                                         const_mem_fun<Confirm, CKeyID, &Confirm::GetSigner>>>,
             // restriction index that helps detect doublesigning
             // it may by quite expensive to index by GetSigner on the fly, but it should happen only on insertion
             ordered_unique<
-                tag<Confirm::ByVote>, composite_key<Confirm,
-                    const_mem_fun<CAnchorConfirmDataPlus, uint256, &CAnchorConfirmDataPlus::GetSignHash>,
-                    const_mem_fun<Confirm, CKeyID, &Confirm::GetSigner>
-                >
-            >
-        >
-    > Confirms;
+                tag<Confirm::ByVote>,
+                composite_key<Confirm,
+                              const_mem_fun<CAnchorConfirmDataPlus, uint256, &CAnchorConfirmDataPlus::GetSignHash>,
+                              const_mem_fun<Confirm, CKeyID, &Confirm::GetSigner>>>>>
+        Confirms;
 
     Confirms confirms;
 
-public:
+   public:
     bool EraseAnchor(AnchorTxHash const &txHash);
     const CAnchorConfirmMessage *GetConfirm(ConfirmMessageHash const &msgHash) const;
     bool Add(CAnchorConfirmMessage const &newConfirmMessage);
     bool Validate(CAnchorConfirmMessage const &confirmMessage) const;
     void Clear();
     void ReVote();
-    std::vector<CAnchorConfirmMessage> GetQuorumFor(CAnchorData::CTeam const & team) const;
+    std::vector<CAnchorConfirmMessage> GetQuorumFor(CAnchorData::CTeam const &team) const;
 
     void ForEachConfirm(std::function<void(Confirm const &)> callback) const;
 };
 
 template <typename TContainer>
-size_t CheckSigs(uint256 const & sigHash, TContainer const & sigs, std::set<CKeyID> const & keys)
-{
+size_t CheckSigs(uint256 const &sigHash, TContainer const &sigs, std::set<CKeyID> const &keys) {
     std::set<CPubKey> uniqueKeys;
-    for (auto const & sig : sigs) {
+    for (auto const &sig : sigs) {
         CPubKey pubkey;
         if (!pubkey.RecoverCompact(sigHash, sig) || keys.find(pubkey.GetID()) == keys.end())
             return false;
@@ -509,33 +468,34 @@ size_t CheckSigs(uint256 const & sigHash, TContainer const & sigs, std::set<CKey
 
 /// dummy, unknown consensus rules yet. may be additional params needed (smth like 'height')
 /// even may be not here, but in CCustomCSView
-uint32_t GetMinAnchorQuorum(CAnchorData::CTeam const & team);
-CAmount GetAnchorSubsidy(int anchorHeight, int prevAnchorHeight, const Consensus::Params& consensusParams);
+uint32_t GetMinAnchorQuorum(CAnchorData::CTeam const &team);
+CAmount GetAnchorSubsidy(int anchorHeight, int prevAnchorHeight, const Consensus::Params &consensusParams);
 
 // thowing exceptions (not a bool due to more verbose rpc errors. may be 'status' or smth? )
 /// Validates all except tx confirmations
-bool ValidateAnchor(CAnchor const & anchor);
+bool ValidateAnchor(CAnchor const &anchor);
 
 // Validate anchor in the context of the active chain. This is used for anchor auths and anchors read from Bitcoin.
-bool ContextualValidateAnchor(const CAnchorData& anchor, CBlockIndex &anchorBlock, uint64_t &anchorCreationHeight);
+bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex &anchorBlock, uint64_t &anchorCreationHeight);
 
 // Get info from data embedded into CAnchorData::nextTeam
-bool GetAnchorEmbeddedData(const CKeyID& data, uint64_t& anchorCreationHeight, std::shared_ptr<std::vector<unsigned char>>& prefix);
+bool GetAnchorEmbeddedData(const CKeyID &data,
+                           uint64_t &anchorCreationHeight,
+                           std::shared_ptr<std::vector<unsigned char>> &prefix);
 
 // Selects "best" of two anchors at the equal btc height (prevs must be checked before)
-CAnchorIndex::AnchorRec const* BestOfTwo(CAnchorIndex::AnchorRec const* a1, CAnchorIndex::AnchorRec const* a2);
+CAnchorIndex::AnchorRec const *BestOfTwo(CAnchorIndex::AnchorRec const *a1, CAnchorIndex::AnchorRec const *a2);
 
 /** Global variables that points to the anchors and their auths (should be protected by cs_main) */
 extern std::unique_ptr<CAnchorAuthIndex> panchorauths;
 extern std::unique_ptr<CAnchorIndex> panchors;
 extern std::unique_ptr<CAnchorAwaitingConfirms> panchorAwaitingConfirms;
 
-namespace spv
-{
+namespace spv {
 // Define comparator and set to hold pending anchors
-using PendingOrderType = std::function<bool (const CAnchorIndex::AnchorRec&, const CAnchorIndex::AnchorRec&)>;
+using PendingOrderType = std::function<bool(const CAnchorIndex::AnchorRec &, const CAnchorIndex::AnchorRec &)>;
 using PendingSet = std::set<CAnchorIndex::AnchorRec, PendingOrderType>;
 extern const PendingOrderType PendingOrder;
-}
+}  // namespace spv
 
-#endif // DEFI_MASTERNODES_ANCHORS_H
+#endif  // DEFI_MASTERNODES_ANCHORS_H

--- a/src/masternodes/auctionhistory.cpp
+++ b/src/masternodes/auctionhistory.cpp
@@ -2,23 +2,22 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
+#include <key_io.h>
 #include <masternodes/auctionhistory.h>
 #include <masternodes/masternodes.h>
-#include <key_io.h>
 
-void CAuctionHistoryView::ForEachAuctionHistory(std::function<bool(AuctionHistoryKey const &, CLazySerialize<AuctionHistoryValue>)> callback, AuctionHistoryKey const & start)
-{
+void CAuctionHistoryView::ForEachAuctionHistory(
+    std::function<bool(AuctionHistoryKey const &, CLazySerialize<AuctionHistoryValue>)> callback,
+    AuctionHistoryKey const &start) {
     ForEach<ByAuctionHistoryKey, AuctionHistoryKey, AuctionHistoryValue>(callback, start);
 }
 
-Res CAuctionHistoryView::WriteAuctionHistory(const AuctionHistoryKey& key, const AuctionHistoryValue& value)
-{
+Res CAuctionHistoryView::WriteAuctionHistory(const AuctionHistoryKey &key, const AuctionHistoryValue &value) {
     WriteBy<ByAuctionHistoryKey>(key, value);
     return Res::Ok();
 }
 
-Res CAuctionHistoryView::EraseAuctionHistoryHeight(uint32_t height)
-{
+Res CAuctionHistoryView::EraseAuctionHistoryHeight(uint32_t height) {
     std::vector<AuctionHistoryKey> keysToDelete;
 
     auto it = LowerBound<ByAuctionHistoryKey>(AuctionHistoryKey{height});
@@ -26,14 +25,13 @@ Res CAuctionHistoryView::EraseAuctionHistoryHeight(uint32_t height)
         keysToDelete.push_back(it.Key());
     }
 
-    for (const auto& key : keysToDelete) {
+    for (const auto &key : keysToDelete) {
         EraseAuctionHistory(key);
     }
     return Res::Ok();
 }
 
-Res CAuctionHistoryView::EraseAuctionHistory(const AuctionHistoryKey& key)
-{
+Res CAuctionHistoryView::EraseAuctionHistory(const AuctionHistoryKey &key) {
     EraseBy<ByAuctionHistoryKey>(key);
     return Res::Ok();
 }

--- a/src/masternodes/auctionhistory.h
+++ b/src/masternodes/auctionhistory.h
@@ -20,8 +20,7 @@ struct AuctionHistoryKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(blockHeight));
             blockHeight = ~blockHeight;
@@ -43,23 +42,25 @@ struct AuctionHistoryValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(bidAmount);
         READWRITE(collaterals);
     }
 };
 
-class CAuctionHistoryView : public virtual CStorageView
-{
-public:
-    Res WriteAuctionHistory(AuctionHistoryKey const & key, AuctionHistoryValue const & value);
-    Res EraseAuctionHistory(AuctionHistoryKey const & key);
+class CAuctionHistoryView : public virtual CStorageView {
+   public:
+    Res WriteAuctionHistory(AuctionHistoryKey const &key, AuctionHistoryValue const &value);
+    Res EraseAuctionHistory(AuctionHistoryKey const &key);
     Res EraseAuctionHistoryHeight(uint32_t height);
-    void ForEachAuctionHistory(std::function<bool(AuctionHistoryKey const &, CLazySerialize<AuctionHistoryValue>)> callback, AuctionHistoryKey const & start = {});
+    void ForEachAuctionHistory(
+        std::function<bool(AuctionHistoryKey const &, CLazySerialize<AuctionHistoryValue>)> callback,
+        AuctionHistoryKey const &start = {});
 
     // tags
-    struct ByAuctionHistoryKey { static constexpr uint8_t prefix() { return 'a'; } };
+    struct ByAuctionHistoryKey {
+        static constexpr uint8_t prefix() { return 'a'; }
+    };
 };
 
-
-#endif //DEFI_MASTERNODES_AUCTIONHISTORY_H
+#endif  // DEFI_MASTERNODES_AUCTIONHISTORY_H

--- a/src/masternodes/balances.h
+++ b/src/masternodes/balances.h
@@ -5,13 +5,12 @@
 #ifndef DEFI_MASTERNODES_BALANCES_H
 #define DEFI_MASTERNODES_BALANCES_H
 
-#include <cstdint>
 #include <amount.h>
-#include <serialize.h>
 #include <script/script.h>
+#include <serialize.h>
+#include <cstdint>
 
-struct CBalances
-{
+struct CBalances {
     TAmounts balances;
 
     Res Add(CTokenAmount amount) {
@@ -59,8 +58,8 @@ struct CBalances
         }
         return CTokenAmount{amount.nTokenId, remainder};
     }
-    Res SubBalances(TAmounts const & other) {
-        for (const auto& kv : other) {
+    Res SubBalances(TAmounts const &other) {
+        for (const auto &kv : other) {
             auto res = Sub(CTokenAmount{kv.first, kv.second});
             if (!res.ok) {
                 return res;
@@ -68,9 +67,9 @@ struct CBalances
         }
         return Res::Ok();
     }
-    CBalances SubBalancesWithRemainder(TAmounts const & other) {
+    CBalances SubBalancesWithRemainder(TAmounts const &other) {
         CBalances remainderBalances;
-        for (const auto& kv : other) {
+        for (const auto &kv : other) {
             CTokenAmount remainder = SubWithRemainder(CTokenAmount{kv.first, kv.second});
             // if remainder token value is zero
             // this addition won't get any effect
@@ -78,8 +77,8 @@ struct CBalances
         }
         return remainderBalances;
     }
-    Res AddBalances(TAmounts const & other) {
-        for (const auto& kv : other) {
+    Res AddBalances(TAmounts const &other) {
+        for (const auto &kv : other) {
             auto res = Add(CTokenAmount{kv.first, kv.second});
             if (!res.ok) {
                 return res;
@@ -91,7 +90,7 @@ struct CBalances
     std::string ToString() const {
         std::string str;
         str.reserve(100);
-        for (const auto& kv : balances) {
+        for (const auto &kv : balances) {
             if (!str.empty()) {
                 str += ",";
             }
@@ -100,25 +99,21 @@ struct CBalances
         return str;
     }
 
-    static CBalances Sum(std::vector<CTokenAmount> const & tokens) {
+    static CBalances Sum(std::vector<CTokenAmount> const &tokens) {
         CBalances res;
-        for (const auto& token : tokens) {
+        for (const auto &token : tokens) {
             res.Add(token);
         }
         return res;
     }
 
-    friend bool operator==(const CBalances& a, const CBalances& b) {
-        return a.balances == b.balances;
-    }
+    friend bool operator==(const CBalances &a, const CBalances &b) { return a.balances == b.balances; }
 
-    friend bool operator!=(const CBalances& a, const CBalances& b) {
-        return a.balances != b.balances;
-    }
+    friend bool operator!=(const CBalances &a, const CBalances &b) { return a.balances != b.balances; }
 
     // NOTE: if some balance from b is hgher than a => a is less than b
-    friend bool operator<(const CBalances& a, const CBalances& b) {
-        for (const auto& b_kv : b.balances) {
+    friend bool operator<(const CBalances &a, const CBalances &b) {
+        for (const auto &b_kv : b.balances) {
             const auto a_value_it = a.balances.find(b_kv.first);
             CAmount a_value = 0;
             if (a_value_it != a.balances.end()) {
@@ -134,7 +129,7 @@ struct CBalances
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         static_assert(std::is_same<decltype(balances), std::map<DCT_ID, CAmount>>::value, "Following code is invalid");
         std::map<uint32_t, CAmount> serializedBalances;
         if (ser_action.ForRead()) {
@@ -149,7 +144,7 @@ struct CBalances
                 serializedBalances.erase(it++);
             }
         } else {
-            for (const auto& it : balances) {
+            for (const auto &it : balances) {
                 serializedBalances.emplace(it.first.v, it.second);
             }
             READWRITE(serializedBalances);
@@ -165,7 +160,7 @@ struct CAccountToUtxosMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(balances);
         READWRITE(VARINT(mintingOutputsStart));
@@ -176,37 +171,37 @@ using CAccounts = std::map<CScript, CBalances>;
 
 struct CAccountToAccountMessage {
     CScript from;
-    CAccounts to; // to -> balances
+    CAccounts to;  // to -> balances
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(to);
     }
 };
 
 struct CAnyAccountsToAccountsMessage {
-    CAccounts from; // from -> balances
-    CAccounts to; // to -> balances
+    CAccounts from;  // from -> balances
+    CAccounts to;    // to -> balances
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(to);
     }
 };
 
 struct CUtxosToAccountMessage {
-    CAccounts to; // to -> balances
+    CAccounts to;  // to -> balances
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(to);
     }
 };
@@ -218,7 +213,7 @@ struct CSmartContractMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(name);
         READWRITE(accounts);
     }
@@ -233,7 +228,7 @@ struct CFutureSwapMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(owner);
         READWRITE(source);
         READWRITE(destination);
@@ -241,9 +236,9 @@ struct CFutureSwapMessage {
     }
 };
 
-inline CBalances SumAllTransfers(CAccounts const & to) {
+inline CBalances SumAllTransfers(CAccounts const &to) {
     CBalances sum;
-    for (const auto& kv : to) {
+    for (const auto &kv : to) {
         sum.AddBalances(kv.second.balances);
     }
     return sum;
@@ -256,9 +251,9 @@ struct BalanceKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(owner);
         READWRITE(WrapBigEndian(tokenID.v));
     }
 };
-#endif //DEFI_MASTERNODES_BALANCES_H
+#endif  // DEFI_MASTERNODES_BALANCES_H

--- a/src/masternodes/communityaccounttypes.h
+++ b/src/masternodes/communityaccounttypes.h
@@ -5,14 +5,13 @@
 #ifndef DEFI_MASTERNODES_COMMUNITYACCOUNTTYPES_H
 #define DEFI_MASTERNODES_COMMUNITYACCOUNTTYPES_H
 
-enum class CommunityAccountType : unsigned char
-{
+enum class CommunityAccountType : unsigned char {
     None = 0,
-    IncentiveFunding    = 'I', // or 'yield farming' - source of community rewards for LP (Liquidity Pools)
-    AnchorReward        = 'A',
-    Loan                = 'L',
-    Options             = 'O',
-    Unallocated         = 'U',
+    IncentiveFunding = 'I',  // or 'yield farming' - source of community rewards for LP (Liquidity Pools)
+    AnchorReward = 'A',
+    Loan = 'L',
+    Options = 'O',
+    Unallocated = 'U',
 };
 
-#endif //DEFI_MASTERNODES_COMMUNITYACCOUNTTYPES_H
+#endif  // DEFI_MASTERNODES_COMMUNITYACCOUNTTYPES_H

--- a/src/masternodes/factory.h
+++ b/src/masternodes/factory.h
@@ -9,10 +9,9 @@
 #include <string>
 
 template <typename TBaseType>
-class Factory
-{
-public:
-    typedef TBaseType * (* Creator)(); // creator function
+class Factory {
+   public:
+    typedef TBaseType *(*Creator)();  // creator function
 
     Factory() = delete;
     ~Factory() = delete;
@@ -23,7 +22,7 @@ public:
         return res.second;
     }
 
-    static TBaseType * Create(std::string const & name) {
+    static TBaseType *Create(std::string const &name) {
         typename TCreators::const_iterator creator(m_creators.find(name));
         if (creator == m_creators.end()) {
             return {};
@@ -31,16 +30,17 @@ public:
         return creator->second();
     }
 
-private:
+   private:
     typedef std::map<std::string, Creator> TCreators;
     static TCreators m_creators;
 
     // force instantiation of definition of static member, do not touch!
-    template<TCreators&> struct dummy_ref { };
+    template <TCreators &>
+    struct dummy_ref {};
     static dummy_ref<m_creators> referrer;
 };
 
-template<typename TBaseType, typename TDerivedType>
+template <typename TBaseType, typename TDerivedType>
 class AutoRegistrator {
     struct exec_registrate {
         exec_registrate() {
@@ -51,14 +51,16 @@ class AutoRegistrator {
     static exec_registrate register_object;
 
     // force instantiation of definition of static member, do not touch!
-    template<exec_registrate&> struct dummy_ref { };
+    template <exec_registrate &>
+    struct dummy_ref {};
     static dummy_ref<register_object> referrer;
 };
 
 template <typename T>
 typename Factory<T>::TCreators Factory<T>::m_creators;
 
-template<typename TBaseType, typename TDerivedType>
-typename AutoRegistrator<TBaseType, TDerivedType>::exec_registrate AutoRegistrator<TBaseType, TDerivedType>::register_object;
+template <typename TBaseType, typename TDerivedType>
+typename AutoRegistrator<TBaseType, TDerivedType>::exec_registrate
+    AutoRegistrator<TBaseType, TDerivedType>::register_object;
 
-#endif // DEFI_MASTERNODES_FACTORY_H
+#endif  // DEFI_MASTERNODES_FACTORY_H

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -2,31 +2,27 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#include <masternodes/mn_rpc.h>
 #include <masternodes/govvariables/attributes.h>
+#include <masternodes/mn_rpc.h>
 
-#include <masternodes/accountshistory.h> /// CAccountsHistoryWriter
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <masternodes/mn_checks.h> /// GetAggregatePrice / CustomTxType
-#include <validation.h> /// GetNextAccPosition
+#include <masternodes/accountshistory.h>  /// CAccountsHistoryWriter
+#include <masternodes/masternodes.h>      /// CCustomCSView
+#include <masternodes/mn_checks.h>        /// GetAggregatePrice / CustomTxType
+#include <validation.h>                   /// GetNextAccPosition
 
-#include <amount.h> /// GetDecimaleString
-#include <core_io.h> /// ValueFromAmount
+#include <amount.h>   /// GetDecimaleString
+#include <core_io.h>  /// ValueFromAmount
 #include <util/strencodings.h>
 
-extern UniValue AmountsToJSON(TAmounts const & diffs, AmountFormat format = AmountFormat::Symbol);
+extern UniValue AmountsToJSON(TAmounts const &diffs, AmountFormat format = AmountFormat::Symbol);
 
 static inline std::string trim_all_ws(std::string s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }));
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), s.end());
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
     return s;
 }
 
-static std::vector<std::string> KeyBreaker(const std::string& str, const char delim = '/'){
+static std::vector<std::string> KeyBreaker(const std::string &str, const char delim = '/') {
     std::string section;
     std::istringstream stream(str);
     std::vector<std::string> strVec;
@@ -37,190 +33,181 @@ static std::vector<std::string> KeyBreaker(const std::string& str, const char de
     return strVec;
 }
 
-const std::map<std::string, uint8_t>& ATTRIBUTES::allowedVersions() {
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedVersions() {
     static const std::map<std::string, uint8_t> versions{
-        {"v0",  VersionTypes::v0},
+        {"v0", VersionTypes::v0},
     };
     return versions;
 }
 
-const std::map<uint8_t, std::string>& ATTRIBUTES::displayVersions() {
+const std::map<uint8_t, std::string> &ATTRIBUTES::displayVersions() {
     static const std::map<uint8_t, std::string> versions{
-        {VersionTypes::v0,  "v0"},
+        {VersionTypes::v0, "v0"},
     };
     return versions;
 }
 
-const std::map<std::string, uint8_t>& ATTRIBUTES::allowedTypes() {
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedTypes() {
     static const std::map<std::string, uint8_t> types{
-        {"locks",       AttributeTypes::Locks},
-        {"oracles",     AttributeTypes::Oracles},
-        {"params",      AttributeTypes::Param},
-        {"poolpairs",   AttributeTypes::Poolpairs},
-        {"token",       AttributeTypes::Token},
+        {"locks", AttributeTypes::Locks},
+        {"oracles", AttributeTypes::Oracles},
+        {"params", AttributeTypes::Param},
+        {"poolpairs", AttributeTypes::Poolpairs},
+        {"token", AttributeTypes::Token},
     };
     return types;
 }
 
-const std::map<uint8_t, std::string>& ATTRIBUTES::displayTypes() {
+const std::map<uint8_t, std::string> &ATTRIBUTES::displayTypes() {
     static const std::map<uint8_t, std::string> types{
-        {AttributeTypes::Live,      "live"},
-        {AttributeTypes::Locks,     "locks"},
-        {AttributeTypes::Oracles,   "oracles"},
-        {AttributeTypes::Param,     "params"},
+        {AttributeTypes::Live, "live"},
+        {AttributeTypes::Locks, "locks"},
+        {AttributeTypes::Oracles, "oracles"},
+        {AttributeTypes::Param, "params"},
         {AttributeTypes::Poolpairs, "poolpairs"},
-        {AttributeTypes::Token,     "token"},
+        {AttributeTypes::Token, "token"},
     };
     return types;
 }
 
-const std::map<std::string, uint8_t>& ATTRIBUTES::allowedParamIDs() {
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedParamIDs() {
     static const std::map<std::string, uint8_t> params{
-        {"dfip2201",    ParamIDs::DFIP2201},
-        {"dfip2203",    ParamIDs::DFIP2203},
-        {"dfip2206a",   ParamIDs::DFIP2206A},
-        // Note: DFIP2206F is currently in beta testing 
-        // for testnet. May not be enabled on mainnet until testing is complete. 
-        {"dfip2206f",   ParamIDs::DFIP2206F},
+        {"dfip2201", ParamIDs::DFIP2201},
+        {"dfip2203", ParamIDs::DFIP2203},
+        {"dfip2206a", ParamIDs::DFIP2206A},
+        // Note: DFIP2206F is currently in beta testing
+        // for testnet. May not be enabled on mainnet until testing is complete.
+        {"dfip2206f", ParamIDs::DFIP2206F},
     };
     return params;
 }
 
-const std::map<std::string, uint8_t>& ATTRIBUTES::allowedLocksIDs() {
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedLocksIDs() {
     static const std::map<std::string, uint8_t> params{
-            {"token",       ParamIDs::TokenID},
+        {"token", ParamIDs::TokenID},
     };
     return params;
 }
 
-const std::map<uint8_t, std::string>& ATTRIBUTES::displayParamsIDs() {
+const std::map<uint8_t, std::string> &ATTRIBUTES::displayParamsIDs() {
     static const std::map<uint8_t, std::string> params{
-        {ParamIDs::DFIP2201,    "dfip2201"},
-        {ParamIDs::DFIP2203,    "dfip2203"},
-        {ParamIDs::DFIP2206A,   "dfip2206a"},
-        // Note: DFIP2206F is currently in beta testing 
-        // for testnet. May not be enabled on mainnet until testing is complete. 
-        {ParamIDs::DFIP2206F,   "dfip2206f"},
-        {ParamIDs::TokenID,     "token"},
-        {ParamIDs::Economy,     "economy"},
+        {ParamIDs::DFIP2201, "dfip2201"},
+        {ParamIDs::DFIP2203, "dfip2203"},
+        {ParamIDs::DFIP2206A, "dfip2206a"},
+        // Note: DFIP2206F is currently in beta testing
+        // for testnet. May not be enabled on mainnet until testing is complete.
+        {ParamIDs::DFIP2206F, "dfip2206f"},
+        {ParamIDs::TokenID, "token"},
+        {ParamIDs::Economy, "economy"},
     };
     return params;
 }
 
-const std::map<std::string, uint8_t>& ATTRIBUTES::allowedOracleIDs() {
-    static const std::map<std::string, uint8_t> params{
-            {"splits",    OracleIDs::Splits}
-    };
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedOracleIDs() {
+    static const std::map<std::string, uint8_t> params{{"splits", OracleIDs::Splits}};
     return params;
 }
 
-const std::map<uint8_t, std::string>& ATTRIBUTES::displayOracleIDs() {
+const std::map<uint8_t, std::string> &ATTRIBUTES::displayOracleIDs() {
     static const std::map<uint8_t, std::string> params{
-            {OracleIDs::Splits,    "splits"},
+        {OracleIDs::Splits, "splits"},
     };
     return params;
 }
 
-const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys() {
+const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys() {
     static const std::map<uint8_t, std::map<std::string, uint8_t>> keys{
-        {
-            AttributeTypes::Token, {
-                {"payback_dfi",             TokenKeys::PaybackDFI},
-                {"payback_dfi_fee_pct",     TokenKeys::PaybackDFIFeePCT},
-                {"loan_payback",            TokenKeys::LoanPayback},
-                {"loan_payback_fee_pct",    TokenKeys::LoanPaybackFeePCT},
-                {"dex_in_fee_pct",          TokenKeys::DexInFeePct},
-                {"dex_out_fee_pct",         TokenKeys::DexOutFeePct},
-                {"dfip2203",                TokenKeys::DFIP2203Enabled},
-                {"fixed_interval_price_id", TokenKeys::FixedIntervalPriceId},
-                {"loan_collateral_enabled", TokenKeys::LoanCollateralEnabled},
-                {"loan_collateral_factor",  TokenKeys::LoanCollateralFactor},
-                {"loan_minting_enabled",    TokenKeys::LoanMintingEnabled},
-                {"loan_minting_interest",   TokenKeys::LoanMintingInterest},
-            }
-        },
-        {
-            AttributeTypes::Poolpairs, {
-                {"token_a_fee_pct",      PoolKeys::TokenAFeePCT},
-                {"token_a_fee_direction",PoolKeys::TokenAFeeDir},
-                {"token_b_fee_pct",      PoolKeys::TokenBFeePCT},
-                {"token_b_fee_direction",PoolKeys::TokenBFeeDir},
-            }
-        },
-        {
-            AttributeTypes::Param, {
-                {"active",                      DFIPKeys::Active},
-                {"minswap",                     DFIPKeys::MinSwap},
-                {"premium",                     DFIPKeys::Premium},
-                {"reward_pct",                  DFIPKeys::RewardPct},
-                {"block_period",                DFIPKeys::BlockPeriod},
-                {"dusd_interest_burn",          DFIPKeys::DUSDInterestBurn},
-                {"dusd_loan_burn",              DFIPKeys::DUSDLoanBurn},
-                {"start_block",                 DFIPKeys::StartBlock},
-            }
-        },
+        {AttributeTypes::Token,
+         {
+             {"payback_dfi", TokenKeys::PaybackDFI},
+             {"payback_dfi_fee_pct", TokenKeys::PaybackDFIFeePCT},
+             {"loan_payback", TokenKeys::LoanPayback},
+             {"loan_payback_fee_pct", TokenKeys::LoanPaybackFeePCT},
+             {"dex_in_fee_pct", TokenKeys::DexInFeePct},
+             {"dex_out_fee_pct", TokenKeys::DexOutFeePct},
+             {"dfip2203", TokenKeys::DFIP2203Enabled},
+             {"fixed_interval_price_id", TokenKeys::FixedIntervalPriceId},
+             {"loan_collateral_enabled", TokenKeys::LoanCollateralEnabled},
+             {"loan_collateral_factor", TokenKeys::LoanCollateralFactor},
+             {"loan_minting_enabled", TokenKeys::LoanMintingEnabled},
+             {"loan_minting_interest", TokenKeys::LoanMintingInterest},
+         }},
+        {AttributeTypes::Poolpairs,
+         {
+             {"token_a_fee_pct", PoolKeys::TokenAFeePCT},
+             {"token_a_fee_direction", PoolKeys::TokenAFeeDir},
+             {"token_b_fee_pct", PoolKeys::TokenBFeePCT},
+             {"token_b_fee_direction", PoolKeys::TokenBFeeDir},
+         }},
+        {AttributeTypes::Param,
+         {
+             {"active", DFIPKeys::Active},
+             {"minswap", DFIPKeys::MinSwap},
+             {"premium", DFIPKeys::Premium},
+             {"reward_pct", DFIPKeys::RewardPct},
+             {"block_period", DFIPKeys::BlockPeriod},
+             {"dusd_interest_burn", DFIPKeys::DUSDInterestBurn},
+             {"dusd_loan_burn", DFIPKeys::DUSDLoanBurn},
+             {"start_block", DFIPKeys::StartBlock},
+         }},
     };
     return keys;
 }
 
-const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys() {
+const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys() {
     static const std::map<uint8_t, std::map<uint8_t, std::string>> keys{
-        {
-            AttributeTypes::Token, {
-                {TokenKeys::PaybackDFI,            "payback_dfi"},
-                {TokenKeys::PaybackDFIFeePCT,      "payback_dfi_fee_pct"},
-                {TokenKeys::LoanPayback,           "loan_payback"},
-                {TokenKeys::LoanPaybackFeePCT,     "loan_payback_fee_pct"},
-                {TokenKeys::DexInFeePct,           "dex_in_fee_pct"},
-                {TokenKeys::DexOutFeePct,          "dex_out_fee_pct"},
-                {TokenKeys::FixedIntervalPriceId,  "fixed_interval_price_id"},
-                {TokenKeys::LoanCollateralEnabled, "loan_collateral_enabled"},
-                {TokenKeys::LoanCollateralFactor,  "loan_collateral_factor"},
-                {TokenKeys::LoanMintingEnabled,    "loan_minting_enabled"},
-                {TokenKeys::LoanMintingInterest,   "loan_minting_interest"},
-                {TokenKeys::DFIP2203Enabled,       "dfip2203"},
-                {TokenKeys::Ascendant,             "ascendant"},
-                {TokenKeys::Descendant,            "descendant"},
-                {TokenKeys::Epitaph,               "epitaph"},
-            }
-        },
-        {
-            AttributeTypes::Poolpairs, {
-                {PoolKeys::TokenAFeePCT,      "token_a_fee_pct"},
-                {PoolKeys::TokenAFeeDir,      "token_a_fee_direction"},
-                {PoolKeys::TokenBFeePCT,      "token_b_fee_pct"},
-                {PoolKeys::TokenBFeeDir,      "token_b_fee_direction"},
-            }
-        },
-        {
-            AttributeTypes::Param, {
-                {DFIPKeys::Active,                  "active"},
-                {DFIPKeys::Premium,                 "premium"},
-                {DFIPKeys::MinSwap,                 "minswap"},
-                {DFIPKeys::RewardPct,               "reward_pct"},
-                {DFIPKeys::BlockPeriod,             "block_period"},
-                {DFIPKeys::DUSDInterestBurn,        "dusd_interest_burn"},
-                {DFIPKeys::DUSDLoanBurn,            "dusd_loan_burn"},
-                {DFIPKeys::StartBlock,              "start_block"},
-            }
-        },
-        {
-            AttributeTypes::Live, {
-                {EconomyKeys::PaybackDFITokens,  "dfi_payback_tokens"},
-                {EconomyKeys::DFIP2203Current,   "dfip2203_current"},
-                {EconomyKeys::DFIP2203Burned,    "dfip2203_burned"},
-                {EconomyKeys::DFIP2203Minted,    "dfip2203_minted"},
-                {EconomyKeys::DexTokens,         "dex"},
-                {EconomyKeys::DFIP2206FCurrent,   "dfip2206f_current"},
-                {EconomyKeys::DFIP2206FBurned,    "dfip2206f_burned"},
-                {EconomyKeys::DFIP2206FMinted,    "dfip2206f_minted"},
-            }
-        },
+        {AttributeTypes::Token,
+         {
+             {TokenKeys::PaybackDFI, "payback_dfi"},
+             {TokenKeys::PaybackDFIFeePCT, "payback_dfi_fee_pct"},
+             {TokenKeys::LoanPayback, "loan_payback"},
+             {TokenKeys::LoanPaybackFeePCT, "loan_payback_fee_pct"},
+             {TokenKeys::DexInFeePct, "dex_in_fee_pct"},
+             {TokenKeys::DexOutFeePct, "dex_out_fee_pct"},
+             {TokenKeys::FixedIntervalPriceId, "fixed_interval_price_id"},
+             {TokenKeys::LoanCollateralEnabled, "loan_collateral_enabled"},
+             {TokenKeys::LoanCollateralFactor, "loan_collateral_factor"},
+             {TokenKeys::LoanMintingEnabled, "loan_minting_enabled"},
+             {TokenKeys::LoanMintingInterest, "loan_minting_interest"},
+             {TokenKeys::DFIP2203Enabled, "dfip2203"},
+             {TokenKeys::Ascendant, "ascendant"},
+             {TokenKeys::Descendant, "descendant"},
+             {TokenKeys::Epitaph, "epitaph"},
+         }},
+        {AttributeTypes::Poolpairs,
+         {
+             {PoolKeys::TokenAFeePCT, "token_a_fee_pct"},
+             {PoolKeys::TokenAFeeDir, "token_a_fee_direction"},
+             {PoolKeys::TokenBFeePCT, "token_b_fee_pct"},
+             {PoolKeys::TokenBFeeDir, "token_b_fee_direction"},
+         }},
+        {AttributeTypes::Param,
+         {
+             {DFIPKeys::Active, "active"},
+             {DFIPKeys::Premium, "premium"},
+             {DFIPKeys::MinSwap, "minswap"},
+             {DFIPKeys::RewardPct, "reward_pct"},
+             {DFIPKeys::BlockPeriod, "block_period"},
+             {DFIPKeys::DUSDInterestBurn, "dusd_interest_burn"},
+             {DFIPKeys::DUSDLoanBurn, "dusd_loan_burn"},
+             {DFIPKeys::StartBlock, "start_block"},
+         }},
+        {AttributeTypes::Live,
+         {
+             {EconomyKeys::PaybackDFITokens, "dfi_payback_tokens"},
+             {EconomyKeys::DFIP2203Current, "dfip2203_current"},
+             {EconomyKeys::DFIP2203Burned, "dfip2203_burned"},
+             {EconomyKeys::DFIP2203Minted, "dfip2203_minted"},
+             {EconomyKeys::DexTokens, "dex"},
+             {EconomyKeys::DFIP2206FCurrent, "dfip2206f_current"},
+             {EconomyKeys::DFIP2206FBurned, "dfip2206f_burned"},
+             {EconomyKeys::DFIP2206FMinted, "dfip2206f_minted"},
+         }},
     };
     return keys;
 }
 
-static ResVal<int32_t> VerifyInt32(const std::string& str) {
+static ResVal<int32_t> VerifyInt32(const std::string &str) {
     int32_t int32;
     if (!ParseInt32(str, &int32)) {
         return Res::Err("Value must be an integer");
@@ -228,7 +215,7 @@ static ResVal<int32_t> VerifyInt32(const std::string& str) {
     return {int32, Res::Ok()};
 }
 
-static ResVal<int32_t> VerifyPositiveInt32(const std::string& str) {
+static ResVal<int32_t> VerifyPositiveInt32(const std::string &str) {
     int32_t int32;
     if (!ParseInt32(str, &int32) || int32 < 0) {
         return Res::Err("Value must be a positive integer");
@@ -236,7 +223,7 @@ static ResVal<int32_t> VerifyPositiveInt32(const std::string& str) {
     return {int32, Res::Ok()};
 }
 
-static ResVal<CAttributeValue> VerifyInt64(const std::string& str) {
+static ResVal<CAttributeValue> VerifyInt64(const std::string &str) {
     CAmount int64;
     if (!ParseInt64(str, &int64) || int64 < 0) {
         return Res::Err("Value must be a positive integer");
@@ -244,7 +231,7 @@ static ResVal<CAttributeValue> VerifyInt64(const std::string& str) {
     return {int64, Res::Ok()};
 }
 
-static ResVal<CAttributeValue> VerifyFloat(const std::string& str) {
+static ResVal<CAttributeValue> VerifyFloat(const std::string &str) {
     CAmount amount = 0;
     if (!ParseFixedPoint(str, 8, &amount) || amount < 0) {
         return Res::Err("Amount must be a positive value");
@@ -252,7 +239,7 @@ static ResVal<CAttributeValue> VerifyFloat(const std::string& str) {
     return {amount, Res::Ok()};
 }
 
-static ResVal<CAttributeValue> VerifyPct(const std::string& str) {
+static ResVal<CAttributeValue> VerifyPct(const std::string &str) {
     auto resVal = VerifyFloat(str);
     if (!resVal) {
         return resVal;
@@ -263,14 +250,14 @@ static ResVal<CAttributeValue> VerifyPct(const std::string& str) {
     return resVal;
 }
 
-static ResVal<CAttributeValue> VerifyBool(const std::string& str) {
+static ResVal<CAttributeValue> VerifyBool(const std::string &str) {
     if (str != "true" && str != "false") {
         return Res::Err(R"(Boolean value must be either "true" or "false")");
     }
     return {str == "true", Res::Ok()};
 }
 
-static ResVal<CAttributeValue> VerifySplit(const std::string& str) {
+static ResVal<CAttributeValue> VerifySplit(const std::string &str) {
     OracleSplits splits;
     const auto pairs = KeyBreaker(str);
     if (pairs.size() != 2) {
@@ -292,7 +279,7 @@ static ResVal<CAttributeValue> VerifySplit(const std::string& str) {
     return {splits, Res::Ok()};
 }
 
-static ResVal<CAttributeValue> VerifyCurrencyPair(const std::string& str) {
+static ResVal<CAttributeValue> VerifyCurrencyPair(const std::string &str) {
     const auto value = KeyBreaker(str);
     if (value.size() != 2) {
         return Res::Err("Exactly two entires expected for currency pair");
@@ -307,7 +294,7 @@ static ResVal<CAttributeValue> VerifyCurrencyPair(const std::string& str) {
 
 static std::set<std::string> dirSet{"both", "in", "out"};
 
-static ResVal<CAttributeValue> VerifyFeeDirection(const std::string& str) {
+static ResVal<CAttributeValue> VerifyFeeDirection(const std::string &str) {
     auto lowerStr = ToLower(str);
     const auto it = dirSet.find(lowerStr);
     if (it == dirSet.end()) {
@@ -316,92 +303,84 @@ static ResVal<CAttributeValue> VerifyFeeDirection(const std::string& str) {
     return {CFeeDir{static_cast<uint8_t>(std::distance(dirSet.begin(), it))}, Res::Ok()};
 }
 
-static bool VerifyToken(const CCustomCSView& view, const uint32_t id) {
+static bool VerifyToken(const CCustomCSView &view, const uint32_t id) {
     return view.GetToken(DCT_ID{id}).has_value();
 }
 
-static inline void rtrim(std::string& s, unsigned char remove) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [&remove](unsigned char ch) {
-        return ch != remove;
-    }).base(), s.end());
+static inline void rtrim(std::string &s, unsigned char remove) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [&remove](unsigned char ch) { return ch != remove; }).base(), s.end());
 }
 
-const std::map<uint8_t, std::map<uint8_t,
-    std::function<ResVal<CAttributeValue>(const std::string&)>>>& ATTRIBUTES::parseValue() {
-
-    static const std::map<uint8_t, std::map<uint8_t,
-        std::function<ResVal<CAttributeValue>(const std::string&)>>> parsers{
-        {
-            AttributeTypes::Token, {
-                {TokenKeys::PaybackDFI,            VerifyBool},
-                {TokenKeys::PaybackDFIFeePCT,      VerifyPct},
-                {TokenKeys::LoanPayback,           VerifyBool},
-                {TokenKeys::LoanPaybackFeePCT,     VerifyPct},
-                {TokenKeys::DexInFeePct,           VerifyPct},
-                {TokenKeys::DexOutFeePct,          VerifyPct},
-                {TokenKeys::FixedIntervalPriceId,  VerifyCurrencyPair},
-                {TokenKeys::LoanCollateralEnabled, VerifyBool},
-                {TokenKeys::LoanCollateralFactor,  VerifyPct},
-                {TokenKeys::LoanMintingEnabled,    VerifyBool},
-                {TokenKeys::LoanMintingInterest,   VerifyFloat},
-                {TokenKeys::DFIP2203Enabled,       VerifyBool},
-            }
-        },
-        {
-            AttributeTypes::Poolpairs, {
-                {PoolKeys::TokenAFeePCT,      VerifyPct},
-                {PoolKeys::TokenAFeeDir,      VerifyFeeDirection},
-                {PoolKeys::TokenBFeePCT,      VerifyPct},
-                {PoolKeys::TokenBFeeDir,      VerifyFeeDirection},
-            }
-        },
-        {
-            AttributeTypes::Param, {
-                {DFIPKeys::Active,                  VerifyBool},
-                {DFIPKeys::Premium,                 VerifyPct},
-                {DFIPKeys::MinSwap,                 VerifyFloat},
-                {DFIPKeys::RewardPct,               VerifyPct},
-                {DFIPKeys::BlockPeriod,             VerifyInt64},
-                {DFIPKeys::DUSDInterestBurn,  VerifyBool},
-                {DFIPKeys::DUSDLoanBurn,      VerifyBool},
-                {DFIPKeys::StartBlock,              VerifyInt64},
-            }
-        },
-        {
-            AttributeTypes::Locks, {
-                {ParamIDs::TokenID,          VerifyBool},
-            }
-        },
-        {
-            AttributeTypes::Oracles, {
-                {OracleIDs::Splits,          VerifySplit},
-            }
-        },
-    };
+const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(const std::string &)>>>
+    &ATTRIBUTES::parseValue() {
+    static const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(const std::string &)>>>
+        parsers{
+            {AttributeTypes::Token,
+             {
+                 {TokenKeys::PaybackDFI, VerifyBool},
+                 {TokenKeys::PaybackDFIFeePCT, VerifyPct},
+                 {TokenKeys::LoanPayback, VerifyBool},
+                 {TokenKeys::LoanPaybackFeePCT, VerifyPct},
+                 {TokenKeys::DexInFeePct, VerifyPct},
+                 {TokenKeys::DexOutFeePct, VerifyPct},
+                 {TokenKeys::FixedIntervalPriceId, VerifyCurrencyPair},
+                 {TokenKeys::LoanCollateralEnabled, VerifyBool},
+                 {TokenKeys::LoanCollateralFactor, VerifyPct},
+                 {TokenKeys::LoanMintingEnabled, VerifyBool},
+                 {TokenKeys::LoanMintingInterest, VerifyFloat},
+                 {TokenKeys::DFIP2203Enabled, VerifyBool},
+             }},
+            {AttributeTypes::Poolpairs,
+             {
+                 {PoolKeys::TokenAFeePCT, VerifyPct},
+                 {PoolKeys::TokenAFeeDir, VerifyFeeDirection},
+                 {PoolKeys::TokenBFeePCT, VerifyPct},
+                 {PoolKeys::TokenBFeeDir, VerifyFeeDirection},
+             }},
+            {AttributeTypes::Param,
+             {
+                 {DFIPKeys::Active, VerifyBool},
+                 {DFIPKeys::Premium, VerifyPct},
+                 {DFIPKeys::MinSwap, VerifyFloat},
+                 {DFIPKeys::RewardPct, VerifyPct},
+                 {DFIPKeys::BlockPeriod, VerifyInt64},
+                 {DFIPKeys::DUSDInterestBurn, VerifyBool},
+                 {DFIPKeys::DUSDLoanBurn, VerifyBool},
+                 {DFIPKeys::StartBlock, VerifyInt64},
+             }},
+            {AttributeTypes::Locks,
+             {
+                 {ParamIDs::TokenID, VerifyBool},
+             }},
+            {AttributeTypes::Oracles,
+             {
+                 {OracleIDs::Splits, VerifySplit},
+             }},
+        };
     return parsers;
 }
 
-ResVal<CScript> GetFutureSwapContractAddress(const std::string& contract) {
+ResVal<CScript> GetFutureSwapContractAddress(const std::string &contract) {
     CScript contractAddress;
     try {
         contractAddress = Params().GetConsensus().smartContracts.at(contract);
-    } catch (const std::out_of_range&) {
+    } catch (const std::out_of_range &) {
         return Res::Err("Failed to get smart contract address from chainparams");
     }
     return {contractAddress, Res::Ok()};
 }
 
-static Res ShowError(const std::string& key, const std::map<std::string, uint8_t>& keys) {
+static Res ShowError(const std::string &key, const std::map<std::string, uint8_t> &keys) {
     std::string error{"Unrecognised " + key + " argument provided, valid " + key + "s are:"};
-    for (const auto& pair : keys) {
+    for (const auto &pair : keys) {
         error += ' ' + pair.first + ',';
     }
     return Res::Err(error);
 }
 
-Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value,
-                                std::function<Res(const CAttributeType&, const CAttributeValue&)> applyVariable) {
-
+Res ATTRIBUTES::ProcessVariable(const std::string &key,
+                                const std::string &value,
+                                std::function<Res(const CAttributeType &, const CAttributeValue &)> applyVariable) {
     if (key.size() > 128) {
         return Res::Err("Identifier exceeds maximum length (128)");
     }
@@ -415,12 +394,12 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
         return Res::Err("Empty value");
     }
 
-    const auto& iver = allowedVersions().find(keys[0]);
+    const auto &iver = allowedVersions().find(keys[0]);
     if (iver == allowedVersions().end()) {
         return Res::Err("Unsupported version");
     }
 
-    const auto& version = iver->second;
+    const auto &version = iver->second;
     if (version != VersionTypes::v0) {
         return Res::Err("Unsupported version");
     }
@@ -496,19 +475,16 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
 
         if (type == AttributeTypes::Param) {
             if (typeId == ParamIDs::DFIP2201) {
-                if (typeKey != DFIPKeys::Active && typeKey != DFIPKeys::Premium  &&
-                    typeKey != DFIPKeys::MinSwap ) {
+                if (typeKey != DFIPKeys::Active && typeKey != DFIPKeys::Premium && typeKey != DFIPKeys::MinSwap) {
                     return Res::Err("Unsupported type for DFIP2201 {%d}", typeKey);
                 }
-            } else if (typeId == ParamIDs::DFIP2203 ||
-                       typeId == ParamIDs::DFIP2206F) {
-                if (typeKey != DFIPKeys::Active && typeKey != DFIPKeys::RewardPct &&
-                    typeKey != DFIPKeys::BlockPeriod && typeKey != DFIPKeys::StartBlock) {
+            } else if (typeId == ParamIDs::DFIP2203 || typeId == ParamIDs::DFIP2206F) {
+                if (typeKey != DFIPKeys::Active && typeKey != DFIPKeys::RewardPct && typeKey != DFIPKeys::BlockPeriod &&
+                    typeKey != DFIPKeys::StartBlock) {
                     return Res::Err("Unsupported type for this DFIP {%d}", typeKey);
                 }
 
-                if (typeKey == DFIPKeys::BlockPeriod ||
-                    typeKey == DFIPKeys::StartBlock) {
+                if (typeKey == DFIPKeys::BlockPeriod || typeKey == DFIPKeys::StartBlock) {
                     if (typeId == ParamIDs::DFIP2203) {
                         futureUpdated = true;
                     } else {
@@ -516,11 +492,10 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
                     }
                 }
             } else if (typeId == ParamIDs::DFIP2206A) {
-                if (typeKey != DFIPKeys::DUSDInterestBurn &&
-                    typeKey != DFIPKeys::DUSDLoanBurn) {
+                if (typeKey != DFIPKeys::DUSDInterestBurn && typeKey != DFIPKeys::DUSDLoanBurn) {
                     return Res::Err("Unsupported type for DFIP2206A {%d}", typeKey);
                 }
-            }  else {
+            } else {
                 return Res::Err("Unsupported Param ID");
             }
         }
@@ -551,13 +526,12 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
             }
             return applyVariable(attrV0, *attribValue.val);
         }
-    } catch (const std::out_of_range&) {
+    } catch (const std::out_of_range &) {
     }
     return Res::Err("No parse function {%d, %d}", type, typeKey);
 }
 
-Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t height, const uint32_t tokenID)
-{
+Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t height, const uint32_t tokenID) {
     CDataStructureV0 blockKey{AttributeTypes::Param, ParamIDs::DFIP2203, DFIPKeys::BlockPeriod};
     const auto blockPeriod = GetValue(blockKey, CAmount{});
     if (blockPeriod == 0) {
@@ -566,17 +540,19 @@ Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t hei
 
     std::map<CFuturesUserKey, CFuturesUserValue> userFuturesValues;
 
-    mnview.ForEachFuturesUserValues([&](const CFuturesUserKey& key, const CFuturesUserValue& futuresValues) {
-        if (tokenID != std::numeric_limits<uint32_t>::max()) {
-            if (futuresValues.source.nTokenId.v == tokenID || futuresValues.destination == tokenID) {
+    mnview.ForEachFuturesUserValues(
+        [&](const CFuturesUserKey &key, const CFuturesUserValue &futuresValues) {
+            if (tokenID != std::numeric_limits<uint32_t>::max()) {
+                if (futuresValues.source.nTokenId.v == tokenID || futuresValues.destination == tokenID) {
+                    userFuturesValues[key] = futuresValues;
+                }
+            } else {
                 userFuturesValues[key] = futuresValues;
             }
-        } else {
-            userFuturesValues[key] = futuresValues;
-        }
 
-        return true;
-    }, {height, {}, std::numeric_limits<uint32_t>::max()});
+            return true;
+        },
+        {height, {}, std::numeric_limits<uint32_t>::max()});
 
     const auto contractAddressValue = GetFutureSwapContractAddress(SMART_CONTRACT_DFIP_2203);
     if (!contractAddressValue) {
@@ -586,15 +562,15 @@ Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t hei
     CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::DFIP2203Current};
     auto balances = GetValue(liveKey, CBalances{});
 
-    CAccountHistoryStorage* historyStore{mnview.GetAccountHistoryStore()};
+    CAccountHistoryStorage *historyStore{mnview.GetAccountHistoryStore()};
     const auto currentHeight = mnview.GetLastHeight() + 1;
 
-    for (const auto& [key, value] : userFuturesValues) {
-
+    for (const auto &[key, value] : userFuturesValues) {
         mnview.EraseFuturesUserValues(key);
 
         CHistoryWriters subWriters{historyStore, nullptr, nullptr};
-        CAccountsHistoryWriter subView(mnview, currentHeight, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &subWriters);
+        CAccountsHistoryWriter subView(
+            mnview, currentHeight, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &subWriters);
 
         auto res = subView.SubBalance(*contractAddressValue, value.source);
         if (!res) {
@@ -603,7 +579,8 @@ Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t hei
         subView.Flush();
 
         CHistoryWriters addWriters{historyStore, nullptr, nullptr};
-        CAccountsHistoryWriter addView(mnview, currentHeight, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &addWriters);
+        CAccountsHistoryWriter addView(
+            mnview, currentHeight, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &addWriters);
 
         res = addView.AddBalance(key.owner, value.source);
         if (!res) {
@@ -622,8 +599,7 @@ Res ATTRIBUTES::RefundFuturesContracts(CCustomCSView &mnview, const uint32_t hei
     return Res::Ok();
 }
 
-Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height)
-{
+Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height) {
     CDataStructureV0 blockKey{AttributeTypes::Param, ParamIDs::DFIP2206F, DFIPKeys::BlockPeriod};
     const auto blockPeriod = GetValue(blockKey, CAmount{});
     if (blockPeriod == 0) {
@@ -632,10 +608,12 @@ Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height)
 
     std::map<CFuturesUserKey, CAmount> userFuturesValues;
 
-    mnview.ForEachFuturesDUSD([&](const CFuturesUserKey& key, const CAmount& amount) {
-        userFuturesValues[key] = amount;
-        return true;
-    }, {height, {}, std::numeric_limits<uint32_t>::max()});
+    mnview.ForEachFuturesDUSD(
+        [&](const CFuturesUserKey &key, const CAmount &amount) {
+            userFuturesValues[key] = amount;
+            return true;
+        },
+        {height, {}, std::numeric_limits<uint32_t>::max()});
 
     const auto contractAddressValue = GetFutureSwapContractAddress(SMART_CONTRACT_DFIP2206F);
     if (!contractAddressValue) {
@@ -645,12 +623,12 @@ Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height)
     CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::DFIP2206FCurrent};
     auto balances = GetValue(liveKey, CBalances{});
 
-    for (const auto& [key, amount] : userFuturesValues) {
-
+    for (const auto &[key, amount] : userFuturesValues) {
         mnview.EraseFuturesDUSD(key);
 
         CHistoryWriters subWriters{paccountHistoryDB.get(), nullptr, nullptr};
-        CAccountsHistoryWriter subView(mnview, height, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &subWriters);
+        CAccountsHistoryWriter subView(
+            mnview, height, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &subWriters);
         auto res = subView.SubBalance(*contractAddressValue, {DCT_ID{}, amount});
         if (!res) {
             return res;
@@ -658,7 +636,8 @@ Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height)
         subView.Flush();
 
         CHistoryWriters addWriters{paccountHistoryDB.get(), nullptr, nullptr};
-        CAccountsHistoryWriter addView(mnview, height, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &addWriters);
+        CAccountsHistoryWriter addView(
+            mnview, height, GetNextAccPosition(), {}, uint8_t(CustomTxType::FutureSwapRefund), &addWriters);
         res = addView.AddBalance(key.owner, {DCT_ID{}, amount});
         if (!res) {
             return res;
@@ -676,7 +655,7 @@ Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height)
     return Res::Ok();
 }
 
-Res ATTRIBUTES::Import(const UniValue & val) {
+Res ATTRIBUTES::Import(const UniValue &val) {
     if (!val.isObject()) {
         return Res::Err("Object of values expected");
     }
@@ -684,16 +663,14 @@ Res ATTRIBUTES::Import(const UniValue & val) {
     std::map<std::string, UniValue> objMap;
     val.getObjMap(objMap);
 
-    for (const auto& pair : objMap) {
+    for (const auto &pair : objMap) {
         auto res = ProcessVariable(
-            pair.first, pair.second.get_str(),
-            [this](const CAttributeType& attribute, const CAttributeValue& value) {
+            pair.first, pair.second.get_str(), [this](const CAttributeType &attribute, const CAttributeValue &value) {
                 if (const auto attrV0 = std::get_if<CDataStructureV0>(&attribute)) {
                     if (attrV0->type == AttributeTypes::Live ||
-                            (attrV0->type == AttributeTypes::Token &&
-                             (attrV0->key == TokenKeys::Ascendant ||
-                              attrV0->key == TokenKeys::Descendant ||
-                              attrV0->key == TokenKeys::Epitaph))) {
+                        (attrV0->type == AttributeTypes::Token &&
+                         (attrV0->key == TokenKeys::Ascendant || attrV0->key == TokenKeys::Descendant ||
+                          attrV0->key == TokenKeys::Epitaph))) {
                         return Res::Err("Attribute cannot be set externally");
                     } else if (attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits) {
                         const auto splitValue = std::get_if<OracleSplits>(&value);
@@ -703,7 +680,7 @@ Res ATTRIBUTES::Import(const UniValue & val) {
                         if (splitValue->size() != 1)
                             return Res::Err("Invalid number of token splits, allowed only one per height!");
 
-                        const auto& [id, multiplier] = *(splitValue->begin());
+                        const auto &[id, multiplier] = *(splitValue->begin());
                         tokenSplits.insert(id);
 
                         SetValue(attribute, *splitValue);
@@ -724,8 +701,7 @@ Res ATTRIBUTES::Import(const UniValue & val) {
                 }
                 SetValue(attribute, value);
                 return Res::Ok();
-            }
-        );
+            });
         if (!res) {
             return res;
         }
@@ -749,22 +725,22 @@ std::set<uint32_t> attrsVersion27TokenHiddenSet = {
 
 UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &prefix) const {
     UniValue ret(UniValue::VOBJ);
-    for (const auto& attribute : attributes) {
+    for (const auto &attribute : attributes) {
         const auto attrV0 = std::get_if<CDataStructureV0>(&attribute.first);
         if (!attrV0) {
             continue;
         }
-        if (filter == GovVarsFilter::LiveAttributes &&
-            attrV0->type != AttributeTypes::Live) {
-                continue;
+        if (filter == GovVarsFilter::LiveAttributes && attrV0->type != AttributeTypes::Live) {
+            continue;
         } else if (filter == GovVarsFilter::Version2Dot7) {
             if (attrV0->type == AttributeTypes::Token &&
-            attrsVersion27TokenHiddenSet.find(attrV0->key) != attrsVersion27TokenHiddenSet.end())
+                attrsVersion27TokenHiddenSet.find(attrV0->key) != attrsVersion27TokenHiddenSet.end())
                 continue;
         }
         try {
             std::string id;
-            if (attrV0->type == AttributeTypes::Param || attrV0->type == AttributeTypes::Live || attrV0->type == AttributeTypes::Locks) {
+            if (attrV0->type == AttributeTypes::Param || attrV0->type == AttributeTypes::Live ||
+                attrV0->type == AttributeTypes::Locks) {
                 id = displayParamsIDs().at(attrV0->typeId);
             } else if (attrV0->type == AttributeTypes::Oracles) {
                 id = displayOracleIDs().at(attrV0->typeId);
@@ -772,12 +748,11 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                 id = KeyBuilder(attrV0->typeId);
             }
 
-            auto const v0Key = attrV0->type == AttributeTypes::Oracles || attrV0->type == AttributeTypes::Locks ? KeyBuilder(attrV0->key) : displayKeys().at(attrV0->type).at(attrV0->key);
+            auto const v0Key = attrV0->type == AttributeTypes::Oracles || attrV0->type == AttributeTypes::Locks
+                                   ? KeyBuilder(attrV0->key)
+                                   : displayKeys().at(attrV0->type).at(attrV0->key);
 
-            auto key = KeyBuilder(displayVersions().at(VersionTypes::v0),
-                                  displayTypes().at(attrV0->type),
-                                  id,
-                                  v0Key);
+            auto key = KeyBuilder(displayVersions().at(VersionTypes::v0), displayTypes().at(attrV0->type), id, v0Key);
 
             if (attrV0->IsExtendedSize()) {
                 key = KeyBuilder(key, attrV0->keyId);
@@ -805,10 +780,8 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
 
                     // Create fee_pct alias of reward_pct.
                     if (v0Key == "reward_pct") {
-                        const auto newKey = KeyBuilder(displayVersions().at(VersionTypes::v0),
-                                                 displayTypes().at(attrV0->type),
-                                                 id,
-                                                 "fee_pct");
+                        const auto newKey = KeyBuilder(
+                            displayVersions().at(VersionTypes::v0), displayTypes().at(attrV0->type), id, "fee_pct");
                         ret.pushKV(newKey, decimalStr);
                     }
                 }
@@ -820,9 +793,9 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                 result.pushKV("paybacktokens", AmountsToJSON(paybacks->tokensPayback.balances));
                 ret.pushKV(key, result);
             } else if (const auto balances = std::get_if<CDexBalances>(&attribute.second)) {
-                for (const auto& pool : *balances) {
-                    auto& dexTokenA = pool.second.totalTokenA;
-                    auto& dexTokenB = pool.second.totalTokenB;
+                for (const auto &pool : *balances) {
+                    auto &dexTokenA = pool.second.totalTokenA;
+                    auto &dexTokenB = pool.second.totalTokenB;
                     auto poolkey = KeyBuilder(key, pool.first.v);
                     ret.pushKV(KeyBuilder(poolkey, "total_commission_a"), ValueFromUint(dexTokenA.commissions));
                     ret.pushKV(KeyBuilder(poolkey, "total_commission_b"), ValueFromUint(dexTokenB.commissions));
@@ -840,9 +813,9 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                     keyValue += KeyBuilder(it->first, it->second);
                 }
                 ret.pushKV(key, keyValue);
-            } else if (const auto& descendantPair = std::get_if<DescendantValue>(&attribute.second)) {
+            } else if (const auto &descendantPair = std::get_if<DescendantValue>(&attribute.second)) {
                 ret.pushKV(key, KeyBuilder(descendantPair->first, descendantPair->second));
-            } else if (const auto& ascendantPair = std::get_if<AscendantValue>(&attribute.second)) {
+            } else if (const auto &ascendantPair = std::get_if<AscendantValue>(&attribute.second)) {
                 ret.pushKV(key, KeyBuilder(ascendantPair->first, ascendantPair->second));
             } else if (const auto currencyPair = std::get_if<CTokenCurrencyPair>(&attribute.second)) {
                 ret.pushKV(key, currencyPair->first + '/' + currencyPair->second);
@@ -855,7 +828,7 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                     ret.pushKV(key, "out");
                 }
             }
-        } catch (const std::out_of_range&) {
+        } catch (const std::out_of_range &) {
             // Should not get here, that's mean maps are mismatched
         }
     }
@@ -866,12 +839,11 @@ UniValue ATTRIBUTES::Export() const {
     return ExportFiltered(GovVarsFilter::All, "");
 }
 
-Res ATTRIBUTES::Validate(const CCustomCSView & view) const
-{
+Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() < Params().GetConsensus().FortCanningHillHeight)
         return Res::Err("Cannot be set before FortCanningHill");
 
-    for (const auto& [key, value] : attributes) {
+    for (const auto &[key, value] : attributes) {
         const auto attrV0 = std::get_if<CDataStructureV0>(&key);
         if (!attrV0) {
             return Res::Err("Unsupported version");
@@ -884,7 +856,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetLoanTokenByID({attrV0->typeId})) {
                             return Res::Err("No such loan token (%d)", attrV0->typeId);
                         }
-                    break;
+                        break;
                     case TokenKeys::LoanPayback:
                     case TokenKeys::LoanPaybackFeePCT:
                         if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
@@ -896,7 +868,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetToken(DCT_ID{attrV0->keyId})) {
                             return Res::Err("No such token (%d)", attrV0->keyId);
                         }
-                    break;
+                        break;
                     case TokenKeys::DexInFeePct:
                     case TokenKeys::DexOutFeePct:
                         if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
@@ -905,7 +877,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetToken(DCT_ID{attrV0->typeId})) {
                             return Res::Err("No such token (%d)", attrV0->typeId);
                         }
-                    break;
+                        break;
                     case TokenKeys::LoanCollateralEnabled:
                     case TokenKeys::LoanCollateralFactor:
                     case TokenKeys::LoanMintingEnabled:
@@ -916,8 +888,8 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!VerifyToken(view, attrV0->typeId)) {
                             return Res::Err("No such token (%d)", attrV0->typeId);
                         }
-                        CDataStructureV0 intervalPriceKey{AttributeTypes::Token, attrV0->typeId,
-                                                          TokenKeys::FixedIntervalPriceId};
+                        CDataStructureV0 intervalPriceKey{
+                            AttributeTypes::Token, attrV0->typeId, TokenKeys::FixedIntervalPriceId};
                         if (GetValue(intervalPriceKey, CTokenCurrencyPair{}) == CTokenCurrencyPair{}) {
                             return Res::Err("Fixed interval price currency pair must be set first");
                         }
@@ -938,15 +910,15 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetLoanTokenByID(DCT_ID{attrV0->typeId})) {
                             return Res::Err("No such loan token (%d)", attrV0->typeId);
                         }
-                    break;
+                        break;
                     case TokenKeys::Ascendant:
                     case TokenKeys::Descendant:
                     case TokenKeys::Epitaph:
-                    break;
+                        break;
                     default:
                         return Res::Err("Unsupported key");
                 }
-            break;
+                break;
 
             case AttributeTypes::Oracles:
                 if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
@@ -957,7 +929,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                     if (!splitMap) {
                         return Res::Err("Unsupported value");
                     }
-                    for (const auto& [tokenId, multipler] : *splitMap) {
+                    for (const auto &[tokenId, multipler] : *splitMap) {
                         if (tokenId == 0) {
                             return Res::Err("Tokenised DFI cannot be split");
                         }
@@ -978,7 +950,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                 } else {
                     return Res::Err("Unsupported key");
                 }
-            break;
+                break;
 
             case AttributeTypes::Poolpairs:
                 switch (attrV0->key) {
@@ -987,7 +959,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetPoolPair({attrV0->typeId})) {
                             return Res::Err("No such pool (%d)", attrV0->typeId);
                         }
-                    break;
+                        break;
                     case PoolKeys::TokenAFeeDir:
                     case PoolKeys::TokenBFeeDir:
                         if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
@@ -996,14 +968,15 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                         if (!view.GetPoolPair({attrV0->typeId})) {
                             return Res::Err("No such pool (%d)", attrV0->typeId);
                         }
-                    break;
+                        break;
                     default:
                         return Res::Err("Unsupported key");
                 }
-            break;
+                break;
 
             case AttributeTypes::Param:
-                if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->key == DFIPKeys::StartBlock || attrV0->typeId == ParamIDs::DFIP2206A) {
+                if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->key == DFIPKeys::StartBlock ||
+                    attrV0->typeId == ParamIDs::DFIP2206A) {
                     if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
                         return Res::Err("Cannot be set before FortCanningSpringHeight");
                     }
@@ -1014,11 +987,11 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                 } else if (attrV0->typeId != ParamIDs::DFIP2201) {
                     return Res::Err("Unrecognised param id");
                 }
-            break;
+                break;
 
             // Live is set internally
             case AttributeTypes::Live:
-            break;
+                break;
 
             case AttributeTypes::Locks:
                 if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
@@ -1030,7 +1003,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                 if (!view.GetLoanTokenByID(DCT_ID{attrV0->key}).has_value()) {
                     return Res::Err("No loan token with id (%d)", attrV0->key);
                 }
-            break;
+                break;
 
             default:
                 return Res::Err("Unrecognised type (%d)", attrV0->type);
@@ -1040,23 +1013,20 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
-{
-    for (const auto& attribute : attributes) {
+Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
+    for (const auto &attribute : attributes) {
         const auto attrV0 = std::get_if<CDataStructureV0>(&attribute.first);
         if (!attrV0) {
             continue;
         }
         if (attrV0->type == AttributeTypes::Poolpairs) {
-            if (attrV0->key == PoolKeys::TokenAFeePCT ||
-                attrV0->key == PoolKeys::TokenBFeePCT) {
+            if (attrV0->key == PoolKeys::TokenAFeePCT || attrV0->key == PoolKeys::TokenBFeePCT) {
                 auto poolId = DCT_ID{attrV0->typeId};
                 auto pool = mnview.GetPoolPair(poolId);
                 if (!pool) {
                     return Res::Err("No such pool (%d)", poolId.v);
                 }
-                auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ?
-                               pool->idTokenA : pool->idTokenB;
+                auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ? pool->idTokenA : pool->idTokenB;
 
                 const auto valuePct = std::get_if<CAmount>(&attribute.second);
                 if (!valuePct) {
@@ -1067,8 +1037,7 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                 }
             }
         } else if (attrV0->type == AttributeTypes::Token) {
-            if (attrV0->key == TokenKeys::DexInFeePct
-            ||  attrV0->key == TokenKeys::DexOutFeePct) {
+            if (attrV0->key == TokenKeys::DexInFeePct || attrV0->key == TokenKeys::DexOutFeePct) {
                 DCT_ID tokenA{attrV0->typeId}, tokenB{~0u};
                 if (attrV0->key == TokenKeys::DexOutFeePct) {
                     std::swap(tokenA, tokenB);
@@ -1087,17 +1056,16 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                         it.Valid() && it.Key() == *currencyPair) {
                         continue;
                     } else if (!OraclePriceFeed(mnview, *currencyPair)) {
-                        return Res::Err("Price feed %s/%s does not belong to any oracle", currencyPair->first,
+                        return Res::Err("Price feed %s/%s does not belong to any oracle",
+                                        currencyPair->first,
                                         currencyPair->second);
                     }
                     CFixedIntervalPrice fixedIntervalPrice;
                     fixedIntervalPrice.priceFeedId = *currencyPair;
                     fixedIntervalPrice.timestamp = time;
                     fixedIntervalPrice.priceRecord[1] = -1;
-                    const auto aggregatePrice = GetAggregatePrice(mnview,
-                                                                  fixedIntervalPrice.priceFeedId.first,
-                                                                  fixedIntervalPrice.priceFeedId.second,
-                                                                  time);
+                    const auto aggregatePrice = GetAggregatePrice(
+                        mnview, fixedIntervalPrice.priceFeedId.first, fixedIntervalPrice.priceFeedId.second, time);
                     if (aggregatePrice) {
                         fixedIntervalPrice.priceRecord[1] = aggregatePrice;
                     }
@@ -1109,7 +1077,6 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                     return Res::Err("Unrecognised value for FixedIntervalPriceId");
                 }
             } else if (attrV0->key == TokenKeys::DFIP2203Enabled) {
-
                 const auto value = std::get_if<bool>(&attribute.second);
                 if (!value) {
                     return Res::Err("Unexpected type");
@@ -1138,7 +1105,6 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
         } else if (attrV0->type == AttributeTypes::Param) {
             if (attrV0->typeId == ParamIDs::DFIP2203) {
                 if (attrV0->key == DFIPKeys::Active) {
-
                     const auto value = std::get_if<bool>(&attribute.second);
                     if (!value) {
                         return Res::Err("Unexpected type");
@@ -1154,7 +1120,6 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                     }
 
                 } else if (attrV0->key == DFIPKeys::BlockPeriod || attrV0->key == DFIPKeys::StartBlock) {
-
                     // Only check this when block period has been set, otherwise
                     // it will fail when DFIP2203 active is set to true.
                     if (!futureUpdated) {
@@ -1168,7 +1133,6 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                 }
             } else if (attrV0->typeId == ParamIDs::DFIP2206F) {
                 if (attrV0->key == DFIPKeys::Active) {
-
                     const auto value = std::get_if<bool>(&attribute.second);
                     if (!value) {
                         return Res::Err("Unexpected type");
@@ -1184,7 +1148,6 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                     }
 
                 } else if (attrV0->key == DFIPKeys::BlockPeriod) {
-
                     // Only check this when block period has been set, otherwise
                     // it will fail when DFIP2206F active is set to true.
                     if (!futureDUSDUpdated) {

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -15,66 +15,66 @@ enum VersionTypes : uint8_t {
 };
 
 enum AttributeTypes : uint8_t {
-    Live      = 'l',
-    Oracles   = 'o',
-    Param     = 'a',
-    Token     = 't',
+    Live = 'l',
+    Oracles = 'o',
+    Param = 'a',
+    Token = 't',
     Poolpairs = 'p',
-    Locks     = 'L',
+    Locks = 'L',
 };
 
-enum ParamIDs : uint8_t  {
-    DFIP2201  = 'a',
-    DFIP2203  = 'b',
-    TokenID   = 'c',
-    Economy   = 'e',
+enum ParamIDs : uint8_t {
+    DFIP2201 = 'a',
+    DFIP2203 = 'b',
+    TokenID = 'c',
+    Economy = 'e',
     DFIP2206A = 'f',
     DFIP2206F = 'g',
 };
 
-enum OracleIDs : uint8_t  {
-    Splits    = 'a',
+enum OracleIDs : uint8_t {
+    Splits = 'a',
 };
 
 enum EconomyKeys : uint8_t {
-    PaybackDFITokens  = 'a',
-    PaybackTokens     = 'b',
-    DFIP2203Current   = 'c',
-    DFIP2203Burned    = 'd',
-    DFIP2203Minted    = 'e',
-    DFIP2206FCurrent  = 'f',
-    DFIP2206FBurned   = 'g',
-    DFIP2206FMinted   = 'h',
-    DexTokens         = 'i',
+    PaybackDFITokens = 'a',
+    PaybackTokens = 'b',
+    DFIP2203Current = 'c',
+    DFIP2203Burned = 'd',
+    DFIP2203Minted = 'e',
+    DFIP2206FCurrent = 'f',
+    DFIP2206FBurned = 'g',
+    DFIP2206FMinted = 'h',
+    DexTokens = 'i',
 };
 
-enum DFIPKeys : uint8_t  {
-    Active                  = 'a',
-    Premium                 = 'b',
-    MinSwap                 = 'c',
-    RewardPct               = 'd',
-    BlockPeriod             = 'e',
-    DUSDInterestBurn  = 'g',
-    DUSDLoanBurn      = 'h',
-    StartBlock              = 'i',
+enum DFIPKeys : uint8_t {
+    Active = 'a',
+    Premium = 'b',
+    MinSwap = 'c',
+    RewardPct = 'd',
+    BlockPeriod = 'e',
+    DUSDInterestBurn = 'g',
+    DUSDLoanBurn = 'h',
+    StartBlock = 'i',
 };
 
-enum TokenKeys : uint8_t  {
-    PaybackDFI            = 'a',
-    PaybackDFIFeePCT      = 'b',
-    LoanPayback           = 'c',
-    LoanPaybackFeePCT     = 'd',
-    DexInFeePct           = 'e',
-    DexOutFeePct          = 'f',
-    DFIP2203Enabled       = 'g',
-    FixedIntervalPriceId  = 'h',
+enum TokenKeys : uint8_t {
+    PaybackDFI = 'a',
+    PaybackDFIFeePCT = 'b',
+    LoanPayback = 'c',
+    LoanPaybackFeePCT = 'd',
+    DexInFeePct = 'e',
+    DexOutFeePct = 'f',
+    DFIP2203Enabled = 'g',
+    FixedIntervalPriceId = 'h',
     LoanCollateralEnabled = 'i',
-    LoanCollateralFactor  = 'j',
-    LoanMintingEnabled    = 'k',
-    LoanMintingInterest   = 'l',
-    Ascendant             = 'm',
-    Descendant            = 'n',
-    Epitaph               = 'o',
+    LoanCollateralFactor = 'j',
+    LoanMintingEnabled = 'k',
+    LoanMintingInterest = 'l',
+    Ascendant = 'm',
+    Descendant = 'n',
+    Epitaph = 'o',
 };
 
 enum PoolKeys : uint8_t {
@@ -93,7 +93,7 @@ struct CDataStructureV0 {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(type);
         READWRITE(typeId);
         READWRITE(VARINT(key));
@@ -105,12 +105,10 @@ struct CDataStructureV0 {
     }
 
     bool IsExtendedSize() const {
-        return type == AttributeTypes::Token
-            && (key == TokenKeys::LoanPayback
-            ||  key == TokenKeys::LoanPaybackFeePCT);
+        return type == AttributeTypes::Token && (key == TokenKeys::LoanPayback || key == TokenKeys::LoanPaybackFeePCT);
     }
 
-    bool operator<(const CDataStructureV0& o) const {
+    bool operator<(const CDataStructureV0 &o) const {
         return std::tie(type, typeId, key, keyId) < std::tie(o.type, o.typeId, o.key, o.keyId);
     }
 };
@@ -120,9 +118,9 @@ struct CDataStructureV1 {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {}
+    inline void SerializationOp(Stream &s, Operation ser_action) {}
 
-     bool operator<(const CDataStructureV1& o) const { return false; }
+    bool operator<(const CDataStructureV1 &o) const { return false; }
 };
 
 struct CTokenPayback {
@@ -132,7 +130,7 @@ struct CTokenPayback {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(tokensFee);
         READWRITE(tokensPayback);
     }
@@ -144,12 +142,12 @@ struct CFeeDir {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(feeDir);
     }
 };
 
-ResVal<CScript> GetFutureSwapContractAddress(const std::string& contract);
+ResVal<CScript> GetFutureSwapContractAddress(const std::string &contract);
 
 struct CDexTokenInfo {
     struct CTokenInfo {
@@ -160,7 +158,7 @@ struct CDexTokenInfo {
         ADD_SERIALIZE_METHODS;
 
         template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action) {
+        inline void SerializationOp(Stream &s, Operation ser_action) {
             READWRITE(swaps);
             READWRITE(feeburn);
             READWRITE(commissions);
@@ -173,24 +171,29 @@ struct CDexTokenInfo {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(totalTokenA);
         READWRITE(totalTokenB);
     }
 };
 
-enum FeeDirValues : uint8_t {
-    Both,
-    In,
-    Out
-};
+enum FeeDirValues : uint8_t { Both, In, Out };
 
 using CDexBalances = std::map<DCT_ID, CDexTokenInfo>;
 using OracleSplits = std::map<uint32_t, int32_t>;
 using DescendantValue = std::pair<uint32_t, int32_t>;
 using AscendantValue = std::pair<uint32_t, std::string>;
 using CAttributeType = std::variant<CDataStructureV0, CDataStructureV1>;
-using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CTokenCurrencyPair, OracleSplits, DescendantValue, AscendantValue, CFeeDir, CDexBalances>;
+using CAttributeValue = std::variant<bool,
+                                     CAmount,
+                                     CBalances,
+                                     CTokenPayback,
+                                     CTokenCurrencyPair,
+                                     OracleSplits,
+                                     DescendantValue,
+                                     AscendantValue,
+                                     CFeeDir,
+                                     CDexBalances>;
 
 enum GovVarsFilter {
     All,
@@ -201,41 +204,38 @@ enum GovVarsFilter {
     Version2Dot7,
 };
 
-class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES>
-{
-public:
+class ATTRIBUTES : public GovVariable, public AutoRegistrator<GovVariable, ATTRIBUTES> {
+   public:
     virtual ~ATTRIBUTES() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     UniValue ExportFiltered(GovVarsFilter filter, const std::string &prefix) const;
 
-    Res Validate(CCustomCSView const& mnview) const override;
+    Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, const uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "ATTRIBUTES"; }
-    static GovVariable * Create() { return new ATTRIBUTES(); }
+    static constexpr char const *TypeName() { return "ATTRIBUTES"; }
+    static GovVariable *Create() { return new ATTRIBUTES(); }
 
-    template<typename T>
-    static void GetIf(std::optional<T>& opt, const CAttributeValue& var) {
+    template <typename T>
+    static void GetIf(std::optional<T> &opt, const CAttributeValue &var) {
         if (auto value = std::get_if<T>(&var)) {
             opt = *value;
         }
     }
 
-    template<typename T>
-    static void GetIf(T& val, const CAttributeValue& var) {
+    template <typename T>
+    static void GetIf(T &val, const CAttributeValue &var) {
         if (auto value = std::get_if<T>(&var)) {
             val = *value;
         }
     }
 
-    template<typename K, typename T>
-    [[nodiscard]] T GetValue(const K& key, T value) const {
+    template <typename K, typename T>
+    [[nodiscard]] T GetValue(const K &key, T value) const {
         static_assert(std::is_convertible_v<K, CAttributeType>);
         auto it = attributes.find(key);
         if (it != attributes.end()) {
@@ -244,29 +244,29 @@ public:
         return value;
     }
 
-    template<typename K, typename T>
-    void SetValue(const K& key, T&& value) {
+    template <typename K, typename T>
+    void SetValue(const K &key, T &&value) {
         static_assert(std::is_convertible_v<K, CAttributeType>);
         static_assert(std::is_convertible_v<T, CAttributeValue>);
         changed.insert(key);
         attributes[key] = std::forward<T>(value);
     }
 
-    template<typename K>
-    void EraseKey(const K& key) {
+    template <typename K>
+    void EraseKey(const K &key) {
         static_assert(std::is_convertible_v<K, CAttributeType>);
         changed.insert(key);
         attributes.erase(key);
     }
 
-    template<typename K>
-    [[nodiscard]] bool CheckKey(const K& key) const {
+    template <typename K>
+    [[nodiscard]] bool CheckKey(const K &key) const {
         static_assert(std::is_convertible_v<K, CAttributeType>);
         return attributes.count(key) > 0;
     }
 
-    template<typename C, typename K>
-    void ForEach(const C& callback, const K& key) const {
+    template <typename C, typename K>
+    void ForEach(const C &callback, const K &key) const {
         static_assert(std::is_convertible_v<K, CAttributeType>);
         static_assert(std::is_invocable_r_v<bool, C, K, CAttributeValue>);
         for (auto it = attributes.lower_bound(key); it != attributes.end(); ++it) {
@@ -278,31 +278,30 @@ public:
         }
     }
 
-    [[nodiscard]] const std::map<CAttributeType, CAttributeValue>& GetAttributesMap() const {
-        return attributes;
-    }
+    [[nodiscard]] const std::map<CAttributeType, CAttributeValue> &GetAttributesMap() const { return attributes; }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(attributes);
     }
-
 
     uint32_t time{0};
 
     // For formatting in export
-    static const std::map<uint8_t, std::string>& displayVersions();
-    static const std::map<uint8_t, std::string>& displayTypes();
-    static const std::map<uint8_t, std::string>& displayParamsIDs();
-    static const std::map<uint8_t, std::string>& displayOracleIDs();
-    static const std::map<uint8_t, std::map<uint8_t, std::string>>& displayKeys();
+    static const std::map<uint8_t, std::string> &displayVersions();
+    static const std::map<uint8_t, std::string> &displayTypes();
+    static const std::map<uint8_t, std::string> &displayParamsIDs();
+    static const std::map<uint8_t, std::string> &displayOracleIDs();
+    static const std::map<uint8_t, std::map<uint8_t, std::string>> &displayKeys();
 
-    Res RefundFuturesContracts(CCustomCSView &mnview, const uint32_t height, const uint32_t tokenID = std::numeric_limits<uint32_t>::max());
+    Res RefundFuturesContracts(CCustomCSView &mnview,
+                               const uint32_t height,
+                               const uint32_t tokenID = std::numeric_limits<uint32_t>::max());
 
-private:
+   private:
     friend class CGovView;
     bool futureUpdated{};
     bool futureDUSDUpdated{};
@@ -311,18 +310,19 @@ private:
     std::map<CAttributeType, CAttributeValue> attributes;
 
     // Defined allowed arguments
-    static const std::map<std::string, uint8_t>& allowedVersions();
-    static const std::map<std::string, uint8_t>& allowedTypes();
-    static const std::map<std::string, uint8_t>& allowedParamIDs();
-    static const std::map<std::string, uint8_t>& allowedLocksIDs();
-    static const std::map<std::string, uint8_t>& allowedOracleIDs();
-    static const std::map<uint8_t, std::map<std::string, uint8_t>>& allowedKeys();
-    static const std::map<uint8_t, std::map<uint8_t,
-            std::function<ResVal<CAttributeValue>(const std::string&)>>>& parseValue();
+    static const std::map<std::string, uint8_t> &allowedVersions();
+    static const std::map<std::string, uint8_t> &allowedTypes();
+    static const std::map<std::string, uint8_t> &allowedParamIDs();
+    static const std::map<std::string, uint8_t> &allowedLocksIDs();
+    static const std::map<std::string, uint8_t> &allowedOracleIDs();
+    static const std::map<uint8_t, std::map<std::string, uint8_t>> &allowedKeys();
+    static const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(const std::string &)>>>
+        &parseValue();
 
-    Res ProcessVariable(const std::string& key, const std::string& value,
-                        std::function<Res(const CAttributeType&, const CAttributeValue&)> applyVariable);
+    Res ProcessVariable(const std::string &key,
+                        const std::string &value,
+                        std::function<Res(const CAttributeType &, const CAttributeValue &)> applyVariable);
     Res RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height);
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_ATTRIBUTES_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_ATTRIBUTES_H

--- a/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
+++ b/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
@@ -2,31 +2,27 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
+#include <core_io.h>  /// ValueFromAmount
 #include <masternodes/govvariables/icx_takerfee_per_btc.h>
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-Res ICX_TAKERFEE_PER_BTC::Import(const UniValue & val)
-{
+Res ICX_TAKERFEE_PER_BTC::Import(const UniValue &val) {
     takerFeePerBTC = AmountFromValue(val);
     return Res::Ok();
 }
 
-UniValue ICX_TAKERFEE_PER_BTC::Export() const
-{
+UniValue ICX_TAKERFEE_PER_BTC::Export() const {
     return ValueFromAmount(takerFeePerBTC);
 }
 
-Res ICX_TAKERFEE_PER_BTC::Validate(const CCustomCSView &mnview) const
-{
+Res ICX_TAKERFEE_PER_BTC::Validate(const CCustomCSView &mnview) const {
     if (takerFeePerBTC <= 0)
         return Res::Err("takerFeePerBTC cannot be 0 or less");
 
     return Res::Ok();
 }
 
-Res ICX_TAKERFEE_PER_BTC::Apply(CCustomCSView & mnview, uint32_t)
-{
+Res ICX_TAKERFEE_PER_BTC::Apply(CCustomCSView &mnview, uint32_t) {
     return mnview.ICXSetTakerFeePerBTC(takerFeePerBTC);
 }

--- a/src/masternodes/govvariables/icx_takerfee_per_btc.h
+++ b/src/masternodes/govvariables/icx_takerfee_per_btc.h
@@ -1,35 +1,32 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_ICX_TAKERFEE_PER_BTC_H
 #define DEFI_MASTERNODES_GOVVARIABLES_ICX_TAKERFEE_PER_BTC_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class ICX_TAKERFEE_PER_BTC : public GovVariable, public AutoRegistrator<GovVariable, ICX_TAKERFEE_PER_BTC>
-{
-public:
+class ICX_TAKERFEE_PER_BTC : public GovVariable, public AutoRegistrator<GovVariable, ICX_TAKERFEE_PER_BTC> {
+   public:
     virtual ~ICX_TAKERFEE_PER_BTC() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "ICX_TAKERFEE_PER_BTC"; }
-    static GovVariable * Create() { return new ICX_TAKERFEE_PER_BTC(); }
+    static constexpr char const *TypeName() { return "ICX_TAKERFEE_PER_BTC"; }
+    static GovVariable *Create() { return new ICX_TAKERFEE_PER_BTC(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(takerFeePerBTC);
     }
-    
+
     CAmount takerFeePerBTC;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_ICX_TAKERFEE_PER_BTC_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_ICX_TAKERFEE_PER_BTC_H

--- a/src/masternodes/govvariables/loan_daily_reward.cpp
+++ b/src/masternodes/govvariables/loan_daily_reward.cpp
@@ -4,31 +4,26 @@
 
 #include <masternodes/govvariables/loan_daily_reward.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res LP_DAILY_LOAN_TOKEN_REWARD::Import(const UniValue & val)
-{
+Res LP_DAILY_LOAN_TOKEN_REWARD::Import(const UniValue &val) {
     dailyReward = AmountFromValue(val);
     return Res::Ok();
 }
 
-UniValue LP_DAILY_LOAN_TOKEN_REWARD::Export() const
-{
+UniValue LP_DAILY_LOAN_TOKEN_REWARD::Export() const {
     return ValueFromAmount(dailyReward);
 }
 
-Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView & view) const
-{
+Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() < Params().GetConsensus().FortCanningHeight)
         return Res::Err("Cannot be set before FortCanning");
 
     return Res::Err("Cannot be set manually.");
 }
 
-Res LP_DAILY_LOAN_TOKEN_REWARD::Apply(CCustomCSView & mnview, uint32_t height)
-{
+Res LP_DAILY_LOAN_TOKEN_REWARD::Apply(CCustomCSView &mnview, uint32_t height) {
     return mnview.SetLoanDailyReward(height, dailyReward);
 }

--- a/src/masternodes/govvariables/loan_daily_reward.h
+++ b/src/masternodes/govvariables/loan_daily_reward.h
@@ -5,34 +5,31 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_LOAN_DAILY_REWARD_H
 #define DEFI_MASTERNODES_GOVVARIABLES_LOAN_DAILY_REWARD_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class LP_DAILY_LOAN_TOKEN_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_LOAN_TOKEN_REWARD>
-{
-public:
+class LP_DAILY_LOAN_TOKEN_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_LOAN_TOKEN_REWARD> {
+   public:
     virtual ~LP_DAILY_LOAN_TOKEN_REWARD() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "LP_DAILY_LOAN_TOKEN_REWARD"; }
-    static GovVariable * Create() { return new LP_DAILY_LOAN_TOKEN_REWARD(); }
+    static constexpr char const *TypeName() { return "LP_DAILY_LOAN_TOKEN_REWARD"; }
+    static GovVariable *Create() { return new LP_DAILY_LOAN_TOKEN_REWARD(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(dailyReward);
     }
     CAmount dailyReward;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_LOAN_DAILY_REWARD_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_LOAN_DAILY_REWARD_H

--- a/src/masternodes/govvariables/loan_liquidation_penalty.cpp
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.cpp
@@ -4,24 +4,20 @@
 
 #include <masternodes/govvariables/loan_liquidation_penalty.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res LOAN_LIQUIDATION_PENALTY::Import(const UniValue & val)
-{
+Res LOAN_LIQUIDATION_PENALTY::Import(const UniValue &val) {
     penalty = AmountFromValue(val);
     return Res::Ok();
 }
 
-UniValue LOAN_LIQUIDATION_PENALTY::Export() const
-{
+UniValue LOAN_LIQUIDATION_PENALTY::Export() const {
     return ValueFromAmount(penalty);
 }
 
-Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView & view) const
-{
+Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() < Params().GetConsensus().FortCanningHeight)
         return Res::Err("Cannot be set before FortCanning");
 
@@ -31,7 +27,6 @@ Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res LOAN_LIQUIDATION_PENALTY::Apply(CCustomCSView & mnview, uint32_t height)
-{
+Res LOAN_LIQUIDATION_PENALTY::Apply(CCustomCSView &mnview, uint32_t height) {
     return mnview.SetLoanLiquidationPenalty(penalty);
 }

--- a/src/masternodes/govvariables/loan_liquidation_penalty.h
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.h
@@ -5,34 +5,31 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_LOAN_LIQUIDATION_PENALTY_H
 #define DEFI_MASTERNODES_GOVVARIABLES_LOAN_LIQUIDATION_PENALTY_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class LOAN_LIQUIDATION_PENALTY : public GovVariable, public AutoRegistrator<GovVariable, LOAN_LIQUIDATION_PENALTY>
-{
-public:
+class LOAN_LIQUIDATION_PENALTY : public GovVariable, public AutoRegistrator<GovVariable, LOAN_LIQUIDATION_PENALTY> {
+   public:
     virtual ~LOAN_LIQUIDATION_PENALTY() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "LOAN_LIQUIDATION_PENALTY"; }
-    static GovVariable * Create() { return new LOAN_LIQUIDATION_PENALTY(); }
+    static constexpr char const *TypeName() { return "LOAN_LIQUIDATION_PENALTY"; }
+    static GovVariable *Create() { return new LOAN_LIQUIDATION_PENALTY(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(penalty);
     }
     CAmount penalty;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_LOAN_LIQUIDATION_PENALTY_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_LOAN_LIQUIDATION_PENALTY_H

--- a/src/masternodes/govvariables/loan_splits.cpp
+++ b/src/masternodes/govvariables/loan_splits.cpp
@@ -4,17 +4,15 @@
 
 #include <masternodes/govvariables/loan_splits.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res LP_LOAN_TOKEN_SPLITS::Import(const UniValue & val)
-{
+Res LP_LOAN_TOKEN_SPLITS::Import(const UniValue &val) {
     if (!val.isObject())
         return Res::Err("object of {poolId: rate,... } expected");
 
-    for (const std::string& key : val.getKeys()) {
+    for (const std::string &key : val.getKeys()) {
         const auto id = DCT_ID::FromString(key);
         if (!id)
             return std::move(id);
@@ -23,27 +21,26 @@ Res LP_LOAN_TOKEN_SPLITS::Import(const UniValue & val)
     return Res::Ok();
 }
 
-UniValue LP_LOAN_TOKEN_SPLITS::Export() const
-{
+UniValue LP_LOAN_TOKEN_SPLITS::Export() const {
     UniValue res(UniValue::VOBJ);
-    for (auto const & kv : splits) {
+    for (auto const &kv : splits) {
         res.pushKV(kv.first.ToString(), ValueFromAmount(kv.second));
     }
     return res;
 }
 
-Res LP_LOAN_TOKEN_SPLITS::Validate(const CCustomCSView & mnview) const
-{
+Res LP_LOAN_TOKEN_SPLITS::Validate(const CCustomCSView &mnview) const {
     if (mnview.GetLastHeight() < Params().GetConsensus().FortCanningHeight)
         return Res::Err("Cannot be set before FortCanning");
 
     CAmount total{0};
-    for (auto const & kv : splits) {
+    for (auto const &kv : splits) {
         if (!mnview.HasPoolPair(kv.first))
             return Res::Err("pool with id=%s not found", kv.first.ToString());
 
         if (kv.second < 0 || kv.second > COIN)
-            return Res::Err("wrong percentage for pool with id=%s, value = %s", kv.first.ToString(), std::to_string(kv.second));
+            return Res::Err(
+                "wrong percentage for pool with id=%s, value = %s", kv.first.ToString(), std::to_string(kv.second));
 
         total += kv.second;
     }
@@ -53,9 +50,8 @@ Res LP_LOAN_TOKEN_SPLITS::Validate(const CCustomCSView & mnview) const
     return Res::Ok();
 }
 
-Res LP_LOAN_TOKEN_SPLITS::Apply(CCustomCSView & mnview, uint32_t height)
-{
-    mnview.ForEachPoolId([&] (DCT_ID poolId) {
+Res LP_LOAN_TOKEN_SPLITS::Apply(CCustomCSView &mnview, uint32_t height) {
+    mnview.ForEachPoolId([&](DCT_ID poolId) {
         // we ought to reset previous value:
         CAmount rewardLoanPct = 0;
         auto it = splits.find(poolId);

--- a/src/masternodes/govvariables/loan_splits.h
+++ b/src/masternodes/govvariables/loan_splits.h
@@ -5,35 +5,32 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_LOAN_SPLITS_H
 #define DEFI_MASTERNODES_GOVVARIABLES_LOAN_SPLITS_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class LP_LOAN_TOKEN_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_LOAN_TOKEN_SPLITS>
-{
-public:
+class LP_LOAN_TOKEN_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_LOAN_TOKEN_SPLITS> {
+   public:
     virtual ~LP_LOAN_TOKEN_SPLITS() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "LP_LOAN_TOKEN_SPLITS"; }
-    static GovVariable * Create() { return new LP_LOAN_TOKEN_SPLITS(); }
+    static constexpr char const *TypeName() { return "LP_LOAN_TOKEN_SPLITS"; }
+    static GovVariable *Create() { return new LP_LOAN_TOKEN_SPLITS(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(splits);
     }
 
     std::map<DCT_ID, CAmount> splits;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_LOAN_SPLITS_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_LOAN_SPLITS_H

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
@@ -4,24 +4,20 @@
 
 #include <masternodes/govvariables/lp_daily_dfi_reward.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res LP_DAILY_DFI_REWARD::Import(const UniValue & val)
-{
+Res LP_DAILY_DFI_REWARD::Import(const UniValue &val) {
     dailyReward = AmountFromValue(val);
     return Res::Ok();
 }
 
-UniValue LP_DAILY_DFI_REWARD::Export() const
-{
+UniValue LP_DAILY_DFI_REWARD::Export() const {
     return ValueFromAmount(dailyReward);
 }
 
-Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView & view) const
-{
+Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() >= Params().GetConsensus().EunosHeight)
         return Res::Err("Cannot be set manually after Eunos hard fork");
 
@@ -29,7 +25,6 @@ Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res LP_DAILY_DFI_REWARD::Apply(CCustomCSView & mnview, uint32_t height)
-{
+Res LP_DAILY_DFI_REWARD::Apply(CCustomCSView &mnview, uint32_t height) {
     return mnview.SetDailyReward(height, dailyReward);
 }

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.h
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.h
@@ -5,34 +5,31 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_LP_DAILY_DFI_REWARD_H
 #define DEFI_MASTERNODES_GOVVARIABLES_LP_DAILY_DFI_REWARD_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class LP_DAILY_DFI_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_DFI_REWARD>
-{
-public:
+class LP_DAILY_DFI_REWARD : public GovVariable, public AutoRegistrator<GovVariable, LP_DAILY_DFI_REWARD> {
+   public:
     virtual ~LP_DAILY_DFI_REWARD() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "LP_DAILY_DFI_REWARD"; }
-    static GovVariable * Create() { return new LP_DAILY_DFI_REWARD(); }
+    static constexpr char const *TypeName() { return "LP_DAILY_DFI_REWARD"; }
+    static GovVariable *Create() { return new LP_DAILY_DFI_REWARD(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(dailyReward);
     }
     CAmount dailyReward;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_LP_DAILY_DFI_REWARD_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_LP_DAILY_DFI_REWARD_H

--- a/src/masternodes/govvariables/lp_splits.cpp
+++ b/src/masternodes/govvariables/lp_splits.cpp
@@ -4,43 +4,40 @@
 
 #include <masternodes/govvariables/lp_splits.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res LP_SPLITS::Import(const UniValue & val)
-{
+Res LP_SPLITS::Import(const UniValue &val) {
     if (!val.isObject())
-        return Res::Err("object of {poolId: rate,... } expected"); /// throw here? cause "AmountFromValue" can throw!
+        return Res::Err("object of {poolId: rate,... } expected");  /// throw here? cause "AmountFromValue" can throw!
 
-    for (const std::string& key : val.getKeys()) {
+    for (const std::string &key : val.getKeys()) {
         const auto id = DCT_ID::FromString(key);
         if (!id)
             return std::move(id);
-        splits.emplace(*id.val, AmountFromValue(val[key]));//todo: AmountFromValue
+        splits.emplace(*id.val, AmountFromValue(val[key]));  // todo: AmountFromValue
     }
     return Res::Ok();
 }
 
-UniValue LP_SPLITS::Export() const
-{
+UniValue LP_SPLITS::Export() const {
     UniValue res(UniValue::VOBJ);
-    for (auto const & kv : splits) {
+    for (auto const &kv : splits) {
         res.pushKV(kv.first.ToString(), ValueFromAmount(kv.second));
     }
     return res;
 }
 
-Res LP_SPLITS::Validate(const CCustomCSView & mnview) const
-{
+Res LP_SPLITS::Validate(const CCustomCSView &mnview) const {
     CAmount total{0};
-    for (auto const & kv : splits) {
+    for (auto const &kv : splits) {
         if (!mnview.HasPoolPair(kv.first))
             return Res::Err("pool with id=%s not found", kv.first.ToString());
 
         if (kv.second < 0 || kv.second > COIN)
-            return Res::Err("wrong percentage for pool with id=%s, value = %s", kv.first.ToString(), std::to_string(kv.second));
+            return Res::Err(
+                "wrong percentage for pool with id=%s, value = %s", kv.first.ToString(), std::to_string(kv.second));
 
         total += kv.second;
     }
@@ -50,9 +47,8 @@ Res LP_SPLITS::Validate(const CCustomCSView & mnview) const
     return Res::Ok();
 }
 
-Res LP_SPLITS::Apply(CCustomCSView & mnview, uint32_t height)
-{
-    mnview.ForEachPoolId([&] (DCT_ID poolId) {
+Res LP_SPLITS::Apply(CCustomCSView &mnview, uint32_t height) {
+    mnview.ForEachPoolId([&](DCT_ID poolId) {
         // we ought to reset previous value:
         CAmount rewardPct = 0;
         auto it = splits.find(poolId);

--- a/src/masternodes/govvariables/lp_splits.h
+++ b/src/masternodes/govvariables/lp_splits.h
@@ -5,31 +5,28 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_LP_SPLITS_H
 #define DEFI_MASTERNODES_GOVVARIABLES_LP_SPLITS_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class LP_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_SPLITS>
-{
-public:
+class LP_SPLITS : public GovVariable, public AutoRegistrator<GovVariable, LP_SPLITS> {
+   public:
     virtual ~LP_SPLITS() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "LP_SPLITS"; }
-    static GovVariable * Create() { return new LP_SPLITS(); }
+    static constexpr char const *TypeName() { return "LP_SPLITS"; }
+    static GovVariable *Create() { return new LP_SPLITS(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         static_assert(std::is_same<decltype(splits), std::map<DCT_ID, CAmount>>::value, "Following code is invalid");
         std::map<uint32_t, CAmount> serliazedSplits;
         if (ser_action.ForRead()) {
@@ -40,7 +37,7 @@ public:
                 serliazedSplits.erase(it++);
             }
         } else {
-            for (const auto& it : splits) {
+            for (const auto &it : splits) {
                 serliazedSplits.emplace(it.first.v, it.second);
             }
             READWRITE(serliazedSplits);
@@ -50,4 +47,4 @@ public:
     std::map<DCT_ID, CAmount> splits;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_LP_SPLITS_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_LP_SPLITS_H

--- a/src/masternodes/govvariables/oracle_block_interval.cpp
+++ b/src/masternodes/govvariables/oracle_block_interval.cpp
@@ -4,13 +4,11 @@
 
 #include <masternodes/govvariables/oracle_block_interval.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res ORACLE_BLOCK_INTERVAL::Import(const UniValue & val)
-{
+Res ORACLE_BLOCK_INTERVAL::Import(const UniValue &val) {
     if (!val.isNum())
         throw JSONRPCError(RPC_TYPE_ERROR, "Block interval amount is not a number");
 
@@ -18,13 +16,11 @@ Res ORACLE_BLOCK_INTERVAL::Import(const UniValue & val)
     return Res::Ok();
 }
 
-UniValue ORACLE_BLOCK_INTERVAL::Export() const
-{
+UniValue ORACLE_BLOCK_INTERVAL::Export() const {
     return static_cast<uint64_t>(blockInterval);
 }
 
-Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView & view) const
-{
+Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() < Params().GetConsensus().FortCanningHeight)
         return Res::Err("Cannot be set before FortCanning");
 
@@ -34,7 +30,6 @@ Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res ORACLE_BLOCK_INTERVAL::Apply(CCustomCSView & mnview, const uint32_t height)
-{
+Res ORACLE_BLOCK_INTERVAL::Apply(CCustomCSView &mnview, const uint32_t height) {
     return mnview.SetIntervalBlock(blockInterval);
 }

--- a/src/masternodes/govvariables/oracle_block_interval.h
+++ b/src/masternodes/govvariables/oracle_block_interval.h
@@ -5,34 +5,31 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_ORACLE_BLOCK_INTERVAL_H
 #define DEFI_MASTERNODES_GOVVARIABLES_ORACLE_BLOCK_INTERVAL_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class ORACLE_BLOCK_INTERVAL : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_BLOCK_INTERVAL>
-{
-public:
+class ORACLE_BLOCK_INTERVAL : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_BLOCK_INTERVAL> {
+   public:
     virtual ~ORACLE_BLOCK_INTERVAL() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, const uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "ORACLE_BLOCK_INTERVAL"; }
-    static GovVariable * Create() { return new ORACLE_BLOCK_INTERVAL(); }
+    static constexpr char const *TypeName() { return "ORACLE_BLOCK_INTERVAL"; }
+    static GovVariable *Create() { return new ORACLE_BLOCK_INTERVAL(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(blockInterval);
     }
     uint32_t blockInterval;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_BLOCK_INTERVAL_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_BLOCK_INTERVAL_H

--- a/src/masternodes/govvariables/oracle_deviation.cpp
+++ b/src/masternodes/govvariables/oracle_deviation.cpp
@@ -4,24 +4,20 @@
 
 #include <masternodes/govvariables/oracle_deviation.h>
 
-#include <core_io.h> /// ValueFromAmount
-#include <masternodes/masternodes.h> /// CCustomCSView
-#include <rpc/util.h> /// AmountFromValue
+#include <core_io.h>                  /// ValueFromAmount
+#include <masternodes/masternodes.h>  /// CCustomCSView
+#include <rpc/util.h>                 /// AmountFromValue
 
-
-Res ORACLE_DEVIATION::Import(const UniValue & val)
-{
+Res ORACLE_DEVIATION::Import(const UniValue &val) {
     deviation = AmountFromValue(val);
     return Res::Ok();
 }
 
-UniValue ORACLE_DEVIATION::Export() const
-{
+UniValue ORACLE_DEVIATION::Export() const {
     return ValueFromAmount(deviation);
 }
 
-Res ORACLE_DEVIATION::Validate(const CCustomCSView & view) const
-{
+Res ORACLE_DEVIATION::Validate(const CCustomCSView &view) const {
     if (view.GetLastHeight() < Params().GetConsensus().FortCanningHeight)
         return Res::Err("Cannot be set before FortCanning");
 
@@ -31,7 +27,6 @@ Res ORACLE_DEVIATION::Validate(const CCustomCSView & view) const
     return Res::Ok();
 }
 
-Res ORACLE_DEVIATION::Apply(CCustomCSView & mnview, uint32_t height)
-{
+Res ORACLE_DEVIATION::Apply(CCustomCSView &mnview, uint32_t height) {
     return mnview.SetPriceDeviation(deviation);
 }

--- a/src/masternodes/govvariables/oracle_deviation.h
+++ b/src/masternodes/govvariables/oracle_deviation.h
@@ -5,34 +5,31 @@
 #ifndef DEFI_MASTERNODES_GOVVARIABLES_ORACLE_DEVIATION_H
 #define DEFI_MASTERNODES_GOVVARIABLES_ORACLE_DEVIATION_H
 
-#include <masternodes/gv.h>
 #include <amount.h>
+#include <masternodes/gv.h>
 
-class ORACLE_DEVIATION : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_DEVIATION>
-{
-public:
+class ORACLE_DEVIATION : public GovVariable, public AutoRegistrator<GovVariable, ORACLE_DEVIATION> {
+   public:
     virtual ~ORACLE_DEVIATION() override {}
 
-    std::string GetName() const override {
-        return TypeName();
-    }
+    std::string GetName() const override { return TypeName(); }
 
     Res Import(UniValue const &val) override;
     UniValue Export() const override;
     Res Validate(CCustomCSView const &mnview) const override;
     Res Apply(CCustomCSView &mnview, uint32_t height) override;
 
-    static constexpr char const * TypeName() { return "ORACLE_DEVIATION"; }
-    static GovVariable * Create() { return new ORACLE_DEVIATION(); }
+    static constexpr char const *TypeName() { return "ORACLE_DEVIATION"; }
+    static GovVariable *Create() { return new ORACLE_DEVIATION(); }
 
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(deviation);
     }
     CAmount deviation;
 };
 
-#endif // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_DEVIATION_H
+#endif  // DEFI_MASTERNODES_GOVVARIABLES_ORACLE_DEVIATION_H

--- a/src/masternodes/gv.cpp
+++ b/src/masternodes/gv.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#include <masternodes/gv.h>
 #include <masternodes/govvariables/attributes.h>
 #include <masternodes/govvariables/icx_takerfee_per_btc.h>
 #include <masternodes/govvariables/loan_daily_reward.h>
@@ -12,10 +11,10 @@
 #include <masternodes/govvariables/lp_splits.h>
 #include <masternodes/govvariables/oracle_block_interval.h>
 #include <masternodes/govvariables/oracle_deviation.h>
+#include <masternodes/gv.h>
 
-Res CGovView::SetVariable(GovVariable const & var)
-{
-    auto WriteVar = [this](GovVariable const & var) {
+Res CGovView::SetVariable(GovVariable const &var) {
+    auto WriteVar = [this](GovVariable const &var) {
         return WriteBy<ByName>(var.GetName(), var) ? Res::Ok() : Res::Err("can't write to DB");
     };
     if (var.GetName() != "ATTRIBUTES") {
@@ -25,11 +24,11 @@ Res CGovView::SetVariable(GovVariable const & var)
     if (!attributes) {
         return WriteVar(var);
     }
-    auto& current = dynamic_cast<const ATTRIBUTES&>(var);
+    auto &current = dynamic_cast<const ATTRIBUTES &>(var);
     if (current.changed.empty()) {
         return Res::Ok();
     }
-    for (auto& key : current.changed) {
+    for (auto &key : current.changed) {
         auto it = current.attributes.find(key);
         if (it == current.attributes.end()) {
             attributes->attributes.erase(key);
@@ -40,8 +39,7 @@ Res CGovView::SetVariable(GovVariable const & var)
     return WriteVar(*attributes);
 }
 
-std::shared_ptr<GovVariable> CGovView::GetVariable(std::string const & name) const
-{
+std::shared_ptr<GovVariable> CGovView::GetVariable(std::string const &name) const {
     auto var = GovVariable::Create(name);
     if (var) {
         /// @todo empty or NO variable??
@@ -51,9 +49,8 @@ std::shared_ptr<GovVariable> CGovView::GetVariable(std::string const & name) con
     return {};
 }
 
-Res CGovView::SetStoredVariables(const std::set<std::shared_ptr<GovVariable>>& govVars, const uint32_t height)
-{
-    for (auto& item : govVars) {
+Res CGovView::SetStoredVariables(const std::set<std::shared_ptr<GovVariable>> &govVars, const uint32_t height) {
+    for (auto &item : govVars) {
         if (!WriteBy<ByHeightVars>(GovVarKey{height, item->GetName()}, *item)) {
             return Res::Err("Cannot write to DB");
         }
@@ -62,8 +59,7 @@ Res CGovView::SetStoredVariables(const std::set<std::shared_ptr<GovVariable>>& g
     return Res::Ok();
 }
 
-std::set<std::shared_ptr<GovVariable>> CGovView::GetStoredVariables(const uint32_t height)
-{
+std::set<std::shared_ptr<GovVariable>> CGovView::GetStoredVariables(const uint32_t height) {
     // Populate a set of Gov vars for specified height
     std::set<std::shared_ptr<GovVariable>> govVars;
     auto it = LowerBound<ByHeightVars>(GovVarKey{height, {}});
@@ -77,8 +73,9 @@ std::set<std::shared_ptr<GovVariable>> CGovView::GetStoredVariables(const uint32
     return govVars;
 }
 
-std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> CGovView::GetStoredVariablesRange(const uint32_t startHeight, const uint32_t endHeight)
-{
+std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> CGovView::GetStoredVariablesRange(
+    const uint32_t startHeight,
+    const uint32_t endHeight) {
     // Populate a set of Gov vars for specified height
     std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> govVars;
     auto it = LowerBound<ByHeightVars>(GovVarKey{startHeight, {}});
@@ -92,8 +89,7 @@ std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> CGovView::GetStor
     return govVars;
 }
 
-std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> CGovView::GetAllStoredVariables()
-{
+std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> CGovView::GetAllStoredVariables() {
     // Populate map by var name as key and map of height and Gov vars as elements.
     std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> govVars;
     auto it = LowerBound<ByHeightVars>(GovVarKey{std::numeric_limits<uint32_t>::min(), {}});
@@ -108,13 +104,12 @@ std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> CGovView
     return govVars;
 }
 
-void CGovView::EraseStoredVariables(const uint32_t height)
-{
+void CGovView::EraseStoredVariables(const uint32_t height) {
     // Retrieve map of vars at specified height
     const auto vars = GetStoredVariables(height);
 
     // Iterate over names at this height and erase
-    for (const auto& var : vars) {
+    for (const auto &var : vars) {
         EraseBy<ByHeightVars>(GovVarKey{height, var->GetName()});
     }
 }

--- a/src/masternodes/gv.h
+++ b/src/masternodes/gv.h
@@ -13,10 +13,9 @@
 class ATTRIBUTES;
 class CCustomCSView;
 
-class GovVariable
-{
-public:
-    static std::shared_ptr<GovVariable> Create(std::string const & name) {
+class GovVariable {
+   public:
+    static std::shared_ptr<GovVariable> Create(std::string const &name) {
         return std::shared_ptr<GovVariable>(Factory<GovVariable>::Create(name));
     }
     virtual ~GovVariable() = default;
@@ -29,31 +28,35 @@ public:
     virtual Res Validate(CCustomCSView const &) const = 0;
     virtual Res Apply(CCustomCSView &, uint32_t) = 0;
 
-    virtual void Serialize(CVectorWriter& s) const = 0;
-    virtual void Unserialize(VectorReader& s) = 0;
+    virtual void Serialize(CVectorWriter &s) const = 0;
+    virtual void Unserialize(VectorReader &s) = 0;
 
-    virtual void Serialize(CDataStream& s) const = 0;
-    virtual void Unserialize(CDataStream& s) = 0;
+    virtual void Serialize(CDataStream &s) const = 0;
+    virtual void Unserialize(CDataStream &s) = 0;
 };
 
-class CGovView : public virtual CStorageView
-{
-public:
-    Res SetVariable(GovVariable const & var);
+class CGovView : public virtual CStorageView {
+   public:
+    Res SetVariable(GovVariable const &var);
     std::shared_ptr<GovVariable> GetVariable(std::string const &govKey) const;
 
-    Res SetStoredVariables(const std::set<std::shared_ptr<GovVariable>>& govVars, const uint32_t height);
+    Res SetStoredVariables(const std::set<std::shared_ptr<GovVariable>> &govVars, const uint32_t height);
     std::set<std::shared_ptr<GovVariable>> GetStoredVariables(const uint32_t height);
-    std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> GetStoredVariablesRange(const uint32_t startHeight, const uint32_t endHeight);
+    std::vector<std::pair<uint32_t, std::shared_ptr<GovVariable>>> GetStoredVariablesRange(const uint32_t startHeight,
+                                                                                           const uint32_t endHeight);
     std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> GetAllStoredVariables();
     void EraseStoredVariables(const uint32_t height);
 
     std::shared_ptr<ATTRIBUTES> GetAttributes() const;
 
-    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t>& tokenIds) const = 0;
+    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) const = 0;
 
-    struct ByHeightVars { static constexpr uint8_t prefix() { return 'G'; } };
-    struct ByName { static constexpr uint8_t prefix() { return 'g'; } };
+    struct ByHeightVars {
+        static constexpr uint8_t prefix() { return 'G'; }
+    };
+    struct ByName {
+        static constexpr uint8_t prefix() { return 'g'; }
+    };
 };
 
 struct GovVarKey {
@@ -63,7 +66,7 @@ struct GovVarKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(WrapBigEndian(height));
         READWRITE(name);
     }
@@ -102,4 +105,4 @@ public:
 };
 */
 
-#endif // DEFI_MASTERNODES_GV_H
+#endif  // DEFI_MASTERNODES_GV_H

--- a/src/masternodes/icxorder.cpp
+++ b/src/masternodes/icxorder.cpp
@@ -1,6 +1,6 @@
+#include <core_io.h>  /// ValueFromAmount
 #include <masternodes/icxorder.h>
-#include <rpc/util.h> /// AmountFromValue
-#include <core_io.h> /// ValueFromAmount
+#include <rpc/util.h>  /// AmountFromValue
 
 const uint32_t CICXOrder::DEFAULT_EXPIRY = 2880;
 const uint8_t CICXOrder::TYPE_INTERNAL = 1;
@@ -33,7 +33,8 @@ const uint32_t CICXSubmitEXTHTLC::MINIMUM_TIMEOUT = 30;
 const uint32_t CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT = 15;
 const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_TIMEOUT = 72;
 const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT = 24;
-// constant for calculating BTC block period in DFI block period per hour (BTC estimated to 6 blocks/h, DFI to 96 blocks/h)
+// constant for calculating BTC block period in DFI block period per hour (BTC estimated to 6 blocks/h, DFI to 96
+// blocks/h)
 const uint32_t CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS = 16;
 const uint32_t CICXSubmitEXTHTLC::EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS = 20;
 const uint8_t CICXSubmitEXTHTLC::STATUS_OPEN = 0;
@@ -42,16 +43,14 @@ const uint8_t CICXSubmitEXTHTLC::STATUS_EXPIRED = 3;
 
 const CAmount CICXOrderView::DEFAULT_DFI_BTC_PRICE = 15000;
 
-std::unique_ptr<CICXOrderView::CICXOrderImpl> CICXOrderView::GetICXOrderByCreationTx(uint256 const & txid) const
-{
-    auto order = ReadBy<ICXOrderCreationTx,CICXOrderImpl>(txid);
+std::unique_ptr<CICXOrderView::CICXOrderImpl> CICXOrderView::GetICXOrderByCreationTx(uint256 const &txid) const {
+    auto order = ReadBy<ICXOrderCreationTx, CICXOrderImpl>(txid);
     if (order)
         return std::make_unique<CICXOrderImpl>(*order);
     return {};
 }
 
-uint8_t CICXOrderView::GetICXOrderStatus(OrderKey const & key) const
-{
+uint8_t CICXOrderView::GetICXOrderStatus(OrderKey const &key) const {
     auto status = ReadBy<ICXOrderOpenKey, uint8_t>(key);
 
     if (!status)
@@ -63,9 +62,8 @@ uint8_t CICXOrderView::GetICXOrderStatus(OrderKey const & key) const
     return {};
 }
 
-Res CICXOrderView::ICXCreateOrder(CICXOrderImpl const & order)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXCreateOrder(CICXOrderImpl const &order) {
+    // this should not happen, but for sure
     if (GetICXOrderByCreationTx(order.creationTx))
         return Res::Err("order with creation tx %s already exists!", order.creationTx.GetHex());
     if (order.orderType != CICXOrder::TYPE_INTERNAL && order.orderType != CICXOrder::TYPE_EXTERNAL)
@@ -82,14 +80,14 @@ Res CICXOrderView::ICXCreateOrder(CICXOrderImpl const & order)
     OrderKey key(order.idToken, order.creationTx);
     WriteBy<ICXOrderCreationTx>(order.creationTx, order);
     WriteBy<ICXOrderOpenKey>(key, CICXOrder::STATUS_OPEN);
-    WriteBy<ICXOrderStatus>(StatusKey(order.creationHeight + order.expiry, order.creationTx), CICXOrder::STATUS_EXPIRED);
+    WriteBy<ICXOrderStatus>(StatusKey(order.creationHeight + order.expiry, order.creationTx),
+                            CICXOrder::STATUS_EXPIRED);
 
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXUpdateOrder(CICXOrderImpl const & order)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXUpdateOrder(CICXOrderImpl const &order) {
+    // this should not happen, but for sure
     if (!GetICXOrderByCreationTx(order.creationTx))
         return Res::Err("order with creation tx %s doesn't exists!", order.creationTx.GetHex());
 
@@ -99,8 +97,7 @@ Res CICXOrderView::ICXUpdateOrder(CICXOrderImpl const & order)
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXCloseOrderTx(CICXOrderImpl const & order, uint8_t const status)
-{
+Res CICXOrderView::ICXCloseOrderTx(CICXOrderImpl const &order, uint8_t const status) {
     WriteBy<ICXOrderCreationTx>(order.creationTx, order);
     OrderKey key(order.idToken, order.creationTx);
     EraseBy<ICXOrderOpenKey>(key);
@@ -110,40 +107,36 @@ Res CICXOrderView::ICXCloseOrderTx(CICXOrderImpl const & order, uint8_t const st
     return Res::Ok();
 }
 
-void CICXOrderView::ForEachICXOrderOpen(std::function<bool (OrderKey const &, uint8_t)> callback, DCT_ID const & id)
-{
+void CICXOrderView::ForEachICXOrderOpen(std::function<bool(OrderKey const &, uint8_t)> callback, DCT_ID const &id) {
     ForEach<ICXOrderOpenKey, OrderKey, uint8_t>(callback, OrderKey{id, {}});
 }
 
-void CICXOrderView::ForEachICXOrderClose(std::function<bool (OrderKey const &, uint8_t)> callback, DCT_ID const & id)
-{
+void CICXOrderView::ForEachICXOrderClose(std::function<bool(OrderKey const &, uint8_t)> callback, DCT_ID const &id) {
     ForEach<ICXOrderCloseKey, OrderKey, uint8_t>(callback, OrderKey{id, {}});
 }
 
-void CICXOrderView::ForEachICXOrderExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height)
-{
+void CICXOrderView::ForEachICXOrderExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                          uint32_t const &height) {
     ForEach<ICXOrderStatus, StatusKey, uint8_t>(callback, StatusKey{height, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXOrderImpl> CICXOrderView::HasICXOrderOpen(DCT_ID const & tokenId, uint256 const & ordertxid)
-{
+std::unique_ptr<CICXOrderView::CICXOrderImpl> CICXOrderView::HasICXOrderOpen(DCT_ID const &tokenId,
+                                                                             uint256 const &ordertxid) {
     auto it = LowerBound<ICXOrderOpenKey>(OrderKey{tokenId, ordertxid});
     if (it.Valid() && it.Key().first == tokenId && it.Key().second == ordertxid)
         return GetICXOrderByCreationTx(it.Key().second);
     return {};
 }
 
-
-std::unique_ptr<CICXOrderView::CICXMakeOfferImpl> CICXOrderView::GetICXMakeOfferByCreationTx(uint256 const & txid) const
-{
-    auto makeoffer = ReadBy<ICXMakeOfferCreationTx,CICXMakeOfferImpl>(txid);
+std::unique_ptr<CICXOrderView::CICXMakeOfferImpl> CICXOrderView::GetICXMakeOfferByCreationTx(
+    uint256 const &txid) const {
+    auto makeoffer = ReadBy<ICXMakeOfferCreationTx, CICXMakeOfferImpl>(txid);
     if (makeoffer)
         return std::make_unique<CICXMakeOfferImpl>(*makeoffer);
     return {};
 }
 
-uint8_t CICXOrderView::GetICXMakeOfferStatus(TxidPairKey const & key) const
-{
+uint8_t CICXOrderView::GetICXMakeOfferStatus(TxidPairKey const &key) const {
     auto status = ReadBy<ICXMakeOfferOpenKey, uint8_t>(key);
 
     if (!status)
@@ -155,9 +148,8 @@ uint8_t CICXOrderView::GetICXMakeOfferStatus(TxidPairKey const & key) const
     return {};
 }
 
-Res CICXOrderView::ICXMakeOffer(CICXMakeOfferImpl const & makeoffer)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXMakeOffer(CICXMakeOfferImpl const &makeoffer) {
+    // this should not happen, but for sure
     if (GetICXMakeOfferByCreationTx(makeoffer.creationTx))
         return Res::Err("makeoffer with creation tx %s already exists!", makeoffer.creationTx.GetHex());
     if (makeoffer.amount == 0)
@@ -165,21 +157,20 @@ Res CICXOrderView::ICXMakeOffer(CICXMakeOfferImpl const & makeoffer)
 
     WriteBy<ICXMakeOfferCreationTx>(makeoffer.creationTx, makeoffer);
     WriteBy<ICXMakeOfferOpenKey>(TxidPairKey(makeoffer.orderTx, makeoffer.creationTx), CICXMakeOffer::STATUS_OPEN);
-    WriteBy<ICXOfferStatus>(StatusKey(makeoffer.creationHeight + makeoffer.expiry, makeoffer.creationTx), CICXMakeOffer::STATUS_EXPIRED);
+    WriteBy<ICXOfferStatus>(StatusKey(makeoffer.creationHeight + makeoffer.expiry, makeoffer.creationTx),
+                            CICXMakeOffer::STATUS_EXPIRED);
 
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXUpdateMakeOffer(CICXMakeOfferImpl const & makeoffer)
-{
+Res CICXOrderView::ICXUpdateMakeOffer(CICXMakeOfferImpl const &makeoffer) {
     WriteBy<ICXMakeOfferCreationTx>(makeoffer.creationTx, makeoffer);
 
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXCloseMakeOfferTx(CICXMakeOfferImpl const & makeoffer, uint8_t const status)
-{
-    TxidPairKey key(makeoffer.orderTx,makeoffer.creationTx);
+Res CICXOrderView::ICXCloseMakeOfferTx(CICXMakeOfferImpl const &makeoffer, uint8_t const status) {
+    TxidPairKey key(makeoffer.orderTx, makeoffer.creationTx);
     EraseBy<ICXMakeOfferOpenKey>(key);
     WriteBy<ICXMakeOfferCloseKey>(key, status);
     EraseBy<ICXOfferStatus>(StatusKey(makeoffer.creationHeight + makeoffer.expiry, makeoffer.creationTx));
@@ -187,40 +178,39 @@ Res CICXOrderView::ICXCloseMakeOfferTx(CICXMakeOfferImpl const & makeoffer, uint
     return Res::Ok();
 }
 
-void CICXOrderView::ForEachICXMakeOfferOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & txid)
-{
+void CICXOrderView::ForEachICXMakeOfferOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                            uint256 const &txid) {
     ForEach<ICXMakeOfferOpenKey, TxidPairKey, uint8_t>(callback, TxidPairKey{txid, {}});
 }
 
-void CICXOrderView::ForEachICXMakeOfferClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & txid)
-{
+void CICXOrderView::ForEachICXMakeOfferClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                             uint256 const &txid) {
     ForEach<ICXMakeOfferCloseKey, TxidPairKey, uint8_t>(callback, TxidPairKey{txid, {}});
 }
 
-void CICXOrderView::ForEachICXMakeOfferExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height)
-{
+void CICXOrderView::ForEachICXMakeOfferExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                              uint32_t const &height) {
     ForEach<ICXOfferStatus, StatusKey, uint8_t>(callback, StatusKey{height, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXMakeOfferImpl> CICXOrderView::HasICXMakeOfferOpen(uint256 const & ordertxid, uint256 const & offertxid)
-{
+std::unique_ptr<CICXOrderView::CICXMakeOfferImpl> CICXOrderView::HasICXMakeOfferOpen(uint256 const &ordertxid,
+                                                                                     uint256 const &offertxid) {
     auto it = LowerBound<ICXMakeOfferOpenKey>(TxidPairKey{ordertxid, offertxid});
     if (it.Valid() && it.Key().first == ordertxid && it.Key().second == offertxid)
         return GetICXMakeOfferByCreationTx(it.Key().second);
     return {};
 }
 
-std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::GetICXSubmitDFCHTLCByCreationTx(uint256 const & txid) const
-{
-    auto submitdfchtlc = ReadBy<ICXSubmitDFCHTLCCreationTx,CICXSubmitDFCHTLCImpl>(txid);
+std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::GetICXSubmitDFCHTLCByCreationTx(
+    uint256 const &txid) const {
+    auto submitdfchtlc = ReadBy<ICXSubmitDFCHTLCCreationTx, CICXSubmitDFCHTLCImpl>(txid);
     if (submitdfchtlc)
         return std::make_unique<CICXSubmitDFCHTLCImpl>(*submitdfchtlc);
     return {};
 }
 
-Res CICXOrderView::ICXSubmitDFCHTLC(CICXSubmitDFCHTLCImpl const & submitdfchtlc)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXSubmitDFCHTLC(CICXSubmitDFCHTLCImpl const &submitdfchtlc) {
+    // this should not happen, but for sure
     if (GetICXSubmitDFCHTLCByCreationTx(submitdfchtlc.creationTx))
         return Res::Err("submitdfchtlc with creation tx %s already exists!", submitdfchtlc.creationTx.GetHex());
     if (submitdfchtlc.amount == 0)
@@ -231,50 +221,54 @@ Res CICXOrderView::ICXSubmitDFCHTLC(CICXSubmitDFCHTLCImpl const & submitdfchtlc)
         return Res::Err("Invalid timeout, must be greater than 0!");
 
     WriteBy<ICXSubmitDFCHTLCCreationTx>(submitdfchtlc.creationTx, submitdfchtlc);
-    WriteBy<ICXSubmitDFCHTLCOpenKey>(TxidPairKey(submitdfchtlc.offerTx, submitdfchtlc.creationTx), CICXSubmitDFCHTLC::STATUS_OPEN);
-    WriteBy<ICXSubmitDFCHTLCStatus>(StatusKey(submitdfchtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitdfchtlc.creationTx), CICXSubmitDFCHTLC::STATUS_EXPIRED);
-    WriteBy<ICXSubmitDFCHTLCStatus>(StatusKey(submitdfchtlc.creationHeight + submitdfchtlc.timeout, submitdfchtlc.creationTx), CICXSubmitDFCHTLC::STATUS_REFUNDED);
+    WriteBy<ICXSubmitDFCHTLCOpenKey>(TxidPairKey(submitdfchtlc.offerTx, submitdfchtlc.creationTx),
+                                     CICXSubmitDFCHTLC::STATUS_OPEN);
+    WriteBy<ICXSubmitDFCHTLCStatus>(
+        StatusKey(submitdfchtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitdfchtlc.creationTx),
+        CICXSubmitDFCHTLC::STATUS_EXPIRED);
+    WriteBy<ICXSubmitDFCHTLCStatus>(
+        StatusKey(submitdfchtlc.creationHeight + submitdfchtlc.timeout, submitdfchtlc.creationTx),
+        CICXSubmitDFCHTLC::STATUS_REFUNDED);
 
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXCloseDFCHTLC(CICXSubmitDFCHTLCImpl const & submitdfchtlc, uint8_t const status)
-{
+Res CICXOrderView::ICXCloseDFCHTLC(CICXSubmitDFCHTLCImpl const &submitdfchtlc, uint8_t const status) {
     WriteBy<ICXSubmitDFCHTLCCreationTx>(submitdfchtlc.creationTx, submitdfchtlc);
     EraseBy<ICXSubmitDFCHTLCOpenKey>(TxidPairKey(submitdfchtlc.offerTx, submitdfchtlc.creationTx));
     WriteBy<ICXSubmitDFCHTLCCloseKey>(TxidPairKey(submitdfchtlc.offerTx, submitdfchtlc.creationTx), status);
 
-    EraseBy<ICXSubmitDFCHTLCStatus>(StatusKey(submitdfchtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitdfchtlc.creationTx));
-    EraseBy<ICXSubmitDFCHTLCStatus>(StatusKey(submitdfchtlc.creationHeight + submitdfchtlc.timeout, submitdfchtlc.creationTx));
+    EraseBy<ICXSubmitDFCHTLCStatus>(StatusKey(
+        submitdfchtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitdfchtlc.creationTx));
+    EraseBy<ICXSubmitDFCHTLCStatus>(
+        StatusKey(submitdfchtlc.creationHeight + submitdfchtlc.timeout, submitdfchtlc.creationTx));
 
     return Res::Ok();
 }
 
-void CICXOrderView::ForEachICXSubmitDFCHTLCOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid)
-{
+void CICXOrderView::ForEachICXSubmitDFCHTLCOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                                uint256 const &offertxid) {
     ForEach<ICXSubmitDFCHTLCOpenKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
 }
 
-void CICXOrderView::ForEachICXSubmitDFCHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid)
-{
+void CICXOrderView::ForEachICXSubmitDFCHTLCClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                                 uint256 const &offertxid) {
     ForEach<ICXSubmitDFCHTLCCloseKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
 }
 
-void CICXOrderView::ForEachICXSubmitDFCHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height)
-{
+void CICXOrderView::ForEachICXSubmitDFCHTLCExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                                  uint32_t const &height) {
     ForEach<ICXSubmitDFCHTLCStatus, StatusKey, uint8_t>(callback, StatusKey{height, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::HasICXSubmitDFCHTLCOpen(uint256 const & offertxid)
-{
+std::unique_ptr<CICXOrderView::CICXSubmitDFCHTLCImpl> CICXOrderView::HasICXSubmitDFCHTLCOpen(uint256 const &offertxid) {
     auto it = LowerBound<ICXSubmitDFCHTLCOpenKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
         return GetICXSubmitDFCHTLCByCreationTx(it.Key().second);
     return {};
 }
 
-bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPreEunosPaya)
-{
+bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const &offertxid, bool isPreEunosPaya) {
     bool result = false;
 
     if (HasICXSubmitDFCHTLCOpen(offertxid))
@@ -288,17 +282,16 @@ bool CICXOrderView::ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPr
     return (result);
 }
 
-std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::GetICXSubmitEXTHTLCByCreationTx(const uint256 & txid) const
-{
-    auto submitexthtlc = ReadBy<ICXSubmitEXTHTLCCreationTx,CICXSubmitEXTHTLCImpl>(txid);
+std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::GetICXSubmitEXTHTLCByCreationTx(
+    const uint256 &txid) const {
+    auto submitexthtlc = ReadBy<ICXSubmitEXTHTLCCreationTx, CICXSubmitEXTHTLCImpl>(txid);
     if (submitexthtlc)
         return std::make_unique<CICXSubmitEXTHTLCImpl>(*submitexthtlc);
     return {};
 }
 
-Res CICXOrderView::ICXSubmitEXTHTLC(CICXSubmitEXTHTLCImpl const & submitexthtlc)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXSubmitEXTHTLC(CICXSubmitEXTHTLCImpl const &submitexthtlc) {
+    // this should not happen, but for sure
     if (GetICXSubmitEXTHTLCByCreationTx(submitexthtlc.creationTx))
         return Res::Err("submitexthtlc with creation tx %s already exists!", submitexthtlc.creationTx.GetHex());
     if (submitexthtlc.amount == 0)
@@ -313,46 +306,47 @@ Res CICXOrderView::ICXSubmitEXTHTLC(CICXSubmitEXTHTLCImpl const & submitexthtlc)
         return Res::Err("Invalid timout, must be greater than 0!");
 
     WriteBy<ICXSubmitEXTHTLCCreationTx>(submitexthtlc.creationTx, submitexthtlc);
-    WriteBy<ICXSubmitEXTHTLCOpenKey>(TxidPairKey(submitexthtlc.offerTx, submitexthtlc.creationTx), CICXSubmitEXTHTLC::STATUS_OPEN);
-    WriteBy<ICXSubmitEXTHTLCStatus>(StatusKey(submitexthtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitexthtlc.creationTx), CICXSubmitEXTHTLC::STATUS_EXPIRED);
+    WriteBy<ICXSubmitEXTHTLCOpenKey>(TxidPairKey(submitexthtlc.offerTx, submitexthtlc.creationTx),
+                                     CICXSubmitEXTHTLC::STATUS_OPEN);
+    WriteBy<ICXSubmitEXTHTLCStatus>(
+        StatusKey(submitexthtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitexthtlc.creationTx),
+        CICXSubmitEXTHTLC::STATUS_EXPIRED);
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXCloseEXTHTLC(CICXSubmitEXTHTLCImpl const & submitexthtlc, uint8_t const status)
-{
+Res CICXOrderView::ICXCloseEXTHTLC(CICXSubmitEXTHTLCImpl const &submitexthtlc, uint8_t const status) {
     WriteBy<ICXSubmitEXTHTLCCreationTx>(submitexthtlc.creationTx, submitexthtlc);
     EraseBy<ICXSubmitEXTHTLCOpenKey>(TxidPairKey(submitexthtlc.offerTx, submitexthtlc.creationTx));
     WriteBy<ICXSubmitEXTHTLCCloseKey>(TxidPairKey(submitexthtlc.offerTx, submitexthtlc.creationTx), status);
-    EraseBy<ICXSubmitEXTHTLCStatus>(StatusKey(submitexthtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitexthtlc.creationTx));
+    EraseBy<ICXSubmitEXTHTLCStatus>(StatusKey(
+        submitexthtlc.creationHeight + CICXMakeOffer::MAKER_DEPOSIT_REFUND_TIMEOUT, submitexthtlc.creationTx));
 
     return Res::Ok();
 }
 
-void CICXOrderView::ForEachICXSubmitEXTHTLCOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid)
-{
-    ForEach<ICXSubmitEXTHTLCOpenKey,TxidPairKey,uint8_t>(callback, TxidPairKey{offertxid, {}});
+void CICXOrderView::ForEachICXSubmitEXTHTLCOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                                uint256 const &offertxid) {
+    ForEach<ICXSubmitEXTHTLCOpenKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
 }
 
-void CICXOrderView::ForEachICXSubmitEXTHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid)
-{
+void CICXOrderView::ForEachICXSubmitEXTHTLCClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                                 uint256 const &offertxid) {
     ForEach<ICXSubmitEXTHTLCCloseKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
 }
 
-void CICXOrderView::ForEachICXSubmitEXTHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height)
-{
+void CICXOrderView::ForEachICXSubmitEXTHTLCExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                                  uint32_t const &height) {
     ForEach<ICXSubmitEXTHTLCStatus, StatusKey, uint8_t>(callback, StatusKey{height, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmitEXTHTLCOpen(uint256 const & offertxid)
-{
+std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmitEXTHTLCOpen(uint256 const &offertxid) {
     auto it = LowerBound<ICXSubmitEXTHTLCOpenKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid)
         return GetICXSubmitEXTHTLCByCreationTx(it.Key().second);
     return {};
 }
 
-bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPreEunosPaya)
-{
+bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const &offertxid, bool isPreEunosPaya) {
     bool result = false;
 
     if (HasICXSubmitEXTHTLCOpen(offertxid))
@@ -366,22 +360,23 @@ bool CICXOrderView::ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPr
     return (result);
 }
 
-std::unique_ptr<CICXOrderView::CICXClaimDFCHTLCImpl> CICXOrderView::GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const
-{
-    auto claimdfchtlc = ReadBy<ICXClaimDFCHTLCCreationTx,CICXClaimDFCHTLCImpl>(txid);
+std::unique_ptr<CICXOrderView::CICXClaimDFCHTLCImpl> CICXOrderView::GetICXClaimDFCHTLCByCreationTx(
+    uint256 const &txid) const {
+    auto claimdfchtlc = ReadBy<ICXClaimDFCHTLCCreationTx, CICXClaimDFCHTLCImpl>(txid);
     if (claimdfchtlc)
         return std::make_unique<CICXClaimDFCHTLCImpl>(*claimdfchtlc);
     return {};
 }
 
-Res CICXOrderView::ICXClaimDFCHTLC(CICXClaimDFCHTLCImpl const & claimdfchtlc, uint256 const & offertxid, CICXOrderImpl const & order)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXClaimDFCHTLC(CICXClaimDFCHTLCImpl const &claimdfchtlc,
+                                   uint256 const &offertxid,
+                                   CICXOrderImpl const &order) {
+    // this should not happen, but for sure
     if (GetICXClaimDFCHTLCByCreationTx(claimdfchtlc.creationTx))
         return Res::Err("claimdfchtlc with creation tx %s already exists!", claimdfchtlc.creationTx.GetHex());
 
     WriteBy<ICXClaimDFCHTLCCreationTx>(claimdfchtlc.creationTx, claimdfchtlc);
-    WriteBy<ICXClaimDFCHTLCKey>(TxidPairKey(offertxid, claimdfchtlc.creationTx),CICXSubmitDFCHTLC::STATUS_CLAIMED);
+    WriteBy<ICXClaimDFCHTLCKey>(TxidPairKey(offertxid, claimdfchtlc.creationTx), CICXSubmitDFCHTLC::STATUS_CLAIMED);
 
     if (order.amountToFill != 0)
         WriteBy<ICXOrderCreationTx>(order.creationTx, order);
@@ -389,22 +384,21 @@ Res CICXOrderView::ICXClaimDFCHTLC(CICXClaimDFCHTLCImpl const & claimdfchtlc, ui
     return Res::Ok();
 }
 
-void CICXOrderView::ForEachICXClaimDFCHTLC(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid)
-{
-     ForEach<ICXClaimDFCHTLCKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
+void CICXOrderView::ForEachICXClaimDFCHTLC(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                           uint256 const &offertxid) {
+    ForEach<ICXClaimDFCHTLCKey, TxidPairKey, uint8_t>(callback, TxidPairKey{offertxid, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXCloseOrderImpl> CICXOrderView::GetICXCloseOrderByCreationTx(uint256 const & txid) const
-{
+std::unique_ptr<CICXOrderView::CICXCloseOrderImpl> CICXOrderView::GetICXCloseOrderByCreationTx(
+    uint256 const &txid) const {
     auto closeorderImpl = ReadBy<ICXCloseOrderCreationTx, CICXCloseOrderImpl>(txid);
     if (closeorderImpl)
         return std::make_unique<CICXCloseOrderImpl>(*closeorderImpl);
     return {};
 }
 
-Res CICXOrderView::ICXCloseOrder(CICXCloseOrderImpl const & closeorder)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXCloseOrder(CICXCloseOrderImpl const &closeorder) {
+    // this should not happen, but for sure
     if (GetICXCloseOrderByCreationTx(closeorder.creationTx))
         return Res::Err("closeorder with creation tx %s already exists!", closeorder.creationTx.GetHex());
 
@@ -413,17 +407,16 @@ Res CICXOrderView::ICXCloseOrder(CICXCloseOrderImpl const & closeorder)
     return Res::Ok();
 }
 
-std::unique_ptr<CICXOrderView::CICXCloseOfferImpl> CICXOrderView::GetICXCloseOfferByCreationTx(uint256 const & txid) const
-{
+std::unique_ptr<CICXOrderView::CICXCloseOfferImpl> CICXOrderView::GetICXCloseOfferByCreationTx(
+    uint256 const &txid) const {
     auto closeofferImpl = ReadBy<ICXCloseOfferCreationTx, CICXCloseOfferImpl>(txid);
     if (closeofferImpl)
         return std::make_unique<CICXCloseOfferImpl>(*closeofferImpl);
     return {};
 }
 
-Res CICXOrderView::ICXCloseOffer(CICXCloseOfferImpl const & closeoffer)
-{
-    //this should not happen, but for sure
+Res CICXOrderView::ICXCloseOffer(CICXCloseOfferImpl const &closeoffer) {
+    // this should not happen, but for sure
     if (GetICXCloseOrderByCreationTx(closeoffer.creationTx))
         return Res::Err("closeooffer with creation tx %s already exists!", closeoffer.creationTx.GetHex());
 
@@ -432,15 +425,13 @@ Res CICXOrderView::ICXCloseOffer(CICXCloseOfferImpl const & closeoffer)
     return Res::Ok();
 }
 
-Res CICXOrderView::ICXSetTakerFeePerBTC(CAmount amount)
-{
+Res CICXOrderView::ICXSetTakerFeePerBTC(CAmount amount) {
     WriteBy<ICXVariables>('A', amount);
 
     return Res::Ok();
 }
 
-CAmount CICXOrderView::ICXGetTakerFeePerBTC()
-{
+CAmount CICXOrderView::ICXGetTakerFeePerBTC() {
     CAmount takerFeePerBTC = CICXMakeOffer::DEFAULT_TAKER_FEE_PER_BTC;
 
     auto fee = ReadBy<ICXVariables, CAmount>('A');

--- a/src/masternodes/icxorder.h
+++ b/src/masternodes/icxorder.h
@@ -5,38 +5,37 @@
 
 #include <amount.h>
 #include <pubkey.h>
-#include <uint256.h>
 #include <script/script.h>
+#include <uint256.h>
 
 #include <flushablestorage.h>
 #include <masternodes/res.h>
 
-class CICXOrder
-{
-public:
-    static const uint32_t DEFAULT_EXPIRY; // default period in blocks after order automatically expires
-    static const uint8_t TYPE_INTERNAL; // type for DFI/BTC orders
-    static const uint8_t TYPE_EXTERNAL; // type for BTC/DFI orders
+class CICXOrder {
+   public:
+    static const uint32_t DEFAULT_EXPIRY;  // default period in blocks after order automatically expires
+    static const uint8_t TYPE_INTERNAL;    // type for DFI/BTC orders
+    static const uint8_t TYPE_EXTERNAL;    // type for BTC/DFI orders
     static const uint8_t STATUS_OPEN;
-    static const uint8_t STATUS_CLOSED; // manually close status
-    static const uint8_t STATUS_FILLED; // completely filled status
-    static const uint8_t STATUS_EXPIRED; // offer expired status
+    static const uint8_t STATUS_CLOSED;   // manually close status
+    static const uint8_t STATUS_FILLED;   // completely filled status
+    static const uint8_t STATUS_EXPIRED;  // offer expired status
     static const std::string CHAIN_BTC;
-    static const std::string TOKEN_BTC; // name of BTC token on DFC
+    static const std::string TOKEN_BTC;  // name of BTC token on DFC
 
-    uint8_t orderType = 0; //is maker buying or selling DFC asset to know which htlc to come first
-    DCT_ID idToken{UINT_MAX}; // used for DFT/BTC
-    CScript ownerAddress; //address for DFI token for fees, and in case of DFC/BTC order for DFC asset
-    CPubKey receivePubkey; // address of BTC pubkey in case of BTC/DFC order
-    CAmount amountFrom = 0; // amount of asset that is sold
-    CAmount amountToFill = 0; // how much is left to fill the order
-    CAmount orderPrice = 0; // price of asset buying in asset selling
-    uint32_t expiry = DEFAULT_EXPIRY; // when the order exipres in number of blocks
+    uint8_t orderType = 0;             // is maker buying or selling DFC asset to know which htlc to come first
+    DCT_ID idToken{UINT_MAX};          // used for DFT/BTC
+    CScript ownerAddress;              // address for DFI token for fees, and in case of DFC/BTC order for DFC asset
+    CPubKey receivePubkey;             // address of BTC pubkey in case of BTC/DFC order
+    CAmount amountFrom = 0;            // amount of asset that is sold
+    CAmount amountToFill = 0;          // how much is left to fill the order
+    CAmount orderPrice = 0;            // price of asset buying in asset selling
+    uint32_t expiry = DEFAULT_EXPIRY;  // when the order exipres in number of blocks
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(orderType);
         READWRITE(idToken);
         READWRITE(ownerAddress);
@@ -48,9 +47,8 @@ public:
     }
 };
 
-class CICXOrderImplemetation : public CICXOrder
-{
-public:
+class CICXOrderImplemetation : public CICXOrder {
+   public:
     uint256 creationTx;
     uint256 closeTx;
     int32_t creationHeight = -1;
@@ -59,7 +57,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXOrder, *this);
         READWRITE(creationTx);
         READWRITE(closeTx);
@@ -73,33 +71,33 @@ struct CICXCreateOrderMessage : public CICXOrder {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXOrder, *this);
     }
 };
 
-class CICXMakeOffer
-{
-public:
-    static const uint32_t DEFAULT_EXPIRY; // default period in blocks after offer automatically expires
+class CICXMakeOffer {
+   public:
+    static const uint32_t DEFAULT_EXPIRY;  // default period in blocks after offer automatically expires
     static const uint32_t EUNOSPAYA_DEFAULT_EXPIRY;
-    static const uint32_t MAKER_DEPOSIT_REFUND_TIMEOUT; // minimum period in DFC blocks in which 2nd HTLC must be created, otherwise makerDeposit is refunded to maker
+    static const uint32_t MAKER_DEPOSIT_REFUND_TIMEOUT;  // minimum period in DFC blocks in which 2nd HTLC must be
+                                                         // created, otherwise makerDeposit is refunded to maker
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLOSED;
     static const uint8_t STATUS_EXPIRED;
     static const int64_t DEFAULT_TAKER_FEE_PER_BTC;
 
-    uint256 orderTx; // txid for which order is the offer
-    CAmount amount = 0; // amount of asset to swap
-    CScript ownerAddress; //address for DFI token for fees, and in case of BTC/DFC order for DFC asset
-    CPubKey receivePubkey; // address or BTC pubkey in case of DFC/BTC order
-    uint32_t expiry = 0; // when the offer exipres in number of blocks
+    uint256 orderTx;        // txid for which order is the offer
+    CAmount amount = 0;     // amount of asset to swap
+    CScript ownerAddress;   // address for DFI token for fees, and in case of BTC/DFC order for DFC asset
+    CPubKey receivePubkey;  // address or BTC pubkey in case of DFC/BTC order
+    uint32_t expiry = 0;    // when the offer exipres in number of blocks
     CAmount takerFee = 0;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(orderTx);
         READWRITE(amount);
         READWRITE(ownerAddress);
@@ -109,9 +107,8 @@ public:
     }
 };
 
-class CICXMakeOfferImplemetation : public CICXMakeOffer
-{
-public:
+class CICXMakeOfferImplemetation : public CICXMakeOffer {
+   public:
     uint256 creationTx;
     uint256 closeTx;
     int32_t creationHeight = -1;
@@ -120,7 +117,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXMakeOffer, *this);
         READWRITE(creationTx);
         READWRITE(closeTx);
@@ -134,33 +131,35 @@ struct CICXMakeOfferMessage : public CICXMakeOffer {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXMakeOffer, *this);
     }
 };
 
-class CICXSubmitDFCHTLC
-{
-public:
-    static const uint32_t MINIMUM_TIMEOUT; // minimum period in blocks after htlc automatically timeouts and funds are returned to owner when it is first htlc
+class CICXSubmitDFCHTLC {
+   public:
+    static const uint32_t MINIMUM_TIMEOUT;  // minimum period in blocks after htlc automatically timeouts and funds are
+                                            // returned to owner when it is first htlc
     static const uint32_t EUNOSPAYA_MINIMUM_TIMEOUT;
-    static const uint32_t MINIMUM_2ND_TIMEOUT; // minimum period in blocks after htlc automatically timeouts and funds are returned to owner when it is second htlc
+    static const uint32_t MINIMUM_2ND_TIMEOUT;  // minimum period in blocks after htlc automatically timeouts and funds
+                                                // are returned to owner when it is second htlc
     static const uint32_t EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLAIMED;
     static const uint8_t STATUS_REFUNDED;
     static const uint8_t STATUS_EXPIRED;
 
-    // This tx is acceptance of the offer, HTLC tx and evidence of HTLC on DFC in the same time. It is a CustomTx on DFC chain
-    uint256 offerTx; // txid for which offer is this HTLC
-    CAmount amount = 0; // amount that is put in HTLC
-    uint256 hash; // hash for the hash lock part
-    uint32_t timeout = 0; // timeout (absolute in blocks) for timelock part
+    // This tx is acceptance of the offer, HTLC tx and evidence of HTLC on DFC in the same time. It is a CustomTx on DFC
+    // chain
+    uint256 offerTx;       // txid for which offer is this HTLC
+    CAmount amount = 0;    // amount that is put in HTLC
+    uint256 hash;          // hash for the hash lock part
+    uint32_t timeout = 0;  // timeout (absolute in blocks) for timelock part
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(offerTx);
         READWRITE(amount);
         READWRITE(hash);
@@ -168,16 +167,15 @@ public:
     }
 };
 
-class CICXSubmitDFCHTLCImplemetation : public CICXSubmitDFCHTLC
-{
-public:
+class CICXSubmitDFCHTLCImplemetation : public CICXSubmitDFCHTLC {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXSubmitDFCHTLC, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -189,26 +187,26 @@ struct CICXSubmitDFCHTLCMessage : public CICXSubmitDFCHTLC {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXSubmitDFCHTLC, *this);
     }
 };
 
-class CICXSubmitEXTHTLC
-{
-public:
-    static const uint32_t MINIMUM_TIMEOUT; // default period in blocks after htlc timeouts when it is first htlc
+class CICXSubmitEXTHTLC {
+   public:
+    static const uint32_t MINIMUM_TIMEOUT;  // default period in blocks after htlc timeouts when it is first htlc
     static const uint32_t EUNOSPAYA_MINIMUM_TIMEOUT;
-    static const uint32_t MINIMUM_2ND_TIMEOUT; // default period in blocks after htlc timeouts when it is second htlc
+    static const uint32_t MINIMUM_2ND_TIMEOUT;  // default period in blocks after htlc timeouts when it is second htlc
     static const uint32_t EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
-    static const uint32_t BTC_BLOCKS_IN_DFI_BLOCKS; // number of BTC blocks in DFI blocks period
-    static const uint32_t EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS; // number of BTC blocks in DFI blocks period
+    static const uint32_t BTC_BLOCKS_IN_DFI_BLOCKS;            // number of BTC blocks in DFI blocks period
+    static const uint32_t EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS;  // number of BTC blocks in DFI blocks period
     static const uint8_t STATUS_OPEN;
     static const uint8_t STATUS_CLOSED;
     static const uint8_t STATUS_EXPIRED;
 
-    // This tx is acceptance of the offer and evidence of HTLC on external chain in the same time. It is a CustomTx on DFC chain
-    uint256 offerTx; // txid for which offer is this HTLC
+    // This tx is acceptance of the offer and evidence of HTLC on external chain in the same time. It is a CustomTx on
+    // DFC chain
+    uint256 offerTx;  // txid for which offer is this HTLC
     CAmount amount = 0;
     uint256 hash;
     std::string htlcscriptAddress;
@@ -218,7 +216,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(offerTx);
         READWRITE(amount);
         READWRITE(hash);
@@ -228,16 +226,15 @@ public:
     }
 };
 
-class CICXSubmitEXTHTLCImplemetation : public CICXSubmitEXTHTLC
-{
-public:
+class CICXSubmitEXTHTLCImplemetation : public CICXSubmitEXTHTLC {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXSubmitEXTHTLC, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -249,36 +246,34 @@ struct CICXSubmitEXTHTLCMessage : public CICXSubmitEXTHTLC {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXSubmitEXTHTLC, *this);
     }
 };
 
-class CICXClaimDFCHTLC
-{
-public:
-    uint256 dfchtlcTx; // txid of claiming DFC HTLC
-    std::vector<unsigned char> seed; // secret for the hash to claim htlc
+class CICXClaimDFCHTLC {
+   public:
+    uint256 dfchtlcTx;                // txid of claiming DFC HTLC
+    std::vector<unsigned char> seed;  // secret for the hash to claim htlc
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(dfchtlcTx);
         READWRITE(seed);
     }
 };
 
-class CICXClaimDFCHTLCImplemetation : public CICXClaimDFCHTLC
-{
-public:
+class CICXClaimDFCHTLCImplemetation : public CICXClaimDFCHTLC {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXClaimDFCHTLC, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -290,34 +285,32 @@ struct CICXClaimDFCHTLCMessage : public CICXClaimDFCHTLC {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXClaimDFCHTLC, *this);
     }
 };
 
-class CICXCloseOrder
-{
-public:
-    uint256 orderTx; //txid of order which will be closed
+class CICXCloseOrder {
+   public:
+    uint256 orderTx;  // txid of order which will be closed
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(orderTx);
     }
 };
 
-class CICXCloseOrderImplemetation : public CICXCloseOrder
-{
-public:
+class CICXCloseOrderImplemetation : public CICXCloseOrder {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXCloseOrder, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -329,34 +322,32 @@ struct CICXCloseOrderMessage : public CICXCloseOrder {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXCloseOrder, *this);
     }
 };
 
-class CICXCloseOffer
-{
-public:
-    uint256 offerTx; //txid of offer which will be closed
+class CICXCloseOffer {
+   public:
+    uint256 offerTx;  // txid of offer which will be closed
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(offerTx);
     }
 };
 
-class CICXCloseOfferImplemetation : public CICXCloseOffer
-{
-public:
+class CICXCloseOfferImplemetation : public CICXCloseOffer {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXCloseOffer, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -368,13 +359,13 @@ struct CICXCloseOfferMessage : public CICXCloseOffer {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CICXCloseOffer, *this);
     }
 };
 
 class CICXOrderView : public virtual CStorageView {
-public:
+   public:
     static const CAmount DEFAULT_DFI_BTC_PRICE;
 
     using OrderKey = std::pair<DCT_ID, uint256>;
@@ -389,90 +380,141 @@ public:
     using CICXCloseOrderImpl = CICXCloseOrderImplemetation;
     using CICXCloseOfferImpl = CICXCloseOfferImplemetation;
 
-    //Order
-    std::unique_ptr<CICXOrderImpl> GetICXOrderByCreationTx(uint256 const & txid) const;
-    uint8_t GetICXOrderStatus(OrderKey const & key) const;
-    Res ICXCreateOrder(CICXOrderImpl const & order);
-    Res ICXUpdateOrder(CICXOrderImpl const & order);
-    Res ICXCloseOrderTx(CICXOrderImpl const & order, uint8_t const);
-    void ForEachICXOrderOpen(std::function<bool (OrderKey const &, uint8_t)> callback, DCT_ID const & pair = {0});
-    void ForEachICXOrderClose(std::function<bool (OrderKey const &, uint8_t)> callback, DCT_ID const & pair = {0});
-    void ForEachICXOrderExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
-    std::unique_ptr<CICXOrderImpl> HasICXOrderOpen(DCT_ID const & tokenId, uint256 const & ordertxid);
+    // Order
+    std::unique_ptr<CICXOrderImpl> GetICXOrderByCreationTx(uint256 const &txid) const;
+    uint8_t GetICXOrderStatus(OrderKey const &key) const;
+    Res ICXCreateOrder(CICXOrderImpl const &order);
+    Res ICXUpdateOrder(CICXOrderImpl const &order);
+    Res ICXCloseOrderTx(CICXOrderImpl const &order, uint8_t const);
+    void ForEachICXOrderOpen(std::function<bool(OrderKey const &, uint8_t)> callback, DCT_ID const &pair = {0});
+    void ForEachICXOrderClose(std::function<bool(OrderKey const &, uint8_t)> callback, DCT_ID const &pair = {0});
+    void ForEachICXOrderExpire(std::function<bool(StatusKey const &, uint8_t)> callback, uint32_t const &height = 0);
+    std::unique_ptr<CICXOrderImpl> HasICXOrderOpen(DCT_ID const &tokenId, uint256 const &ordertxid);
 
-    //MakeOffer
-    std::unique_ptr<CICXMakeOfferImpl> GetICXMakeOfferByCreationTx(uint256 const & txid) const;
-    uint8_t GetICXMakeOfferStatus(TxidPairKey const & key) const;
-    Res ICXMakeOffer(CICXMakeOfferImpl const & makeoffer);
-    Res ICXUpdateMakeOffer(CICXMakeOfferImpl const & makeoffer);
-    Res ICXCloseMakeOfferTx(CICXMakeOfferImpl const & order, uint8_t const);
-    void ForEachICXMakeOfferOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & ordertxid = uint256());
-    void ForEachICXMakeOfferClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & ordertxid = uint256());
-    void ForEachICXMakeOfferExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
-    std::unique_ptr<CICXMakeOfferImpl> HasICXMakeOfferOpen(uint256 const & ordertxid, uint256 const & offertxid);
+    // MakeOffer
+    std::unique_ptr<CICXMakeOfferImpl> GetICXMakeOfferByCreationTx(uint256 const &txid) const;
+    uint8_t GetICXMakeOfferStatus(TxidPairKey const &key) const;
+    Res ICXMakeOffer(CICXMakeOfferImpl const &makeoffer);
+    Res ICXUpdateMakeOffer(CICXMakeOfferImpl const &makeoffer);
+    Res ICXCloseMakeOfferTx(CICXMakeOfferImpl const &order, uint8_t const);
+    void ForEachICXMakeOfferOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                 uint256 const &ordertxid = uint256());
+    void ForEachICXMakeOfferClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                  uint256 const &ordertxid = uint256());
+    void ForEachICXMakeOfferExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                   uint32_t const &height = 0);
+    std::unique_ptr<CICXMakeOfferImpl> HasICXMakeOfferOpen(uint256 const &ordertxid, uint256 const &offertxid);
 
-    //SubmitDFCHTLC
-    std::unique_ptr<CICXSubmitDFCHTLCImpl> GetICXSubmitDFCHTLCByCreationTx(uint256 const & txid) const;
-    Res ICXSubmitDFCHTLC(CICXSubmitDFCHTLCImpl const & dfchtlc);
-    Res ICXCloseDFCHTLC(CICXSubmitDFCHTLCImpl const & dfchtlc, uint8_t const);
-    void ForEachICXSubmitDFCHTLCOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
-    void ForEachICXSubmitDFCHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
-    void ForEachICXSubmitDFCHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
-    std::unique_ptr<CICXSubmitDFCHTLCImpl> HasICXSubmitDFCHTLCOpen(uint256 const & offertxid);
-    bool ExistedICXSubmitDFCHTLC(uint256 const & offertxid, bool isPreEunosPaya);
+    // SubmitDFCHTLC
+    std::unique_ptr<CICXSubmitDFCHTLCImpl> GetICXSubmitDFCHTLCByCreationTx(uint256 const &txid) const;
+    Res ICXSubmitDFCHTLC(CICXSubmitDFCHTLCImpl const &dfchtlc);
+    Res ICXCloseDFCHTLC(CICXSubmitDFCHTLCImpl const &dfchtlc, uint8_t const);
+    void ForEachICXSubmitDFCHTLCOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                     uint256 const &offertxid = uint256());
+    void ForEachICXSubmitDFCHTLCClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                      uint256 const &offertxid = uint256());
+    void ForEachICXSubmitDFCHTLCExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                       uint32_t const &height = 0);
+    std::unique_ptr<CICXSubmitDFCHTLCImpl> HasICXSubmitDFCHTLCOpen(uint256 const &offertxid);
+    bool ExistedICXSubmitDFCHTLC(uint256 const &offertxid, bool isPreEunosPaya);
 
+    // SubmitEXTHTLC
+    std::unique_ptr<CICXSubmitEXTHTLCImpl> GetICXSubmitEXTHTLCByCreationTx(uint256 const &txid) const;
+    Res ICXSubmitEXTHTLC(CICXSubmitEXTHTLCImpl const &dfchtlc);
+    Res ICXCloseEXTHTLC(CICXSubmitEXTHTLCImpl const &exthtlc, uint8_t const);
+    void ForEachICXSubmitEXTHTLCOpen(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                     uint256 const &offertxid = uint256());
+    void ForEachICXSubmitEXTHTLCClose(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                      uint256 const &offertxid = uint256());
+    void ForEachICXSubmitEXTHTLCExpire(std::function<bool(StatusKey const &, uint8_t)> callback,
+                                       uint32_t const &height = 0);
+    std::unique_ptr<CICXSubmitEXTHTLCImpl> HasICXSubmitEXTHTLCOpen(uint256 const &offertxid);
+    bool ExistedICXSubmitEXTHTLC(uint256 const &offertxid, bool isPreEunosPaya);
 
-    //SubmitEXTHTLC
-    std::unique_ptr<CICXSubmitEXTHTLCImpl> GetICXSubmitEXTHTLCByCreationTx(uint256 const & txid) const;
-    Res ICXSubmitEXTHTLC(CICXSubmitEXTHTLCImpl const & dfchtlc);
-    Res ICXCloseEXTHTLC(CICXSubmitEXTHTLCImpl const & exthtlc, uint8_t const);
-    void ForEachICXSubmitEXTHTLCOpen(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
-    void ForEachICXSubmitEXTHTLCClose(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
-    void ForEachICXSubmitEXTHTLCExpire(std::function<bool (StatusKey const &, uint8_t)> callback, uint32_t const & height = 0);
-    std::unique_ptr<CICXSubmitEXTHTLCImpl> HasICXSubmitEXTHTLCOpen(uint256 const & offertxid);
-    bool ExistedICXSubmitEXTHTLC(uint256 const & offertxid, bool isPreEunosPaya);
+    // ClaimDFCHTLC
+    std::unique_ptr<CICXClaimDFCHTLCImpl> GetICXClaimDFCHTLCByCreationTx(uint256 const &txid) const;
+    Res ICXClaimDFCHTLC(CICXClaimDFCHTLCImpl const &claimdfchtlc, uint256 const &offertxid, CICXOrderImpl const &order);
+    void ForEachICXClaimDFCHTLC(std::function<bool(TxidPairKey const &, uint8_t)> callback,
+                                uint256 const &offertxid = uint256());
 
-    //ClaimDFCHTLC
-    std::unique_ptr<CICXClaimDFCHTLCImpl> GetICXClaimDFCHTLCByCreationTx(uint256 const & txid) const;
-    Res ICXClaimDFCHTLC(CICXClaimDFCHTLCImpl const & claimdfchtlc, uint256 const & offertxid, CICXOrderImpl const & order);
-    void ForEachICXClaimDFCHTLC(std::function<bool (TxidPairKey const &, uint8_t)> callback, uint256 const & offertxid = uint256());
+    // CloseOrder
+    std::unique_ptr<CICXCloseOrderImpl> GetICXCloseOrderByCreationTx(uint256 const &txid) const;
+    Res ICXCloseOrder(CICXCloseOrderImpl const &closeorder);
 
-    //CloseOrder
-    std::unique_ptr<CICXCloseOrderImpl> GetICXCloseOrderByCreationTx(uint256 const & txid) const;
-    Res ICXCloseOrder(CICXCloseOrderImpl const & closeorder);
-
-    //CloseOrder
-    std::unique_ptr<CICXCloseOfferImpl> GetICXCloseOfferByCreationTx(uint256 const & txid) const;
-    Res ICXCloseOffer(CICXCloseOfferImpl const & closeoffer);
+    // CloseOrder
+    std::unique_ptr<CICXCloseOfferImpl> GetICXCloseOfferByCreationTx(uint256 const &txid) const;
+    Res ICXCloseOffer(CICXCloseOfferImpl const &closeoffer);
 
     // ICX_TAKERFEE_PER_BTC
     Res ICXSetTakerFeePerBTC(CAmount amount);
     CAmount ICXGetTakerFeePerBTC();
 
-    struct ICXOrderCreationTx         { static constexpr uint8_t prefix() { return '1'; } };
-    struct ICXMakeOfferCreationTx     { static constexpr uint8_t prefix() { return '2'; } };
-    struct ICXSubmitDFCHTLCCreationTx { static constexpr uint8_t prefix() { return '3'; } };
-    struct ICXSubmitEXTHTLCCreationTx { static constexpr uint8_t prefix() { return '4'; } };
-    struct ICXClaimDFCHTLCCreationTx  { static constexpr uint8_t prefix() { return '5'; } };
-    struct ICXCloseOrderCreationTx    { static constexpr uint8_t prefix() { return '6'; } };
-    struct ICXCloseOfferCreationTx    { static constexpr uint8_t prefix() { return '7'; } };
+    struct ICXOrderCreationTx {
+        static constexpr uint8_t prefix() { return '1'; }
+    };
+    struct ICXMakeOfferCreationTx {
+        static constexpr uint8_t prefix() { return '2'; }
+    };
+    struct ICXSubmitDFCHTLCCreationTx {
+        static constexpr uint8_t prefix() { return '3'; }
+    };
+    struct ICXSubmitEXTHTLCCreationTx {
+        static constexpr uint8_t prefix() { return '4'; }
+    };
+    struct ICXClaimDFCHTLCCreationTx {
+        static constexpr uint8_t prefix() { return '5'; }
+    };
+    struct ICXCloseOrderCreationTx {
+        static constexpr uint8_t prefix() { return '6'; }
+    };
+    struct ICXCloseOfferCreationTx {
+        static constexpr uint8_t prefix() { return '7'; }
+    };
 
-    struct ICXOrderOpenKey            { static constexpr uint8_t prefix() { return 0x01; } };
-    struct ICXOrderCloseKey           { static constexpr uint8_t prefix() { return 0x02; } };
-    struct ICXMakeOfferOpenKey        { static constexpr uint8_t prefix() { return 0x03; } };
-    struct ICXMakeOfferCloseKey       { static constexpr uint8_t prefix() { return 0x04; } };
-    struct ICXSubmitDFCHTLCOpenKey    { static constexpr uint8_t prefix() { return 0x05; } };
-    struct ICXSubmitDFCHTLCCloseKey   { static constexpr uint8_t prefix() { return 0x06; } };
-    struct ICXSubmitEXTHTLCOpenKey    { static constexpr uint8_t prefix() { return 0x07; } };
-    struct ICXSubmitEXTHTLCCloseKey   { static constexpr uint8_t prefix() { return 0x08; } };
-    struct ICXClaimDFCHTLCKey         { static constexpr uint8_t prefix() { return 0x09; } };
+    struct ICXOrderOpenKey {
+        static constexpr uint8_t prefix() { return 0x01; }
+    };
+    struct ICXOrderCloseKey {
+        static constexpr uint8_t prefix() { return 0x02; }
+    };
+    struct ICXMakeOfferOpenKey {
+        static constexpr uint8_t prefix() { return 0x03; }
+    };
+    struct ICXMakeOfferCloseKey {
+        static constexpr uint8_t prefix() { return 0x04; }
+    };
+    struct ICXSubmitDFCHTLCOpenKey {
+        static constexpr uint8_t prefix() { return 0x05; }
+    };
+    struct ICXSubmitDFCHTLCCloseKey {
+        static constexpr uint8_t prefix() { return 0x06; }
+    };
+    struct ICXSubmitEXTHTLCOpenKey {
+        static constexpr uint8_t prefix() { return 0x07; }
+    };
+    struct ICXSubmitEXTHTLCCloseKey {
+        static constexpr uint8_t prefix() { return 0x08; }
+    };
+    struct ICXClaimDFCHTLCKey {
+        static constexpr uint8_t prefix() { return 0x09; }
+    };
 
-    struct ICXOrderStatus             { static constexpr uint8_t prefix() { return 0x0A; } };
-    struct ICXOfferStatus             { static constexpr uint8_t prefix() { return 0x0B; } };
-    struct ICXSubmitDFCHTLCStatus     { static constexpr uint8_t prefix() { return 0x0C; } };
-    struct ICXSubmitEXTHTLCStatus     { static constexpr uint8_t prefix() { return 0x0D; } };
+    struct ICXOrderStatus {
+        static constexpr uint8_t prefix() { return 0x0A; }
+    };
+    struct ICXOfferStatus {
+        static constexpr uint8_t prefix() { return 0x0B; }
+    };
+    struct ICXSubmitDFCHTLCStatus {
+        static constexpr uint8_t prefix() { return 0x0C; }
+    };
+    struct ICXSubmitEXTHTLCStatus {
+        static constexpr uint8_t prefix() { return 0x0D; }
+    };
 
-    struct ICXVariables               { static constexpr uint8_t prefix() { return 0x0F; } };
+    struct ICXVariables {
+        static constexpr uint8_t prefix() { return 0x0F; }
+    };
 };
 
-#endif // DEFI_MASTERNODES_ICXORDER_H
+#endif  // DEFI_MASTERNODES_ICXORDER_H

--- a/src/masternodes/incentivefunding.cpp
+++ b/src/masternodes/incentivefunding.cpp
@@ -4,8 +4,7 @@
 
 #include <masternodes/incentivefunding.h>
 
-CAmount CCommunityBalancesView::GetCommunityBalance(CommunityAccountType account) const
-{
+CAmount CCommunityBalancesView::GetCommunityBalance(CommunityAccountType account) const {
     CAmount val;
     bool ok = ReadBy<ById>(static_cast<unsigned char>(account), val);
     if (ok) {
@@ -14,8 +13,7 @@ CAmount CCommunityBalancesView::GetCommunityBalance(CommunityAccountType account
     return 0;
 }
 
-Res CCommunityBalancesView::SetCommunityBalance(CommunityAccountType account, CAmount amount)
-{
+Res CCommunityBalancesView::SetCommunityBalance(CommunityAccountType account, CAmount amount) {
     // deny negative values on db level!
     if (amount < 0) {
         return Res::Err("negative amount");
@@ -24,16 +22,16 @@ Res CCommunityBalancesView::SetCommunityBalance(CommunityAccountType account, CA
     return Res::Ok();
 }
 
-void CCommunityBalancesView::ForEachCommunityBalance(std::function<bool (CommunityAccountType, CLazySerialize<CAmount>)> callback)
-{
-    ForEach<ById, unsigned char, CAmount>([&callback] (unsigned char const & key, CLazySerialize<CAmount> val) {
-        return callback(CommunityAccountCodeToType(key), val);
-    }, '\0');
-
+void CCommunityBalancesView::ForEachCommunityBalance(
+    std::function<bool(CommunityAccountType, CLazySerialize<CAmount>)> callback) {
+    ForEach<ById, unsigned char, CAmount>(
+        [&callback](unsigned char const &key, CLazySerialize<CAmount> val) {
+            return callback(CommunityAccountCodeToType(key), val);
+        },
+        '\0');
 }
 
-Res CCommunityBalancesView::AddCommunityBalance(CommunityAccountType account, CAmount amount)
-{
+Res CCommunityBalancesView::AddCommunityBalance(CommunityAccountType account, CAmount amount) {
     if (amount == 0) {
         return Res::Ok();
     }
@@ -41,8 +39,7 @@ Res CCommunityBalancesView::AddCommunityBalance(CommunityAccountType account, CA
     return !res.ok ? res : SetCommunityBalance(account, *res.val);
 }
 
-Res CCommunityBalancesView::SubCommunityBalance(CommunityAccountType account, CAmount amount)
-{
+Res CCommunityBalancesView::SubCommunityBalance(CommunityAccountType account, CAmount amount) {
     if (amount == 0) {
         return Res::Ok();
     }

--- a/src/masternodes/incentivefunding.h
+++ b/src/masternodes/incentivefunding.h
@@ -5,12 +5,12 @@
 #ifndef DEFI_MASTERNODES_INCENTIVEFUNDING_H
 #define DEFI_MASTERNODES_INCENTIVEFUNDING_H
 
+#include <amount.h>
 #include <flushablestorage.h>
 #include <masternodes/communityaccounttypes.h>
 #include <masternodes/res.h>
-#include <amount.h>
 
-inline CommunityAccountType CommunityAccountCodeToType (unsigned char ch) {
+inline CommunityAccountType CommunityAccountCodeToType(unsigned char ch) {
     char const types[] = "IALOU";
     if (memchr(types, ch, strlen(types)))
         return static_cast<CommunityAccountType>(ch);
@@ -18,23 +18,25 @@ inline CommunityAccountType CommunityAccountCodeToType (unsigned char ch) {
         return CommunityAccountType::None;
 }
 
-inline char const * GetCommunityAccountName(CommunityAccountType t)
-{
-    switch (t)
-    {
-        case CommunityAccountType::IncentiveFunding: return "IncentiveFunding";
-        case CommunityAccountType::AnchorReward:     return "AnchorReward";
-        case CommunityAccountType::Loan:             return "Loan";
-        case CommunityAccountType::Options:          return "Options";
-        case CommunityAccountType::Unallocated:      return "Burnt";
+inline char const *GetCommunityAccountName(CommunityAccountType t) {
+    switch (t) {
+        case CommunityAccountType::IncentiveFunding:
+            return "IncentiveFunding";
+        case CommunityAccountType::AnchorReward:
+            return "AnchorReward";
+        case CommunityAccountType::Loan:
+            return "Loan";
+        case CommunityAccountType::Options:
+            return "Options";
+        case CommunityAccountType::Unallocated:
+            return "Burnt";
         default:
             return "Unknown";
     }
 }
 
-class CCommunityBalancesView : public virtual CStorageView
-{
-public:
+class CCommunityBalancesView : public virtual CStorageView {
+   public:
     CAmount GetCommunityBalance(CommunityAccountType account) const;
     Res SetCommunityBalance(CommunityAccountType account, CAmount amount);
 
@@ -44,7 +46,9 @@ public:
     Res SubCommunityBalance(CommunityAccountType account, CAmount amount);
 
     // tags
-    struct ById { static constexpr uint8_t prefix() { return 'F'; } };
+    struct ById {
+        static constexpr uint8_t prefix() { return 'F'; }
+    };
 };
 
-#endif //DEFI_MASTERNODES_INCENTIVEFUNDING_H
+#endif  // DEFI_MASTERNODES_INCENTIVEFUNDING_H

--- a/src/masternodes/loan.h
+++ b/src/masternodes/loan.h
@@ -6,15 +6,13 @@
 
 #include <flushablestorage.h>
 #include <masternodes/balances.h>
-#include <masternodes/res.h>
 #include <masternodes/oracles.h>
+#include <masternodes/res.h>
 #include <masternodes/vault.h>
 #include <script/script.h>
 
-
-class CLoanSetCollateralToken
-{
-public:
+class CLoanSetCollateralToken {
+   public:
     DCT_ID idToken{UINT_MAX};
     CAmount factor;
     CTokenCurrencyPair fixedIntervalPriceId;
@@ -23,7 +21,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(idToken);
         READWRITE(factor);
         READWRITE(fixedIntervalPriceId);
@@ -31,16 +29,15 @@ public:
     }
 };
 
-class CLoanSetCollateralTokenImplementation : public CLoanSetCollateralToken
-{
-public:
+class CLoanSetCollateralTokenImplementation : public CLoanSetCollateralToken {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CLoanSetCollateralToken, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -52,14 +49,13 @@ struct CLoanSetCollateralTokenMessage : public CLoanSetCollateralToken {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CLoanSetCollateralToken, *this);
     }
 };
 
-class CLoanSetLoanToken
-{
-public:
+class CLoanSetLoanToken {
+   public:
     std::string symbol;
     std::string name;
     CTokenCurrencyPair fixedIntervalPriceId;
@@ -69,7 +65,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(symbol);
         READWRITE(name);
         READWRITE(fixedIntervalPriceId);
@@ -78,16 +74,15 @@ public:
     }
 };
 
-class CLoanSetLoanTokenImplementation : public CLoanSetLoanToken
-{
-public:
+class CLoanSetLoanTokenImplementation : public CLoanSetLoanToken {
+   public:
     uint256 creationTx;
     int32_t creationHeight = -1;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CLoanSetLoanToken, *this);
         READWRITE(creationTx);
         READWRITE(creationHeight);
@@ -99,7 +94,7 @@ struct CLoanSetLoanTokenMessage : public CLoanSetLoanToken {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CLoanSetLoanToken, *this);
     }
 };
@@ -111,21 +106,20 @@ struct CLoanUpdateLoanTokenMessage : public CLoanSetLoanToken {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CLoanSetLoanToken, *this);
         READWRITE(tokenTx);
     }
 };
 
-struct CollateralTokenKey
-{
+struct CollateralTokenKey {
     DCT_ID id;
     uint32_t height;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(id);
 
         if (ser_action.ForRead()) {
@@ -138,78 +132,71 @@ struct CollateralTokenKey
     }
 };
 
-struct CLoanSchemeData
-{
+struct CLoanSchemeData {
     uint32_t ratio;
     CAmount rate;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(ratio);
         READWRITE(rate);
     }
 };
 
-struct CLoanScheme : public CLoanSchemeData
-{
+struct CLoanScheme : public CLoanSchemeData {
     std::string identifier;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CLoanSchemeData,*this);
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITEAS(CLoanSchemeData, *this);
         READWRITE(identifier);
     }
 };
 
-struct CLoanSchemeCreation : public CLoanScheme
-{
+struct CLoanSchemeCreation : public CLoanScheme {
     uint256 schemeCreationTxid;
 };
 
-struct CLoanSchemeMessage : public CLoanScheme
-{
+struct CLoanSchemeMessage : public CLoanScheme {
     uint64_t updateHeight{0};
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CLoanScheme,*this);
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITEAS(CLoanScheme, *this);
         READWRITE(updateHeight);
     }
 };
 
-struct CDefaultLoanSchemeMessage
-{
+struct CDefaultLoanSchemeMessage {
     std::string identifier;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(identifier);
     }
 };
 
-struct CDestroyLoanSchemeMessage : public CDefaultLoanSchemeMessage
-{
+struct CDestroyLoanSchemeMessage : public CDefaultLoanSchemeMessage {
     uint64_t destroyHeight{0};
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CDefaultLoanSchemeMessage, *this);
         READWRITE(destroyHeight);
     }
 };
 
-struct CInterestRate
-{
+struct CInterestRate {
     uint32_t height;
     CAmount interestPerBlock;
     CAmount interestToHeight;
@@ -217,15 +204,14 @@ struct CInterestRate
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(height);
         READWRITE(interestPerBlock);
         READWRITE(interestToHeight);
     }
 };
 
-struct CInterestRateV2
-{
+struct CInterestRateV2 {
     uint32_t height;
     base_uint<128> interestPerBlock;
     base_uint<128> interestToHeight;
@@ -233,15 +219,14 @@ struct CInterestRateV2
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(height);
         READWRITE(interestPerBlock);
         READWRITE(interestToHeight);
     }
 };
 
-inline CInterestRate ConvertInterestRateToV1(const CInterestRateV2& rate1)
-{
+inline CInterestRate ConvertInterestRateToV1(const CInterestRateV2 &rate1) {
     CInterestRate rate2{};
     rate2.height = rate1.height;
     rate2.interestPerBlock = rate1.interestPerBlock.GetLow64();
@@ -250,8 +235,7 @@ inline CInterestRate ConvertInterestRateToV1(const CInterestRateV2& rate1)
     return rate2;
 }
 
-inline CInterestRateV2 ConvertInterestRateToV2(const CInterestRate& rate1)
-{
+inline CInterestRateV2 ConvertInterestRateToV2(const CInterestRate &rate1) {
     CInterestRateV2 rate2{};
     rate2.height = rate1.height;
     rate2.interestPerBlock = rate1.interestPerBlock;
@@ -260,21 +244,20 @@ inline CInterestRateV2 ConvertInterestRateToV2(const CInterestRate& rate1)
     return rate2;
 }
 
-static const CAmount HIGH_PRECISION_SCALER = COIN * COIN; // 1,0000,0000,0000,0000
+static const CAmount HIGH_PRECISION_SCALER = COIN * COIN;  // 1,0000,0000,0000,0000
 
-CAmount TotalInterest(const CInterestRateV2& rate, uint32_t height);
-CAmount InterestPerBlock(const CInterestRateV2& rate, uint32_t height);
-base_uint<128> TotalInterestCalculation(const CInterestRateV2& rate, uint32_t height);
-CAmount CeilInterest(const base_uint<128>& value, uint32_t height);
+CAmount TotalInterest(const CInterestRateV2 &rate, uint32_t height);
+CAmount InterestPerBlock(const CInterestRateV2 &rate, uint32_t height);
+base_uint<128> TotalInterestCalculation(const CInterestRateV2 &rate, uint32_t height);
+CAmount CeilInterest(const base_uint<128> &value, uint32_t height);
 
-std::string GetInterestPerBlockHighPrecisionString(const base_uint<128>& value);
-std::optional<std::string> TryGetInterestPerBlockHighPrecisionString(const base_uint<128>& value);
+std::string GetInterestPerBlockHighPrecisionString(const base_uint<128> &value);
+std::optional<std::string> TryGetInterestPerBlockHighPrecisionString(const base_uint<128> &value);
 
 base_uint<128> InterestPerBlockCalculationV2(CAmount amount, CAmount tokenInterest, CAmount schemeInterest);
 
-class CLoanTakeLoanMessage
-{
-public:
+class CLoanTakeLoanMessage {
+   public:
     CVaultId vaultId;
     CScript to;
     CBalances amounts;
@@ -282,16 +265,15 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(to);
         READWRITE(amounts);
     }
 };
 
-class CLoanPaybackLoanMessage
-{
-public:
+class CLoanPaybackLoanMessage {
+   public:
     CVaultId vaultId;
     CScript from;
     CBalances amounts;
@@ -299,16 +281,15 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(from);
         READWRITE(amounts);
     }
 };
 
-class CLoanPaybackLoanV2Message
-{
-public:
+class CLoanPaybackLoanV2Message {
+   public:
     CVaultId vaultId;
     CScript from;
     std::map<DCT_ID, CBalances> loans;
@@ -316,7 +297,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(from);
         READWRITE(loans);
@@ -324,71 +305,113 @@ public:
 };
 
 class CLoanView : public virtual CStorageView {
-public:
+   public:
     using CLoanSetCollateralTokenImpl = CLoanSetCollateralTokenImplementation;
     using CLoanSetLoanTokenImpl = CLoanSetLoanTokenImplementation;
 
-    std::optional<CLoanSetCollateralTokenImpl> GetLoanCollateralToken(uint256 const & txid) const;
-    Res CreateLoanCollateralToken(CLoanSetCollateralTokenImpl const & collToken);
-    Res EraseLoanCollateralToken(const CLoanSetCollateralTokenImpl& collToken);
-    void ForEachLoanCollateralToken(std::function<bool (CollateralTokenKey const &, uint256 const &)> callback, CollateralTokenKey const & start = {DCT_ID{0}, UINT_MAX});
-    std::optional<CLoanSetCollateralTokenImpl> HasLoanCollateralToken(CollateralTokenKey const & key);
+    std::optional<CLoanSetCollateralTokenImpl> GetLoanCollateralToken(uint256 const &txid) const;
+    Res CreateLoanCollateralToken(CLoanSetCollateralTokenImpl const &collToken);
+    Res EraseLoanCollateralToken(const CLoanSetCollateralTokenImpl &collToken);
+    void ForEachLoanCollateralToken(std::function<bool(CollateralTokenKey const &, uint256 const &)> callback,
+                                    CollateralTokenKey const &start = {DCT_ID{0}, UINT_MAX});
+    std::optional<CLoanSetCollateralTokenImpl> HasLoanCollateralToken(CollateralTokenKey const &key);
 
-    std::optional<CLoanSetLoanTokenImpl> GetLoanToken(uint256 const & txid) const;
-    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(DCT_ID const & id) const = 0;
-    Res SetLoanToken(CLoanSetLoanTokenImpl const & loanToken, DCT_ID const & id);
-    Res UpdateLoanToken(CLoanSetLoanTokenImpl const & loanToken, DCT_ID const & id);
-    Res EraseLoanToken(const DCT_ID& id);
-    void ForEachLoanToken(std::function<bool (DCT_ID const &, CLoanSetLoanTokenImpl const &)> callback, DCT_ID const & start = {0});
+    std::optional<CLoanSetLoanTokenImpl> GetLoanToken(uint256 const &txid) const;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(DCT_ID const &id) const = 0;
+    Res SetLoanToken(CLoanSetLoanTokenImpl const &loanToken, DCT_ID const &id);
+    Res UpdateLoanToken(CLoanSetLoanTokenImpl const &loanToken, DCT_ID const &id);
+    Res EraseLoanToken(const DCT_ID &id);
+    void ForEachLoanToken(std::function<bool(DCT_ID const &, CLoanSetLoanTokenImpl const &)> callback,
+                          DCT_ID const &start = {0});
 
-    Res StoreLoanScheme(const CLoanSchemeMessage& loanScheme);
-    Res StoreDefaultLoanScheme(const std::string& loanSchemeID);
-    Res StoreDelayedLoanScheme(const CLoanSchemeMessage& loanScheme);
-    Res StoreDelayedDestroyScheme(const CDestroyLoanSchemeMessage& loanScheme);
-    Res EraseLoanScheme(const std::string& loanSchemeID);
-    void EraseDelayedLoanScheme(const std::string& loanSchemeID, uint64_t height);
-    void EraseDelayedDestroyScheme(const std::string& loanSchemeID);
+    Res StoreLoanScheme(const CLoanSchemeMessage &loanScheme);
+    Res StoreDefaultLoanScheme(const std::string &loanSchemeID);
+    Res StoreDelayedLoanScheme(const CLoanSchemeMessage &loanScheme);
+    Res StoreDelayedDestroyScheme(const CDestroyLoanSchemeMessage &loanScheme);
+    Res EraseLoanScheme(const std::string &loanSchemeID);
+    void EraseDelayedLoanScheme(const std::string &loanSchemeID, uint64_t height);
+    void EraseDelayedDestroyScheme(const std::string &loanSchemeID);
     std::optional<std::string> GetDefaultLoanScheme();
-    std::optional<CLoanSchemeData> GetLoanScheme(const std::string& loanSchemeID);
-    std::optional<uint64_t> GetDestroyLoanScheme(const std::string& loanSchemeID);
-    void ForEachLoanScheme(std::function<bool (const std::string&, const CLoanSchemeData&)> callback);
-    void ForEachDelayedLoanScheme(std::function<bool (const std::pair<std::string, uint64_t>&, const CLoanSchemeMessage&)> callback);
-    void ForEachDelayedDestroyScheme(std::function<bool (const std::string&, const uint64_t&)> callback);
+    std::optional<CLoanSchemeData> GetLoanScheme(const std::string &loanSchemeID);
+    std::optional<uint64_t> GetDestroyLoanScheme(const std::string &loanSchemeID);
+    void ForEachLoanScheme(std::function<bool(const std::string &, const CLoanSchemeData &)> callback);
+    void ForEachDelayedLoanScheme(
+        std::function<bool(const std::pair<std::string, uint64_t> &, const CLoanSchemeMessage &)> callback);
+    void ForEachDelayedDestroyScheme(std::function<bool(const std::string &, const uint64_t &)> callback);
 
-    Res DeleteInterest(const CVaultId& vaultId, uint32_t height);
-    void EraseInterestDirect(const CVaultId& vaultId, DCT_ID id);
-    std::optional<CInterestRateV2> GetInterestRate(const CVaultId& loanSchemeID, DCT_ID id, uint32_t height);
-    void WriteInterestRate(const std::pair<CVaultId, DCT_ID>& pair, const CInterestRateV2& rate, uint32_t height);
-    Res StoreInterest(uint32_t height, const CVaultId& vaultId, const std::string& loanSchemeID, DCT_ID id, CAmount loanIncreased);
-    Res EraseInterest(uint32_t height, const CVaultId& vaultId, const std::string& loanSchemeID, DCT_ID id, CAmount loanDecreased, CAmount interestDecreased);
-    void ForEachVaultInterest(std::function<bool(const CVaultId&, DCT_ID, CInterestRate)> callback, const CVaultId& vaultId = uint256(), DCT_ID id = {0});
-    void ForEachVaultInterestV2(std::function<bool(const CVaultId&, DCT_ID, CInterestRateV2)> callback, const CVaultId& vaultId = uint256(), DCT_ID id = {0});
+    Res DeleteInterest(const CVaultId &vaultId, uint32_t height);
+    void EraseInterestDirect(const CVaultId &vaultId, DCT_ID id);
+    std::optional<CInterestRateV2> GetInterestRate(const CVaultId &loanSchemeID, DCT_ID id, uint32_t height);
+    void WriteInterestRate(const std::pair<CVaultId, DCT_ID> &pair, const CInterestRateV2 &rate, uint32_t height);
+    Res StoreInterest(uint32_t height,
+                      const CVaultId &vaultId,
+                      const std::string &loanSchemeID,
+                      DCT_ID id,
+                      CAmount loanIncreased);
+    Res EraseInterest(uint32_t height,
+                      const CVaultId &vaultId,
+                      const std::string &loanSchemeID,
+                      DCT_ID id,
+                      CAmount loanDecreased,
+                      CAmount interestDecreased);
+    void ForEachVaultInterest(std::function<bool(const CVaultId &, DCT_ID, CInterestRate)> callback,
+                              const CVaultId &vaultId = uint256(),
+                              DCT_ID id = {0});
+    void ForEachVaultInterestV2(std::function<bool(const CVaultId &, DCT_ID, CInterestRateV2)> callback,
+                                const CVaultId &vaultId = uint256(),
+                                DCT_ID id = {0});
     void RevertInterestRateToV1();
     void MigrateInterestRateToV2(CVaultView &view, uint32_t height);
 
-    Res AddLoanToken(const CVaultId& vaultId, CTokenAmount amount);
-    Res SubLoanToken(const CVaultId& vaultId, CTokenAmount amount);
-    std::optional<CBalances> GetLoanTokens(const CVaultId& vaultId);
-    void ForEachLoanTokenAmount(std::function<bool (const CVaultId&,  const CBalances&)> callback);
+    Res AddLoanToken(const CVaultId &vaultId, CTokenAmount amount);
+    Res SubLoanToken(const CVaultId &vaultId, CTokenAmount amount);
+    std::optional<CBalances> GetLoanTokens(const CVaultId &vaultId);
+    void ForEachLoanTokenAmount(std::function<bool(const CVaultId &, const CBalances &)> callback);
 
     Res SetLoanLiquidationPenalty(CAmount penalty);
     CAmount GetLoanLiquidationPenalty();
 
-    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(const DCT_ID& id) const = 0;
-    [[nodiscard]] virtual std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(const DCT_ID& id) const = 0;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(
+        const DCT_ID &id) const = 0;
+    [[nodiscard]] virtual std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(
+        const DCT_ID &id) const = 0;
 
-    struct LoanSetCollateralTokenCreationTx { static constexpr uint8_t prefix() { return 0x10; } };
-    struct LoanSetCollateralTokenKey        { static constexpr uint8_t prefix() { return 0x11; } };
-    struct LoanSetLoanTokenCreationTx       { static constexpr uint8_t prefix() { return 0x12; } };
-    struct LoanSetLoanTokenKey              { static constexpr uint8_t prefix() { return 0x13; } };
-    struct LoanSchemeKey                    { static constexpr uint8_t prefix() { return 0x14; } };
-    struct DefaultLoanSchemeKey             { static constexpr uint8_t prefix() { return 0x15; } };
-    struct DelayedLoanSchemeKey             { static constexpr uint8_t prefix() { return 0x16; } };
-    struct DestroyLoanSchemeKey             { static constexpr uint8_t prefix() { return 0x17; } };
-    struct LoanInterestByVault              { static constexpr uint8_t prefix() { return 0x18; } };
-    struct LoanTokenAmount                  { static constexpr uint8_t prefix() { return 0x19; } };
-    struct LoanLiquidationPenalty           { static constexpr uint8_t prefix() { return 0x1A; } };
-    struct LoanInterestV2ByVault            { static constexpr uint8_t prefix() { return 0x1B; } };
+    struct LoanSetCollateralTokenCreationTx {
+        static constexpr uint8_t prefix() { return 0x10; }
+    };
+    struct LoanSetCollateralTokenKey {
+        static constexpr uint8_t prefix() { return 0x11; }
+    };
+    struct LoanSetLoanTokenCreationTx {
+        static constexpr uint8_t prefix() { return 0x12; }
+    };
+    struct LoanSetLoanTokenKey {
+        static constexpr uint8_t prefix() { return 0x13; }
+    };
+    struct LoanSchemeKey {
+        static constexpr uint8_t prefix() { return 0x14; }
+    };
+    struct DefaultLoanSchemeKey {
+        static constexpr uint8_t prefix() { return 0x15; }
+    };
+    struct DelayedLoanSchemeKey {
+        static constexpr uint8_t prefix() { return 0x16; }
+    };
+    struct DestroyLoanSchemeKey {
+        static constexpr uint8_t prefix() { return 0x17; }
+    };
+    struct LoanInterestByVault {
+        static constexpr uint8_t prefix() { return 0x18; }
+    };
+    struct LoanTokenAmount {
+        static constexpr uint8_t prefix() { return 0x19; }
+    };
+    struct LoanLiquidationPenalty {
+        static constexpr uint8_t prefix() { return 0x1A; }
+    };
+    struct LoanInterestV2ByVault {
+        static constexpr uint8_t prefix() { return 0x1B; }
+    };
 };
 
-#endif // DEFI_MASTERNODES_LOAN_H
+#endif  // DEFI_MASTERNODES_LOAN_H

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#include <masternodes/masternodes.h>
 #include <masternodes/accountshistory.h>
 #include <masternodes/anchors.h>
 #include <masternodes/govvariables/attributes.h>
+#include <masternodes/masternodes.h>
 #include <masternodes/mn_checks.h>
 #include <masternodes/vaulthistory.h>
 
@@ -14,12 +14,12 @@
 #include <core_io.h>
 #include <net_processing.h>
 #include <primitives/transaction.h>
+#include <rpc/resultcache.h>
 #include <script/script.h>
 #include <script/standard.h>
 #include <validation.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
-#include <rpc/resultcache.h>
 
 #include <algorithm>
 #include <functional>
@@ -28,31 +28,28 @@
 std::unique_ptr<CCustomCSView> pcustomcsview;
 std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 
-int GetMnActivationDelay(int height)
-{
+int GetMnActivationDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight ||
-    (Params().NetworkIDString() == CBaseChainParams::TESTNET && height >= Params().GetConsensus().FortCanningHeight)) {
+    if (height < Params().GetConsensus().EunosHeight || (Params().NetworkIDString() == CBaseChainParams::TESTNET &&
+                                                         height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.activationDelay;
     }
 
     return Params().GetConsensus().mn.newActivationDelay;
 }
 
-int GetMnResignDelay(int height)
-{
+int GetMnResignDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight ||
-    (Params().NetworkIDString() == CBaseChainParams::TESTNET && height >= Params().GetConsensus().FortCanningHeight)) {
+    if (height < Params().GetConsensus().EunosHeight || (Params().NetworkIDString() == CBaseChainParams::TESTNET &&
+                                                         height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.resignDelay;
     }
 
     return Params().GetConsensus().mn.newResignDelay;
 }
 
-CAmount GetMnCollateralAmount(int height)
-{
-    auto& consensus = Params().GetConsensus();
+CAmount GetMnCollateralAmount(int height) {
+    auto &consensus = Params().GetConsensus();
     if (height < consensus.DakotaHeight) {
         return consensus.mn.collateralAmount;
     } else {
@@ -60,55 +57,50 @@ CAmount GetMnCollateralAmount(int height)
     }
 }
 
-CAmount GetMnCreationFee(int)
-{
+CAmount GetMnCreationFee(int) {
     return Params().GetConsensus().mn.creationFee;
 }
 
-CAmount GetTokenCollateralAmount()
-{
+CAmount GetTokenCollateralAmount() {
     return Params().GetConsensus().token.collateralAmount;
 }
 
-CAmount GetTokenCreationFee(int)
-{
+CAmount GetTokenCreationFee(int) {
     return Params().GetConsensus().token.creationFee;
 }
 
 CMasternode::CMasternode()
-    : mintedBlocks(0)
-    , ownerAuthAddress()
-    , ownerType(0)
-    , operatorAuthAddress()
-    , operatorType(0)
-    , rewardAddress()
-    , rewardAddressType(0)
-    , creationHeight(0)
-    , resignHeight(-1)
-    , version(-1)
-    , resignTx()
-    , banTx()
-{
-}
+    : mintedBlocks(0),
+      ownerAuthAddress(),
+      ownerType(0),
+      operatorAuthAddress(),
+      operatorType(0),
+      rewardAddress(),
+      rewardAddressType(0),
+      creationHeight(0),
+      resignHeight(-1),
+      version(-1),
+      resignTx(),
+      banTx() {}
 
-CMasternode::State CMasternode::GetState(int height) const
-{
+CMasternode::State CMasternode::GetState(int height) const {
     int EunosPayaHeight = Params().GetConsensus().EunosPayaHeight;
 
     if (height < creationHeight) {
         return State::UNKNOWN;
     }
 
-    if (resignHeight == -1 || height < resignHeight) { // enabled or pre-enabled
+    if (resignHeight == -1 || height < resignHeight) {  // enabled or pre-enabled
         // Special case for genesis block
-        int activationDelay = height < EunosPayaHeight ? GetMnActivationDelay(height) : GetMnActivationDelay(creationHeight);
+        int activationDelay =
+            height < EunosPayaHeight ? GetMnActivationDelay(height) : GetMnActivationDelay(creationHeight);
         if (creationHeight == 0 || height >= creationHeight + activationDelay) {
             return State::ENABLED;
         }
         return State::PRE_ENABLED;
     }
 
-    if (resignHeight != -1) { // pre-resigned or resigned
+    if (resignHeight != -1) {  // pre-resigned or resigned
         int resignDelay = height < EunosPayaHeight ? GetMnResignDelay(height) : GetMnResignDelay(resignHeight);
         if (height < resignHeight + resignDelay) {
             return State::PRE_RESIGNED;
@@ -118,8 +110,7 @@ CMasternode::State CMasternode::GetState(int height) const
     return State::UNKNOWN;
 }
 
-bool CMasternode::IsActive(int height) const
-{
+bool CMasternode::IsActive(int height) const {
     State state = GetState(height);
     if (height >= Params().GetConsensus().EunosPayaHeight) {
         return state == ENABLED;
@@ -127,8 +118,7 @@ bool CMasternode::IsActive(int height) const
     return state == ENABLED || state == PRE_RESIGNED;
 }
 
-std::string CMasternode::GetHumanReadableState(State state)
-{
+std::string CMasternode::GetHumanReadableState(State state) {
     switch (state) {
         case PRE_ENABLED:
             return "PRE_ENABLED";
@@ -143,95 +133,80 @@ std::string CMasternode::GetHumanReadableState(State state)
     }
 }
 
-std::string CMasternode::GetTimelockToString(TimeLock timelock)
-{
-  switch (timelock) {
-    case FIVEYEAR : return "FIVEYEARTIMELOCK";
-    case TENYEAR  : return "TENYEARTIMELOCK";
-    default       : return "NONE";
-  }
+std::string CMasternode::GetTimelockToString(TimeLock timelock) {
+    switch (timelock) {
+        case FIVEYEAR:
+            return "FIVEYEARTIMELOCK";
+        case TENYEAR:
+            return "TENYEARTIMELOCK";
+        default:
+            return "NONE";
+    }
 }
 
-bool operator==(CMasternode const & a, CMasternode const & b)
-{
-    return (a.mintedBlocks == b.mintedBlocks &&
-            a.ownerType == b.ownerType &&
-            a.ownerAuthAddress == b.ownerAuthAddress &&
-            a.operatorType == b.operatorType &&
-            a.operatorAuthAddress == b.operatorAuthAddress &&
-            a.rewardAddress == b.rewardAddress &&
-            a.rewardAddressType == b.rewardAddressType &&
-            a.creationHeight == b.creationHeight &&
-            a.resignHeight == b.resignHeight &&
-            a.version == b.version &&
-            a.resignTx == b.resignTx &&
-            a.banTx == b.banTx
-            );
+bool operator==(CMasternode const &a, CMasternode const &b) {
+    return (a.mintedBlocks == b.mintedBlocks && a.ownerType == b.ownerType &&
+            a.ownerAuthAddress == b.ownerAuthAddress && a.operatorType == b.operatorType &&
+            a.operatorAuthAddress == b.operatorAuthAddress && a.rewardAddress == b.rewardAddress &&
+            a.rewardAddressType == b.rewardAddressType && a.creationHeight == b.creationHeight &&
+            a.resignHeight == b.resignHeight && a.version == b.version && a.resignTx == b.resignTx &&
+            a.banTx == b.banTx);
 }
 
-bool operator!=(CMasternode const & a, CMasternode const & b)
-{
+bool operator!=(CMasternode const &a, CMasternode const &b) {
     return !(a == b);
 }
 
 /*
  * Check that given node is involved in anchor's subsystem for a given height (or smth like that)
  */
-//bool IsAnchorInvolved(const uint256 & nodeId, int height) const
+// bool IsAnchorInvolved(const uint256 & nodeId, int height) const
 //{
 //    /// @todo to be implemented
 //    return false;
 //}
 
-
-
-
 /*
  *  CMasternodesView
  */
-std::optional<CMasternode> CMasternodesView::GetMasternode(const uint256 & id) const
-{
+std::optional<CMasternode> CMasternodesView::GetMasternode(const uint256 &id) const {
     return ReadBy<ID, CMasternode>(id);
 }
 
-std::optional<uint256> CMasternodesView::GetMasternodeIdByOperator(const CKeyID & id) const
-{
+std::optional<uint256> CMasternodesView::GetMasternodeIdByOperator(const CKeyID &id) const {
     return ReadBy<Operator, uint256>(id);
 }
 
-std::optional<uint256> CMasternodesView::GetMasternodeIdByOwner(const CKeyID & id) const
-{
+std::optional<uint256> CMasternodesView::GetMasternodeIdByOwner(const CKeyID &id) const {
     return ReadBy<Owner, uint256>(id);
 }
 
-void CMasternodesView::ForEachMasternode(std::function<bool (const uint256 &, CLazySerialize<CMasternode>)> callback, uint256 const & start)
-{
+void CMasternodesView::ForEachMasternode(std::function<bool(const uint256 &, CLazySerialize<CMasternode>)> callback,
+                                         uint256 const &start) {
     ForEach<ID, uint256, CMasternode>(callback, start);
 }
 
-void CMasternodesView::IncrementMintedBy(const uint256& nodeId)
-{
+void CMasternodesView::IncrementMintedBy(const uint256 &nodeId) {
     auto node = GetMasternode(nodeId);
     assert(node);
     ++node->mintedBlocks;
     WriteBy<ID>(nodeId, *node);
 }
 
-void CMasternodesView::DecrementMintedBy(const uint256& nodeId)
-{
+void CMasternodesView::DecrementMintedBy(const uint256 &nodeId) {
     auto node = GetMasternode(nodeId);
     assert(node);
     --node->mintedBlocks;
     WriteBy<ID>(nodeId, *node);
 }
 
-std::optional<std::pair<CKeyID, uint256> > CMasternodesView::AmIOperator() const
-{
+std::optional<std::pair<CKeyID, uint256>> CMasternodesView::AmIOperator() const {
     auto const operators = gArgs.GetArgs("-masternode_operator");
-    for(auto const & key : operators) {
+    for (auto const &key : operators) {
         CTxDestination const dest = DecodeDestination(key);
-        CKeyID const authAddress = dest.index() == PKHashType ? CKeyID(std::get<PKHash>(dest)) :
-                                   dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest)) : CKeyID();
+        CKeyID const authAddress = dest.index() == PKHashType         ? CKeyID(std::get<PKHash>(dest))
+                                   : dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest))
+                                                                      : CKeyID();
         if (!authAddress.IsNull()) {
             if (auto nodeId = GetMasternodeIdByOperator(authAddress)) {
                 return std::make_pair(authAddress, *nodeId);
@@ -241,14 +216,14 @@ std::optional<std::pair<CKeyID, uint256> > CMasternodesView::AmIOperator() const
     return {};
 }
 
-std::set<std::pair<CKeyID, uint256>> CMasternodesView::GetOperatorsMulti() const
-{
+std::set<std::pair<CKeyID, uint256>> CMasternodesView::GetOperatorsMulti() const {
     auto const operators = gArgs.GetArgs("-masternode_operator");
     std::set<std::pair<CKeyID, uint256>> operatorPairs;
-    for(auto const & key : operators) {
+    for (auto const &key : operators) {
         CTxDestination const dest = DecodeDestination(key);
-        CKeyID const authAddress = dest.index() == PKHashType ? CKeyID(std::get<PKHash>(dest)) :
-                                   dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest)) : CKeyID();
+        CKeyID const authAddress = dest.index() == PKHashType         ? CKeyID(std::get<PKHash>(dest))
+                                   : dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest))
+                                                                      : CKeyID();
         if (!authAddress.IsNull()) {
             if (auto nodeId = GetMasternodeIdByOperator(authAddress)) {
                 operatorPairs.insert(std::make_pair(authAddress, *nodeId));
@@ -259,28 +234,28 @@ std::set<std::pair<CKeyID, uint256>> CMasternodesView::GetOperatorsMulti() const
     return operatorPairs;
 }
 
-std::optional<std::pair<CKeyID, uint256> > CMasternodesView::AmIOwner() const
-{
+std::optional<std::pair<CKeyID, uint256>> CMasternodesView::AmIOwner() const {
     CTxDestination dest = DecodeDestination(gArgs.GetArg("-masternode_owner", ""));
-    CKeyID const authAddress = dest.index() == PKHashType ? CKeyID(std::get<PKHash>(dest)) : (dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest)) : CKeyID());
+    CKeyID const authAddress =
+        dest.index() == PKHashType
+            ? CKeyID(std::get<PKHash>(dest))
+            : (dest.index() == WitV0KeyHashType ? CKeyID(std::get<WitnessV0KeyHash>(dest)) : CKeyID());
     if (!authAddress.IsNull()) {
         auto nodeId = GetMasternodeIdByOwner(authAddress);
         if (nodeId)
-            return { std::make_pair(authAddress, *nodeId) };
+            return {std::make_pair(authAddress, *nodeId)};
     }
     return {};
 }
 
-Res CMasternodesView::CreateMasternode(const uint256 & nodeId, const CMasternode & node, uint16_t timelock)
-{
+Res CMasternodesView::CreateMasternode(const uint256 &nodeId, const CMasternode &node, uint16_t timelock) {
     // Check auth addresses and that there in no MN with such owner or operator
     if ((node.operatorType != 1 && node.operatorType != 4) || (node.ownerType != 1 && node.ownerType != 4) ||
-        node.ownerAuthAddress.IsNull() || node.operatorAuthAddress.IsNull() ||
-        GetMasternode(nodeId) ||
-        GetMasternodeIdByOwner(node.ownerAuthAddress)    || GetMasternodeIdByOperator(node.ownerAuthAddress) ||
-        GetMasternodeIdByOwner(node.operatorAuthAddress) || GetMasternodeIdByOperator(node.operatorAuthAddress)
-        ) {
-        return Res::Err("bad owner and|or operator address (should be P2PKH or P2WPKH only) or node with those addresses exists");
+        node.ownerAuthAddress.IsNull() || node.operatorAuthAddress.IsNull() || GetMasternode(nodeId) ||
+        GetMasternodeIdByOwner(node.ownerAuthAddress) || GetMasternodeIdByOperator(node.ownerAuthAddress) ||
+        GetMasternodeIdByOwner(node.operatorAuthAddress) || GetMasternodeIdByOperator(node.operatorAuthAddress)) {
+        return Res::Err(
+            "bad owner and|or operator address (should be P2PKH or P2WPKH only) or node with those addresses exists");
     }
 
     WriteBy<ID>(nodeId, node);
@@ -294,8 +269,7 @@ Res CMasternodesView::CreateMasternode(const uint256 & nodeId, const CMasternode
     return Res::Ok();
 }
 
-Res CMasternodesView::ResignMasternode(const uint256 & nodeId, const uint256 & txid, int height)
-{
+Res CMasternodesView::ResignMasternode(const uint256 &nodeId, const uint256 &txid, int height) {
     // auth already checked!
     auto node = GetMasternode(nodeId);
     if (!node) {
@@ -315,15 +289,17 @@ Res CMasternodesView::ResignMasternode(const uint256 & nodeId, const uint256 & t
         return Res::Err("Trying to resign masternode before timelock expiration.");
     }
 
-    node->resignTx =  txid;
+    node->resignTx = txid;
     node->resignHeight = height;
     WriteBy<ID>(nodeId, *node);
 
     return Res::Ok();
 }
 
-Res CMasternodesView::SetForcedRewardAddress(uint256 const & nodeId, const char rewardAddressType, CKeyID const & rewardAddress, int height)
-{
+Res CMasternodesView::SetForcedRewardAddress(uint256 const &nodeId,
+                                             const char rewardAddressType,
+                                             CKeyID const &rewardAddress,
+                                             int height) {
     // Temporarily disabled for 2.2
     return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -349,8 +325,7 @@ Res CMasternodesView::SetForcedRewardAddress(uint256 const & nodeId, const char 
     return Res::Ok();
 }
 
-Res CMasternodesView::RemForcedRewardAddress(uint256 const & nodeId, int height)
-{
+Res CMasternodesView::RemForcedRewardAddress(uint256 const &nodeId, int height) {
     // Temporarily disabled for 2.2
     return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -370,7 +345,10 @@ Res CMasternodesView::RemForcedRewardAddress(uint256 const & nodeId, int height)
     return Res::Ok();
 }
 
-Res CMasternodesView::UpdateMasternode(uint256 const & nodeId, char operatorType, const CKeyID& operatorAuthAddress, int height) {
+Res CMasternodesView::UpdateMasternode(uint256 const &nodeId,
+                                       char operatorType,
+                                       const CKeyID &operatorAuthAddress,
+                                       int height) {
     // Temporarily disabled for 2.2
     return Res::Err("updatemasternode is disabled for Fort Canning");
 
@@ -402,98 +380,97 @@ Res CMasternodesView::UpdateMasternode(uint256 const & nodeId, char operatorType
     return Res::Ok();
 }
 
-void CMasternodesView::SetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t &blockHeight, const int64_t& time)
-{
+void CMasternodesView::SetMasternodeLastBlockTime(const CKeyID &minter,
+                                                  const uint32_t &blockHeight,
+                                                  const int64_t &time) {
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
     WriteBy<Staker>(MNBlockTimeKey{*nodeId, blockHeight}, time);
 }
 
-std::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t height)
-{
+std::optional<int64_t> CMasternodesView::GetMasternodeLastBlockTime(const CKeyID &minter, const uint32_t height) {
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
     int64_t time{0};
 
-    ForEachMinterNode([&](const MNBlockTimeKey &key, int64_t blockTime)
-    {
-        if (key.masternodeID == nodeId)
-        {
-            time = blockTime;
-        }
+    ForEachMinterNode(
+        [&](const MNBlockTimeKey &key, int64_t blockTime) {
+            if (key.masternodeID == nodeId) {
+                time = blockTime;
+            }
 
-        // Get first result only and exit
-        return false;
-    }, MNBlockTimeKey{*nodeId, height - 1});
+            // Get first result only and exit
+            return false;
+        },
+        MNBlockTimeKey{*nodeId, height - 1});
 
-    if (time)
-    {
+    if (time) {
         return time;
     }
 
     return {};
 }
 
-void CMasternodesView::EraseMasternodeLastBlockTime(const uint256& nodeId, const uint32_t& blockHeight)
-{
+void CMasternodesView::EraseMasternodeLastBlockTime(const uint256 &nodeId, const uint32_t &blockHeight) {
     EraseBy<Staker>(MNBlockTimeKey{nodeId, blockHeight});
 }
 
-void CMasternodesView::ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start)
-{
+void CMasternodesView::ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback,
+                                         MNBlockTimeKey const &start) {
     ForEach<Staker, MNBlockTimeKey, int64_t>(callback, start);
 }
 
-void CMasternodesView::SetSubNodesBlockTime(const CKeyID & minter, const uint32_t &blockHeight, const uint8_t id, const int64_t& time)
-{
+void CMasternodesView::SetSubNodesBlockTime(const CKeyID &minter,
+                                            const uint32_t &blockHeight,
+                                            const uint8_t id,
+                                            const int64_t &time) {
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
     WriteBy<SubNode>(SubNodeBlockTimeKey{*nodeId, id, blockHeight}, time);
 }
 
-std::vector<int64_t> CMasternodesView::GetSubNodesBlockTime(const CKeyID & minter, const uint32_t height)
-{
+std::vector<int64_t> CMasternodesView::GetSubNodesBlockTime(const CKeyID &minter, const uint32_t height) {
     auto nodeId = GetMasternodeIdByOperator(minter);
     assert(nodeId);
 
     std::vector<int64_t> times(SUBNODE_COUNT, 0);
 
     for (uint8_t i{0}; i < SUBNODE_COUNT; ++i) {
-        ForEachSubNode([&](const SubNodeBlockTimeKey &key, int64_t blockTime)
-        {
-            if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningHeight)) {
-                if (key.masternodeID == nodeId && key.subnode == i) {
+        ForEachSubNode(
+            [&](const SubNodeBlockTimeKey &key, int64_t blockTime) {
+                if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningHeight)) {
+                    if (key.masternodeID == nodeId && key.subnode == i) {
+                        times[i] = blockTime;
+                    }
+                } else if (key.masternodeID == nodeId) {
                     times[i] = blockTime;
                 }
-            } else if (key.masternodeID == nodeId) {
-                times[i] = blockTime;
-            }
 
-            // Get first result only and exit
-            return false;
-        }, SubNodeBlockTimeKey{*nodeId, i, height - 1});
+                // Get first result only and exit
+                return false;
+            },
+            SubNodeBlockTimeKey{*nodeId, i, height - 1});
     }
 
     return times;
 }
 
-void CMasternodesView::ForEachSubNode(std::function<bool(SubNodeBlockTimeKey const &, CLazySerialize<int64_t>)> callback, SubNodeBlockTimeKey const & start)
-{
+void CMasternodesView::ForEachSubNode(
+    std::function<bool(SubNodeBlockTimeKey const &, CLazySerialize<int64_t>)> callback,
+    SubNodeBlockTimeKey const &start) {
     ForEach<SubNode, SubNodeBlockTimeKey, int64_t>(callback, start);
 }
 
-void CMasternodesView::EraseSubNodesLastBlockTime(const uint256& nodeId, const uint32_t& blockHeight)
-{
+void CMasternodesView::EraseSubNodesLastBlockTime(const uint256 &nodeId, const uint32_t &blockHeight) {
     for (uint8_t i{0}; i < SUBNODE_COUNT; ++i) {
         EraseBy<SubNode>(SubNodeBlockTimeKey{nodeId, i, blockHeight});
     }
 }
 
-uint16_t CMasternodesView::GetTimelock(const uint256& nodeId, const CMasternode& node, const uint64_t height) const
-{
+uint16_t CMasternodesView::GetTimelock(const uint256 &nodeId, const CMasternode &node, const uint64_t height) const {
     auto timelock = ReadBy<Timelock, uint16_t>(nodeId);
     if (timelock) {
         LOCK(cs_main);
@@ -518,15 +495,17 @@ uint16_t CMasternodesView::GetTimelock(const uint256& nodeId, const CMasternode&
         // Below expiration return timelock
         if (averageTime < timelockExpire) {
             return *timelock;
-        } else { // Expired. Return null.
+        } else {  // Expired. Return null.
             return 0;
         }
     }
     return 0;
 }
 
-std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID& keyID, const uint32_t blockHeight, const int32_t creationHeight, const uint16_t timelock)
-{
+std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID &keyID,
+                                                     const uint32_t blockHeight,
+                                                     const int32_t creationHeight,
+                                                     const uint16_t timelock) {
     // Get last block time for non-subnode staking
     std::optional<int64_t> stakerBlockTime = GetMasternodeLastBlockTime(keyID, blockHeight);
 
@@ -539,7 +518,8 @@ std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID& keyID, const 
     }
 
     if (auto block = ::ChainActive()[Params().GetConsensus().EunosPayaHeight]) {
-        if (creationHeight < Params().GetConsensus().DakotaCrescentHeight && !stakerBlockTime && !subNodesBlockTime[0]) {
+        if (creationHeight < Params().GetConsensus().DakotaCrescentHeight && !stakerBlockTime &&
+            !subNodesBlockTime[0]) {
             if (auto dakotaBlock = ::ChainActive()[Params().GetConsensus().DakotaCrescentHeight]) {
                 subNodesBlockTime[0] = dakotaBlock->GetBlockTime();
             }
@@ -560,16 +540,14 @@ std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID& keyID, const 
 /*
  *  CLastHeightView
  */
-int CLastHeightView::GetLastHeight() const
-{
+int CLastHeightView::GetLastHeight() const {
     int result;
     if (Read(Height::prefix(), result))
         return result;
     return 0;
 }
 
-void CLastHeightView::SetLastHeight(int height)
-{
+void CLastHeightView::SetLastHeight(int height) {
     SetLastValidatedHeight(height);
     Write(Height::prefix(), height);
 }
@@ -577,31 +555,26 @@ void CLastHeightView::SetLastHeight(int height)
 /*
  *  CFoundationsDebtView
  */
-CAmount CFoundationsDebtView::GetFoundationsDebt() const
-{
+CAmount CFoundationsDebtView::GetFoundationsDebt() const {
     CAmount debt(0);
-    if(Read(Debt::prefix(), debt))
+    if (Read(Debt::prefix(), debt))
         assert(debt >= 0);
     return debt;
 }
 
-void CFoundationsDebtView::SetFoundationsDebt(CAmount debt)
-{
+void CFoundationsDebtView::SetFoundationsDebt(CAmount debt) {
     assert(debt >= 0);
     Write(Debt::prefix(), debt);
 }
 
-
 /*
  *  CTeamView
  */
-void CTeamView::SetTeam(const CTeamView::CTeam & newTeam)
-{
+void CTeamView::SetTeam(const CTeamView::CTeam &newTeam) {
     Write(CurrentTeam::prefix(), newTeam);
 }
 
-CTeamView::CTeam CTeamView::GetCurrentTeam() const
-{
+CTeamView::CTeam CTeamView::GetCurrentTeam() const {
     CTeam team;
     if (Read(CurrentTeam::prefix(), team) && team.size() > 0)
         return team;
@@ -609,19 +582,24 @@ CTeamView::CTeam CTeamView::GetCurrentTeam() const
     return Params().GetGenesisTeam();
 }
 
-void CTeamView::SetAnchorTeams(const CTeam& authTeam, const CTeam& confirmTeam, const int height)
-{
+void CTeamView::SetAnchorTeams(const CTeam &authTeam, const CTeam &confirmTeam, const int height) {
     // Called after fork height
     if (height < Params().GetConsensus().DakotaHeight) {
-        LogPrint(BCLog::ANCHORING, "%s: Called below fork. Fork: %d Arg height: %d\n",
-                 __func__, Params().GetConsensus().DakotaHeight, height);
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Called below fork. Fork: %d Arg height: %d\n",
+                 __func__,
+                 Params().GetConsensus().DakotaHeight,
+                 height);
         return;
     }
 
     // Called every on team change intercal from fork height
     if (height % Params().GetConsensus().mn.anchoringTeamChange != 0) {
-        LogPrint(BCLog::ANCHORING, "%s: Not called on interval of %d, arg height %d\n",
-                 __func__, Params().GetConsensus().mn.anchoringTeamChange, height);
+        LogPrint(BCLog::ANCHORING,
+                 "%s: Not called on interval of %d, arg height %d\n",
+                 __func__,
+                 Params().GetConsensus().mn.anchoringTeamChange,
+                 height);
         return;
     }
 
@@ -634,15 +612,13 @@ void CTeamView::SetAnchorTeams(const CTeam& authTeam, const CTeam& confirmTeam, 
     }
 }
 
-std::optional<CTeamView::CTeam> CTeamView::GetAuthTeam(int height) const
-{
+std::optional<CTeamView::CTeam> CTeamView::GetAuthTeam(int height) const {
     height -= height % Params().GetConsensus().mn.anchoringTeamChange;
 
     return ReadBy<AuthTeam, CTeam>(height);
 }
 
-std::optional<CTeamView::CTeam> CTeamView::GetConfirmTeam(int height) const
-{
+std::optional<CTeamView::CTeam> CTeamView::GetConfirmTeam(int height) const {
     height -= height % Params().GetConsensus().mn.anchoringTeamChange;
 
     return ReadBy<ConfirmTeam, CTeam>(height);
@@ -651,23 +627,23 @@ std::optional<CTeamView::CTeam> CTeamView::GetConfirmTeam(int height) const
 /*
  *  CAnchorRewardsView
  */
-std::optional<CAnchorRewardsView::RewardTxHash> CAnchorRewardsView::GetRewardForAnchor(const CAnchorRewardsView::AnchorTxHash & btcTxHash) const
-{
+std::optional<CAnchorRewardsView::RewardTxHash> CAnchorRewardsView::GetRewardForAnchor(
+    const CAnchorRewardsView::AnchorTxHash &btcTxHash) const {
     return ReadBy<BtcTx, RewardTxHash>(btcTxHash);
 }
 
-void CAnchorRewardsView::AddRewardForAnchor(const CAnchorRewardsView::AnchorTxHash & btcTxHash, const CAnchorRewardsView::RewardTxHash & rewardTxHash)
-{
+void CAnchorRewardsView::AddRewardForAnchor(const CAnchorRewardsView::AnchorTxHash &btcTxHash,
+                                            const CAnchorRewardsView::RewardTxHash &rewardTxHash) {
     WriteBy<BtcTx>(btcTxHash, rewardTxHash);
 }
 
-void CAnchorRewardsView::RemoveRewardForAnchor(const CAnchorRewardsView::AnchorTxHash & btcTxHash)
-{
+void CAnchorRewardsView::RemoveRewardForAnchor(const CAnchorRewardsView::AnchorTxHash &btcTxHash) {
     EraseBy<BtcTx>(btcTxHash);
 }
 
-void CAnchorRewardsView::ForEachAnchorReward(std::function<bool (const CAnchorRewardsView::AnchorTxHash &, CLazySerialize<CAnchorRewardsView::RewardTxHash>)> callback)
-{
+void CAnchorRewardsView::ForEachAnchorReward(
+    std::function<bool(const CAnchorRewardsView::AnchorTxHash &, CLazySerialize<CAnchorRewardsView::RewardTxHash>)>
+        callback) {
     ForEach<BtcTx, AnchorTxHash, RewardTxHash>(callback);
 }
 
@@ -675,29 +651,27 @@ void CAnchorRewardsView::ForEachAnchorReward(std::function<bool (const CAnchorRe
  *  CAnchorConfirmsView
  */
 
-void CAnchorConfirmsView::AddAnchorConfirmData(const CAnchorConfirmDataPlus& data)
-{
+void CAnchorConfirmsView::AddAnchorConfirmData(const CAnchorConfirmDataPlus &data) {
     WriteBy<BtcTx>(data.btcTxHash, data);
 }
 
-void CAnchorConfirmsView::EraseAnchorConfirmData(uint256 btcTxHash)
-{
+void CAnchorConfirmsView::EraseAnchorConfirmData(uint256 btcTxHash) {
     EraseBy<BtcTx>(btcTxHash);
 }
 
-void CAnchorConfirmsView::ForEachAnchorConfirmData(std::function<bool(const AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus>)> callback)
-{
+void CAnchorConfirmsView::ForEachAnchorConfirmData(
+    std::function<bool(const AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus>)> callback) {
     ForEach<BtcTx, AnchorTxHash, CAnchorConfirmDataPlus>(callback);
 }
 
-std::vector<CAnchorConfirmDataPlus> CAnchorConfirmsView::GetAnchorConfirmData()
-{
+std::vector<CAnchorConfirmDataPlus> CAnchorConfirmsView::GetAnchorConfirmData() {
     std::vector<CAnchorConfirmDataPlus> confirms;
 
-    ForEachAnchorConfirmData([&confirms](const CAnchorConfirmsView::AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus> data) {
-        confirms.push_back(data);
-        return true;
-    });
+    ForEachAnchorConfirmData(
+        [&confirms](const CAnchorConfirmsView::AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus> data) {
+            confirms.push_back(data);
+            return true;
+        });
 
     return confirms;
 }
@@ -706,71 +680,59 @@ std::vector<CAnchorConfirmDataPlus> CAnchorConfirmsView::GetAnchorConfirmData()
  *  CSettingsView
  */
 
-void CSettingsView::SetDexStatsLastHeight(const int32_t height)
-{
+void CSettingsView::SetDexStatsLastHeight(const int32_t height) {
     WriteBy<KVSettings>(DEX_STATS_LAST_HEIGHT, height);
 }
 
-std::optional<int32_t> CSettingsView::GetDexStatsLastHeight()
-{
+std::optional<int32_t> CSettingsView::GetDexStatsLastHeight() {
     return ReadBy<KVSettings, int32_t>(DEX_STATS_LAST_HEIGHT);
 }
 
-void CSettingsView::SetDexStatsEnabled(const bool enabled)
-{
+void CSettingsView::SetDexStatsEnabled(const bool enabled) {
     WriteBy<KVSettings>(DEX_STATS_ENABLED, enabled);
 }
 
-std::optional<bool> CSettingsView::GetDexStatsEnabled()
-{
+std::optional<bool> CSettingsView::GetDexStatsEnabled() {
     return ReadBy<KVSettings, bool>(DEX_STATS_ENABLED);
 }
 /*
  *  CCustomCSView
  */
-CCustomCSView::CCustomCSView()
-{
+CCustomCSView::CCustomCSView() {
     CheckPrefixes();
 }
 
 CCustomCSView::~CCustomCSView() = default;
 
-CCustomCSView::CCustomCSView(CStorageKV & st)
-    : CStorageView(new CFlushableStorageKV(st))
-{
+CCustomCSView::CCustomCSView(CStorageKV &st) : CStorageView(new CFlushableStorageKV(st)) {
     CheckPrefixes();
 }
 
 // cache-upon-a-cache (not a copy!) constructor
-CCustomCSView::CCustomCSView(CCustomCSView & other)
-    : CStorageView(new CFlushableStorageKV(other.DB()))
-{
+CCustomCSView::CCustomCSView(CCustomCSView &other) : CStorageView(new CFlushableStorageKV(other.DB())) {
     CheckPrefixes();
 }
 
-int CCustomCSView::GetDbVersion() const
-{
+int CCustomCSView::GetDbVersion() const {
     int version;
     if (Read(DbVersion::prefix(), version))
         return version;
     return 0;
 }
 
-void CCustomCSView::SetDbVersion(int version)
-{
+void CCustomCSView::SetDbVersion(int version) {
     Write(DbVersion::prefix(), version);
 }
 
-CTeamView::CTeam CCustomCSView::CalcNextTeam(int height, const uint256 & stakeModifier)
-{
+CTeamView::CTeam CCustomCSView::CalcNextTeam(int height, const uint256 &stakeModifier) {
     if (stakeModifier == uint256())
         return Params().GetGenesisTeam();
 
     int anchoringTeamSize = Params().GetConsensus().mn.anchoringTeamSize;
 
     std::map<arith_uint256, CKeyID, std::less<arith_uint256>> priorityMN;
-    ForEachMasternode([&] (uint256 const & id, CMasternode node) {
-        if(!node.IsActive(height))
+    ForEachMasternode([&](uint256 const &id, CMasternode node) {
+        if (!node.IsActive(height))
             return true;
 
         CDataStream ss{SER_GETHASH, PROTOCOL_VERSION};
@@ -780,26 +742,22 @@ CTeamView::CTeam CCustomCSView::CalcNextTeam(int height, const uint256 & stakeMo
     });
 
     CTeam newTeam;
-    auto && it = priorityMN.begin();
+    auto &&it = priorityMN.begin();
     for (int i = 0; i < anchoringTeamSize && it != priorityMN.end(); ++i, ++it) {
         newTeam.insert(it->second);
     }
     return newTeam;
 }
 
-enum AnchorTeams {
-    AuthTeam,
-    ConfirmTeam
-};
+enum AnchorTeams { AuthTeam, ConfirmTeam };
 
-void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlockIndex *pindexNew)
-{
+void CCustomCSView::CalcAnchoringTeams(const uint256 &stakeModifier, const CBlockIndex *pindexNew) {
     std::set<uint256> masternodeIDs;
-    const int blockSample = 7 * Params().GetConsensus().blocksPerDay(); // One week
+    const int blockSample = 7 * Params().GetConsensus().blocksPerDay();  // One week
 
     {
         LOCK(cs_main);
-        const CBlockIndex* pindex = pindexNew;
+        const CBlockIndex *pindex = pindexNew;
         for (int i{0}; pindex && i < blockSample; pindex = pindex->pprev, ++i) {
             if (auto id = GetMasternodeIdByOperator(pindex->minterKey())) {
                 masternodeIDs.insert(*id);
@@ -809,8 +767,8 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
 
     std::map<arith_uint256, CKeyID, std::less<arith_uint256>> authMN;
     std::map<arith_uint256, CKeyID, std::less<arith_uint256>> confirmMN;
-    ForEachMasternode([&] (uint256 const & id, CMasternode node) {
-        if(!node.IsActive(pindexNew->nHeight))
+    ForEachMasternode([&](uint256 const &id, CMasternode node) {
+        if (!node.IsActive(pindexNew->nHeight))
             return true;
 
         // Not in our list of MNs from last week, skip.
@@ -820,11 +778,13 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
 
         CDataStream authStream{SER_GETHASH, PROTOCOL_VERSION};
         authStream << id << stakeModifier << static_cast<int>(AnchorTeams::AuthTeam);
-        authMN.insert(std::make_pair(UintToArith256(Hash(authStream.begin(), authStream.end())), node.operatorAuthAddress));
+        authMN.insert(
+            std::make_pair(UintToArith256(Hash(authStream.begin(), authStream.end())), node.operatorAuthAddress));
 
         CDataStream confirmStream{SER_GETHASH, PROTOCOL_VERSION};
         confirmStream << id << stakeModifier << static_cast<int>(AnchorTeams::ConfirmTeam);
-        confirmMN.insert(std::make_pair(UintToArith256(Hash(confirmStream.begin(), confirmStream.end())), node.operatorAuthAddress));
+        confirmMN.insert(
+            std::make_pair(UintToArith256(Hash(confirmStream.begin(), confirmStream.end())), node.operatorAuthAddress));
 
         return true;
     });
@@ -832,7 +792,7 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
     int anchoringTeamSize = Params().GetConsensus().mn.anchoringTeamSize;
 
     CTeam authTeam;
-    auto && it = authMN.begin();
+    auto &&it = authMN.begin();
     for (int i = 0; i < anchoringTeamSize && it != authMN.end(); ++i, ++it) {
         authTeam.insert(it->second);
     }
@@ -851,20 +811,22 @@ void CCustomCSView::CalcAnchoringTeams(const uint256 & stakeModifier, const CBlo
     // Debug logging
     LogPrint(BCLog::ANCHORING, "MNs found: %d Team sizes: %d\n", masternodeIDs.size(), authTeam.size());
 
-    for (auto& item : authTeam) {
+    for (auto &item : authTeam) {
         LogPrint(BCLog::ANCHORING, "Auth team operator addresses: %s\n", item.ToString());
     }
 
-    for (auto& item : confirmTeam) {
+    for (auto &item : confirmTeam) {
         LogPrint(BCLog::ANCHORING, "Confirm team operator addresses: %s\n", item.ToString());
     }
 }
 
 /// @todo newbase move to networking?
-void CCustomCSView::CreateAndRelayConfirmMessageIfNeed(const CAnchorIndex::AnchorRec *anchor, const uint256 & btcTxHash, const CKey& masternodeKey)
-{
+void CCustomCSView::CreateAndRelayConfirmMessageIfNeed(const CAnchorIndex::AnchorRec *anchor,
+                                                       const uint256 &btcTxHash,
+                                                       const CKey &masternodeKey) {
     auto prev = panchors->GetAnchorByTx(anchor->anchor.previousAnchor);
-    auto confirmMessage = CAnchorConfirmMessage::CreateSigned(anchor->anchor, prev ? prev->anchor.height : 0, btcTxHash, masternodeKey, anchor->btcHeight);
+    auto confirmMessage = CAnchorConfirmMessage::CreateSigned(
+        anchor->anchor, prev ? prev->anchor.height : 0, btcTxHash, masternodeKey, anchor->btcHeight);
 
     if (panchorAwaitingConfirms->Add(*confirmMessage)) {
         LogPrint(BCLog::ANCHORING, "%s: Create message %s\n", __func__, confirmMessage->GetHash().GetHex());
@@ -872,18 +834,16 @@ void CCustomCSView::CreateAndRelayConfirmMessageIfNeed(const CAnchorIndex::Ancho
     }
 }
 
-void CCustomCSView::OnUndoTx(uint256 const & txid, uint32_t height)
-{
+void CCustomCSView::OnUndoTx(uint256 const &txid, uint32_t height) {
     const auto undo = GetUndo(UndoKey{height, txid});
     if (!undo) {
-        return; // not custom tx, or no changes done
+        return;  // not custom tx, or no changes done
     }
-    CUndo::Revert(GetStorage(), *undo); // revert the changes of this tx
-    DelUndo(UndoKey{height, txid}); // erase undo data, it served its purpose
+    CUndo::Revert(GetStorage(), *undo);  // revert the changes of this tx
+    DelUndo(UndoKey{height, txid});      // erase undo data, it served its purpose
 }
 
-bool CCustomCSView::CanSpend(const uint256 & txId, int height) const
-{
+bool CCustomCSView::CanSpend(const uint256 &txId, int height) const {
     auto node = GetMasternode(txId);
     // check if it was mn collateral and mn was resigned or banned
     if (node) {
@@ -896,57 +856,55 @@ bool CCustomCSView::CanSpend(const uint256 & txId, int height) const
     return !pair || pair->second.destructionTx != uint256{} || pair->second.IsPoolShare();
 }
 
-bool CCustomCSView::CalculateOwnerRewards(CScript const & owner, uint32_t targetHeight)
-{
+bool CCustomCSView::CalculateOwnerRewards(CScript const &owner, uint32_t targetHeight) {
     auto balanceHeight = GetBalancesHeight(owner);
     if (balanceHeight >= targetHeight) {
         return false;
     }
-    ForEachPoolId([&] (DCT_ID const & poolId) {
+    ForEachPoolId([&](DCT_ID const &poolId) {
         auto height = GetShare(poolId, owner);
         if (!height || *height >= targetHeight) {
-            return true; // no share or target height is before a pool share' one
+            return true;  // no share or target height is before a pool share' one
         }
-        auto onLiquidity = [&]() -> CAmount {
-            return GetBalance(owner, poolId).nValue;
-        };
+        auto onLiquidity = [&]() -> CAmount { return GetBalance(owner, poolId).nValue; };
         auto beginHeight = std::max(*height, balanceHeight);
-        CalculatePoolRewards(poolId, onLiquidity, beginHeight, targetHeight,
-            [&](RewardType, CTokenAmount amount, uint32_t height) {
+        CalculatePoolRewards(
+            poolId, onLiquidity, beginHeight, targetHeight, [&](RewardType, CTokenAmount amount, uint32_t height) {
                 auto res = AddBalance(owner, amount);
                 if (!res) {
-                    LogPrintf("Pool rewards: can't update balance of %s: %s, height %ld\n", owner.GetHex(), res.msg, targetHeight);
+                    LogPrintf("Pool rewards: can't update balance of %s: %s, height %ld\n",
+                              owner.GetHex(),
+                              res.msg,
+                              targetHeight);
                 }
-            }
-        );
+            });
         return true;
     });
 
     return UpdateBalancesHeight(owner, targetHeight);
 }
 
-double CCollateralLoans::calcRatio(uint64_t maxRatio) const
-{
+double CCollateralLoans::calcRatio(uint64_t maxRatio) const {
     return !totalLoans ? double(maxRatio) : double(totalCollaterals) / totalLoans;
 }
 
-uint32_t CCollateralLoans::ratio() const
-{
+uint32_t CCollateralLoans::ratio() const {
     constexpr auto maxRatio = std::numeric_limits<uint32_t>::max();
     auto ratio = calcRatio(maxRatio) * 100;
     return ratio > maxRatio ? maxRatio : uint32_t(lround(ratio));
 }
 
-CAmount CCollateralLoans::precisionRatio() const
-{
+CAmount CCollateralLoans::precisionRatio() const {
     constexpr auto maxRatio = std::numeric_limits<CAmount>::max();
     auto ratio = calcRatio(maxRatio);
     const auto precision = COIN * 100;
     return ratio > maxRatio / precision ? -COIN : CAmount(ratio * precision);
 }
 
-ResVal<CAmount> CCustomCSView::GetAmountInCurrency(CAmount amount, CTokenCurrencyPair priceFeedId, bool useNextPrice, bool requireLivePrice)
-{
+ResVal<CAmount> CCustomCSView::GetAmountInCurrency(CAmount amount,
+                                                   CTokenCurrencyPair priceFeedId,
+                                                   bool useNextPrice,
+                                                   bool requireLivePrice) {
     auto priceResult = GetValidatedIntervalPrice(priceFeedId, useNextPrice, requireLivePrice);
     if (!priceResult)
         return priceResult;
@@ -959,9 +917,12 @@ ResVal<CAmount> CCustomCSView::GetAmountInCurrency(CAmount amount, CTokenCurrenc
     return ResVal<CAmount>(amountInCurrency, Res::Ok());
 }
 
-ResVal<CCollateralLoans> CCustomCSView::GetLoanCollaterals(CVaultId const& vaultId, CBalances const& collaterals, uint32_t height,
-                                                           int64_t blockTime, bool useNextPrice, bool requireLivePrice)
-{
+ResVal<CCollateralLoans> CCustomCSView::GetLoanCollaterals(CVaultId const &vaultId,
+                                                           CBalances const &collaterals,
+                                                           uint32_t height,
+                                                           int64_t blockTime,
+                                                           bool useNextPrice,
+                                                           bool requireLivePrice) {
     auto vault = GetVault(vaultId);
     if (!vault || vault->isUnderLiquidation)
         return Res::Err("Vault is under liquidation");
@@ -975,18 +936,23 @@ ResVal<CCollateralLoans> CCustomCSView::GetLoanCollaterals(CVaultId const& vault
     if (!res)
         return std::move(res);
 
-    LogPrint(BCLog::LOAN, "\t\t%s(): totalCollaterals - %lld, totalLoans - %lld, ratio - %d\n",
-        __func__, result.totalCollaterals, result.totalLoans, result.ratio());
+    LogPrint(BCLog::LOAN,
+             "\t\t%s(): totalCollaterals - %lld, totalLoans - %lld, ratio - %d\n",
+             __func__,
+             result.totalCollaterals,
+             result.totalLoans,
+             result.ratio());
 
     return ResVal<CCollateralLoans>(result, Res::Ok());
 }
 
-ResVal<CAmount> CCustomCSView::GetValidatedIntervalPrice(const CTokenCurrencyPair& priceFeedId, bool useNextPrice, bool requireLivePrice)
-{
+ResVal<CAmount> CCustomCSView::GetValidatedIntervalPrice(const CTokenCurrencyPair &priceFeedId,
+                                                         bool useNextPrice,
+                                                         bool requireLivePrice) {
     auto tokenSymbol = priceFeedId.first;
     auto currency = priceFeedId.second;
 
-    LogPrint(BCLog::ORACLE,"\t\t%s()->for_loans->%s->", __func__, tokenSymbol); /* Continued */
+    LogPrint(BCLog::ORACLE, "\t\t%s()->for_loans->%s->", __func__, tokenSymbol); /* Continued */
 
     auto priceFeed = GetFixedIntervalPrice(priceFeedId);
     if (!priceFeed)
@@ -1003,14 +969,17 @@ ResVal<CAmount> CCustomCSView::GetValidatedIntervalPrice(const CTokenCurrencyPai
     return ResVal<CAmount>(price, Res::Ok());
 }
 
-Res CCustomCSView::PopulateLoansData(CCollateralLoans& result, CVaultId const& vaultId, uint32_t height,
-                                     int64_t blockTime, bool useNextPrice, bool requireLivePrice)
-{
+Res CCustomCSView::PopulateLoansData(CCollateralLoans &result,
+                                     CVaultId const &vaultId,
+                                     uint32_t height,
+                                     int64_t blockTime,
+                                     bool useNextPrice,
+                                     bool requireLivePrice) {
     auto loanTokens = GetLoanTokens(vaultId);
     if (!loanTokens)
         return Res::Ok();
 
-    for (const auto& loan : loanTokens->balances) {
+    for (const auto &loan : loanTokens->balances) {
         auto loanTokenId = loan.first;
         auto loanTokenAmount = loan.second;
 
@@ -1025,10 +994,11 @@ Res CCustomCSView::PopulateLoansData(CCollateralLoans& result, CVaultId const& v
         if (rate->height > height)
             return Res::Err("Trying to read loans in the past");
 
-        LogPrint(BCLog::LOAN,"\t\t%s()->for_loans->%s->", __func__, token->symbol); /* Continued */
+        LogPrint(BCLog::LOAN, "\t\t%s()->for_loans->%s->", __func__, token->symbol); /* Continued */
 
         auto totalAmount = loanTokenAmount + TotalInterest(*rate, height);
-        auto amountInCurrency = GetAmountInCurrency(totalAmount, token->fixedIntervalPriceId, useNextPrice, requireLivePrice);
+        auto amountInCurrency =
+            GetAmountInCurrency(totalAmount, token->fixedIntervalPriceId, useNextPrice, requireLivePrice);
         if (!amountInCurrency)
             return std::move(amountInCurrency);
 
@@ -1043,10 +1013,14 @@ Res CCustomCSView::PopulateLoansData(CCollateralLoans& result, CVaultId const& v
     return Res::Ok();
 }
 
-Res CCustomCSView::PopulateCollateralData(CCollateralLoans& result, CVaultId const& vaultId, CBalances const& collaterals,
-                                          uint32_t height, int64_t blockTime, bool useNextPrice, bool requireLivePrice)
-{
-    for (const auto& col : collaterals.balances) {
+Res CCustomCSView::PopulateCollateralData(CCollateralLoans &result,
+                                          CVaultId const &vaultId,
+                                          CBalances const &collaterals,
+                                          uint32_t height,
+                                          int64_t blockTime,
+                                          bool useNextPrice,
+                                          bool requireLivePrice) {
+    for (const auto &col : collaterals.balances) {
         auto tokenId = col.first;
         auto tokenAmount = col.second;
 
@@ -1054,7 +1028,8 @@ Res CCustomCSView::PopulateCollateralData(CCollateralLoans& result, CVaultId con
         if (!token)
             return Res::Err("Collateral token with id (%s) does not exist!", tokenId.ToString());
 
-        auto amountInCurrency = GetAmountInCurrency(tokenAmount, token->fixedIntervalPriceId, useNextPrice, requireLivePrice);
+        auto amountInCurrency =
+            GetAmountInCurrency(tokenAmount, token->fixedIntervalPriceId, useNextPrice, requireLivePrice);
         if (!amountInCurrency)
             return std::move(amountInCurrency);
 
@@ -1076,7 +1051,7 @@ uint256 CCustomCSView::MerkleRoot() {
     if (rawMap.empty()) {
         return {};
     }
-    auto isAttributes = [](const TBytes& key) {
+    auto isAttributes = [](const TBytes &key) {
         MapKV map = {std::make_pair(key, TBytes{})};
         // Attributes should not be part of merkle root
         static const std::string attributes("ATTRIBUTES");
@@ -1087,16 +1062,16 @@ uint256 CCustomCSView::MerkleRoot() {
     auto it = NewKVIterator<CUndosView::ByUndoKey>(UndoKey{}, rawMap);
     for (; it.Valid(); it.Next()) {
         CUndo value = it.Value();
-        auto& map = value.before;
+        auto &map = value.before;
         for (auto it = map.begin(); it != map.end();) {
             isAttributes(it->first) ? map.erase(it++) : ++it;
         }
-        auto key = std::make_pair(CUndosView::ByUndoKey::prefix(), static_cast<const UndoKey&>(it.Key()));
+        auto key = std::make_pair(CUndosView::ByUndoKey::prefix(), static_cast<const UndoKey &>(it.Key()));
         rawMap[DbTypeToBytes(key)] = DbTypeToBytes(value);
     }
 
     std::vector<uint256> hashes;
-    for (const auto& [key, value] : rawMap) {
+    for (const auto &[key, value] : rawMap) {
         if (!isAttributes(key)) {
             hashes.push_back(Hash2(key, value ? *value : TBytes{}));
         }
@@ -1104,14 +1079,13 @@ uint256 CCustomCSView::MerkleRoot() {
     return ComputeMerkleRoot(std::move(hashes));
 }
 
-bool CCustomCSView::AreTokensLocked(const std::set<uint32_t>& tokenIds) const
-{
+bool CCustomCSView::AreTokensLocked(const std::set<uint32_t> &tokenIds) const {
     const auto attributes = GetAttributes();
     if (!attributes) {
         return false;
     }
 
-    for (const auto& tokenId : tokenIds) {
+    for (const auto &tokenId : tokenIds) {
         CDataStructureV0 lockKey{AttributeTypes::Locks, ParamIDs::TokenID, tokenId};
         if (attributes->GetValue(lockKey, false)) {
             return true;
@@ -1121,8 +1095,7 @@ bool CCustomCSView::AreTokensLocked(const std::set<uint32_t>& tokenIds) const
     return false;
 }
 
-std::optional<CTokensView::CTokenImpl> CCustomCSView::GetTokenGuessId(const std::string & str, DCT_ID & id) const
-{
+std::optional<CTokensView::CTokenImpl> CCustomCSView::GetTokenGuessId(const std::string &str, DCT_ID &id) const {
     std::string const key = trim_ws(str);
 
     if (key.empty()) {
@@ -1149,8 +1122,7 @@ std::optional<CTokensView::CTokenImpl> CCustomCSView::GetTokenGuessId(const std:
     return {};
 }
 
-std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenByID(DCT_ID const & id) const
-{
+std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenByID(DCT_ID const &id) const {
     auto loanToken = ReadBy<LoanSetLoanTokenKey, CLoanSetLoanTokenImpl>(id);
     if (loanToken) {
         return loanToken;
@@ -1159,14 +1131,12 @@ std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenByID(
     return GetLoanTokenFromAttributes(id);
 }
 
-std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const & team)
-{
+std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const &team) {
     AssertLockHeld(cs_main);
 
     std::map<CKeyID, CKey> operatorDetails;
     auto const mnIds = pcustomcsview->GetOperatorsMulti();
-    for (const auto& mnId : mnIds)
-    {
+    for (const auto &mnId : mnIds) {
         auto node = pcustomcsview->GetMasternode(mnId.second);
         if (!node) {
             continue;
@@ -1175,7 +1145,7 @@ std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const & team)
         if (node->IsActive(height) && team.find(mnId.first) != team.end()) {
             CKey masternodeKey;
             std::vector<std::shared_ptr<CWallet>> wallets = GetWallets();
-            for (auto const & wallet : wallets) {
+            for (auto const &wallet : wallets) {
                 if (wallet->GetKey(mnId.first, masternodeKey)) {
                     break;
                 }
@@ -1190,14 +1160,14 @@ std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const & team)
     return operatorDetails;
 }
 
-std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenFromAttributes(const DCT_ID& id) const {
+std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenFromAttributes(const DCT_ID &id) const {
     if (const auto attributes = GetAttributes()) {
-
         CDataStructureV0 pairKey{AttributeTypes::Token, id.v, TokenKeys::FixedIntervalPriceId};
         CDataStructureV0 interestKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingInterest};
         CDataStructureV0 mintableKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingEnabled};
 
-        if (const auto token = GetToken(id); token && attributes->CheckKey(pairKey) && attributes->CheckKey(interestKey) && attributes->CheckKey(mintableKey)) {
+        if (const auto token = GetToken(id); token && attributes->CheckKey(pairKey) &&
+                                             attributes->CheckKey(interestKey) && attributes->CheckKey(mintableKey)) {
             CLoanView::CLoanSetLoanTokenImpl loanToken;
             loanToken.fixedIntervalPriceId = attributes->GetValue(pairKey, CTokenCurrencyPair{});
             loanToken.interest = attributes->GetValue(interestKey, CAmount{});
@@ -1211,7 +1181,8 @@ std::optional<CLoanView::CLoanSetLoanTokenImpl> CCustomCSView::GetLoanTokenFromA
     return {};
 }
 
-std::optional<CLoanView::CLoanSetCollateralTokenImpl> CCustomCSView::GetCollateralTokenFromAttributes(const DCT_ID& id) const {
+std::optional<CLoanView::CLoanSetCollateralTokenImpl> CCustomCSView::GetCollateralTokenFromAttributes(
+    const DCT_ID &id) const {
     if (const auto attributes = GetAttributes()) {
         CLoanSetCollateralTokenImplementation collToken;
 
@@ -1219,7 +1190,6 @@ std::optional<CLoanView::CLoanSetCollateralTokenImpl> CCustomCSView::GetCollater
         CDataStructureV0 factorKey{AttributeTypes::Token, id.v, TokenKeys::LoanCollateralFactor};
 
         if (attributes->CheckKey(pairKey) && attributes->CheckKey(factorKey)) {
-
             collToken.fixedIntervalPriceId = attributes->GetValue(pairKey, CTokenCurrencyPair{});
             collToken.factor = attributes->GetValue(factorKey, CAmount{0});
             collToken.idToken = id;
@@ -1236,11 +1206,11 @@ std::optional<CLoanView::CLoanSetCollateralTokenImpl> CCustomCSView::GetCollater
     return {};
 }
 
-CAccountHistoryStorage* CCustomCSView::GetAccountHistoryStore() {
+CAccountHistoryStorage *CCustomCSView::GetAccountHistoryStore() {
     return accHistoryStore.get();
 }
 
-CVaultHistoryStorage* CCustomCSView::GetVaultHistoryStore() {
+CVaultHistoryStorage *CCustomCSView::GetVaultHistoryStore() {
     return vauHistoryStore.get();
 }
 

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -7,8 +7,6 @@
 
 #include <amount.h>
 #include <flushablestorage.h>
-#include <pubkey.h>
-#include <serialize.h>
 #include <masternodes/accounts.h>
 #include <masternodes/anchors.h>
 #include <masternodes/gv.h>
@@ -20,14 +18,16 @@
 #include <masternodes/tokens.h>
 #include <masternodes/undos.h>
 #include <masternodes/vault.h>
+#include <pubkey.h>
+#include <serialize.h>
 #include <uint256.h>
 #include <wallet/ismine.h>
 
+#include <stdint.h>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <set>
-#include <stdint.h>
 
 class CAccountHistoryStorage;
 class CBlockIndex;
@@ -44,22 +44,17 @@ CAmount GetMnCollateralAmount(int height);
 
 constexpr uint8_t SUBNODE_COUNT{4};
 
-class CMasternode
-{
-public:
+class CMasternode {
+   public:
     enum State {
         PRE_ENABLED,
         ENABLED,
         PRE_RESIGNED,
         RESIGNED,
-        UNKNOWN // unreachable
+        UNKNOWN  // unreachable
     };
 
-    enum TimeLock {
-        ZEROYEAR,
-        FIVEYEAR = 260,
-        TENYEAR = 520
-    };
+    enum TimeLock { ZEROYEAR, FIVEYEAR = 260, TENYEAR = 520 };
 
     enum Version : int32_t {
         PRE_FORT_CANNING = -1,
@@ -104,8 +99,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(mintedBlocks);
         READWRITE(ownerAuthAddress);
         READWRITE(ownerType);
@@ -127,20 +121,18 @@ public:
     }
 
     //! equality test
-    friend bool operator==(CMasternode const & a, CMasternode const & b);
-    friend bool operator!=(CMasternode const & a, CMasternode const & b);
+    friend bool operator==(CMasternode const &a, CMasternode const &b);
+    friend bool operator!=(CMasternode const &a, CMasternode const &b);
 };
 
-
-struct MNBlockTimeKey
-{
+struct MNBlockTimeKey {
     uint256 masternodeID;
     uint32_t blockHeight;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(masternodeID);
 
         if (ser_action.ForRead()) {
@@ -153,8 +145,7 @@ struct MNBlockTimeKey
     }
 };
 
-struct SubNodeBlockTimeKey
-{
+struct SubNodeBlockTimeKey {
     uint256 masternodeID;
     uint8_t subnode;
     uint32_t blockHeight;
@@ -162,7 +153,7 @@ struct SubNodeBlockTimeKey
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(masternodeID);
         READWRITE(subnode);
 
@@ -176,20 +167,20 @@ struct SubNodeBlockTimeKey
     }
 };
 
-class CMasternodesView : public virtual CStorageView
-{
+class CMasternodesView : public virtual CStorageView {
     std::map<CKeyID, std::pair<uint32_t, int64_t>> minterTimeCache;
 
-public:
-//    CMasternodesView() = default;
+   public:
+    //    CMasternodesView() = default;
 
-    std::optional<CMasternode> GetMasternode(uint256 const & id) const;
-    std::optional<uint256> GetMasternodeIdByOperator(CKeyID const & id) const;
-    std::optional<uint256> GetMasternodeIdByOwner(CKeyID const & id) const;
-    void ForEachMasternode(std::function<bool(uint256 const &, CLazySerialize<CMasternode>)> callback, uint256 const & start = uint256());
+    std::optional<CMasternode> GetMasternode(uint256 const &id) const;
+    std::optional<uint256> GetMasternodeIdByOperator(CKeyID const &id) const;
+    std::optional<uint256> GetMasternodeIdByOwner(CKeyID const &id) const;
+    void ForEachMasternode(std::function<bool(uint256 const &, CLazySerialize<CMasternode>)> callback,
+                           uint256 const &start = uint256());
 
-    void IncrementMintedBy(const uint256& nodeId);
-    void DecrementMintedBy(const uint256& nodeId);
+    void IncrementMintedBy(const uint256 &nodeId);
+    void DecrementMintedBy(const uint256 &nodeId);
 
     std::optional<std::pair<CKeyID, uint256>> AmIOperator() const;
     std::optional<std::pair<CKeyID, uint256>> AmIOwner() const;
@@ -197,110 +188,138 @@ public:
     // Multiple operator support
     std::set<std::pair<CKeyID, uint256>> GetOperatorsMulti() const;
 
-    Res CreateMasternode(uint256 const & nodeId, CMasternode const & node, uint16_t timelock);
-    Res ResignMasternode(uint256 const & nodeId, uint256 const & txid, int height);
-    Res SetForcedRewardAddress(uint256 const & nodeId, const char rewardAddressType, CKeyID const & rewardAddress, int height);
-    Res RemForcedRewardAddress(uint256 const & nodeId, int height);
-    Res UpdateMasternode(uint256 const & nodeId, char operatorType, const CKeyID& operatorAuthAddress, int height);
+    Res CreateMasternode(uint256 const &nodeId, CMasternode const &node, uint16_t timelock);
+    Res ResignMasternode(uint256 const &nodeId, uint256 const &txid, int height);
+    Res SetForcedRewardAddress(uint256 const &nodeId,
+                               const char rewardAddressType,
+                               CKeyID const &rewardAddress,
+                               int height);
+    Res RemForcedRewardAddress(uint256 const &nodeId, int height);
+    Res UpdateMasternode(uint256 const &nodeId, char operatorType, const CKeyID &operatorAuthAddress, int height);
 
     // Get blocktimes for non-subnode and subnode with fork logic
-    std::vector<int64_t> GetBlockTimes(const CKeyID& keyID, const uint32_t blockHeight, const int32_t creationHeight, const uint16_t timelock);
+    std::vector<int64_t> GetBlockTimes(const CKeyID &keyID,
+                                       const uint32_t blockHeight,
+                                       const int32_t creationHeight,
+                                       const uint16_t timelock);
 
     // Non-subnode block times
-    void SetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t &blockHeight, const int64_t &time);
-    std::optional<int64_t> GetMasternodeLastBlockTime(const CKeyID & minter, const uint32_t height);
-    void EraseMasternodeLastBlockTime(const uint256 &minter, const uint32_t& blockHeight);
-    void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback, MNBlockTimeKey const & start = {});
+    void SetMasternodeLastBlockTime(const CKeyID &minter, const uint32_t &blockHeight, const int64_t &time);
+    std::optional<int64_t> GetMasternodeLastBlockTime(const CKeyID &minter, const uint32_t height);
+    void EraseMasternodeLastBlockTime(const uint256 &minter, const uint32_t &blockHeight);
+    void ForEachMinterNode(std::function<bool(MNBlockTimeKey const &, CLazySerialize<int64_t>)> callback,
+                           MNBlockTimeKey const &start = {});
 
     // Subnode block times
-    void SetSubNodesBlockTime(const CKeyID & minter, const uint32_t &blockHeight, const uint8_t id, const int64_t& time);
-    std::vector<int64_t> GetSubNodesBlockTime(const CKeyID & minter, const uint32_t height);
-    void EraseSubNodesLastBlockTime(const uint256& nodeId, const uint32_t& blockHeight);
-    void ForEachSubNode(std::function<bool(SubNodeBlockTimeKey const &, CLazySerialize<int64_t>)> callback, SubNodeBlockTimeKey const & start = {});
+    void SetSubNodesBlockTime(const CKeyID &minter, const uint32_t &blockHeight, const uint8_t id, const int64_t &time);
+    std::vector<int64_t> GetSubNodesBlockTime(const CKeyID &minter, const uint32_t height);
+    void EraseSubNodesLastBlockTime(const uint256 &nodeId, const uint32_t &blockHeight);
+    void ForEachSubNode(std::function<bool(SubNodeBlockTimeKey const &, CLazySerialize<int64_t>)> callback,
+                        SubNodeBlockTimeKey const &start = {});
 
-    uint16_t GetTimelock(const uint256& nodeId, const CMasternode& node, const uint64_t height) const;
+    uint16_t GetTimelock(const uint256 &nodeId, const CMasternode &node, const uint64_t height) const;
 
     // tags
-    struct ID       { static constexpr uint8_t prefix() { return 'M'; } };
-    struct Operator { static constexpr uint8_t prefix() { return 'o'; } };
-    struct Owner    { static constexpr uint8_t prefix() { return 'w'; } };
+    struct ID {
+        static constexpr uint8_t prefix() { return 'M'; }
+    };
+    struct Operator {
+        static constexpr uint8_t prefix() { return 'o'; }
+    };
+    struct Owner {
+        static constexpr uint8_t prefix() { return 'w'; }
+    };
 
     // For storing last staked block time
-    struct Staker   { static constexpr uint8_t prefix() { return 'X'; } };
-    struct SubNode  { static constexpr uint8_t prefix() { return 'Z'; } };
+    struct Staker {
+        static constexpr uint8_t prefix() { return 'X'; }
+    };
+    struct SubNode {
+        static constexpr uint8_t prefix() { return 'Z'; }
+    };
 
     // Store long term time lock
-    struct Timelock { static constexpr uint8_t prefix() { return 'K'; } };
+    struct Timelock {
+        static constexpr uint8_t prefix() { return 'K'; }
+    };
 };
 
-class CLastHeightView : public virtual CStorageView
-{
-public:
+class CLastHeightView : public virtual CStorageView {
+   public:
     int GetLastHeight() const;
     void SetLastHeight(int height);
 
-    struct Height { static constexpr uint8_t prefix() { return 'H'; } };
+    struct Height {
+        static constexpr uint8_t prefix() { return 'H'; }
+    };
 };
 
-class CFoundationsDebtView : public virtual CStorageView
-{
-public:
+class CFoundationsDebtView : public virtual CStorageView {
+   public:
     CAmount GetFoundationsDebt() const;
     void SetFoundationsDebt(CAmount debt);
 
-    struct Debt { static constexpr uint8_t prefix() { return 'd'; } };
+    struct Debt {
+        static constexpr uint8_t prefix() { return 'd'; }
+    };
 };
 
-class CTeamView : public virtual CStorageView
-{
-public:
+class CTeamView : public virtual CStorageView {
+   public:
     using CTeam = CAnchorData::CTeam;
 
-    void SetTeam(CTeam const & newTeam);
-    void SetAnchorTeams(CTeam const & authTeam, CTeam const & confirmTeam, const int height);
+    void SetTeam(CTeam const &newTeam);
+    void SetAnchorTeams(CTeam const &authTeam, CTeam const &confirmTeam, const int height);
 
     CTeam GetCurrentTeam() const;
     std::optional<CTeam> GetAuthTeam(int height) const;
     std::optional<CTeam> GetConfirmTeam(int height) const;
 
-    struct AuthTeam     { static constexpr uint8_t prefix() { return 'v'; } };
-    struct ConfirmTeam  { static constexpr uint8_t prefix() { return 'V'; } };
-    struct CurrentTeam  { static constexpr uint8_t prefix() { return 't'; } };
+    struct AuthTeam {
+        static constexpr uint8_t prefix() { return 'v'; }
+    };
+    struct ConfirmTeam {
+        static constexpr uint8_t prefix() { return 'V'; }
+    };
+    struct CurrentTeam {
+        static constexpr uint8_t prefix() { return 't'; }
+    };
 };
 
-class CAnchorRewardsView : public virtual CStorageView
-{
-public:
+class CAnchorRewardsView : public virtual CStorageView {
+   public:
     using RewardTxHash = uint256;
     using AnchorTxHash = uint256;
 
     std::optional<RewardTxHash> GetRewardForAnchor(AnchorTxHash const &btcTxHash) const;
 
-    void AddRewardForAnchor(AnchorTxHash const &btcTxHash, RewardTxHash const & rewardTxHash);
+    void AddRewardForAnchor(AnchorTxHash const &btcTxHash, RewardTxHash const &rewardTxHash);
     void RemoveRewardForAnchor(AnchorTxHash const &btcTxHash);
     void ForEachAnchorReward(std::function<bool(AnchorTxHash const &, CLazySerialize<RewardTxHash>)> callback);
 
-    struct BtcTx { static constexpr uint8_t prefix() { return 'r'; } };
+    struct BtcTx {
+        static constexpr uint8_t prefix() { return 'r'; }
+    };
 };
 
-class CAnchorConfirmsView : public virtual CStorageView
-{
-public:
+class CAnchorConfirmsView : public virtual CStorageView {
+   public:
     using AnchorTxHash = uint256;
 
     std::vector<CAnchorConfirmDataPlus> GetAnchorConfirmData();
 
-    void AddAnchorConfirmData(const CAnchorConfirmDataPlus& data);
+    void AddAnchorConfirmData(const CAnchorConfirmDataPlus &data);
     void EraseAnchorConfirmData(const uint256 btcTxHash);
-    void ForEachAnchorConfirmData(std::function<bool(const AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus>)> callback);
+    void ForEachAnchorConfirmData(
+        std::function<bool(const AnchorTxHash &, CLazySerialize<CAnchorConfirmDataPlus>)> callback);
 
-    struct BtcTx { static constexpr uint8_t prefix() { return 'x'; } };
+    struct BtcTx {
+        static constexpr uint8_t prefix() { return 'x'; }
+    };
 };
 
-class CSettingsView : public virtual CStorageView
-{
-
-public:
+class CSettingsView : public virtual CStorageView {
+   public:
     const std::string DEX_STATS_LAST_HEIGHT = "DexStatsLastHeight";
     const std::string DEX_STATS_ENABLED = "DexStatsEnabled";
 
@@ -309,14 +328,16 @@ public:
     void SetDexStatsEnabled(bool enabled);
     std::optional<bool> GetDexStatsEnabled();
 
-    struct KVSettings { static constexpr uint8_t prefix() { return '0'; } };
+    struct KVSettings {
+        static constexpr uint8_t prefix() { return '0'; }
+    };
 };
 
-class CCollateralLoans { // in USD
+class CCollateralLoans {  // in USD
 
     double calcRatio(uint64_t maxRatio) const;
 
-public:
+   public:
     uint64_t totalCollaterals;
     uint64_t totalLoans;
     std::vector<CTokenAmount> collaterals;
@@ -328,7 +349,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(totalCollaterals);
         READWRITE(totalLoans);
         READWRITE(collaterals);
@@ -336,114 +357,190 @@ public:
     }
 };
 
-template<typename T>
-inline void CheckPrefix()
-{
-}
+template <typename T>
+inline void CheckPrefix() {}
 
-template<typename T1, typename T2, typename... TN>
-inline void CheckPrefix()
-{
+template <typename T1, typename T2, typename... TN>
+inline void CheckPrefix() {
     static_assert(T1::prefix() != T2::prefix(), "prefixes are equal");
     CheckPrefix<T1, TN...>();
     CheckPrefix<T2, TN...>();
 }
 
-class CCustomCSView
-        : public CMasternodesView
-        , public CLastHeightView
-        , public CTeamView
-        , public CFoundationsDebtView
-        , public CAnchorRewardsView
-        , public CTokensView
-        , public CAccountsView
-        , public CCommunityBalancesView
-        , public CUndosView
-        , public CPoolPairView
-        , public CGovView
-        , public CAnchorConfirmsView
-        , public COracleView
-        , public CICXOrderView
-        , public CLoanView
-        , public CVaultView
-        , public CSettingsView
-{
-    void CheckPrefixes()
-    {
-        CheckPrefix<
-            CMasternodesView        ::  ID, Operator, Owner, Staker, SubNode, Timelock,
-            CLastHeightView         ::  Height,
-            CTeamView               ::  AuthTeam, ConfirmTeam, CurrentTeam,
-            CFoundationsDebtView    ::  Debt,
-            CAnchorRewardsView      ::  BtcTx,
-            CTokensView             ::  ID, Symbol, CreationTx, LastDctId,
-            CAccountsView           ::  ByBalanceKey, ByHeightKey, ByFuturesSwapKey,
-            CCommunityBalancesView  ::  ById,
-            CUndosView              ::  ByUndoKey,
-            CPoolPairView           ::  ByID, ByPair, ByShare, ByIDPair, ByPoolSwap, ByReserves, ByRewardPct, ByRewardLoanPct,
-                                        ByPoolReward, ByDailyReward, ByCustomReward, ByTotalLiquidity, ByDailyLoanReward,
-                                        ByPoolLoanReward, ByTokenDexFeePct,
-            CGovView                ::  ByName, ByHeightVars,
-            CAnchorConfirmsView     ::  BtcTx,
-            COracleView             ::  ByName, FixedIntervalBlockKey, FixedIntervalPriceKey, PriceDeviation,
-            CICXOrderView           ::  ICXOrderCreationTx, ICXMakeOfferCreationTx, ICXSubmitDFCHTLCCreationTx,
-                                        ICXSubmitEXTHTLCCreationTx, ICXClaimDFCHTLCCreationTx, ICXCloseOrderCreationTx,
-                                        ICXCloseOfferCreationTx, ICXOrderOpenKey, ICXOrderCloseKey, ICXMakeOfferOpenKey,
-                                        ICXMakeOfferCloseKey, ICXSubmitDFCHTLCOpenKey, ICXSubmitDFCHTLCCloseKey,
-                                        ICXSubmitEXTHTLCOpenKey, ICXSubmitEXTHTLCCloseKey, ICXClaimDFCHTLCKey,
-                                        ICXOrderStatus, ICXOfferStatus, ICXSubmitDFCHTLCStatus, ICXSubmitEXTHTLCStatus, ICXVariables,
-            CLoanView               ::  LoanSetCollateralTokenCreationTx, LoanSetCollateralTokenKey, LoanSetLoanTokenCreationTx,
-                                        LoanSetLoanTokenKey, LoanSchemeKey, DefaultLoanSchemeKey, DelayedLoanSchemeKey,
-                                        DestroyLoanSchemeKey, LoanInterestByVault, LoanTokenAmount, LoanLiquidationPenalty, LoanInterestV2ByVault,
-            CVaultView              ::  VaultKey, OwnerVaultKey, CollateralKey, AuctionBatchKey, AuctionHeightKey, AuctionBidKey,
-            CSettingsView           ::  KVSettings
-        >();
+class CCustomCSView : public CMasternodesView,
+                      public CLastHeightView,
+                      public CTeamView,
+                      public CFoundationsDebtView,
+                      public CAnchorRewardsView,
+                      public CTokensView,
+                      public CAccountsView,
+                      public CCommunityBalancesView,
+                      public CUndosView,
+                      public CPoolPairView,
+                      public CGovView,
+                      public CAnchorConfirmsView,
+                      public COracleView,
+                      public CICXOrderView,
+                      public CLoanView,
+                      public CVaultView,
+                      public CSettingsView {
+    void CheckPrefixes() {
+        CheckPrefix<CMasternodesView ::ID,
+                    Operator,
+                    Owner,
+                    Staker,
+                    SubNode,
+                    Timelock,
+                    CLastHeightView ::Height,
+                    CTeamView ::AuthTeam,
+                    ConfirmTeam,
+                    CurrentTeam,
+                    CFoundationsDebtView ::Debt,
+                    CAnchorRewardsView ::BtcTx,
+                    CTokensView ::ID,
+                    Symbol,
+                    CreationTx,
+                    LastDctId,
+                    CAccountsView ::ByBalanceKey,
+                    ByHeightKey,
+                    ByFuturesSwapKey,
+                    CCommunityBalancesView ::ById,
+                    CUndosView ::ByUndoKey,
+                    CPoolPairView ::ByID,
+                    ByPair,
+                    ByShare,
+                    ByIDPair,
+                    ByPoolSwap,
+                    ByReserves,
+                    ByRewardPct,
+                    ByRewardLoanPct,
+                    ByPoolReward,
+                    ByDailyReward,
+                    ByCustomReward,
+                    ByTotalLiquidity,
+                    ByDailyLoanReward,
+                    ByPoolLoanReward,
+                    ByTokenDexFeePct,
+                    CGovView ::ByName,
+                    ByHeightVars,
+                    CAnchorConfirmsView ::BtcTx,
+                    COracleView ::ByName,
+                    FixedIntervalBlockKey,
+                    FixedIntervalPriceKey,
+                    PriceDeviation,
+                    CICXOrderView ::ICXOrderCreationTx,
+                    ICXMakeOfferCreationTx,
+                    ICXSubmitDFCHTLCCreationTx,
+                    ICXSubmitEXTHTLCCreationTx,
+                    ICXClaimDFCHTLCCreationTx,
+                    ICXCloseOrderCreationTx,
+                    ICXCloseOfferCreationTx,
+                    ICXOrderOpenKey,
+                    ICXOrderCloseKey,
+                    ICXMakeOfferOpenKey,
+                    ICXMakeOfferCloseKey,
+                    ICXSubmitDFCHTLCOpenKey,
+                    ICXSubmitDFCHTLCCloseKey,
+                    ICXSubmitEXTHTLCOpenKey,
+                    ICXSubmitEXTHTLCCloseKey,
+                    ICXClaimDFCHTLCKey,
+                    ICXOrderStatus,
+                    ICXOfferStatus,
+                    ICXSubmitDFCHTLCStatus,
+                    ICXSubmitEXTHTLCStatus,
+                    ICXVariables,
+                    CLoanView ::LoanSetCollateralTokenCreationTx,
+                    LoanSetCollateralTokenKey,
+                    LoanSetLoanTokenCreationTx,
+                    LoanSetLoanTokenKey,
+                    LoanSchemeKey,
+                    DefaultLoanSchemeKey,
+                    DelayedLoanSchemeKey,
+                    DestroyLoanSchemeKey,
+                    LoanInterestByVault,
+                    LoanTokenAmount,
+                    LoanLiquidationPenalty,
+                    LoanInterestV2ByVault,
+                    CVaultView ::VaultKey,
+                    OwnerVaultKey,
+                    CollateralKey,
+                    AuctionBatchKey,
+                    AuctionHeightKey,
+                    AuctionBidKey,
+                    CSettingsView ::KVSettings>();
     }
-private:
-    Res PopulateLoansData(CCollateralLoans& result, CVaultId const& vaultId, uint32_t height, int64_t blockTime, bool useNextPrice, bool requireLivePrice);
-    Res PopulateCollateralData(CCollateralLoans& result, CVaultId const& vaultId, CBalances const& collaterals, uint32_t height, int64_t blockTime, bool useNextPrice, bool requireLivePrice);
+
+   private:
+    Res PopulateLoansData(CCollateralLoans &result,
+                          CVaultId const &vaultId,
+                          uint32_t height,
+                          int64_t blockTime,
+                          bool useNextPrice,
+                          bool requireLivePrice);
+    Res PopulateCollateralData(CCollateralLoans &result,
+                               CVaultId const &vaultId,
+                               CBalances const &collaterals,
+                               uint32_t height,
+                               int64_t blockTime,
+                               bool useNextPrice,
+                               bool requireLivePrice);
 
     std::unique_ptr<CAccountHistoryStorage> accHistoryStore;
     std::unique_ptr<CVaultHistoryStorage> vauHistoryStore;
-public:
+
+   public:
     // Increase version when underlaying tables are changed
     static constexpr const int DbVersion = 1;
 
     CCustomCSView();
-    explicit CCustomCSView(CStorageKV & st);
+    explicit CCustomCSView(CStorageKV &st);
 
     // cache-upon-a-cache (not a copy!) constructor
-    CCustomCSView(CCustomCSView & other);
+    CCustomCSView(CCustomCSView &other);
 
     ~CCustomCSView();
 
     // cause depends on current mns:
-    CTeamView::CTeam CalcNextTeam(int height, uint256 const & stakeModifier);
+    CTeamView::CTeam CalcNextTeam(int height, uint256 const &stakeModifier);
 
     // Generate auth and custom anchor teams based on current block
-    void CalcAnchoringTeams(uint256 const & stakeModifier, const CBlockIndex *pindexNew);
+    void CalcAnchoringTeams(uint256 const &stakeModifier, const CBlockIndex *pindexNew);
 
     /// @todo newbase move to networking?
-    void CreateAndRelayConfirmMessageIfNeed(const CAnchorIndex::AnchorRec* anchor, const uint256 & btcTxHash, const CKey &masternodeKey);
+    void CreateAndRelayConfirmMessageIfNeed(const CAnchorIndex::AnchorRec *anchor,
+                                            const uint256 &btcTxHash,
+                                            const CKey &masternodeKey);
 
     // simplified version of undo, without any unnecessary undo data
-    void OnUndoTx(uint256 const & txid, uint32_t height);
+    void OnUndoTx(uint256 const &txid, uint32_t height);
 
-    bool CanSpend(const uint256 & txId, int height) const;
+    bool CanSpend(const uint256 &txId, int height) const;
 
-    bool CalculateOwnerRewards(CScript const & owner, uint32_t height);
+    bool CalculateOwnerRewards(CScript const &owner, uint32_t height);
 
-    ResVal<CAmount> GetAmountInCurrency(CAmount amount, CTokenCurrencyPair priceFeedId, bool useNextPrice = false, bool requireLivePrice = true);
+    ResVal<CAmount> GetAmountInCurrency(CAmount amount,
+                                        CTokenCurrencyPair priceFeedId,
+                                        bool useNextPrice = false,
+                                        bool requireLivePrice = true);
 
-    ResVal<CCollateralLoans> GetLoanCollaterals(CVaultId const & vaultId, CBalances const & collaterals, uint32_t height, int64_t blockTime, bool useNextPrice = false, bool requireLivePrice = true);
+    ResVal<CCollateralLoans> GetLoanCollaterals(CVaultId const &vaultId,
+                                                CBalances const &collaterals,
+                                                uint32_t height,
+                                                int64_t blockTime,
+                                                bool useNextPrice = false,
+                                                bool requireLivePrice = true);
 
-    ResVal<CAmount> GetValidatedIntervalPrice(const CTokenCurrencyPair& priceFeedId, bool useNextPrice, bool requireLivePrice);
+    ResVal<CAmount> GetValidatedIntervalPrice(const CTokenCurrencyPair &priceFeedId,
+                                              bool useNextPrice,
+                                              bool requireLivePrice);
 
-    [[nodiscard]] bool AreTokensLocked(const std::set<uint32_t>& tokenIds) const override;
-    [[nodiscard]] std::optional<CTokenImpl> GetTokenGuessId(const std::string & str, DCT_ID & id) const override;
-    [[nodiscard]] std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(DCT_ID const & id) const override;
-    [[nodiscard]] std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(const DCT_ID& id) const override;
-    [[nodiscard]] std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(const DCT_ID& id) const override;
+    [[nodiscard]] bool AreTokensLocked(const std::set<uint32_t> &tokenIds) const override;
+    [[nodiscard]] std::optional<CTokenImpl> GetTokenGuessId(const std::string &str, DCT_ID &id) const override;
+    [[nodiscard]] std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(DCT_ID const &id) const override;
+    [[nodiscard]] std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(
+        const DCT_ID &id) const override;
+    [[nodiscard]] std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(
+        const DCT_ID &id) const override;
 
     void SetDbVersion(int version);
 
@@ -452,22 +549,22 @@ public:
     uint256 MerkleRoot();
 
     // we construct it as it
-    CFlushableStorageKV& GetStorage() {
-        return static_cast<CFlushableStorageKV&>(DB());
-    }
+    CFlushableStorageKV &GetStorage() { return static_cast<CFlushableStorageKV &>(DB()); }
 
-    virtual CAccountHistoryStorage* GetAccountHistoryStore();
-    CVaultHistoryStorage* GetVaultHistoryStore();
+    virtual CAccountHistoryStorage *GetAccountHistoryStore();
+    CVaultHistoryStorage *GetVaultHistoryStore();
     void SetAccountHistoryStore();
     void SetVaultHistoryStore();
 
-    struct DbVersion { static constexpr uint8_t prefix() { return 'D'; } };
+    struct DbVersion {
+        static constexpr uint8_t prefix() { return 'D'; }
+    };
 };
 
-std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const & team);
+std::map<CKeyID, CKey> AmISignerNow(int height, CAnchorData::CTeam const &team);
 
 /** Global DB and view that holds enhanced chainstate data (should be protected by cs_main) */
 extern std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 extern std::unique_ptr<CCustomCSView> pcustomcsview;
 
-#endif // DEFI_MASTERNODES_MASTERNODES_H
+#endif  // DEFI_MASTERNODES_MASTERNODES_H

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -20,90 +20,144 @@
 #include <masternodes/govvariables/oracle_block_interval.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <txmempool.h>
 #include <streams.h>
+#include <txmempool.h>
 #include <validation.h>
 
 #include <algorithm>
 
 std::string ToString(CustomTxType type) {
-    switch (type)
-    {
-        case CustomTxType::CreateMasternode:    return "CreateMasternode";
-        case CustomTxType::ResignMasternode:    return "ResignMasternode";
-        case CustomTxType::SetForcedRewardAddress: return "SetForcedRewardAddress";
-        case CustomTxType::RemForcedRewardAddress: return "RemForcedRewardAddress";
-        case CustomTxType::UpdateMasternode:    return "UpdateMasternode";
-        case CustomTxType::CreateToken:         return "CreateToken";
-        case CustomTxType::UpdateToken:         return "UpdateToken";
-        case CustomTxType::UpdateTokenAny:      return "UpdateTokenAny";
-        case CustomTxType::MintToken:           return "MintToken";
-        case CustomTxType::CreatePoolPair:      return "CreatePoolPair";
-        case CustomTxType::UpdatePoolPair:      return "UpdatePoolPair";
-        case CustomTxType::PoolSwap:            return "PoolSwap";
-        case CustomTxType::PoolSwapV2:          return "PoolSwap";
-        case CustomTxType::AddPoolLiquidity:    return "AddPoolLiquidity";
-        case CustomTxType::RemovePoolLiquidity: return "RemovePoolLiquidity";
-        case CustomTxType::UtxosToAccount:      return "UtxosToAccount";
-        case CustomTxType::AccountToUtxos:      return "AccountToUtxos";
-        case CustomTxType::AccountToAccount:    return "AccountToAccount";
-        case CustomTxType::AnyAccountsToAccounts:   return "AnyAccountsToAccounts";
-        case CustomTxType::SmartContract:       return "SmartContract";
-        case CustomTxType::FutureSwap:          return "DFIP2203";
-        case CustomTxType::SetGovVariable:      return "SetGovVariable";
-        case CustomTxType::SetGovVariableHeight:return "SetGovVariableHeight";
-        case CustomTxType::AppointOracle:       return "AppointOracle";
-        case CustomTxType::RemoveOracleAppoint: return "RemoveOracleAppoint";
-        case CustomTxType::UpdateOracleAppoint: return "UpdateOracleAppoint";
-        case CustomTxType::SetOracleData:       return "SetOracleData";
-        case CustomTxType::AutoAuthPrep:        return "AutoAuth";
-        case CustomTxType::ICXCreateOrder:      return "ICXCreateOrder";
-        case CustomTxType::ICXMakeOffer:        return "ICXMakeOffer";
-        case CustomTxType::ICXSubmitDFCHTLC:    return "ICXSubmitDFCHTLC";
-        case CustomTxType::ICXSubmitEXTHTLC:    return "ICXSubmitEXTHTLC";
-        case CustomTxType::ICXClaimDFCHTLC:     return "ICXClaimDFCHTLC";
-        case CustomTxType::ICXCloseOrder:       return "ICXCloseOrder";
-        case CustomTxType::ICXCloseOffer:       return "ICXCloseOffer";
-        case CustomTxType::SetLoanCollateralToken: return "SetLoanCollateralToken";
-        case CustomTxType::SetLoanToken:        return "SetLoanToken";
-        case CustomTxType::UpdateLoanToken:     return "UpdateLoanToken";
-        case CustomTxType::LoanScheme:          return "LoanScheme";
-        case CustomTxType::DefaultLoanScheme:   return "DefaultLoanScheme";
-        case CustomTxType::DestroyLoanScheme:   return "DestroyLoanScheme";
-        case CustomTxType::Vault:               return "Vault";
-        case CustomTxType::CloseVault:          return "CloseVault";
-        case CustomTxType::UpdateVault:         return "UpdateVault";
-        case CustomTxType::DepositToVault:      return "DepositToVault";
-        case CustomTxType::WithdrawFromVault:   return "WithdrawFromVault";
-        case CustomTxType::TakeLoan:            return "TakeLoan";
-        case CustomTxType::PaybackLoan:         return "PaybackLoan";
-        case CustomTxType::PaybackLoanV2:       return "PaybackLoan";
-        case CustomTxType::AuctionBid:          return "AuctionBid";
-        case CustomTxType::FutureSwapExecution: return "FutureSwapExecution";
-        case CustomTxType::FutureSwapRefund:    return "FutureSwapRefund";
-        case CustomTxType::TokenSplit:          return "TokenSplit";
-        case CustomTxType::Reject:              return "Reject";
-        case CustomTxType::None:                return "None";
+    switch (type) {
+        case CustomTxType::CreateMasternode:
+            return "CreateMasternode";
+        case CustomTxType::ResignMasternode:
+            return "ResignMasternode";
+        case CustomTxType::SetForcedRewardAddress:
+            return "SetForcedRewardAddress";
+        case CustomTxType::RemForcedRewardAddress:
+            return "RemForcedRewardAddress";
+        case CustomTxType::UpdateMasternode:
+            return "UpdateMasternode";
+        case CustomTxType::CreateToken:
+            return "CreateToken";
+        case CustomTxType::UpdateToken:
+            return "UpdateToken";
+        case CustomTxType::UpdateTokenAny:
+            return "UpdateTokenAny";
+        case CustomTxType::MintToken:
+            return "MintToken";
+        case CustomTxType::CreatePoolPair:
+            return "CreatePoolPair";
+        case CustomTxType::UpdatePoolPair:
+            return "UpdatePoolPair";
+        case CustomTxType::PoolSwap:
+            return "PoolSwap";
+        case CustomTxType::PoolSwapV2:
+            return "PoolSwap";
+        case CustomTxType::AddPoolLiquidity:
+            return "AddPoolLiquidity";
+        case CustomTxType::RemovePoolLiquidity:
+            return "RemovePoolLiquidity";
+        case CustomTxType::UtxosToAccount:
+            return "UtxosToAccount";
+        case CustomTxType::AccountToUtxos:
+            return "AccountToUtxos";
+        case CustomTxType::AccountToAccount:
+            return "AccountToAccount";
+        case CustomTxType::AnyAccountsToAccounts:
+            return "AnyAccountsToAccounts";
+        case CustomTxType::SmartContract:
+            return "SmartContract";
+        case CustomTxType::FutureSwap:
+            return "DFIP2203";
+        case CustomTxType::SetGovVariable:
+            return "SetGovVariable";
+        case CustomTxType::SetGovVariableHeight:
+            return "SetGovVariableHeight";
+        case CustomTxType::AppointOracle:
+            return "AppointOracle";
+        case CustomTxType::RemoveOracleAppoint:
+            return "RemoveOracleAppoint";
+        case CustomTxType::UpdateOracleAppoint:
+            return "UpdateOracleAppoint";
+        case CustomTxType::SetOracleData:
+            return "SetOracleData";
+        case CustomTxType::AutoAuthPrep:
+            return "AutoAuth";
+        case CustomTxType::ICXCreateOrder:
+            return "ICXCreateOrder";
+        case CustomTxType::ICXMakeOffer:
+            return "ICXMakeOffer";
+        case CustomTxType::ICXSubmitDFCHTLC:
+            return "ICXSubmitDFCHTLC";
+        case CustomTxType::ICXSubmitEXTHTLC:
+            return "ICXSubmitEXTHTLC";
+        case CustomTxType::ICXClaimDFCHTLC:
+            return "ICXClaimDFCHTLC";
+        case CustomTxType::ICXCloseOrder:
+            return "ICXCloseOrder";
+        case CustomTxType::ICXCloseOffer:
+            return "ICXCloseOffer";
+        case CustomTxType::SetLoanCollateralToken:
+            return "SetLoanCollateralToken";
+        case CustomTxType::SetLoanToken:
+            return "SetLoanToken";
+        case CustomTxType::UpdateLoanToken:
+            return "UpdateLoanToken";
+        case CustomTxType::LoanScheme:
+            return "LoanScheme";
+        case CustomTxType::DefaultLoanScheme:
+            return "DefaultLoanScheme";
+        case CustomTxType::DestroyLoanScheme:
+            return "DestroyLoanScheme";
+        case CustomTxType::Vault:
+            return "Vault";
+        case CustomTxType::CloseVault:
+            return "CloseVault";
+        case CustomTxType::UpdateVault:
+            return "UpdateVault";
+        case CustomTxType::DepositToVault:
+            return "DepositToVault";
+        case CustomTxType::WithdrawFromVault:
+            return "WithdrawFromVault";
+        case CustomTxType::TakeLoan:
+            return "TakeLoan";
+        case CustomTxType::PaybackLoan:
+            return "PaybackLoan";
+        case CustomTxType::PaybackLoanV2:
+            return "PaybackLoan";
+        case CustomTxType::AuctionBid:
+            return "AuctionBid";
+        case CustomTxType::FutureSwapExecution:
+            return "FutureSwapExecution";
+        case CustomTxType::FutureSwapRefund:
+            return "FutureSwapRefund";
+        case CustomTxType::TokenSplit:
+            return "TokenSplit";
+        case CustomTxType::Reject:
+            return "Reject";
+        case CustomTxType::None:
+            return "None";
     }
     return "None";
 }
 
-CustomTxType FromString(const std::string& str) {
+CustomTxType FromString(const std::string &str) {
     static const auto customTxTypeMap = []() {
-     std::map<std::string, CustomTxType> generatedMap;
-     for (auto i = 0u; i < 256; i++) {
-          auto txType = static_cast<CustomTxType>(i);
-          generatedMap.emplace(ToString(txType), txType);
-     }
-     return generatedMap;
+        std::map<std::string, CustomTxType> generatedMap;
+        for (auto i = 0u; i < 256; i++) {
+            auto txType = static_cast<CustomTxType>(i);
+            generatedMap.emplace(ToString(txType), txType);
+        }
+        return generatedMap;
     }();
     auto type = customTxTypeMap.find(str);
     return type == customTxTypeMap.end() ? CustomTxType::None : type->second;
 }
 
-static ResVal<CBalances> BurntTokens(CTransaction const & tx) {
+static ResVal<CBalances> BurntTokens(CTransaction const &tx) {
     CBalances balances;
-    for (const auto& out : tx.vout) {
+    for (const auto &out : tx.vout) {
         if (out.scriptPubKey.size() > 0 && out.scriptPubKey[0] == OP_RETURN) {
             auto res = balances.Add(out.TokenAmount());
             if (!res.ok) {
@@ -114,9 +168,9 @@ static ResVal<CBalances> BurntTokens(CTransaction const & tx) {
     return {balances, Res::Ok()};
 }
 
-static ResVal<CBalances> MintedTokens(CTransaction const & tx, uint32_t mintingOutputsStart) {
+static ResVal<CBalances> MintedTokens(CTransaction const &tx, uint32_t mintingOutputsStart) {
     CBalances balances;
-    for (uint32_t i = mintingOutputsStart; i < (uint32_t) tx.vout.size(); i++) {
+    for (uint32_t i = mintingOutputsStart; i < (uint32_t)tx.vout.size(); i++) {
         auto res = balances.Add(tx.vout[i].TokenAmount());
         if (!res.ok) {
             return res;
@@ -126,140 +180,193 @@ static ResVal<CBalances> MintedTokens(CTransaction const & tx, uint32_t mintingO
 }
 
 CCustomTxMessage customTypeToMessage(CustomTxType txType) {
-    switch (txType)
-    {
-        case CustomTxType::CreateMasternode:        return CCreateMasterNodeMessage{};
-        case CustomTxType::ResignMasternode:        return CResignMasterNodeMessage{};
-        case CustomTxType::SetForcedRewardAddress:  return CSetForcedRewardAddressMessage{};
-        case CustomTxType::RemForcedRewardAddress:  return CRemForcedRewardAddressMessage{};
-        case CustomTxType::UpdateMasternode:        return CUpdateMasterNodeMessage{};
-        case CustomTxType::CreateToken:             return CCreateTokenMessage{};
-        case CustomTxType::UpdateToken:             return CUpdateTokenPreAMKMessage{};
-        case CustomTxType::UpdateTokenAny:          return CUpdateTokenMessage{};
-        case CustomTxType::MintToken:               return CMintTokensMessage{};
-        case CustomTxType::CreatePoolPair:          return CCreatePoolPairMessage{};
-        case CustomTxType::UpdatePoolPair:          return CUpdatePoolPairMessage{};
-        case CustomTxType::PoolSwap:                return CPoolSwapMessage{};
-        case CustomTxType::PoolSwapV2:              return CPoolSwapMessageV2{};
-        case CustomTxType::AddPoolLiquidity:        return CLiquidityMessage{};
-        case CustomTxType::RemovePoolLiquidity:     return CRemoveLiquidityMessage{};
-        case CustomTxType::UtxosToAccount:          return CUtxosToAccountMessage{};
-        case CustomTxType::AccountToUtxos:          return CAccountToUtxosMessage{};
-        case CustomTxType::AccountToAccount:        return CAccountToAccountMessage{};
-        case CustomTxType::AnyAccountsToAccounts:   return CAnyAccountsToAccountsMessage{};
-        case CustomTxType::SmartContract:           return CSmartContractMessage{};
-        case CustomTxType::FutureSwap:                return CFutureSwapMessage{};
-        case CustomTxType::SetGovVariable:          return CGovernanceMessage{};
-        case CustomTxType::SetGovVariableHeight:    return CGovernanceHeightMessage{};
-        case CustomTxType::AppointOracle:           return CAppointOracleMessage{};
-        case CustomTxType::RemoveOracleAppoint:     return CRemoveOracleAppointMessage{};
-        case CustomTxType::UpdateOracleAppoint:     return CUpdateOracleAppointMessage{};
-        case CustomTxType::SetOracleData:           return CSetOracleDataMessage{};
-        case CustomTxType::AutoAuthPrep:            return CCustomTxMessageNone{};
-        case CustomTxType::ICXCreateOrder:          return CICXCreateOrderMessage{};
-        case CustomTxType::ICXMakeOffer:            return CICXMakeOfferMessage{};
-        case CustomTxType::ICXSubmitDFCHTLC:        return CICXSubmitDFCHTLCMessage{};
-        case CustomTxType::ICXSubmitEXTHTLC:        return CICXSubmitEXTHTLCMessage{};
-        case CustomTxType::ICXClaimDFCHTLC:         return CICXClaimDFCHTLCMessage{};
-        case CustomTxType::ICXCloseOrder:           return CICXCloseOrderMessage{};
-        case CustomTxType::ICXCloseOffer:           return CICXCloseOfferMessage{};
-        case CustomTxType::SetLoanCollateralToken:  return CLoanSetCollateralTokenMessage{};
-        case CustomTxType::SetLoanToken:            return CLoanSetLoanTokenMessage{};
-        case CustomTxType::UpdateLoanToken:         return CLoanUpdateLoanTokenMessage{};
-        case CustomTxType::LoanScheme:              return CLoanSchemeMessage{};
-        case CustomTxType::DefaultLoanScheme:       return CDefaultLoanSchemeMessage{};
-        case CustomTxType::DestroyLoanScheme:       return CDestroyLoanSchemeMessage{};
-        case CustomTxType::Vault:                   return CVaultMessage{};
-        case CustomTxType::CloseVault:              return CCloseVaultMessage{};
-        case CustomTxType::UpdateVault:             return CUpdateVaultMessage{};
-        case CustomTxType::DepositToVault:          return CDepositToVaultMessage{};
-        case CustomTxType::WithdrawFromVault:       return CWithdrawFromVaultMessage{};
-        case CustomTxType::TakeLoan:                return CLoanTakeLoanMessage{};
-        case CustomTxType::PaybackLoan:             return CLoanPaybackLoanMessage{};
-        case CustomTxType::PaybackLoanV2:           return CLoanPaybackLoanV2Message{};
-        case CustomTxType::AuctionBid:              return CAuctionBidMessage{};
-        case CustomTxType::FutureSwapExecution:     return CCustomTxMessageNone{};
-        case CustomTxType::FutureSwapRefund:        return CCustomTxMessageNone{};
-        case CustomTxType::TokenSplit:              return CCustomTxMessageNone{};
-        case CustomTxType::Reject:                  return CCustomTxMessageNone{};
-        case CustomTxType::None:                    return CCustomTxMessageNone{};
+    switch (txType) {
+        case CustomTxType::CreateMasternode:
+            return CCreateMasterNodeMessage{};
+        case CustomTxType::ResignMasternode:
+            return CResignMasterNodeMessage{};
+        case CustomTxType::SetForcedRewardAddress:
+            return CSetForcedRewardAddressMessage{};
+        case CustomTxType::RemForcedRewardAddress:
+            return CRemForcedRewardAddressMessage{};
+        case CustomTxType::UpdateMasternode:
+            return CUpdateMasterNodeMessage{};
+        case CustomTxType::CreateToken:
+            return CCreateTokenMessage{};
+        case CustomTxType::UpdateToken:
+            return CUpdateTokenPreAMKMessage{};
+        case CustomTxType::UpdateTokenAny:
+            return CUpdateTokenMessage{};
+        case CustomTxType::MintToken:
+            return CMintTokensMessage{};
+        case CustomTxType::CreatePoolPair:
+            return CCreatePoolPairMessage{};
+        case CustomTxType::UpdatePoolPair:
+            return CUpdatePoolPairMessage{};
+        case CustomTxType::PoolSwap:
+            return CPoolSwapMessage{};
+        case CustomTxType::PoolSwapV2:
+            return CPoolSwapMessageV2{};
+        case CustomTxType::AddPoolLiquidity:
+            return CLiquidityMessage{};
+        case CustomTxType::RemovePoolLiquidity:
+            return CRemoveLiquidityMessage{};
+        case CustomTxType::UtxosToAccount:
+            return CUtxosToAccountMessage{};
+        case CustomTxType::AccountToUtxos:
+            return CAccountToUtxosMessage{};
+        case CustomTxType::AccountToAccount:
+            return CAccountToAccountMessage{};
+        case CustomTxType::AnyAccountsToAccounts:
+            return CAnyAccountsToAccountsMessage{};
+        case CustomTxType::SmartContract:
+            return CSmartContractMessage{};
+        case CustomTxType::FutureSwap:
+            return CFutureSwapMessage{};
+        case CustomTxType::SetGovVariable:
+            return CGovernanceMessage{};
+        case CustomTxType::SetGovVariableHeight:
+            return CGovernanceHeightMessage{};
+        case CustomTxType::AppointOracle:
+            return CAppointOracleMessage{};
+        case CustomTxType::RemoveOracleAppoint:
+            return CRemoveOracleAppointMessage{};
+        case CustomTxType::UpdateOracleAppoint:
+            return CUpdateOracleAppointMessage{};
+        case CustomTxType::SetOracleData:
+            return CSetOracleDataMessage{};
+        case CustomTxType::AutoAuthPrep:
+            return CCustomTxMessageNone{};
+        case CustomTxType::ICXCreateOrder:
+            return CICXCreateOrderMessage{};
+        case CustomTxType::ICXMakeOffer:
+            return CICXMakeOfferMessage{};
+        case CustomTxType::ICXSubmitDFCHTLC:
+            return CICXSubmitDFCHTLCMessage{};
+        case CustomTxType::ICXSubmitEXTHTLC:
+            return CICXSubmitEXTHTLCMessage{};
+        case CustomTxType::ICXClaimDFCHTLC:
+            return CICXClaimDFCHTLCMessage{};
+        case CustomTxType::ICXCloseOrder:
+            return CICXCloseOrderMessage{};
+        case CustomTxType::ICXCloseOffer:
+            return CICXCloseOfferMessage{};
+        case CustomTxType::SetLoanCollateralToken:
+            return CLoanSetCollateralTokenMessage{};
+        case CustomTxType::SetLoanToken:
+            return CLoanSetLoanTokenMessage{};
+        case CustomTxType::UpdateLoanToken:
+            return CLoanUpdateLoanTokenMessage{};
+        case CustomTxType::LoanScheme:
+            return CLoanSchemeMessage{};
+        case CustomTxType::DefaultLoanScheme:
+            return CDefaultLoanSchemeMessage{};
+        case CustomTxType::DestroyLoanScheme:
+            return CDestroyLoanSchemeMessage{};
+        case CustomTxType::Vault:
+            return CVaultMessage{};
+        case CustomTxType::CloseVault:
+            return CCloseVaultMessage{};
+        case CustomTxType::UpdateVault:
+            return CUpdateVaultMessage{};
+        case CustomTxType::DepositToVault:
+            return CDepositToVaultMessage{};
+        case CustomTxType::WithdrawFromVault:
+            return CWithdrawFromVaultMessage{};
+        case CustomTxType::TakeLoan:
+            return CLoanTakeLoanMessage{};
+        case CustomTxType::PaybackLoan:
+            return CLoanPaybackLoanMessage{};
+        case CustomTxType::PaybackLoanV2:
+            return CLoanPaybackLoanV2Message{};
+        case CustomTxType::AuctionBid:
+            return CAuctionBidMessage{};
+        case CustomTxType::FutureSwapExecution:
+            return CCustomTxMessageNone{};
+        case CustomTxType::FutureSwapRefund:
+            return CCustomTxMessageNone{};
+        case CustomTxType::TokenSplit:
+            return CCustomTxMessageNone{};
+        case CustomTxType::Reject:
+            return CCustomTxMessageNone{};
+        case CustomTxType::None:
+            return CCustomTxMessageNone{};
     }
     return CCustomTxMessageNone{};
 }
 
-extern std::string ScriptToString(CScript const& script);
+extern std::string ScriptToString(CScript const &script);
 
-class CCustomMetadataParseVisitor
-{
+class CCustomMetadataParseVisitor {
     uint32_t height;
-    const Consensus::Params& consensus;
-    const std::vector<unsigned char>& metadata;
+    const Consensus::Params &consensus;
+    const std::vector<unsigned char> &metadata;
 
     Res isPostAMKFork() const {
-        if(static_cast<int>(height) < consensus.AMKHeight) {
+        if (static_cast<int>(height) < consensus.AMKHeight) {
             return Res::Err("called before AMK height");
         }
         return Res::Ok();
     }
 
     Res isPostBayfrontFork() const {
-        if(static_cast<int>(height) < consensus.BayfrontHeight) {
+        if (static_cast<int>(height) < consensus.BayfrontHeight) {
             return Res::Err("called before Bayfront height");
         }
         return Res::Ok();
     }
 
     Res isPostBayfrontGardensFork() const {
-        if(static_cast<int>(height) < consensus.BayfrontGardensHeight) {
+        if (static_cast<int>(height) < consensus.BayfrontGardensHeight) {
             return Res::Err("called before Bayfront Gardens height");
         }
         return Res::Ok();
     }
 
     Res isPostEunosFork() const {
-        if(static_cast<int>(height) < consensus.EunosHeight) {
+        if (static_cast<int>(height) < consensus.EunosHeight) {
             return Res::Err("called before Eunos height");
         }
         return Res::Ok();
     }
 
     Res isPostEunosPayaFork() const {
-        if(static_cast<int>(height) < consensus.EunosPayaHeight) {
+        if (static_cast<int>(height) < consensus.EunosPayaHeight) {
             return Res::Err("called before EunosPaya height");
         }
         return Res::Ok();
     }
 
     Res isPostFortCanningFork() const {
-        if(static_cast<int>(height) < consensus.FortCanningHeight) {
+        if (static_cast<int>(height) < consensus.FortCanningHeight) {
             return Res::Err("called before FortCanning height");
         }
         return Res::Ok();
     }
 
     Res isPostFortCanningHillFork() const {
-        if(static_cast<int>(height) < consensus.FortCanningHillHeight) {
+        if (static_cast<int>(height) < consensus.FortCanningHillHeight) {
             return Res::Err("called before FortCanningHill height");
         }
         return Res::Ok();
     }
 
     Res isPostFortCanningRoadFork() const {
-        if(static_cast<int>(height) < consensus.FortCanningRoadHeight) {
+        if (static_cast<int>(height) < consensus.FortCanningRoadHeight) {
             return Res::Err("called before FortCanningRoad height");
         }
         return Res::Ok();
     }
 
     Res isPostGreatWorldFork() const {
-        if(static_cast<int>(height) < consensus.GreatWorldHeight) {
+        if (static_cast<int>(height) < consensus.GreatWorldHeight) {
             return Res::Err("called before GreatWorldHeight height");
         }
         return Res::Ok();
     }
 
-    template<typename T>
-    Res serialize(T& obj) const {
+    template <typename T>
+    Res serialize(T &obj) const {
         CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
         ss >> obj;
         if (!ss.empty()) {
@@ -268,24 +375,22 @@ class CCustomMetadataParseVisitor
         return Res::Ok();
     }
 
-public:
+   public:
     CCustomMetadataParseVisitor(uint32_t height,
-                                const Consensus::Params& consensus,
-                                const std::vector<unsigned char>& metadata)
+                                const Consensus::Params &consensus,
+                                const std::vector<unsigned char> &metadata)
         : height(height), consensus(consensus), metadata(metadata) {}
 
-    Res operator()(CCreateMasterNodeMessage& obj) const {
-        return serialize(obj);
-    }
+    Res operator()(CCreateMasterNodeMessage &obj) const { return serialize(obj); }
 
-    Res operator()(CResignMasterNodeMessage& obj) const {
+    Res operator()(CResignMasterNodeMessage &obj) const {
         if (metadata.size() != sizeof(obj)) {
             return Res::Err("metadata must contain 32 bytes");
         }
         return serialize(obj);
     }
 
-    Res operator()(CSetForcedRewardAddressMessage& obj) const {
+    Res operator()(CSetForcedRewardAddressMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -293,7 +398,7 @@ public:
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CRemForcedRewardAddressMessage& obj) const {
+    Res operator()(CRemForcedRewardAddressMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -301,7 +406,7 @@ public:
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CUpdateMasterNodeMessage& obj) const {
+    Res operator()(CUpdateMasterNodeMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("updatemasternode is disabled for Fort Canning");
 
@@ -309,78 +414,78 @@ public:
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CCreateTokenMessage& obj) const {
+    Res operator()(CCreateTokenMessage &obj) const {
         auto res = isPostAMKFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CUpdateTokenPreAMKMessage& obj) const {
+    Res operator()(CUpdateTokenPreAMKMessage &obj) const {
         auto res = isPostAMKFork();
         if (!res) {
             return res;
         }
-        if(isPostBayfrontFork()) {
+        if (isPostBayfrontFork()) {
             return Res::Err("called post Bayfront height");
         }
         return serialize(obj);
     }
 
-    Res operator()(CUpdateTokenMessage& obj) const {
+    Res operator()(CUpdateTokenMessage &obj) const {
         auto res = isPostBayfrontFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CMintTokensMessage& obj) const {
+    Res operator()(CMintTokensMessage &obj) const {
         auto res = isPostAMKFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CPoolSwapMessage& obj) const {
+    Res operator()(CPoolSwapMessage &obj) const {
         auto res = isPostBayfrontFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLiquidityMessage& obj) const {
+    Res operator()(CLiquidityMessage &obj) const {
         auto res = isPostBayfrontFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CRemoveLiquidityMessage& obj) const {
+    Res operator()(CRemoveLiquidityMessage &obj) const {
         auto res = isPostBayfrontFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CUtxosToAccountMessage& obj) const {
+    Res operator()(CUtxosToAccountMessage &obj) const {
         auto res = isPostAMKFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CAccountToUtxosMessage& obj) const {
+    Res operator()(CAccountToUtxosMessage &obj) const {
         auto res = isPostAMKFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CAccountToAccountMessage& obj) const {
+    Res operator()(CAccountToAccountMessage &obj) const {
         auto res = isPostAMKFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CAnyAccountsToAccountsMessage& obj) const {
+    Res operator()(CAnyAccountsToAccountsMessage &obj) const {
         auto res = isPostBayfrontGardensFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CSmartContractMessage& obj) const {
+    Res operator()(CSmartContractMessage &obj) const {
         auto res = isPostFortCanningHillFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CFutureSwapMessage& obj) const {
+    Res operator()(CFutureSwapMessage &obj) const {
         auto res = isPostFortCanningRoadFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CCreatePoolPairMessage& obj) const {
+    Res operator()(CCreatePoolPairMessage &obj) const {
         auto res = isPostBayfrontFork();
         if (!res) {
             return res;
@@ -400,7 +505,7 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(CUpdatePoolPairMessage& obj) const {
+    Res operator()(CUpdatePoolPairMessage &obj) const {
         auto res = isPostBayfrontFork();
         if (!res) {
             return res;
@@ -424,14 +529,14 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(CGovernanceMessage& obj) const {
+    Res operator()(CGovernanceMessage &obj) const {
         auto res = isPostBayfrontFork();
         if (!res) {
             return res;
         }
         std::string name;
         CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
-        while(!ss.empty()) {
+        while (!ss.empty()) {
             ss >> name;
             auto var = GovVariable::Create(name);
             if (!var) {
@@ -443,7 +548,7 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(CGovernanceHeightMessage& obj) const {
+    Res operator()(CGovernanceHeightMessage &obj) const {
         auto res = isPostFortCanningFork();
         if (!res) {
             return res;
@@ -460,167 +565,164 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(CAppointOracleMessage& obj) const {
+    Res operator()(CAppointOracleMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CRemoveOracleAppointMessage& obj) const {
+    Res operator()(CRemoveOracleAppointMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CUpdateOracleAppointMessage& obj) const {
+    Res operator()(CUpdateOracleAppointMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CSetOracleDataMessage& obj) const {
+    Res operator()(CSetOracleDataMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXCreateOrderMessage& obj) const {
+    Res operator()(CICXCreateOrderMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXMakeOfferMessage& obj) const {
+    Res operator()(CICXMakeOfferMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXSubmitDFCHTLCMessage& obj) const {
+    Res operator()(CICXSubmitDFCHTLCMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXSubmitEXTHTLCMessage& obj) const {
+    Res operator()(CICXSubmitEXTHTLCMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXClaimDFCHTLCMessage& obj) const {
+    Res operator()(CICXClaimDFCHTLCMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXCloseOrderMessage& obj) const {
+    Res operator()(CICXCloseOrderMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CICXCloseOfferMessage& obj) const {
+    Res operator()(CICXCloseOfferMessage &obj) const {
         auto res = isPostEunosFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CPoolSwapMessageV2& obj) const {
+    Res operator()(CPoolSwapMessageV2 &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanSetCollateralTokenMessage& obj) const {
+    Res operator()(CLoanSetCollateralTokenMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanSetLoanTokenMessage& obj) const {
+    Res operator()(CLoanSetLoanTokenMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanUpdateLoanTokenMessage& obj) const {
+    Res operator()(CLoanUpdateLoanTokenMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanSchemeMessage& obj) const {
+    Res operator()(CLoanSchemeMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CDefaultLoanSchemeMessage& obj) const {
+    Res operator()(CDefaultLoanSchemeMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CDestroyLoanSchemeMessage& obj) const {
+    Res operator()(CDestroyLoanSchemeMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CVaultMessage& obj) const {
+    Res operator()(CVaultMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CCloseVaultMessage& obj) const {
+    Res operator()(CCloseVaultMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CUpdateVaultMessage& obj) const {
+    Res operator()(CUpdateVaultMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CDepositToVaultMessage& obj) const {
+    Res operator()(CDepositToVaultMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CWithdrawFromVaultMessage& obj) const {
+    Res operator()(CWithdrawFromVaultMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanTakeLoanMessage& obj) const {
+    Res operator()(CLoanTakeLoanMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanPaybackLoanMessage& obj) const {
+    Res operator()(CLoanPaybackLoanMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CLoanPaybackLoanV2Message& obj) const {
+    Res operator()(CLoanPaybackLoanV2Message &obj) const {
         auto res = isPostFortCanningRoadFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CAuctionBidMessage& obj) const {
+    Res operator()(CAuctionBidMessage &obj) const {
         auto res = isPostFortCanningFork();
         return !res ? res : serialize(obj);
     }
 
-    Res operator()(CCustomTxMessageNone&) const {
-        return Res::Ok();
-    }
+    Res operator()(CCustomTxMessageNone &) const { return Res::Ok(); }
 };
 
-class CCustomTxVisitor
-{
-protected:
+class CCustomTxVisitor {
+   protected:
     uint32_t height;
-    CCustomCSView& mnview;
-    const CTransaction& tx;
-    const CCoinsViewCache& coins;
-    const Consensus::Params& consensus;
+    CCustomCSView &mnview;
+    const CTransaction &tx;
+    const CCoinsViewCache &coins;
+    const Consensus::Params &consensus;
 
-public:
-    CCustomTxVisitor(const CTransaction& tx,
+   public:
+    CCustomTxVisitor(const CTransaction &tx,
                      uint32_t height,
-                     const CCoinsViewCache& coins,
-                     CCustomCSView& mnview,
-                     const Consensus::Params& consensus)
+                     const CCoinsViewCache &coins,
+                     CCustomCSView &mnview,
+                     const Consensus::Params &consensus)
 
         : height(height), mnview(mnview), tx(tx), coins(coins), consensus(consensus) {}
 
-    bool HasAuth(const CScript& auth) const {
-        for (const auto& input : tx.vin) {
-            const Coin& coin = coins.AccessCoin(input.prevout);
+    bool HasAuth(const CScript &auth) const {
+        for (const auto &input : tx.vin) {
+            const Coin &coin = coins.AccessCoin(input.prevout);
             if (!coin.IsSpent() && coin.out.scriptPubKey == auth) {
                 return true;
             }
@@ -628,8 +730,8 @@ public:
         return false;
     }
 
-    Res HasCollateralAuth(const uint256& collateralTx) const {
-        const Coin& auth = coins.AccessCoin(COutPoint(collateralTx, 1)); // always n=1 output
+    Res HasCollateralAuth(const uint256 &collateralTx) const {
+        const Coin &auth = coins.AccessCoin(COutPoint(collateralTx, 1));  // always n=1 output
         if (!HasAuth(auth.out.scriptPubKey)) {
             return Res::Err("tx must have at least one input from the owner");
         }
@@ -637,8 +739,8 @@ public:
     }
 
     Res HasFoundationAuth() const {
-        for (const auto& input : tx.vin) {
-            const Coin& coin = coins.AccessCoin(input.prevout);
+        for (const auto &input : tx.vin) {
+            const Coin &coin = coins.AccessCoin(input.prevout);
             if (!coin.IsSpent() && consensus.foundationMembers.count(coin.out.scriptPubKey) > 0) {
                 return Res::Ok();
             }
@@ -647,18 +749,16 @@ public:
     }
 
     Res CheckMasternodeCreationTx() const {
-        if (tx.vout.size() < 2
-        || tx.vout[0].nValue < GetMnCreationFee(height) || tx.vout[0].nTokenId != DCT_ID{0}
-        || tx.vout[1].nValue != GetMnCollateralAmount(height) || tx.vout[1].nTokenId != DCT_ID{0}) {
+        if (tx.vout.size() < 2 || tx.vout[0].nValue < GetMnCreationFee(height) || tx.vout[0].nTokenId != DCT_ID{0} ||
+            tx.vout[1].nValue != GetMnCollateralAmount(height) || tx.vout[1].nTokenId != DCT_ID{0}) {
             return Res::Err("malformed tx vouts (wrong creation fee or collateral amount)");
         }
         return Res::Ok();
     }
 
     Res CheckTokenCreationTx() const {
-        if (tx.vout.size() < 2
-        || tx.vout[0].nValue < GetTokenCreationFee(height) || tx.vout[0].nTokenId != DCT_ID{0}
-        || tx.vout[1].nValue != GetTokenCollateralAmount() || tx.vout[1].nTokenId != DCT_ID{0}) {
+        if (tx.vout.size() < 2 || tx.vout[0].nValue < GetTokenCreationFee(height) || tx.vout[0].nTokenId != DCT_ID{0} ||
+            tx.vout[1].nValue != GetTokenCollateralAmount() || tx.vout[1].nTokenId != DCT_ID{0}) {
             return Res::Err("malformed tx vouts (wrong creation fee or collateral amount)");
         }
         return Res::Ok();
@@ -674,7 +774,7 @@ public:
         return Res::Ok();
     }
 
-    Res TransferTokenBalance(DCT_ID id, CAmount amount, CScript const & from, CScript const & to) const {
+    Res TransferTokenBalance(DCT_ID id, CAmount amount, CScript const &from, CScript const &to) const {
         assert(!from.empty() || !to.empty());
 
         CTokenAmount tokenAmount{id, amount};
@@ -687,7 +787,7 @@ public:
 
         // if "to" not supplied it will only sub balance from "form" address
         if (!to.empty()) {
-            auto res = mnview.AddBalance(to,tokenAmount);
+            auto res = mnview.AddBalance(to, tokenAmount);
             if (!res)
                 return res;
         }
@@ -695,15 +795,17 @@ public:
         return Res::Ok();
     }
 
-    DCT_ID FindTokenByPartialSymbolName(const std::string& symbol) const {
+    DCT_ID FindTokenByPartialSymbolName(const std::string &symbol) const {
         DCT_ID res{0};
-        mnview.ForEachToken([&](DCT_ID id, CTokenImplementation token) {
-            if (token.symbol.find(symbol) == 0) {
-                res = id;
-                return false;
-            }
-            return true;
-        }, DCT_ID{1});
+        mnview.ForEachToken(
+            [&](DCT_ID id, CTokenImplementation token) {
+                if (token.symbol.find(symbol) == 0) {
+                    res = id;
+                    return false;
+                }
+                return true;
+            },
+            DCT_ID{1});
         assert(res.v != 0);
         return res;
     }
@@ -723,16 +825,19 @@ public:
     }
 
     CAmount CalculateTakerFee(CAmount amount) const {
-        return (arith_uint256(amount) * arith_uint256(mnview.ICXGetTakerFeePerBTC()) / arith_uint256(COIN)
-              * arith_uint256(GetDFIperBTC()) / arith_uint256(COIN)).GetLow64();
+        return (arith_uint256(amount) * arith_uint256(mnview.ICXGetTakerFeePerBTC()) / arith_uint256(COIN) *
+                arith_uint256(GetDFIperBTC()) / arith_uint256(COIN))
+            .GetLow64();
     }
 
-    ResVal<CScript> MintableToken(DCT_ID id, const CTokenImplementation& token) const {
+    ResVal<CScript> MintableToken(DCT_ID id, const CTokenImplementation &token) const {
         if (token.destructionTx != uint256{}) {
-            return Res::Err("token %s already destroyed at height %i by tx %s", token.symbol,
-                            token.destructionHeight, token.destructionTx.GetHex());
+            return Res::Err("token %s already destroyed at height %i by tx %s",
+                            token.symbol,
+                            token.destructionHeight,
+                            token.destructionTx.GetHex());
         }
-        const Coin& auth = coins.AccessCoin(COutPoint(token.creationTx, 1)); // always n=1 output
+        const Coin &auth = coins.AccessCoin(COutPoint(token.creationTx, 1));  // always n=1 output
 
         // pre-bayfront logic:
         if (static_cast<int>(height) < consensus.BayfrontHeight) {
@@ -760,10 +865,11 @@ public:
             return Res::Err("token %s is not mintable!", id.ToString());
         }
 
-        if (!HasAuth(auth.out.scriptPubKey)) { // in the case of DAT, it's ok to do not check foundation auth cause exact DAT owner is foundation member himself
+        if (!HasAuth(auth.out.scriptPubKey)) {  // in the case of DAT, it's ok to do not check foundation auth cause
+                                                // exact DAT owner is foundation member himself
             if (!token.IsDAT()) {
                 return Res::Err("tx must have at least one input from token owner");
-            } else if (!HasFoundationAuth()) { // Is a DAT, check founders auth
+            } else if (!HasFoundationAuth()) {  // Is a DAT, check founders auth
                 return Res::Err("token is DAT and tx not from foundation member");
             }
         }
@@ -771,7 +877,7 @@ public:
         return {auth.out.scriptPubKey, Res::Ok()};
     }
 
-    Res eraseEmptyBalances(TAmounts& balances) const {
+    Res eraseEmptyBalances(TAmounts &balances) const {
         for (auto it = balances.begin(), next_it = it; it != balances.end(); it = next_it) {
             ++next_it;
 
@@ -787,8 +893,8 @@ public:
         return Res::Ok();
     }
 
-    Res setShares(const CScript& owner, const TAmounts& balances) const {
-        for (const auto& balance : balances) {
+    Res setShares(const CScript &owner, const TAmounts &balances) const {
+        for (const auto &balance : balances) {
             auto token = mnview.GetToken(balance.first);
             if (token && token->IsPoolShare()) {
                 const auto bal = mnview.GetBalance(owner, balance.first);
@@ -803,8 +909,8 @@ public:
         return Res::Ok();
     }
 
-    Res delShares(const CScript& owner, const TAmounts& balances) const {
-        for (const auto& kv : balances) {
+    Res delShares(const CScript &owner, const TAmounts &balances) const {
+        for (const auto &kv : balances) {
             auto token = mnview.GetToken(kv.first);
             if (token && token->IsPoolShare()) {
                 const auto balance = mnview.GetBalance(owner, kv.first);
@@ -820,13 +926,13 @@ public:
     }
 
     // we need proxy view to prevent add/sub balance record
-    void CalculateOwnerRewards(const CScript& owner) const {
+    void CalculateOwnerRewards(const CScript &owner) const {
         CCustomCSView view(mnview);
         view.CalculateOwnerRewards(owner, height);
         view.Flush();
     }
 
-    Res subBalanceDelShares(const CScript& owner, const CBalances& balance) const {
+    Res subBalanceDelShares(const CScript &owner, const CBalances &balance) const {
         CalculateOwnerRewards(owner);
         auto res = mnview.SubBalances(owner, balance);
         if (!res) {
@@ -835,14 +941,14 @@ public:
         return delShares(owner, balance.balances);
     }
 
-    Res addBalanceSetShares(const CScript& owner, const CBalances& balance) const {
+    Res addBalanceSetShares(const CScript &owner, const CBalances &balance) const {
         CalculateOwnerRewards(owner);
         auto res = mnview.AddBalances(owner, balance);
         return !res ? res : setShares(owner, balance.balances);
     }
 
-    Res addBalancesSetShares(const CAccounts& accounts) const {
-        for (const auto& account : accounts) {
+    Res addBalancesSetShares(const CAccounts &accounts) const {
+        for (const auto &account : accounts) {
             auto res = addBalanceSetShares(account.first, account.second);
             if (!res) {
                 return res;
@@ -851,8 +957,8 @@ public:
         return Res::Ok();
     }
 
-    Res subBalancesDelShares(const CAccounts& accounts) const {
-        for (const auto& account : accounts) {
+    Res subBalancesDelShares(const CAccounts &accounts) const {
+        for (const auto &account : accounts) {
             auto res = subBalanceDelShares(account.first, account.second);
             if (!res) {
                 return res;
@@ -861,9 +967,9 @@ public:
         return Res::Ok();
     }
 
-    Res normalizeTokenCurrencyPair(std::set<CTokenCurrencyPair>& tokenCurrency) const {
+    Res normalizeTokenCurrencyPair(std::set<CTokenCurrencyPair> &tokenCurrency) const {
         std::set<CTokenCurrencyPair> trimmed;
-        for (const auto& pair : tokenCurrency) {
+        for (const auto &pair : tokenCurrency) {
             auto token = trim_ws(pair.first).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
             auto currency = trim_ws(pair.second).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
             if (token.empty() || currency.empty()) {
@@ -874,27 +980,25 @@ public:
         tokenCurrency = std::move(trimmed);
         return Res::Ok();
     }
-    bool IsTokensMigratedToGovVar() const {
-        return static_cast<int>(height) > consensus.FortCanningCrunchHeight + 1;
-    }
+    bool IsTokensMigratedToGovVar() const { return static_cast<int>(height) > consensus.FortCanningCrunchHeight + 1; }
 };
 
-class CCustomTxApplyVisitor : public CCustomTxVisitor
-{
+class CCustomTxApplyVisitor : public CCustomTxVisitor {
     uint64_t time;
     uint32_t txn;
-public:
-    CCustomTxApplyVisitor(const CTransaction& tx,
+
+   public:
+    CCustomTxApplyVisitor(const CTransaction &tx,
                           uint32_t height,
-                          const CCoinsViewCache& coins,
-                          CCustomCSView& mnview,
-                          const Consensus::Params& consensus,
+                          const CCoinsViewCache &coins,
+                          CCustomCSView &mnview,
+                          const Consensus::Params &consensus,
                           uint64_t time,
                           uint32_t txn)
 
         : CCustomTxVisitor(tx, height, coins, mnview, consensus), time(time), txn(txn) {}
 
-    Res operator()(const CCreateMasterNodeMessage& obj) const {
+    Res operator()(const CCreateMasterNodeMessage &obj) const {
         auto res = CheckMasternodeCreationTx();
         if (!res) {
             return res;
@@ -905,7 +1009,7 @@ public:
         }
 
         if (height >= static_cast<uint32_t>(Params().GetConsensus().EunosPayaHeight)) {
-            switch(obj.timelock) {
+            switch (obj.timelock) {
                 case CMasternode::ZEROYEAR:
                 case CMasternode::FIVEYEAR:
                 case CMasternode::TENYEAR:
@@ -951,12 +1055,12 @@ public:
         return res;
     }
 
-    Res operator()(const CResignMasterNodeMessage& obj) const {
+    Res operator()(const CResignMasterNodeMessage &obj) const {
         auto res = HasCollateralAuth(obj);
         return !res ? res : mnview.ResignMasternode(obj, tx.GetHash(), height);
     }
 
-    Res operator()(const CSetForcedRewardAddressMessage& obj) const {
+    Res operator()(const CSetForcedRewardAddressMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -971,7 +1075,7 @@ public:
         return mnview.SetForcedRewardAddress(obj.nodeId, obj.rewardAddressType, obj.rewardAddress, height);
     }
 
-    Res operator()(const CRemForcedRewardAddressMessage& obj) const {
+    Res operator()(const CRemForcedRewardAddressMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("reward address change is disabled for Fort Canning");
 
@@ -986,7 +1090,7 @@ public:
         return mnview.RemForcedRewardAddress(obj.nodeId, height);
     }
 
-    Res operator()(const CUpdateMasterNodeMessage& obj) const {
+    Res operator()(const CUpdateMasterNodeMessage &obj) const {
         // Temporarily disabled for 2.2
         return Res::Err("updatemasternode is disabled for Fort Canning");
 
@@ -994,26 +1098,27 @@ public:
         return !res ? res : mnview.UpdateMasternode(obj.mnId, obj.operatorType, obj.operatorAuthAddress, height);
     }
 
-    Res operator()(const CCreateTokenMessage& obj) const {
+    Res operator()(const CCreateTokenMessage &obj) const {
         auto res = CheckTokenCreationTx();
         if (!res) {
             return res;
         }
 
         CTokenImplementation token;
-        static_cast<CToken&>(token) = obj;
+        static_cast<CToken &>(token) = obj;
 
         token.symbol = trim_ws(token.symbol).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
         token.name = trim_ws(token.name).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
         token.creationTx = tx.GetHash();
         token.creationHeight = height;
 
-        //check foundation auth
+        // check foundation auth
         if (token.IsDAT() && !HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
 
-        if (static_cast<int>(height) >= consensus.BayfrontHeight) { // formal compatibility if someone cheat and create LPS token on the pre-bayfront node
+        if (static_cast<int>(height) >= consensus.BayfrontHeight) {  // formal compatibility if someone cheat and create
+                                                                     // LPS token on the pre-bayfront node
             if (token.IsPoolShare()) {
                 return Res::Err("Cant't manually create 'Liquidity Pool Share' token; use poolpair creation");
             }
@@ -1022,14 +1127,14 @@ public:
         return mnview.CreateToken(token, static_cast<int>(height) < consensus.BayfrontHeight);
     }
 
-    Res operator()(const CUpdateTokenPreAMKMessage& obj) const {
+    Res operator()(const CUpdateTokenPreAMKMessage &obj) const {
         auto pair = mnview.GetTokenByCreationTx(obj.tokenTx);
         if (!pair) {
             return Res::Err("token with creationTx %s does not exist", obj.tokenTx.ToString());
         }
         auto token = pair->second;
 
-        //check foundation auth
+        // check foundation auth
         auto res = HasFoundationAuth();
 
         if (token.IsDAT() != obj.isDAT && pair->first >= CTokensView::DCT_ID_START) {
@@ -1039,20 +1144,20 @@ public:
         return res;
     }
 
-    Res operator()(const CUpdateTokenMessage& obj) const {
+    Res operator()(const CUpdateTokenMessage &obj) const {
         auto pair = mnview.GetTokenByCreationTx(obj.tokenTx);
         if (!pair) {
             return Res::Err("token with creationTx %s does not exist", obj.tokenTx.ToString());
         }
         if (pair->first == DCT_ID{0}) {
-            return Res::Err("Can't alter DFI token!"); // may be redundant cause DFI is 'finalized'
+            return Res::Err("Can't alter DFI token!");  // may be redundant cause DFI is 'finalized'
         }
 
         if (mnview.AreTokensLocked({pair->first.v})) {
             return Res::Err("Cannot update token during lock");
         }
 
-        const auto& token = pair->second;
+        const auto &token = pair->second;
 
         // need to check it exectly here cause lps has no collateral auth (that checked next)
         if (token.IsPoolShare()) {
@@ -1060,7 +1165,7 @@ public:
         }
 
         // check auth, depends from token's "origins"
-        const Coin& auth = coins.AccessCoin(COutPoint(token.creationTx, 1)); // always n=1 output
+        const Coin &auth = coins.AccessCoin(COutPoint(token.creationTx, 1));  // always n=1 output
         bool isFoundersToken = consensus.foundationMembers.count(auth.out.scriptPubKey) > 0;
 
         auto res = Res::Ok();
@@ -1072,8 +1177,9 @@ public:
 
         // Check for isDAT change in non-foundation token after set height
         if (static_cast<int>(height) >= consensus.BayfrontMarinaHeight) {
-            //check foundation auth
-            if (obj.token.IsDAT() != token.IsDAT() && !HasFoundationAuth()) { //no need to check Authority if we don't create isDAT
+            // check foundation auth
+            if (obj.token.IsDAT() != token.IsDAT() &&
+                !HasFoundationAuth()) {  // no need to check Authority if we don't create isDAT
                 return Res::Err("can't set isDAT to true, tx not from foundation member");
             }
         }
@@ -1089,12 +1195,13 @@ public:
         return mnview.UpdateToken(updatedToken);
     }
 
-    Res operator()(const CMintTokensMessage& obj) const {
+    Res operator()(const CMintTokensMessage &obj) const {
         // check auth and increase balance of token's owner
-        for (const auto& kv : obj.balances) {
-            const DCT_ID& tokenId = kv.first;
+        for (const auto &kv : obj.balances) {
+            const DCT_ID &tokenId = kv.first;
 
-            if (Params().NetworkIDString() == CBaseChainParams::MAIN && height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) &&
+            if (Params().NetworkIDString() == CBaseChainParams::MAIN &&
+                height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) &&
                 mnview.GetLoanTokenByID(tokenId)) {
                 return Res::Err("Loan tokens cannot be minted");
             }
@@ -1123,8 +1230,8 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(const CCreatePoolPairMessage& obj) const {
-        //check foundation auth
+    Res operator()(const CCreatePoolPairMessage &obj) const {
+        // check foundation auth
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
@@ -1132,7 +1239,8 @@ public:
             return Res::Err("wrong commission");
         }
 
-        if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningCrunchHeight) && obj.pairSymbol.find('/') != std::string::npos) {
+        if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningCrunchHeight) &&
+            obj.pairSymbol.find('/') != std::string::npos) {
             return Res::Err("token symbol should not contain '/'");
         }
 
@@ -1141,7 +1249,7 @@ public:
         auto pairSymbol = obj.pairSymbol;
         poolPair.creationTx = tx.GetHash();
         poolPair.creationHeight = height;
-        auto& rewards = poolPair.rewards;
+        auto &rewards = poolPair.rewards;
 
         auto tokenA = mnview.GetToken(poolPair.idTokenA);
         if (!tokenA) {
@@ -1153,7 +1261,9 @@ public:
             return Res::Err("token %s does not exist!", poolPair.idTokenB.ToString());
         }
 
-        const auto symbolLength = height >= static_cast<uint32_t>(consensus.FortCanningHeight) ? CToken::MAX_TOKEN_POOLPAIR_LENGTH : CToken::MAX_TOKEN_SYMBOL_LENGTH;
+        const auto symbolLength = height >= static_cast<uint32_t>(consensus.FortCanningHeight)
+                                      ? CToken::MAX_TOKEN_POOLPAIR_LENGTH
+                                      : CToken::MAX_TOKEN_SYMBOL_LENGTH;
         if (pairSymbol.empty()) {
             pairSymbol = trim_ws(tokenA->symbol + "-" + tokenB->symbol).substr(0, symbolLength);
         } else {
@@ -1161,10 +1271,8 @@ public:
         }
 
         CTokenImplementation token;
-        token.flags = (uint8_t)CToken::TokenFlags::DAT |
-                      (uint8_t)CToken::TokenFlags::LPS |
-                      (uint8_t)CToken::TokenFlags::Tradeable |
-                      (uint8_t)CToken::TokenFlags::Finalized;
+        token.flags = (uint8_t)CToken::TokenFlags::DAT | (uint8_t)CToken::TokenFlags::LPS |
+                      (uint8_t)CToken::TokenFlags::Tradeable | (uint8_t)CToken::TokenFlags::Finalized;
 
         token.name = trim_ws(tokenA->name + "-" + tokenB->name).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
         token.symbol = pairSymbol;
@@ -1188,8 +1296,8 @@ public:
         return mnview.SetPoolPair(tokenId, height, poolPair);
     }
 
-    Res operator()(const CUpdatePoolPairMessage& obj) const {
-        //check foundation auth
+    Res operator()(const CUpdatePoolPairMessage &obj) const {
+        // check foundation auth
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
@@ -1197,8 +1305,9 @@ public:
         auto rewards = obj.rewards;
         if (!rewards.balances.empty()) {
             // Check for special case to wipe rewards
-            if (!(rewards.balances.size() == 1 && rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()}
-            && rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max())) {
+            if (!(rewards.balances.size() == 1 &&
+                  rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()} &&
+                  rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max())) {
                 // Check if tokens exist and remove empty reward amounts
                 auto res = eraseEmptyBalances(rewards.balances);
                 if (!res) {
@@ -1209,7 +1318,7 @@ public:
         return mnview.UpdatePoolPair(obj.poolId, height, obj.status, obj.commission, obj.ownerAddress, rewards);
     }
 
-    Res operator()(const CPoolSwapMessage& obj) const {
+    Res operator()(const CPoolSwapMessage &obj) const {
         // check auth
         if (!HasAuth(obj.from)) {
             return Res::Err("tx must have at least one input from account owner");
@@ -1218,7 +1327,7 @@ public:
         return CPoolSwap(obj, height).ExecuteSwap(mnview, {});
     }
 
-    Res operator()(const CPoolSwapMessageV2& obj) const {
+    Res operator()(const CPoolSwapMessageV2 &obj) const {
         // check auth
         if (!HasAuth(obj.swapInfo.from)) {
             return Res::Err("tx must have at least one input from account owner");
@@ -1231,7 +1340,7 @@ public:
         return CPoolSwap(obj.swapInfo, height).ExecuteSwap(mnview, obj.poolIDs);
     }
 
-    Res operator()(const CLiquidityMessage& obj) const {
+    Res operator()(const CLiquidityMessage &obj) const {
         CBalances sumTx = SumAllTransfers(obj.from);
         if (sumTx.balances.size() != 2) {
             return Res::Err("the pool pair requires two tokens");
@@ -1250,13 +1359,13 @@ public:
             return Res::Err("there is no such pool pair");
         }
 
-        for (const auto& kv : obj.from) {
+        for (const auto &kv : obj.from) {
             if (!HasAuth(kv.first)) {
                 return Res::Err("tx must have at least one input from account owner");
             }
         }
 
-        for (const auto& kv : obj.from) {
+        for (const auto &kv : obj.from) {
             CalculateOwnerRewards(kv.first);
             auto res = mnview.SubBalances(kv.first, kv.second);
             if (!res) {
@@ -1264,8 +1373,8 @@ public:
             }
         }
 
-        const auto& lpTokenID = pair->first;
-        auto& pool = pair->second;
+        const auto &lpTokenID = pair->first;
+        auto &pool = pair->second;
 
         // normalize A & B to correspond poolpair's tokens
         if (amountA.first != pool.idTokenA) {
@@ -1273,17 +1382,20 @@ public:
         }
 
         bool slippageProtection = static_cast<int>(height) >= consensus.BayfrontMarinaHeight;
-        auto res = pool.AddLiquidity(amountA.second, amountB.second, [&] /*onMint*/(CAmount liqAmount) {
-
-            CBalances balance{TAmounts{{lpTokenID, liqAmount}}};
-            return addBalanceSetShares(obj.shareAddress, balance);
-        }, slippageProtection);
+        auto res = pool.AddLiquidity(
+            amountA.second,
+            amountB.second,
+            [&] /*onMint*/ (CAmount liqAmount) {
+                CBalances balance{TAmounts{{lpTokenID, liqAmount}}};
+                return addBalanceSetShares(obj.shareAddress, balance);
+            },
+            slippageProtection);
 
         return !res ? res : mnview.SetPoolPair(lpTokenID, height, pool);
     }
 
-    Res operator()(const CRemoveLiquidityMessage& obj) const {
-        const auto& from = obj.from;
+    Res operator()(const CRemoveLiquidityMessage &obj) const {
+        const auto &from = obj.from;
         auto amount = obj.amount;
 
         // checked internally too. remove here?
@@ -1300,7 +1412,7 @@ public:
             return Res::Err("tx must have at least one input from account owner");
         }
 
-        CPoolPair& pool = pair.value();
+        CPoolPair &pool = pair.value();
 
         // subtract liq.balance BEFORE RemoveLiquidity call to check balance correctness
         {
@@ -1311,8 +1423,7 @@ public:
             }
         }
 
-        auto res = pool.RemoveLiquidity(amount.nValue, [&] (CAmount amountA, CAmount amountB) {
-
+        auto res = pool.RemoveLiquidity(amount.nValue, [&](CAmount amountA, CAmount amountB) {
             CalculateOwnerRewards(from);
             CBalances balances{TAmounts{{pool.idTokenA, amountA}, {pool.idTokenB, amountB}}};
             return mnview.AddBalances(from, balances);
@@ -1321,7 +1432,7 @@ public:
         return !res ? res : mnview.SetPoolPair(amount.nTokenId, height, pool);
     }
 
-    Res operator()(const CUtxosToAccountMessage& obj) const {
+    Res operator()(const CUtxosToAccountMessage &obj) const {
         // check enough tokens are "burnt"
         const auto burnt = BurntTokens(tx);
         if (!burnt) {
@@ -1330,14 +1441,15 @@ public:
 
         const auto mustBeBurnt = SumAllTransfers(obj.to);
         if (*burnt.val != mustBeBurnt) {
-            return Res::Err("transfer tokens mismatch burnt tokens: (%s) != (%s)", mustBeBurnt.ToString(), burnt.val->ToString());
+            return Res::Err(
+                "transfer tokens mismatch burnt tokens: (%s) != (%s)", mustBeBurnt.ToString(), burnt.val->ToString());
         }
 
         // transfer
         return addBalancesSetShares(obj.to);
     }
 
-    Res operator()(const CAccountToUtxosMessage& obj) const {
+    Res operator()(const CAccountToUtxosMessage &obj) const {
         // check auth
         if (!HasAuth(obj.from)) {
             return Res::Err("tx must have at least one input from account owner");
@@ -1350,12 +1462,14 @@ public:
         }
 
         if (obj.balances != *minted.val) {
-            return Res::Err("amount of minted tokens in UTXOs and metadata do not match: (%s) != (%s)", minted.val->ToString(), obj.balances.ToString());
+            return Res::Err("amount of minted tokens in UTXOs and metadata do not match: (%s) != (%s)",
+                            minted.val->ToString(),
+                            obj.balances.ToString());
         }
 
         // block for non-DFI transactions
-        for (const auto& kv : obj.balances.balances) {
-            const DCT_ID& tokenId = kv.first;
+        for (const auto &kv : obj.balances.balances) {
+            const DCT_ID &tokenId = kv.first;
             if (tokenId != DCT_ID{0}) {
                 return Res::Err("only available for DFI transactions");
             }
@@ -1365,7 +1479,7 @@ public:
         return subBalanceDelShares(obj.from, obj.balances);
     }
 
-    Res operator()(const CAccountToAccountMessage& obj) const {
+    Res operator()(const CAccountToAccountMessage &obj) const {
         // check auth
         if (!HasAuth(obj.from)) {
             return Res::Err("tx must have at least one input from account owner");
@@ -1376,8 +1490,7 @@ public:
         return !res ? res : addBalancesSetShares(obj.to);
     }
 
-
-    Res HandleDFIP2201Contract(const CSmartContractMessage& obj) const {
+    Res HandleDFIP2201Contract(const CSmartContractMessage &obj) const {
         const auto attributes = mnview.GetAttributes();
         if (!attributes)
             return Res::Err("Attributes unavailable");
@@ -1396,12 +1509,12 @@ public:
         if (obj.accounts.begin()->second.balances.size() != 1)
             return Res::Err("Only one amount entry expected for " + obj.name);
 
-        const auto& script = obj.accounts.begin()->first;
+        const auto &script = obj.accounts.begin()->first;
         if (!HasAuth(script))
             return Res::Err("Must have at least one input from supplied address");
 
-        const auto& id = obj.accounts.begin()->second.balances.begin()->first;
-        const auto& amount = obj.accounts.begin()->second.balances.begin()->second;
+        const auto &id = obj.accounts.begin()->second.balances.begin()->first;
+        const auto &amount = obj.accounts.begin()->second.balances.begin()->second;
 
         if (amount <= 0)
             return Res::Err("Amount out of range");
@@ -1424,9 +1537,8 @@ public:
         if (!res)
             return res;
 
-        const CTokenCurrencyPair btcUsd{"BTC","USD"};
-        const CTokenCurrencyPair dfiUsd{"DFI","USD"};
-
+        const CTokenCurrencyPair btcUsd{"BTC", "USD"};
+        const CTokenCurrencyPair dfiUsd{"DFI", "USD"};
 
         bool useNextPrice{false}, requireLivePrice{true};
         auto resVal = mnview.GetValidatedIntervalPrice(btcUsd, useNextPrice, requireLivePrice);
@@ -1436,7 +1548,7 @@ public:
         CDataStructureV0 premiumKey{AttributeTypes::Param, ParamIDs::DFIP2201, DFIPKeys::Premium};
         auto premium = attributes->GetValue(premiumKey, CAmount{2500000});
 
-        const auto& btcPrice = MultiplyAmounts(*resVal.val, premium + COIN);
+        const auto &btcPrice = MultiplyAmounts(*resVal.val, premium + COIN);
 
         resVal = mnview.GetValidatedIntervalPrice(dfiUsd, useNextPrice, requireLivePrice);
         if (!resVal)
@@ -1455,7 +1567,7 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(const CSmartContractMessage& obj) const {
+    Res operator()(const CSmartContractMessage &obj) const {
         if (obj.accounts.empty()) {
             return Res::Err("Contract account parameters missing");
         }
@@ -1472,7 +1584,7 @@ public:
         return Res::Err("Specified smart contract not found");
     }
 
-    Res operator()(const CFutureSwapMessage& obj) const {
+    Res operator()(const CFutureSwapMessage &obj) const {
         if (!HasAuth(obj.owner)) {
             return Res::Err("Transaction must have at least one input from owner");
         }
@@ -1488,8 +1600,7 @@ public:
         CDataStructureV0 activeKey{AttributeTypes::Param, paramID, DFIPKeys::Active};
         CDataStructureV0 blockKey{AttributeTypes::Param, paramID, DFIPKeys::BlockPeriod};
         CDataStructureV0 rewardKey{AttributeTypes::Param, paramID, DFIPKeys::RewardPct};
-        if (!attributes->GetValue(activeKey, false) ||
-            !attributes->CheckKey(blockKey) ||
+        if (!attributes->GetValue(activeKey, false) || !attributes->CheckKey(blockKey) ||
             !attributes->CheckKey(rewardKey)) {
             return Res::Err("%s not currently active", dfiToDUSD ? "DFIP2206F" : "DFIP2203");
         }
@@ -1550,7 +1661,8 @@ public:
                 }
 
                 if (obj.destination != id.v) {
-                    return Res::Err("Incorrect destination defined for DFI swap, DUSD destination expected id: %d", id.v);
+                    return Res::Err("Incorrect destination defined for DFI swap, DUSD destination expected id: %d",
+                                    id.v);
                 }
             }
         }
@@ -1570,37 +1682,39 @@ public:
         }
 
         if (obj.withdraw) {
-
             CTokenAmount totalFutures{};
             totalFutures.nTokenId = obj.source.nTokenId;
 
             if (!dfiToDUSD) {
                 std::map<CFuturesUserKey, CFuturesUserValue> userFuturesValues;
 
-                mnview.ForEachFuturesUserValues([&](const CFuturesUserKey& key, const CFuturesUserValue& futuresValues) {
-                    if (key.owner == obj.owner &&
-                        futuresValues.source.nTokenId == obj.source.nTokenId &&
-                        futuresValues.destination == obj.destination) {
-                        userFuturesValues[key] = futuresValues;
-                    }
-                    return true;
-                }, {height, obj.owner, std::numeric_limits<uint32_t>::max()});
+                mnview.ForEachFuturesUserValues(
+                    [&](const CFuturesUserKey &key, const CFuturesUserValue &futuresValues) {
+                        if (key.owner == obj.owner && futuresValues.source.nTokenId == obj.source.nTokenId &&
+                            futuresValues.destination == obj.destination) {
+                            userFuturesValues[key] = futuresValues;
+                        }
+                        return true;
+                    },
+                    {height, obj.owner, std::numeric_limits<uint32_t>::max()});
 
-                for (const auto& [key, value] : userFuturesValues) {
+                for (const auto &[key, value] : userFuturesValues) {
                     totalFutures.Add(value.source.nValue);
                     mnview.EraseFuturesUserValues(key);
                 }
             } else {
                 std::map<CFuturesUserKey, CAmount> userFuturesValues;
 
-                mnview.ForEachFuturesDUSD([&](const CFuturesUserKey& key, const CAmount& futuresValues) {
-                    if (key.owner == obj.owner) {
-                        userFuturesValues[key] = futuresValues;
-                    }
-                    return true;
-                }, {height, obj.owner, std::numeric_limits<uint32_t>::max()});
+                mnview.ForEachFuturesDUSD(
+                    [&](const CFuturesUserKey &key, const CAmount &futuresValues) {
+                        if (key.owner == obj.owner) {
+                            userFuturesValues[key] = futuresValues;
+                        }
+                        return true;
+                    },
+                    {height, obj.owner, std::numeric_limits<uint32_t>::max()});
 
-                for (const auto& [key, amount] : userFuturesValues) {
+                for (const auto &[key, amount] : userFuturesValues) {
                     totalFutures.Add(amount);
                     mnview.EraseFuturesDUSD(key);
                 }
@@ -1657,9 +1771,9 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(const CAnyAccountsToAccountsMessage& obj) const {
+    Res operator()(const CAnyAccountsToAccountsMessage &obj) const {
         // check auth
-        for (const auto& kv : obj.from) {
+        for (const auto &kv : obj.from) {
             if (!HasAuth(kv.first)) {
                 return Res::Err("tx must have at least one input from account owner");
             }
@@ -1680,12 +1794,12 @@ public:
         return !res ? res : addBalancesSetShares(obj.to);
     }
 
-    Res operator()(const CGovernanceMessage& obj) const {
-        //check foundation auth
+    Res operator()(const CGovernanceMessage &obj) const {
+        // check foundation auth
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
-        for(const auto& gov : obj.govs) {
+        for (const auto &gov : obj.govs) {
             Res res{};
 
             auto var = gov;
@@ -1701,9 +1815,8 @@ public:
                 govVar->time = time;
 
                 // Validate as complete set. Check for future conflicts between key pairs.
-                if (!(res = govVar->Import(var->Export()))
-                    ||  !(res = govVar->Validate(mnview))
-                    ||  !(res = govVar->Apply(mnview, height)))
+                if (!(res = govVar->Import(var->Export())) || !(res = govVar->Validate(mnview)) ||
+                    !(res = govVar->Apply(mnview, height)))
                     return Res::Err("%s: %s", var->GetName(), res.msg);
 
                 var = govVar;
@@ -1738,8 +1851,8 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(const CGovernanceHeightMessage& obj) const {
-        //check foundation auth
+    Res operator()(const CGovernanceHeightMessage &obj) const {
+        // check foundation auth
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
@@ -1754,7 +1867,6 @@ public:
         // Validate GovVariables before storing
         // TODO remove GW check after fork height. No conflict expected as attrs should not been set by height before.
         if (height >= uint32_t(consensus.FortCanningCrunchHeight) && obj.govVar->GetName() == "ATTRIBUTES") {
-
             auto govVar = mnview.GetAttributes();
             if (!govVar) {
                 return Res::Err("%s: %s", obj.govVar->GetName(), "Failed to get existing ATTRIBUTES");
@@ -1765,12 +1877,12 @@ public:
 
             Res res{};
             CCustomCSView govCache(mnview);
-            for (const auto& [varHeight, var] : storedGovVars) {
+            for (const auto &[varHeight, var] : storedGovVars) {
                 if (var->GetName() == "ATTRIBUTES") {
-                    if (!(res = govVar->Import(var->Export())) ||
-                        !(res = govVar->Validate(govCache)) ||
+                    if (!(res = govVar->Import(var->Export())) || !(res = govVar->Validate(govCache)) ||
                         !(res = govVar->Apply(govCache, varHeight))) {
-                        return Res::Err("%s: Cumulative application of Gov vars failed: %s", obj.govVar->GetName(), res.msg);
+                        return Res::Err(
+                            "%s: Cumulative application of Gov vars failed: %s", obj.govVar->GetName(), res.msg);
                     }
                 }
             }
@@ -1786,35 +1898,34 @@ public:
         return Res::Ok();
     }
 
-    Res operator()(const CAppointOracleMessage& obj) const {
+    Res operator()(const CAppointOracleMessage &obj) const {
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
         COracle oracle;
-        static_cast<CAppointOracleMessage&>(oracle) = obj;
+        static_cast<CAppointOracleMessage &>(oracle) = obj;
         auto res = normalizeTokenCurrencyPair(oracle.availablePairs);
         return !res ? res : mnview.AppointOracle(tx.GetHash(), oracle);
     }
 
-    Res operator()(const CUpdateOracleAppointMessage& obj) const {
+    Res operator()(const CUpdateOracleAppointMessage &obj) const {
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
         COracle oracle;
-        static_cast<CAppointOracleMessage&>(oracle) = obj.newOracleAppoint;
+        static_cast<CAppointOracleMessage &>(oracle) = obj.newOracleAppoint;
         auto res = normalizeTokenCurrencyPair(oracle.availablePairs);
         return !res ? res : mnview.UpdateOracle(obj.oracleId, std::move(oracle));
     }
 
-    Res operator()(const CRemoveOracleAppointMessage& obj) const {
+    Res operator()(const CRemoveOracleAppointMessage &obj) const {
         if (!HasFoundationAuth()) {
             return Res::Err("tx not from foundation member");
         }
         return mnview.RemoveOracle(obj.oracleId);
     }
 
-    Res operator()(const CSetOracleDataMessage& obj) const {
-
+    Res operator()(const CSetOracleDataMessage &obj) const {
         auto oracle = mnview.GetOracleData(obj.oracleId);
         if (!oracle) {
             return Res::Err("failed to retrieve oracle <%s> from database", obj.oracleId.GetHex());
@@ -1823,16 +1934,16 @@ public:
             return Res::Err("tx must have at least one input from account owner");
         }
         if (height >= uint32_t(Params().GetConsensus().FortCanningHeight)) {
-            for (const auto& tokenPrice : obj.tokenPrices) {
-                for (const auto& price : tokenPrice.second) {
+            for (const auto &tokenPrice : obj.tokenPrices) {
+                for (const auto &price : tokenPrice.second) {
                     if (price.second <= 0) {
                         return Res::Err("Amount out of range");
                     }
                     auto timestamp = time;
                     extern bool diffInHour(int64_t time1, int64_t time2);
                     if (!diffInHour(obj.timestamp, timestamp)) {
-                        return Res::Err("Timestamp (%d) is out of price update window (median: %d)",
-                            obj.timestamp, timestamp);
+                        return Res::Err(
+                            "Timestamp (%d) is out of price update window (median: %d)", obj.timestamp, timestamp);
                     }
                 }
             }
@@ -1840,13 +1951,13 @@ public:
         return mnview.SetOracleData(obj.oracleId, obj.timestamp, obj.tokenPrices);
     }
 
-    Res operator()(const CICXCreateOrderMessage& obj) const {
+    Res operator()(const CICXCreateOrderMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXOrderImplemetation order;
-        static_cast<CICXOrder&>(order) = obj;
+        static_cast<CICXOrder &>(order) = obj;
 
         order.creationTx = tx.GetHash();
         order.creationHeight = height;
@@ -1870,13 +1981,13 @@ public:
         return !res ? res : mnview.ICXCreateOrder(order);
     }
 
-    Res operator()(const CICXMakeOfferMessage& obj) const {
+    Res operator()(const CICXMakeOfferMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXMakeOfferImplemetation makeoffer;
-        static_cast<CICXMakeOffer&>(makeoffer) = obj;
+        static_cast<CICXMakeOffer &>(makeoffer) = obj;
 
         makeoffer.creationTx = tx.GetHash();
         makeoffer.creationHeight = height;
@@ -1888,7 +1999,8 @@ public:
         if (!order)
             return Res::Err("order with creation tx " + makeoffer.orderTx.GetHex() + " does not exists!");
 
-        auto expiry = static_cast<int>(height) < consensus.EunosPayaHeight ? CICXMakeOffer::DEFAULT_EXPIRY : CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY;
+        auto expiry = static_cast<int>(height) < consensus.EunosPayaHeight ? CICXMakeOffer::DEFAULT_EXPIRY
+                                                                           : CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY;
 
         if (makeoffer.expiry < expiry)
             return Res::Err("offer expiry must be greater than %d!", expiry - 1);
@@ -1903,7 +2015,8 @@ public:
                 return Res::Err("receivePubkey must be valid pubkey");
 
             // calculating takerFee
-            CAmount BTCAmount(static_cast<CAmount>((arith_uint256(makeoffer.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
+            CAmount BTCAmount(static_cast<CAmount>(
+                (arith_uint256(makeoffer.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
             makeoffer.takerFee = CalculateTakerFee(BTCAmount);
         }
 
@@ -1914,14 +2027,14 @@ public:
         return !res ? res : mnview.ICXMakeOffer(makeoffer);
     }
 
-    Res operator()(const CICXSubmitDFCHTLCMessage& obj) const {
+    Res operator()(const CICXSubmitDFCHTLCMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res) {
             return res;
         }
 
         CICXSubmitDFCHTLCImplemetation submitdfchtlc;
-        static_cast<CICXSubmitDFCHTLC&>(submitdfchtlc) = obj;
+        static_cast<CICXSubmitDFCHTLC &>(submitdfchtlc) = obj;
 
         submitdfchtlc.creationTx = tx.GetHash();
         submitdfchtlc.creationHeight = height;
@@ -1942,7 +2055,6 @@ public:
 
         CScript srcAddr;
         if (order->orderType == CICXOrder::TYPE_INTERNAL) {
-
             // check auth
             if (!HasAuth(order->ownerAddress))
                 return Res::Err("tx must have at least one input from order owner");
@@ -1963,23 +2075,27 @@ public:
 
             CScript offerTxidAddr(offer->creationTx.begin(), offer->creationTx.end());
 
-            CAmount calcAmount(static_cast<CAmount>((arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+            CAmount calcAmount(static_cast<CAmount>(
+                (arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN))
+                    .GetLow64()));
             if (calcAmount > offer->amount)
                 return Res::Err("amount must be lower or equal the offer one");
 
             CAmount takerFee = offer->takerFee;
-            //EunosPaya: calculating adjusted takerFee only if amount in htlc different than in offer
-            if (static_cast<int>(height) >= consensus.EunosPayaHeight)
-            {
-                if (calcAmount < offer->amount)
-                {
-                    CAmount BTCAmount(static_cast<CAmount>((arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
-                    takerFee = static_cast<CAmount>((arith_uint256(BTCAmount) * arith_uint256(offer->takerFee) / arith_uint256(offer->amount)).GetLow64());
+            // EunosPaya: calculating adjusted takerFee only if amount in htlc different than in offer
+            if (static_cast<int>(height) >= consensus.EunosPayaHeight) {
+                if (calcAmount < offer->amount) {
+                    CAmount BTCAmount(static_cast<CAmount>(
+                        (arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN))
+                            .GetLow64()));
+                    takerFee = static_cast<CAmount>(
+                        (arith_uint256(BTCAmount) * arith_uint256(offer->takerFee) / arith_uint256(offer->amount))
+                            .GetLow64());
                 }
-            }
-            else
-            {
-                CAmount BTCAmount(static_cast<CAmount>((arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+            } else {
+                CAmount BTCAmount(static_cast<CAmount>(
+                    (arith_uint256(submitdfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN))
+                        .GetLow64()));
                 takerFee = CalculateTakerFee(BTCAmount);
             }
 
@@ -2016,24 +2132,24 @@ public:
 
             auto exthtlc = mnview.HasICXSubmitEXTHTLCOpen(submitdfchtlc.offerTx);
             if (!exthtlc)
-                return Res::Err("offer (%s) needs to have ext htlc submitted first, but no external htlc found!", submitdfchtlc.offerTx.GetHex());
+                return Res::Err("offer (%s) needs to have ext htlc submitted first, but no external htlc found!",
+                                submitdfchtlc.offerTx.GetHex());
 
-            CAmount calcAmount(static_cast<CAmount>((arith_uint256(exthtlc->amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+            CAmount calcAmount(static_cast<CAmount>(
+                (arith_uint256(exthtlc->amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
             if (submitdfchtlc.amount != calcAmount)
                 return Res::Err("amount must be equal to calculated exthtlc amount");
 
             if (submitdfchtlc.hash != exthtlc->hash)
                 return Res::Err("Invalid hash, dfc htlc hash is different than extarnal htlc hash - %s != %s",
-                        submitdfchtlc.hash.GetHex(),exthtlc->hash.GetHex());
+                                submitdfchtlc.hash.GetHex(),
+                                exthtlc->hash.GetHex());
 
             uint32_t timeout, btcBlocksInDfi;
-            if (static_cast<int>(height) < consensus.EunosPayaHeight)
-            {
+            if (static_cast<int>(height) < consensus.EunosPayaHeight) {
                 timeout = CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT;
                 btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
-            }
-            else
-            {
+            } else {
                 timeout = CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
                 btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
             }
@@ -2052,13 +2168,13 @@ public:
         return !res ? res : mnview.ICXSubmitDFCHTLC(submitdfchtlc);
     }
 
-    Res operator()(const CICXSubmitEXTHTLCMessage& obj) const {
+    Res operator()(const CICXSubmitEXTHTLCMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXSubmitEXTHTLCImplemetation submitexthtlc;
-        static_cast<CICXSubmitEXTHTLC&>(submitexthtlc) = obj;
+        static_cast<CICXSubmitEXTHTLC &>(submitexthtlc) = obj;
 
         submitexthtlc.creationTx = tx.GetHash();
         submitexthtlc.creationHeight = height;
@@ -2071,22 +2187,24 @@ public:
         if (!order)
             return Res::Err("order with creation tx %s does not exists!", offer->orderTx.GetHex());
 
-        if (order->creationHeight + order->expiry < height + (submitexthtlc.timeout * CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS))
+        if (order->creationHeight + order->expiry <
+            height + (submitexthtlc.timeout * CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS))
             return Res::Err("order will expire before ext htlc expires!");
 
         if (mnview.HasICXSubmitEXTHTLCOpen(submitexthtlc.offerTx))
             return Res::Err("ext htlc already submitted!");
 
         if (order->orderType == CICXOrder::TYPE_INTERNAL) {
-
             if (!HasAuth(offer->ownerAddress))
                 return Res::Err("tx must have at least one input from offer owner");
 
             auto dfchtlc = mnview.HasICXSubmitDFCHTLCOpen(submitexthtlc.offerTx);
             if (!dfchtlc)
-                return Res::Err("offer (%s) needs to have dfc htlc submitted first, but no dfc htlc found!", submitexthtlc.offerTx.GetHex());
+                return Res::Err("offer (%s) needs to have dfc htlc submitted first, but no dfc htlc found!",
+                                submitexthtlc.offerTx.GetHex());
 
-            CAmount calcAmount(static_cast<CAmount>((arith_uint256(dfchtlc->amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+            CAmount calcAmount(static_cast<CAmount>(
+                (arith_uint256(dfchtlc->amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
             if (submitexthtlc.amount != calcAmount)
                 return Res::Err("amount must be equal to calculated dfchtlc amount");
 
@@ -2094,13 +2212,10 @@ public:
                 return Res::Err("Invalid hash, external htlc hash is different than dfc htlc hash");
 
             uint32_t timeout, btcBlocksInDfi;
-            if (static_cast<int>(height) < consensus.EunosPayaHeight)
-            {
+            if (static_cast<int>(height) < consensus.EunosPayaHeight) {
                 timeout = CICXSubmitEXTHTLC::MINIMUM_2ND_TIMEOUT;
                 btcBlocksInDfi = CICXSubmitEXTHTLC::BTC_BLOCKS_IN_DFI_BLOCKS;
-            }
-            else
-            {
+            } else {
                 timeout = CICXSubmitEXTHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
                 btcBlocksInDfi = CICXSubmitEXTHTLC::EUNOSPAYA_BTC_BLOCKS_IN_DFI_BLOCKS;
             }
@@ -2111,7 +2226,6 @@ public:
             if (submitexthtlc.timeout * btcBlocksInDfi >= (dfchtlc->creationHeight + dfchtlc->timeout) - height)
                 return Res::Err("timeout must be less than expiration period of 1st htlc in DFC blocks");
         } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
-
             if (!HasAuth(order->ownerAddress))
                 return Res::Err("tx must have at least one input from order owner");
 
@@ -2129,22 +2243,24 @@ public:
 
             CScript offerTxidAddr(offer->creationTx.begin(), offer->creationTx.end());
 
-            CAmount calcAmount(static_cast<CAmount>((arith_uint256(submitexthtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+            CAmount calcAmount(static_cast<CAmount>(
+                (arith_uint256(submitexthtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN))
+                    .GetLow64()));
             if (calcAmount > offer->amount)
                 return Res::Err("amount must be lower or equal the offer one");
 
             CAmount takerFee = offer->takerFee;
-            //EunosPaya: calculating adjusted takerFee only if amount in htlc different than in offer
-            if (static_cast<int>(height) >= consensus.EunosPayaHeight)
-            {
-                if (calcAmount < offer->amount)
-                {
-                    CAmount BTCAmount(static_cast<CAmount>((arith_uint256(offer->amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
-                    takerFee = static_cast<CAmount>((arith_uint256(submitexthtlc.amount) * arith_uint256(offer->takerFee) / arith_uint256(BTCAmount)).GetLow64());
+            // EunosPaya: calculating adjusted takerFee only if amount in htlc different than in offer
+            if (static_cast<int>(height) >= consensus.EunosPayaHeight) {
+                if (calcAmount < offer->amount) {
+                    CAmount BTCAmount(static_cast<CAmount>(
+                        (arith_uint256(offer->amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice))
+                            .GetLow64()));
+                    takerFee = static_cast<CAmount>((arith_uint256(submitexthtlc.amount) *
+                                                     arith_uint256(offer->takerFee) / arith_uint256(BTCAmount))
+                                                        .GetLow64());
                 }
-            }
-            else
-            {
+            } else {
                 takerFee = CalculateTakerFee(submitexthtlc.amount);
             }
 
@@ -2173,13 +2289,13 @@ public:
         return !res ? res : mnview.ICXSubmitEXTHTLC(submitexthtlc);
     }
 
-    Res operator()(const CICXClaimDFCHTLCMessage& obj) const {
+    Res operator()(const CICXClaimDFCHTLCMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXClaimDFCHTLCImplemetation claimdfchtlc;
-        static_cast<CICXClaimDFCHTLC&>(claimdfchtlc) = obj;
+        static_cast<CICXClaimDFCHTLC &>(claimdfchtlc) = obj;
 
         claimdfchtlc.creationTx = tx.GetHash();
         claimdfchtlc.creationHeight = height;
@@ -2193,13 +2309,13 @@ public:
 
         uint256 calcHash;
         uint8_t calcSeedBytes[32];
-        CSHA256()
-            .Write(claimdfchtlc.seed.data(), claimdfchtlc.seed.size())
-            .Finalize(calcSeedBytes);
+        CSHA256().Write(claimdfchtlc.seed.data(), claimdfchtlc.seed.size()).Finalize(calcSeedBytes);
         calcHash.SetHex(HexStr(calcSeedBytes, calcSeedBytes + 32));
 
         if (dfchtlc->hash != calcHash)
-            return Res::Err("hash generated from given seed is different than in dfc htlc: %s - %s!", calcHash.GetHex(), dfchtlc->hash.GetHex());
+            return Res::Err("hash generated from given seed is different than in dfc htlc: %s - %s!",
+                            calcHash.GetHex(),
+                            dfchtlc->hash.GetHex());
 
         auto offer = mnview.GetICXMakeOfferByCreationTx(dfchtlc->offerTx);
         if (!offer)
@@ -2216,12 +2332,10 @@ public:
         // claim DFC HTLC to receiveAddress
         CalculateOwnerRewards(order->ownerAddress);
         CScript htlcTxidAddr(dfchtlc->creationTx.begin(), dfchtlc->creationTx.end());
-        if (order->orderType == CICXOrder::TYPE_INTERNAL)
-        {
+        if (order->orderType == CICXOrder::TYPE_INTERNAL) {
             CalculateOwnerRewards(offer->ownerAddress);
             res = TransferTokenBalance(order->idToken, dfchtlc->amount, htlcTxidAddr, offer->ownerAddress);
-        }
-        else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
+        } else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
             res = TransferTokenBalance(order->idToken, dfchtlc->amount, htlcTxidAddr, order->ownerAddress);
         if (!res)
             return res;
@@ -2247,7 +2361,8 @@ public:
         if (order->orderType == CICXOrder::TYPE_INTERNAL)
             order->amountToFill -= dfchtlc->amount;
         else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-            order->amountToFill -= static_cast<CAmount>((arith_uint256(dfchtlc->amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64());
+            order->amountToFill -= static_cast<CAmount>(
+                (arith_uint256(dfchtlc->amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64());
 
         // Order fulfilled, close order.
         if (order->amountToFill == 0) {
@@ -2258,7 +2373,7 @@ public:
                 return res;
         }
 
-        res = mnview.ICXClaimDFCHTLC(claimdfchtlc,offer->creationTx,*order);
+        res = mnview.ICXClaimDFCHTLC(claimdfchtlc, offer->creationTx, *order);
         if (!res)
             return res;
         // Close offer
@@ -2269,24 +2384,22 @@ public:
         if (!res)
             return res;
 
-        if (static_cast<int>(height) >= consensus.EunosPayaHeight)
-        {
+        if (static_cast<int>(height) >= consensus.EunosPayaHeight) {
             if (exthtlc)
                 return mnview.ICXCloseEXTHTLC(*exthtlc, CICXSubmitEXTHTLC::STATUS_CLOSED);
             else
                 return (Res::Ok());
-        }
-        else
+        } else
             return mnview.ICXCloseEXTHTLC(*exthtlc, CICXSubmitEXTHTLC::STATUS_CLOSED);
     }
 
-    Res operator()(const CICXCloseOrderMessage& obj) const {
+    Res operator()(const CICXCloseOrderMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXCloseOrderImplemetation closeorder;
-        static_cast<CICXCloseOrder&>(closeorder) = obj;
+        static_cast<CICXCloseOrder &>(closeorder) = obj;
 
         closeorder.creationTx = tx.GetHash();
         closeorder.creationHeight = height;
@@ -2318,16 +2431,16 @@ public:
         }
 
         res = mnview.ICXCloseOrder(closeorder);
-        return !res ? res : mnview.ICXCloseOrderTx(*order,CICXOrder::STATUS_CLOSED);
+        return !res ? res : mnview.ICXCloseOrderTx(*order, CICXOrder::STATUS_CLOSED);
     }
 
-    Res operator()(const CICXCloseOfferMessage& obj) const {
+    Res operator()(const CICXCloseOfferMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
 
         CICXCloseOfferImplemetation closeoffer;
-        static_cast<CICXCloseOffer&>(closeoffer) = obj;
+        static_cast<CICXCloseOffer &>(closeoffer) = obj;
 
         closeoffer.creationTx = tx.GetHash();
         closeoffer.creationHeight = height;
@@ -2355,27 +2468,24 @@ public:
 
         bool isPreEunosPaya = static_cast<int>(height) < consensus.EunosPayaHeight;
 
-        if (order->orderType == CICXOrder::TYPE_INTERNAL && !mnview.ExistedICXSubmitDFCHTLC(offer->creationTx, isPreEunosPaya))
-        {
+        if (order->orderType == CICXOrder::TYPE_INTERNAL &&
+            !mnview.ExistedICXSubmitDFCHTLC(offer->creationTx, isPreEunosPaya)) {
             // subtract takerFee from txidAddr and return to owner
             CScript txidAddr(offer->creationTx.begin(), offer->creationTx.end());
             CalculateOwnerRewards(offer->ownerAddress);
             res = TransferTokenBalance(DCT_ID{0}, offer->takerFee, txidAddr, offer->ownerAddress);
             if (!res)
                 return res;
-        }
-        else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
+        } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
             // subtract the balance from txidAddr and return to owner
             CScript txidAddr(offer->creationTx.begin(), offer->creationTx.end());
             CalculateOwnerRewards(offer->ownerAddress);
-            if (isPreEunosPaya)
-            {
+            if (isPreEunosPaya) {
                 res = TransferTokenBalance(order->idToken, offer->amount, txidAddr, offer->ownerAddress);
                 if (!res)
                     return res;
             }
-            if (!mnview.ExistedICXSubmitEXTHTLC(offer->creationTx, isPreEunosPaya))
-            {
+            if (!mnview.ExistedICXSubmitEXTHTLC(offer->creationTx, isPreEunosPaya)) {
                 res = TransferTokenBalance(DCT_ID{0}, offer->takerFee, txidAddr, offer->ownerAddress);
                 if (!res)
                     return res;
@@ -2386,7 +2496,7 @@ public:
         return !res ? res : mnview.ICXCloseMakeOfferTx(*offer, CICXMakeOffer::STATUS_CLOSED);
     }
 
-    Res operator()(const CLoanSetCollateralTokenMessage& obj) const {
+    Res operator()(const CLoanSetCollateralTokenMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2394,9 +2504,8 @@ public:
         if (!HasFoundationAuth())
             return Res::Err("tx not from foundation member!");
 
-        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
-        {
-            const auto& tokenId = obj.idToken.v;
+        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+            const auto &tokenId = obj.idToken.v;
 
             auto attributes = mnview.GetAttributes();
             attributes->time = time;
@@ -2435,7 +2544,7 @@ public:
         }
 
         CLoanSetCollateralTokenImplementation collToken;
-        static_cast<CLoanSetCollateralToken&>(collToken) = obj;
+        static_cast<CLoanSetCollateralToken &>(collToken) = obj;
 
         collToken.creationTx = tx.GetHash();
         collToken.creationHeight = height;
@@ -2451,20 +2560,23 @@ public:
             return Res::Err("activateAfterBlock cannot be less than current height!");
 
         if (!OraclePriceFeed(mnview, collToken.fixedIntervalPriceId))
-            return Res::Err("Price feed %s/%s does not belong to any oracle", collToken.fixedIntervalPriceId.first, collToken.fixedIntervalPriceId.second);
+            return Res::Err("Price feed %s/%s does not belong to any oracle",
+                            collToken.fixedIntervalPriceId.first,
+                            collToken.fixedIntervalPriceId.second);
 
         CFixedIntervalPrice fixedIntervalPrice;
         fixedIntervalPrice.priceFeedId = collToken.fixedIntervalPriceId;
 
         LogPrint(BCLog::LOAN, "CLoanSetCollateralTokenMessage()->"); /* Continued */
-        auto price = GetAggregatePrice(mnview, collToken.fixedIntervalPriceId.first, collToken.fixedIntervalPriceId.second, time);
+        auto price = GetAggregatePrice(
+            mnview, collToken.fixedIntervalPriceId.first, collToken.fixedIntervalPriceId.second, time);
         if (!price)
             return Res::Err(price.msg);
 
         fixedIntervalPrice.priceRecord[1] = price;
         fixedIntervalPrice.timestamp = time;
 
-        LogPrint(BCLog::ORACLE,"CLoanSetCollateralTokenMessage()->"); /* Continued */
+        LogPrint(BCLog::ORACLE, "CLoanSetCollateralTokenMessage()->"); /* Continued */
         auto resSetFixedPrice = mnview.SetFixedIntervalPrice(fixedIntervalPrice);
         if (!resSetFixedPrice)
             return Res::Err(resSetFixedPrice.msg);
@@ -2472,7 +2584,7 @@ public:
         return mnview.CreateLoanCollateralToken(collToken);
     }
 
-    Res operator()(const CLoanSetLoanTokenMessage& obj) const {
+    Res operator()(const CLoanSetLoanTokenMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2489,16 +2601,17 @@ public:
         token.name = trim_ws(obj.name).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
         token.creationTx = tx.GetHash();
         token.creationHeight = height;
-        token.flags = obj.mintable ? static_cast<uint8_t>(CToken::TokenFlags::Default) : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
-        token.flags |= static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
+        token.flags = obj.mintable ? static_cast<uint8_t>(CToken::TokenFlags::Default)
+                                   : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
+        token.flags |=
+            static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
 
         auto tokenId = mnview.CreateToken(token);
         if (!tokenId)
             return std::move(tokenId);
 
-        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
-        {
-            const auto& id = tokenId.val->v;
+        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+            const auto &id = tokenId.val->v;
 
             auto attributes = mnview.GetAttributes();
             attributes->time = time;
@@ -2537,17 +2650,20 @@ public:
         }
 
         CLoanSetLoanTokenImplementation loanToken;
-        static_cast<CLoanSetLoanToken&>(loanToken) = obj;
+        static_cast<CLoanSetLoanToken &>(loanToken) = obj;
 
         loanToken.creationTx = tx.GetHash();
         loanToken.creationHeight = height;
 
-        auto nextPrice = GetAggregatePrice(mnview, obj.fixedIntervalPriceId.first, obj.fixedIntervalPriceId.second, time);
+        auto nextPrice =
+            GetAggregatePrice(mnview, obj.fixedIntervalPriceId.first, obj.fixedIntervalPriceId.second, time);
         if (!nextPrice)
             return Res::Err(nextPrice.msg);
 
         if (!OraclePriceFeed(mnview, obj.fixedIntervalPriceId))
-            return Res::Err("Price feed %s/%s does not belong to any oracle", obj.fixedIntervalPriceId.first, obj.fixedIntervalPriceId.second);
+            return Res::Err("Price feed %s/%s does not belong to any oracle",
+                            obj.fixedIntervalPriceId.first,
+                            obj.fixedIntervalPriceId.second);
 
         CFixedIntervalPrice fixedIntervalPrice;
         fixedIntervalPrice.priceFeedId = loanToken.fixedIntervalPriceId;
@@ -2561,7 +2677,7 @@ public:
         return mnview.SetLoanToken(loanToken, *(tokenId.val));
     }
 
-    Res operator()(const CLoanUpdateLoanTokenMessage& obj) const {
+    Res operator()(const CLoanUpdateLoanTokenMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2576,8 +2692,10 @@ public:
         if (!pair)
             return Res::Err("Loan token (%s) does not exist!", obj.tokenTx.GetHex());
 
-        auto loanToken = (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) ?
-                mnview.GetLoanTokenByID(pair->first) : mnview.GetLoanToken(obj.tokenTx);
+        auto loanToken =
+            (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
+                ? mnview.GetLoanTokenByID(pair->first)
+                : mnview.GetLoanToken(obj.tokenTx);
 
         if (!loanToken)
             return Res::Err("Loan token (%s) does not exist!", obj.tokenTx.GetHex());
@@ -2601,9 +2719,8 @@ public:
         if (!res)
             return res;
 
-        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
-        {
-            const auto& id = pair->first.v;
+        if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+            const auto &id = pair->first.v;
 
             auto attributes = mnview.GetAttributes();
             attributes->time = time;
@@ -2643,7 +2760,9 @@ public:
 
         if (obj.fixedIntervalPriceId != loanToken->fixedIntervalPriceId) {
             if (!OraclePriceFeed(mnview, obj.fixedIntervalPriceId))
-                return Res::Err("Price feed %s/%s does not belong to any oracle", obj.fixedIntervalPriceId.first, obj.fixedIntervalPriceId.second);
+                return Res::Err("Price feed %s/%s does not belong to any oracle",
+                                obj.fixedIntervalPriceId.first,
+                                obj.fixedIntervalPriceId.second);
 
             loanToken->fixedIntervalPriceId = obj.fixedIntervalPriceId;
         }
@@ -2651,7 +2770,7 @@ public:
         return mnview.UpdateLoanToken(*loanToken, pair->first);
     }
 
-    Res operator()(const CLoanSchemeMessage& obj) const {
+    Res operator()(const CLoanSchemeMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res) {
             return res;
@@ -2676,8 +2795,7 @@ public:
         // Look for loan scheme which already has matching rate and ratio
         bool duplicateLoan = false;
         std::string duplicateID;
-        mnview.ForEachLoanScheme([&](const std::string& key, const CLoanSchemeData& data)
-        {
+        mnview.ForEachLoanScheme([&](const std::string &key, const CLoanSchemeData &data) {
             // Duplicate scheme already exists
             if (data.ratio == obj.ratio && data.rate == obj.rate) {
                 duplicateLoan = true;
@@ -2692,19 +2810,21 @@ public:
         } else {
             // Look for delayed loan scheme which already has matching rate and ratio
             std::pair<std::string, uint64_t> duplicateKey;
-            mnview.ForEachDelayedLoanScheme([&](const std::pair<std::string, uint64_t>& key, const CLoanSchemeMessage& data)
-            {
-                // Duplicate delayed loan scheme
-                if (data.ratio == obj.ratio && data.rate == obj.rate) {
-                    duplicateLoan = true;
-                    duplicateKey = key;
-                    return false;
-                }
-                return true;
-            });
+            mnview.ForEachDelayedLoanScheme(
+                [&](const std::pair<std::string, uint64_t> &key, const CLoanSchemeMessage &data) {
+                    // Duplicate delayed loan scheme
+                    if (data.ratio == obj.ratio && data.rate == obj.rate) {
+                        duplicateLoan = true;
+                        duplicateKey = key;
+                        return false;
+                    }
+                    return true;
+                });
 
             if (duplicateLoan) {
-                return Res::Err("Loan scheme %s with same interestrate and mincolratio pending on block %d", duplicateKey.first, duplicateKey.second);
+                return Res::Err("Loan scheme %s with same interestrate and mincolratio pending on block %d",
+                                duplicateKey.first,
+                                duplicateKey.second);
             }
         }
 
@@ -2718,7 +2838,8 @@ public:
         }
 
         // Update set, not max uint64_t which indicates immediate update and not updated on this block.
-        if (obj.updateHeight && obj.updateHeight != std::numeric_limits<uint64_t>::max() && obj.updateHeight != height) {
+        if (obj.updateHeight && obj.updateHeight != std::numeric_limits<uint64_t>::max() &&
+            obj.updateHeight != height) {
             if (obj.updateHeight < height) {
                 return Res::Err("Update height below current block height, set future height");
             }
@@ -2734,7 +2855,7 @@ public:
         return mnview.StoreLoanScheme(obj);
     }
 
-    Res operator()(const CDefaultLoanSchemeMessage& obj) const {
+    Res operator()(const CDefaultLoanSchemeMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res) {
             return res;
@@ -2761,10 +2882,11 @@ public:
             return Res::Err("Cannot set %s as default, set to destroyed on block %d", obj.identifier, *height);
         }
 
-        return mnview.StoreDefaultLoanScheme(obj.identifier);;
+        return mnview.StoreDefaultLoanScheme(obj.identifier);
+        ;
     }
 
-    Res operator()(const CDestroyLoanSchemeMessage& obj) const {
+    Res operator()(const CDestroyLoanSchemeMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res) {
             return res;
@@ -2795,7 +2917,7 @@ public:
             return mnview.StoreDelayedDestroyScheme(obj);
         }
 
-        mnview.ForEachVault([&](const CVaultId& vaultId, CVaultData vault) {
+        mnview.ForEachVault([&](const CVaultId &vaultId, CVaultData vault) {
             if (vault.schemeId == obj.identifier) {
                 vault.schemeId = *mnview.GetDefaultLoanScheme();
                 mnview.StoreVault(vaultId, vault);
@@ -2806,19 +2928,18 @@ public:
         return mnview.EraseLoanScheme(obj.identifier);
     }
 
-    Res operator()(const CVaultMessage& obj) const {
-
+    Res operator()(const CVaultMessage &obj) const {
         auto vaultCreationFee = consensus.vaultCreationFee;
         if (tx.vout[0].nValue != vaultCreationFee || tx.vout[0].nTokenId != DCT_ID{0}) {
             return Res::Err("malformed tx vouts, creation vault fee is %s DFI", GetDecimaleString(vaultCreationFee));
         }
 
         CVaultData vault{};
-        static_cast<CVaultMessage&>(vault) = obj;
+        static_cast<CVaultMessage &>(vault) = obj;
 
         // set loan scheme to default if non provided
         if (obj.schemeId.empty()) {
-            if (auto defaultScheme = mnview.GetDefaultLoanScheme()){
+            if (auto defaultScheme = mnview.GetDefaultLoanScheme()) {
                 vault.schemeId = *defaultScheme;
             } else {
                 return Res::Err("There is no default loan scheme");
@@ -2839,7 +2960,7 @@ public:
         return mnview.StoreVault(vaultId, vault);
     }
 
-    Res operator()(const CCloseVaultMessage& obj) const {
+    Res operator()(const CCloseVaultMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2862,7 +2983,7 @@ public:
 
         CalculateOwnerRewards(obj.to);
         if (auto collaterals = mnview.GetVaultCollaterals(obj.vaultId)) {
-            for (const auto& col : collaterals->balances) {
+            for (const auto &col : collaterals->balances) {
                 auto res = mnview.AddBalance(obj.to, {col.first, col.second});
                 if (!res)
                     return res;
@@ -2880,7 +3001,7 @@ public:
         return !res ? res : mnview.EraseVault(obj.vaultId);
     }
 
-    Res operator()(const CUpdateVaultMessage& obj) const {
+    Res operator()(const CUpdateVaultMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2913,15 +3034,19 @@ public:
         if (vault->schemeId != obj.schemeId)
             if (auto collaterals = mnview.GetVaultCollaterals(obj.vaultId))
                 for (int i = 0; i < 2; i++) {
-                    LogPrint(BCLog::LOAN,"CUpdateVaultMessage():\n");
+                    LogPrint(BCLog::LOAN, "CUpdateVaultMessage():\n");
                     bool useNextPrice = i > 0, requireLivePrice = true;
-                    auto collateralsLoans = mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
+                    auto collateralsLoans = mnview.GetLoanCollaterals(
+                        obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
                     if (!collateralsLoans)
                         return std::move(collateralsLoans);
 
                     auto scheme = mnview.GetLoanScheme(obj.schemeId);
                     if (collateralsLoans.val->ratio() < scheme->ratio)
-                        return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d", collateralsLoans.val->ratio(), scheme->ratio);
+                        return Res::Err(
+                            "Vault does not have enough collateralization ratio defined by loan scheme - %d < %d",
+                            collateralsLoans.val->ratio(),
+                            scheme->ratio);
                 }
 
         vault->schemeId = obj.schemeId;
@@ -2929,7 +3054,7 @@ public:
         return mnview.UpdateVault(obj.vaultId, *vault);
     }
 
-    Res operator()(const CDepositToVaultMessage& obj) const {
+    Res operator()(const CDepositToVaultMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -2949,17 +3074,19 @@ public:
 
         // If collateral token exist make sure it is enabled.
         if (mnview.GetCollateralTokenFromAttributes(obj.amount.nTokenId)) {
-            CDataStructureV0 collateralKey{AttributeTypes::Token, obj.amount.nTokenId.v, TokenKeys::LoanCollateralEnabled};
+            CDataStructureV0 collateralKey{
+                AttributeTypes::Token, obj.amount.nTokenId.v, TokenKeys::LoanCollateralEnabled};
             if (const auto attributes = mnview.GetAttributes(); !attributes->GetValue(collateralKey, false)) {
                 return Res::Err("Collateral token (%d) is disabled", obj.amount.nTokenId.v);
             }
         }
 
-        //check balance
+        // check balance
         CalculateOwnerRewards(obj.from);
         res = mnview.SubBalance(obj.from, obj.amount);
         if (!res)
-            return Res::Err("Insufficient funds: can't subtract balance of %s: %s\n", ScriptToString(obj.from), res.msg);
+            return Res::Err(
+                "Insufficient funds: can't subtract balance of %s: %s\n", ScriptToString(obj.from), res.msg);
 
         res = mnview.AddVaultCollateral(obj.vaultId, obj.amount);
         if (!res)
@@ -2968,19 +3095,22 @@ public:
         bool useNextPrice = false, requireLivePrice = false;
         auto collaterals = mnview.GetVaultCollaterals(obj.vaultId);
 
-        LogPrint(BCLog::LOAN,"CDepositToVaultMessage():\n");
-        auto collateralsLoans = mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
+        LogPrint(BCLog::LOAN, "CDepositToVaultMessage():\n");
+        auto collateralsLoans =
+            mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
         if (!collateralsLoans)
             return std::move(collateralsLoans);
 
         auto scheme = mnview.GetLoanScheme(vault->schemeId);
         if (collateralsLoans.val->ratio() < scheme->ratio)
-            return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d", collateralsLoans.val->ratio(), scheme->ratio);
+            return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d",
+                            collateralsLoans.val->ratio(),
+                            scheme->ratio);
 
         return Res::Ok();
     }
 
-    Res operator()(const CWithdrawFromVaultMessage& obj) const {
+    Res operator()(const CWithdrawFromVaultMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -3005,10 +3135,8 @@ public:
         if (!res)
             return res;
 
-        if (mnview.GetLoanTokens(obj.vaultId))
-        {
-            if (auto collaterals = mnview.GetVaultCollaterals(obj.vaultId))
-            {
+        if (mnview.GetLoanTokens(obj.vaultId)) {
+            if (auto collaterals = mnview.GetVaultCollaterals(obj.vaultId)) {
                 std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> tokenDUSD;
                 if (static_cast<int>(height) >= consensus.FortCanningRoadHeight) {
                     tokenDUSD = mnview.GetToken("DUSD");
@@ -3017,39 +3145,44 @@ public:
                 for (int i = 0; i < 2; i++) {
                     // check collaterals for active and next price
                     bool useNextPrice = i > 0, requireLivePrice = true;
-                    LogPrint(BCLog::LOAN,"CWithdrawFromVaultMessage():\n");
-                    auto collateralsLoans = mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
+                    LogPrint(BCLog::LOAN, "CWithdrawFromVaultMessage():\n");
+                    auto collateralsLoans = mnview.GetLoanCollaterals(
+                        obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
                     if (!collateralsLoans)
                         return std::move(collateralsLoans);
 
                     if (collateralsLoans.val->ratio() < scheme->ratio)
-                        return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d", collateralsLoans.val->ratio(), scheme->ratio);
+                        return Res::Err(
+                            "Vault does not have enough collateralization ratio defined by loan scheme - %d < %d",
+                            collateralsLoans.val->ratio(),
+                            scheme->ratio);
 
                     uint64_t totalCollaterals = 0;
 
-                    for (auto& col : collateralsLoans.val->collaterals)
-                        if (col.nTokenId == DCT_ID{0}
-                        || (tokenDUSD && col.nTokenId == tokenDUSD->first))
+                    for (auto &col : collateralsLoans.val->collaterals)
+                        if (col.nTokenId == DCT_ID{0} || (tokenDUSD && col.nTokenId == tokenDUSD->first))
                             totalCollaterals += col.nValue;
 
                     if (static_cast<int>(height) < consensus.FortCanningHillHeight) {
                         if (totalCollaterals < collateralsLoans.val->totalCollaterals / 2)
                             return Res::Err("At least 50%% of the collateral must be in DFI");
                     } else {
-                        if (arith_uint256(totalCollaterals) * 100 < arith_uint256(collateralsLoans.val->totalLoans) * scheme->ratio / 2)
-                            return static_cast<int>(height) < consensus.FortCanningRoadHeight ? Res::Err("At least 50%% of the minimum required collateral must be in DFI")
-                                                                                              : Res::Err("At least 50%% of the minimum required collateral must be in DFI or DUSD");
+                        if (arith_uint256(totalCollaterals) * 100 <
+                            arith_uint256(collateralsLoans.val->totalLoans) * scheme->ratio / 2)
+                            return static_cast<int>(height) < consensus.FortCanningRoadHeight
+                                       ? Res::Err("At least 50%% of the minimum required collateral must be in DFI")
+                                       : Res::Err(
+                                             "At least 50%% of the minimum required collateral must be in DFI or DUSD");
                     }
                 }
-            }
-            else
+            } else
                 return Res::Err("Cannot withdraw all collaterals as there are still active loans in this vault");
         }
 
         return mnview.AddBalance(obj.to, obj.amount);
     }
 
-    Res operator()(const CLoanTakeLoanMessage& obj) const {
+    Res operator()(const CLoanTakeLoanMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -3073,15 +3206,15 @@ public:
             return Res::Err("Vault with id %s has no collaterals", obj.vaultId.GetHex());
 
         uint64_t totalLoansActivePrice = 0, totalLoansNextPrice = 0;
-        for (const auto& kv : obj.amounts.balances)
-        {
-            const DCT_ID& tokenId = kv.first;
+        for (const auto &kv : obj.amounts.balances) {
+            const DCT_ID &tokenId = kv.first;
             auto loanToken = mnview.GetLoanTokenByID(tokenId);
             if (!loanToken)
                 return Res::Err("Loan token with id (%s) does not exist!", tokenId.ToString());
 
             if (!loanToken->mintable)
-                return Res::Err("Loan cannot be taken on token with id (%s) as \"mintable\" is currently false",tokenId.ToString());
+                return Res::Err("Loan cannot be taken on token with id (%s) as \"mintable\" is currently false",
+                                tokenId.ToString());
 
             res = mnview.AddLoanToken(obj.vaultId, CTokenAmount{kv.first, kv.second});
             if (!res)
@@ -3093,7 +3226,7 @@ public:
 
             auto tokenCurrency = loanToken->fixedIntervalPriceId;
 
-            LogPrint(BCLog::ORACLE,"CLoanTakeLoanMessage()->%s->", loanToken->symbol); /* Continued */
+            LogPrint(BCLog::ORACLE, "CLoanTakeLoanMessage()->%s->", loanToken->symbol); /* Continued */
             auto priceFeed = mnview.GetFixedIntervalPrice(tokenCurrency);
             if (!priceFeed)
                 return Res::Err(priceFeed.msg);
@@ -3106,9 +3239,10 @@ public:
                 auto price = priceFeed.val->priceRecord[int(i > 0)];
                 auto amount = MultiplyAmounts(price, kv.second);
                 if (price > COIN && amount < kv.second)
-                    return Res::Err("Value/price too high (%s/%s)", GetDecimaleString(kv.second), GetDecimaleString(price));
+                    return Res::Err(
+                        "Value/price too high (%s/%s)", GetDecimaleString(kv.second), GetDecimaleString(price));
 
-                auto& totalLoans = i > 0 ? totalLoansNextPrice : totalLoansActivePrice;
+                auto &totalLoans = i > 0 ? totalLoansNextPrice : totalLoansActivePrice;
                 auto prevLoans = totalLoans;
                 totalLoans += amount;
                 if (prevLoans > totalLoans)
@@ -3119,8 +3253,7 @@ public:
             if (!res)
                 return res;
 
-            const auto& address = !obj.to.empty() ? obj.to
-                                                  : vault->ownerAddress;
+            const auto &address = !obj.to.empty() ? obj.to : vault->ownerAddress;
             CalculateOwnerRewards(address);
             res = mnview.AddBalance(address, CTokenAmount{kv.first, kv.second});
             if (!res)
@@ -3135,61 +3268,62 @@ public:
         for (int i = 0; i < 2; i++) {
             // check ratio against current and active price
             bool useNextPrice = i > 0, requireLivePrice = true;
-            LogPrint(BCLog::LOAN,"CLoanTakeLoanMessage():\n");
-            auto collateralsLoans = mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
+            LogPrint(BCLog::LOAN, "CLoanTakeLoanMessage():\n");
+            auto collateralsLoans =
+                mnview.GetLoanCollaterals(obj.vaultId, *collaterals, height, time, useNextPrice, requireLivePrice);
             if (!collateralsLoans)
                 return std::move(collateralsLoans);
 
             if (collateralsLoans.val->ratio() < scheme->ratio)
-                return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d", collateralsLoans.val->ratio(), scheme->ratio);
+                return Res::Err("Vault does not have enough collateralization ratio defined by loan scheme - %d < %d",
+                                collateralsLoans.val->ratio(),
+                                scheme->ratio);
 
             uint64_t totalCollaterals = 0;
 
-            for (auto& col : collateralsLoans.val->collaterals)
-                if (col.nTokenId == DCT_ID{0}
-                || (tokenDUSD && col.nTokenId == tokenDUSD->first))
+            for (auto &col : collateralsLoans.val->collaterals)
+                if (col.nTokenId == DCT_ID{0} || (tokenDUSD && col.nTokenId == tokenDUSD->first))
                     totalCollaterals += col.nValue;
 
             if (static_cast<int>(height) < consensus.FortCanningHillHeight) {
                 if (totalCollaterals < collateralsLoans.val->totalCollaterals / 2)
                     return Res::Err("At least 50%% of the collateral must be in DFI when taking a loan.");
             } else {
-                if (arith_uint256(totalCollaterals) * 100 < arith_uint256(collateralsLoans.val->totalLoans) * scheme->ratio / 2)
-                    return static_cast<int>(height) < consensus.FortCanningRoadHeight ? Res::Err("At least 50%% of the minimum required collateral must be in DFI when taking a loan.")
-                                                                                      : Res::Err("At least 50%% of the minimum required collateral must be in DFI or DUSD when taking a loan.");
+                if (arith_uint256(totalCollaterals) * 100 <
+                    arith_uint256(collateralsLoans.val->totalLoans) * scheme->ratio / 2)
+                    return static_cast<int>(height) < consensus.FortCanningRoadHeight
+                               ? Res::Err(
+                                     "At least 50%% of the minimum required collateral must be in DFI when taking a "
+                                     "loan.")
+                               : Res::Err(
+                                     "At least 50%% of the minimum required collateral must be in DFI or DUSD when "
+                                     "taking a loan.");
             }
         }
         return Res::Ok();
     }
 
-    Res operator()(const CLoanPaybackLoanMessage& obj) const {
+    Res operator()(const CLoanPaybackLoanMessage &obj) const {
         std::map<DCT_ID, CBalances> loans;
-        for (auto& balance: obj.amounts.balances) {
+        for (auto &balance : obj.amounts.balances) {
             auto id = balance.first;
             auto amount = balance.second;
 
-            CBalances* loan;
-            if (id == DCT_ID{0})
-            {
+            CBalances *loan;
+            if (id == DCT_ID{0}) {
                 auto tokenDUSD = mnview.GetToken("DUSD");
                 if (!tokenDUSD)
                     return Res::Err("Loan token DUSD does not exist!");
                 loan = &loans[tokenDUSD->first];
-            }
-            else
+            } else
                 loan = &loans[id];
 
             loan->Add({id, amount});
         }
-        return (*this)(
-            CLoanPaybackLoanV2Message{
-                obj.vaultId,
-                obj.from,
-                loans
-            });
+        return (*this)(CLoanPaybackLoanV2Message{obj.vaultId, obj.from, loans});
     }
 
-    Res operator()(const CLoanPaybackLoanV2Message& obj) const {
+    Res operator()(const CLoanPaybackLoanV2Message &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -3207,21 +3341,20 @@ public:
         if (!HasAuth(obj.from))
             return Res::Err("tx must have at least one input from token owner");
 
-        if (static_cast<int>(height) < consensus.FortCanningRoadHeight && !IsVaultPriceValid(mnview, obj.vaultId, height))
+        if (static_cast<int>(height) < consensus.FortCanningRoadHeight &&
+            !IsVaultPriceValid(mnview, obj.vaultId, height))
             return Res::Err("Cannot payback loan while any of the asset's price is invalid");
 
         auto shouldSetVariable = false;
         auto attributes = mnview.GetAttributes();
 
-        for (const auto& idx : obj.loans)
-        {
+        for (const auto &idx : obj.loans) {
             DCT_ID loanTokenId = idx.first;
             auto loanToken = mnview.GetLoanTokenByID(loanTokenId);
             if (!loanToken)
                 return Res::Err("Loan token with id (%s) does not exist!", loanTokenId.ToString());
 
-            for (const auto& kv : idx.second.balances)
-            {
+            for (const auto &kv : idx.second.balances) {
                 DCT_ID paybackTokenId = kv.first;
                 auto paybackAmount = kv.second;
                 CAmount paybackUsdPrice{0}, loanUsdPrice{0}, penaltyPct{COIN};
@@ -3230,8 +3363,7 @@ public:
                 if (!paybackToken)
                     return Res::Err("Token with id (%s) does not exists", paybackTokenId.ToString());
 
-                if (loanTokenId != paybackTokenId)
-                {
+                if (loanTokenId != paybackTokenId) {
                     if (!IsVaultPriceValid(mnview, obj.vaultId, height))
                         return Res::Err("Cannot payback loan while any of the asset's price is invalid");
 
@@ -3239,28 +3371,28 @@ public:
                         return Res::Err("Payback is not currently active");
 
                     // search in token to token
-                    if (paybackTokenId != DCT_ID{0})
-                    {
-                        CDataStructureV0 activeKey{AttributeTypes::Token, loanTokenId.v, TokenKeys::LoanPayback, paybackTokenId.v};
+                    if (paybackTokenId != DCT_ID{0}) {
+                        CDataStructureV0 activeKey{
+                            AttributeTypes::Token, loanTokenId.v, TokenKeys::LoanPayback, paybackTokenId.v};
                         if (!attributes->GetValue(activeKey, false))
-                            return Res::Err("Payback of loan via %s token is not currently active", paybackToken->symbol);
+                            return Res::Err("Payback of loan via %s token is not currently active",
+                                            paybackToken->symbol);
 
-                        CDataStructureV0 penaltyKey{AttributeTypes::Token, loanTokenId.v, TokenKeys::LoanPaybackFeePCT, paybackTokenId.v};
+                        CDataStructureV0 penaltyKey{
+                            AttributeTypes::Token, loanTokenId.v, TokenKeys::LoanPaybackFeePCT, paybackTokenId.v};
                         penaltyPct -= attributes->GetValue(penaltyKey, CAmount{0});
-                    }
-                    else
-                    {
+                    } else {
                         CDataStructureV0 activeKey{AttributeTypes::Token, loanTokenId.v, TokenKeys::PaybackDFI};
                         if (!attributes->GetValue(activeKey, false))
-                            return Res::Err("Payback of loan via %s token is not currently active", paybackToken->symbol);
+                            return Res::Err("Payback of loan via %s token is not currently active",
+                                            paybackToken->symbol);
 
                         CDataStructureV0 penaltyKey{AttributeTypes::Token, loanTokenId.v, TokenKeys::PaybackDFIFeePCT};
                         penaltyPct -= attributes->GetValue(penaltyKey, COIN / 100);
-
                     }
 
                     // Get token price in USD
-                    const CTokenCurrencyPair tokenUsdPair{paybackToken->symbol,"USD"};
+                    const CTokenCurrencyPair tokenUsdPair{paybackToken->symbol, "USD"};
                     bool useNextPrice{false}, requireLivePrice{true};
                     const auto resVal = mnview.GetValidatedIntervalPrice(tokenUsdPair, useNextPrice, requireLivePrice);
                     if (!resVal)
@@ -3271,18 +3403,18 @@ public:
                     // Calculate the DFI amount in DUSD
                     auto usdAmount = MultiplyAmounts(paybackUsdPrice, kv.second);
 
-                    if (loanToken->symbol == "DUSD")
-                    {
+                    if (loanToken->symbol == "DUSD") {
                         paybackAmount = usdAmount;
                         if (paybackUsdPrice > COIN && paybackAmount < kv.second)
-                            return Res::Err("Value/price too high (%s/%s)", GetDecimaleString(kv.second), GetDecimaleString(paybackUsdPrice));
-                    }
-                    else
-                    {
+                            return Res::Err("Value/price too high (%s/%s)",
+                                            GetDecimaleString(kv.second),
+                                            GetDecimaleString(paybackUsdPrice));
+                    } else {
                         // Get dToken price in USD
                         const CTokenCurrencyPair dTokenUsdPair{loanToken->symbol, "USD"};
                         bool useNextPrice{false}, requireLivePrice{true};
-                        const auto resVal = mnview.GetValidatedIntervalPrice(dTokenUsdPair, useNextPrice, requireLivePrice);
+                        const auto resVal =
+                            mnview.GetValidatedIntervalPrice(dTokenUsdPair, useNextPrice, requireLivePrice);
                         if (!resVal)
                             return std::move(resVal);
 
@@ -3304,17 +3436,14 @@ public:
                 if (!rate)
                     return Res::Err("Cannot get interest rate for this token (%s)!", loanToken->symbol);
 
-                LogPrint(BCLog::LOAN,"CLoanPaybackLoanMessage()->%s->", loanToken->symbol); /* Continued */
+                LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage()->%s->", loanToken->symbol); /* Continued */
                 auto subInterest = TotalInterest(*rate, height);
                 auto subLoan = paybackAmount - subInterest;
 
-                if (paybackAmount < subInterest)
-                {
+                if (paybackAmount < subInterest) {
                     subInterest = paybackAmount;
                     subLoan = 0;
-                }
-                else if (it->second - subLoan < 0)
-                {
+                } else if (it->second - subLoan < 0) {
                     subLoan = it->second;
                 }
 
@@ -3322,67 +3451,67 @@ public:
                 if (!res)
                     return res;
 
-                LogPrint(BCLog::LOAN,"CLoanPaybackLoanMessage()->%s->", loanToken->symbol); /* Continued */
+                LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage()->%s->", loanToken->symbol); /* Continued */
                 res = mnview.EraseInterest(height, obj.vaultId, vault->schemeId, loanTokenId, subLoan, subInterest);
                 if (!res)
                     return res;
 
-                if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight && subLoan < it->second)
-                {
+                if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight && subLoan < it->second) {
                     auto newRate = mnview.GetInterestRate(obj.vaultId, loanTokenId, height);
                     if (!newRate)
                         return Res::Err("Cannot get interest rate for this token (%s)!", loanToken->symbol);
 
                     if (newRate->interestPerBlock == 0)
-                        return Res::Err("Cannot payback this amount of loan for %s, either payback full amount or less than this amount!", loanToken->symbol);
+                        return Res::Err(
+                            "Cannot payback this amount of loan for %s, either payback full amount or less than this "
+                            "amount!",
+                            loanToken->symbol);
                 }
 
                 CalculateOwnerRewards(obj.from);
 
-                if (paybackTokenId == loanTokenId)
-                {
+                if (paybackTokenId == loanTokenId) {
                     res = mnview.SubMintedTokens(loanTokenId, subLoan);
                     if (!res)
                         return res;
 
                     // subtract loan amount first, interest is burning below
-                    LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Sub loan from balance - %lld, height - %d\n", subLoan, height);
+                    LogPrint(BCLog::LOAN,
+                             "CLoanPaybackLoanMessage(): Sub loan from balance - %lld, height - %d\n",
+                             subLoan,
+                             height);
                     res = mnview.SubBalance(obj.from, CTokenAmount{loanTokenId, subLoan});
                     if (!res)
                         return res;
 
                     // burn interest Token->USD->DFI->burnAddress
-                    if (subInterest)
-                    {
-                        LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Swapping %s interest to DFI - %lld, height - %d\n", loanToken->symbol, subInterest, height);
-                        res = SwapToDFIorDUSD(mnview, loanTokenId, subInterest, obj.from, consensus.burnAddress, height);
+                    if (subInterest) {
+                        LogPrint(BCLog::LOAN,
+                                 "CLoanPaybackLoanMessage(): Swapping %s interest to DFI - %lld, height - %d\n",
+                                 loanToken->symbol,
+                                 subInterest,
+                                 height);
+                        res =
+                            SwapToDFIorDUSD(mnview, loanTokenId, subInterest, obj.from, consensus.burnAddress, height);
                     }
-                }
-                else
-                {
+                } else {
                     CAmount subInToken;
                     auto subAmount = subLoan + subInterest;
 
                     // if payback overpay loan and interest amount
-                    if (paybackAmount > subAmount)
-                    {
-                        if (loanToken->symbol == "DUSD")
-                        {
+                    if (paybackAmount > subAmount) {
+                        if (loanToken->symbol == "DUSD") {
                             subInToken = DivideAmounts(subAmount, paybackUsdPrice);
                             if (MultiplyAmounts(subInToken, paybackUsdPrice) != subAmount)
                                 subInToken += 1;
-                        }
-                        else
-                        {
+                        } else {
                             auto tempAmount = MultiplyAmounts(subAmount, loanUsdPrice);
 
                             subInToken = DivideAmounts(tempAmount, paybackUsdPrice);
                             if (DivideAmounts(MultiplyAmounts(subInToken, paybackUsdPrice), loanUsdPrice) != subAmount)
                                 subInToken += 1;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         subInToken = kv.second;
                     }
 
@@ -3390,21 +3519,26 @@ public:
 
                     auto penalty = MultiplyAmounts(subInToken, COIN - penaltyPct);
 
-                    if (paybackTokenId == DCT_ID{0})
-                    {
-                        CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackDFITokens};
+                    if (paybackTokenId == DCT_ID{0}) {
+                        CDataStructureV0 liveKey{
+                            AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackDFITokens};
                         auto balances = attributes->GetValue(liveKey, CBalances{});
 
                         balances.Add(CTokenAmount{loanTokenId, subAmount});
                         balances.Add(CTokenAmount{paybackTokenId, penalty});
                         attributes->SetValue(liveKey, balances);
 
-                        LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Burning interest and loan in %s directly - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
+                        LogPrint(BCLog::LOAN,
+                                 "CLoanPaybackLoanMessage(): Burning interest and loan in %s directly - total loan "
+                                 "%lld (%lld %s), height - %d\n",
+                                 paybackToken->symbol,
+                                 subLoan + subInterest,
+                                 subInToken,
+                                 paybackToken->symbol,
+                                 height);
 
                         res = TransferTokenBalance(paybackTokenId, subInToken, obj.from, consensus.burnAddress);
-                    }
-                    else
-                    {
+                    } else {
                         CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackTokens};
                         auto balances = attributes->GetValue(liveKey, CTokenPayback{});
 
@@ -3412,12 +3546,26 @@ public:
                         balances.tokensFee.Add(CTokenAmount{paybackTokenId, penalty});
                         attributes->SetValue(liveKey, balances);
 
-                        LogPrint(BCLog::LOAN, "CLoanPaybackLoanMessage(): Swapping %s to DFI and burning it - total loan %lld (%lld %s), height - %d\n", paybackToken->symbol, subLoan + subInterest, subInToken, paybackToken->symbol, height);
+                        LogPrint(BCLog::LOAN,
+                                 "CLoanPaybackLoanMessage(): Swapping %s to DFI and burning it - total loan %lld (%lld "
+                                 "%s), height - %d\n",
+                                 paybackToken->symbol,
+                                 subLoan + subInterest,
+                                 subInToken,
+                                 paybackToken->symbol,
+                                 height);
 
-                        CDataStructureV0 directBurnKey{AttributeTypes::Param, ParamIDs::DFIP2206A, DFIPKeys::DUSDLoanBurn};
+                        CDataStructureV0 directBurnKey{
+                            AttributeTypes::Param, ParamIDs::DFIP2206A, DFIPKeys::DUSDLoanBurn};
                         auto directLoanBurn = attributes->GetValue(directBurnKey, false);
 
-                        res = SwapToDFIorDUSD(mnview, paybackTokenId, subInToken, obj.from, consensus.burnAddress, height, !directLoanBurn);
+                        res = SwapToDFIorDUSD(mnview,
+                                              paybackTokenId,
+                                              subInToken,
+                                              obj.from,
+                                              consensus.burnAddress,
+                                              height,
+                                              !directLoanBurn);
                     }
                 }
 
@@ -3429,7 +3577,7 @@ public:
         return shouldSetVariable ? mnview.SetVariable(*attributes) : Res::Ok();
     }
 
-    Res operator()(const CAuctionBidMessage& obj) const {
+    Res operator()(const CAuctionBidMessage &obj) const {
         auto res = CheckCustomTx();
         if (!res)
             return res;
@@ -3462,46 +3610,48 @@ public:
         if (!bid) {
             auto amount = MultiplyAmounts(batch->loanAmount.nValue, COIN + data->liquidationPenalty);
             if (amount > obj.amount.nValue)
-                return Res::Err("First bid should include liquidation penalty of %d%%", data->liquidationPenalty * 100 / COIN);
+                return Res::Err("First bid should include liquidation penalty of %d%%",
+                                data->liquidationPenalty * 100 / COIN);
 
-            if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight
-            && data->liquidationPenalty && obj.amount.nValue == batch->loanAmount.nValue)
+            if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight && data->liquidationPenalty &&
+                obj.amount.nValue == batch->loanAmount.nValue)
                 return Res::Err("First bid should be higher than batch one");
         } else {
             auto amount = MultiplyAmounts(bid->second.nValue, COIN + (COIN / 100));
             if (amount > obj.amount.nValue)
                 return Res::Err("Bid override should be at least 1%% higher than current one");
 
-            if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight
-            && obj.amount.nValue == bid->second.nValue)
+            if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight &&
+                obj.amount.nValue == bid->second.nValue)
                 return Res::Err("Bid override should be higher than last one");
 
             // immediate refund previous bid
             CalculateOwnerRewards(bid->first);
             mnview.AddBalance(bid->first, bid->second);
         }
-        //check balance
+        // check balance
         CalculateOwnerRewards(obj.from);
         res = mnview.SubBalance(obj.from, obj.amount);
         return !res ? res : mnview.StoreAuctionBid({obj.vaultId, obj.index}, {obj.from, obj.amount});
     }
 
-    Res operator()(const CCustomTxMessageNone&) const {
-        return Res::Ok();
-    }
+    Res operator()(const CCustomTxMessageNone &) const { return Res::Ok(); }
 };
 
-Res CustomMetadataParse(uint32_t height, const Consensus::Params& consensus, const std::vector<unsigned char>& metadata, CCustomTxMessage& txMessage) {
+Res CustomMetadataParse(uint32_t height,
+                        const Consensus::Params &consensus,
+                        const std::vector<unsigned char> &metadata,
+                        CCustomTxMessage &txMessage) {
     try {
         return std::visit(CCustomMetadataParseVisitor(height, consensus, metadata), txMessage);
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
         return Res::Err(e.what());
     } catch (...) {
         return Res::Err("unexpected error");
     }
 }
 
-bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params& consensus) {
+bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params &consensus) {
     // All the heights that are involved in disabled Txs
     auto fortCanningParkHeight = static_cast<uint32_t>(consensus.FortCanningParkHeight);
     auto fortCanningHillHeight = static_cast<uint32_t>(consensus.FortCanningHillHeight);
@@ -3520,7 +3670,7 @@ bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params& c
                 return true;
             default:
                 break;
-            }
+        }
     }
 
     // ICXCreateOrder      = '1',
@@ -3544,34 +3694,47 @@ bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params& c
     }
 }
 
-bool IsDisabledTx(uint32_t height, const CTransaction& tx, const Consensus::Params& consensus) {
+bool IsDisabledTx(uint32_t height, const CTransaction &tx, const Consensus::Params &consensus) {
     TBytes dummy;
     auto txType = GuessCustomTxType(tx, dummy);
     return IsDisabledTx(height, txType, consensus);
 }
 
-Res CustomTxVisit(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, uint32_t height, const Consensus::Params& consensus, const CCustomTxMessage& txMessage, uint64_t time, uint32_t txn) {
+Res CustomTxVisit(CCustomCSView &mnview,
+                  const CCoinsViewCache &coins,
+                  const CTransaction &tx,
+                  uint32_t height,
+                  const Consensus::Params &consensus,
+                  const CCustomTxMessage &txMessage,
+                  uint64_t time,
+                  uint32_t txn) {
     if (IsDisabledTx(height, tx, consensus)) {
         return Res::ErrCode(CustomTxErrCodes::Fatal, "Disabled custom transaction");
     }
     try {
         return std::visit(CCustomTxApplyVisitor(tx, height, coins, mnview, consensus, time, txn), txMessage);
-    } catch (const std::bad_variant_access& e) {
+    } catch (const std::bad_variant_access &e) {
         return Res::Err(e.what());
     } catch (...) {
         return Res::Err("unexpected error");
     }
 }
 
-bool ShouldReturnNonFatalError(const CTransaction& tx, uint32_t height) {
+bool ShouldReturnNonFatalError(const CTransaction &tx, uint32_t height) {
     static const std::map<uint32_t, uint256> skippedTx = {
-        { 471222, uint256S("0ab0b76352e2d865761f4c53037041f33e1200183d55cdf6b09500d6f16b7329") },
+        {471222, uint256S("0ab0b76352e2d865761f4c53037041f33e1200183d55cdf6b09500d6f16b7329")},
     };
     auto it = skippedTx.find(height);
     return it != skippedTx.end() && it->second == tx.GetHash();
 }
 
-void PopulateVaultHistoryData(CHistoryWriters* writers, CAccountsHistoryWriter& view, const CCustomTxMessage& txMessage, const CustomTxType txType, const uint32_t height, const uint32_t txn, const uint256& txid) {
+void PopulateVaultHistoryData(CHistoryWriters *writers,
+                              CAccountsHistoryWriter &view,
+                              const CCustomTxMessage &txMessage,
+                              const CustomTxType txType,
+                              const uint32_t height,
+                              const uint32_t txn,
+                              const uint256 &txid) {
     if (txType == CustomTxType::Vault) {
         auto obj = std::get<CVaultMessage>(txMessage);
         writers->schemeID = obj.schemeId;
@@ -3611,20 +3774,29 @@ void PopulateVaultHistoryData(CHistoryWriters* writers, CAccountsHistoryWriter& 
         if (!obj.updateHeight) {
             writers->globalLoanScheme.schemeCreationTxid = txid;
         } else {
-            writers->vaultView->ForEachGlobalScheme([&writers](VaultGlobalSchemeKey const & key, CLazySerialize<VaultGlobalSchemeValue> value) {
-                if (value.get().loanScheme.identifier != writers->globalLoanScheme.identifier) {
-                    return true;
-                }
-                writers->globalLoanScheme.schemeCreationTxid = key.schemeCreationTxid;
-                return false;
-            }, {height, txn, {}});
+            writers->vaultView->ForEachGlobalScheme(
+                [&writers](VaultGlobalSchemeKey const &key, CLazySerialize<VaultGlobalSchemeValue> value) {
+                    if (value.get().loanScheme.identifier != writers->globalLoanScheme.identifier) {
+                        return true;
+                    }
+                    writers->globalLoanScheme.schemeCreationTxid = key.schemeCreationTxid;
+                    return false;
+                },
+                {height, txn, {}});
         }
     }
 }
 
-Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height, uint64_t time, uint32_t txn, CHistoryWriters* writers) {
+Res ApplyCustomTx(CCustomCSView &mnview,
+                  const CCoinsViewCache &coins,
+                  const CTransaction &tx,
+                  const Consensus::Params &consensus,
+                  uint32_t height,
+                  uint64_t time,
+                  uint32_t txn,
+                  CHistoryWriters *writers) {
     auto res = Res::Ok();
-    if (tx.IsCoinBase() && height > 0) { // genesis contains custom coinbase txs
+    if (tx.IsCoinBase() && height > 0) {  // genesis contains custom coinbase txs
         return res;
     }
     std::vector<unsigned char> metadata;
@@ -3642,7 +3814,7 @@ Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTr
     CAccountsHistoryWriter view(mnview, height, txn, tx.GetHash(), uint8_t(txType), writers);
     if ((res = CustomMetadataParse(height, consensus, metadata, txMessage))) {
         if (pvaultHistoryDB && writers) {
-           PopulateVaultHistoryData(writers, view, txMessage, txType, height, txn, tx.GetHash());
+            PopulateVaultHistoryData(writers, view, txMessage, txType, height, txn, tx.GetHash());
         }
         res = CustomTxVisit(view, coins, tx, height, consensus, txMessage, time, txn);
 
@@ -3677,7 +3849,7 @@ Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTr
     }
 
     // construct undo
-    auto& flushable = view.GetStorage();
+    auto &flushable = view.GetStorage();
     auto undo = CUndo::Construct(mnview.GetStorage(), flushable.GetRaw());
     // flush changes
     view.Flush();
@@ -3688,8 +3860,12 @@ Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTr
     return res;
 }
 
-ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const & tx, int height, uint256 const & prevStakeModifier, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
-{
+ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
+                                    CTransaction const &tx,
+                                    int height,
+                                    uint256 const &prevStakeModifier,
+                                    std::vector<unsigned char> const &metadata,
+                                    Consensus::Params const &consensusParams) {
     if (height >= consensusParams.DakotaHeight) {
         return Res::Err("Old anchor TX type after Dakota fork. Height %d", height);
     }
@@ -3700,8 +3876,10 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
 
     auto rewardTx = mnview.GetRewardForAnchor(finMsg.btcTxHash);
     if (rewardTx) {
-        return Res::ErrDbg("bad-ar-exists", "reward for anchor %s already exists (tx: %s)",
-                           finMsg.btcTxHash.ToString(), (*rewardTx).ToString());
+        return Res::ErrDbg("bad-ar-exists",
+                           "reward for anchor %s already exists (tx: %s)",
+                           finMsg.btcTxHash.ToString(),
+                           (*rewardTx).ToString());
     }
 
     if (!finMsg.CheckConfirmSigs()) {
@@ -3709,8 +3887,10 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
     }
 
     if (finMsg.sigs.size() < GetMinAnchorQuorum(finMsg.currentTeam)) {
-        return Res::ErrDbg("bad-ar-sigs-quorum", "anchor sigs (%d) < min quorum (%) ",
-                           finMsg.sigs.size(), GetMinAnchorQuorum(finMsg.currentTeam));
+        return Res::ErrDbg("bad-ar-sigs-quorum",
+                           "anchor sigs (%d) < min quorum (%) ",
+                           finMsg.sigs.size(),
+                           GetMinAnchorQuorum(finMsg.currentTeam));
     }
 
     // check reward sum
@@ -3721,19 +3901,21 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
 
         auto const anchorReward = mnview.GetCommunityBalance(CommunityAccountType::AnchorReward);
         if (cbValues.begin()->second != anchorReward) {
-            return Res::ErrDbg("bad-ar-amount", "anchor pays wrong amount (actual=%d vs expected=%d)",
-                               cbValues.begin()->second, anchorReward);
+            return Res::ErrDbg("bad-ar-amount",
+                               "anchor pays wrong amount (actual=%d vs expected=%d)",
+                               cbValues.begin()->second,
+                               anchorReward);
         }
-    }
-    else { // pre-AMK logic
+    } else {  // pre-AMK logic
         auto anchorReward = GetAnchorSubsidy(finMsg.anchorHeight, finMsg.prevAnchorHeight, consensusParams);
         if (tx.GetValueOut() > anchorReward) {
-            return Res::ErrDbg("bad-ar-amount", "anchor pays too much (actual=%d vs limit=%d)",
-                               tx.GetValueOut(), anchorReward);
+            return Res::ErrDbg(
+                "bad-ar-amount", "anchor pays too much (actual=%d vs limit=%d)", tx.GetValueOut(), anchorReward);
         }
     }
 
-    CTxDestination destination = finMsg.rewardKeyType == 1 ? CTxDestination(PKHash(finMsg.rewardKeyID)) : CTxDestination(WitnessV0KeyHash(finMsg.rewardKeyID));
+    CTxDestination destination = finMsg.rewardKeyType == 1 ? CTxDestination(PKHash(finMsg.rewardKeyID))
+                                                           : CTxDestination(WitnessV0KeyHash(finMsg.rewardKeyID));
     if (tx.vout[1].scriptPubKey != GetScriptForDestination(destination)) {
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
@@ -3747,18 +3929,24 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView & mnview, CTransaction const &
     }
     mnview.SetTeam(finMsg.nextTeam);
     if (height >= consensusParams.AMKHeight) {
-        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
-        mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
-    }
-    else {
+        LogPrint(BCLog::ACCOUNTCHANGE,
+                 "AccountChange: txid=%s fund=%s change=%s\n",
+                 tx.GetHash().ToString(),
+                 GetCommunityAccountName(CommunityAccountType::AnchorReward),
+                 (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+        mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0);  // just reset
+    } else {
         mnview.SetFoundationsDebt(mnview.GetFoundationsDebt() + tx.GetValueOut());
     }
 
-    return { finMsg.btcTxHash, Res::Ok() };
+    return {finMsg.btcTxHash, Res::Ok()};
 }
 
-ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction const & tx, int height, std::vector<unsigned char> const & metadata, Consensus::Params const & consensusParams)
-{
+ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView &mnview,
+                                        CTransaction const &tx,
+                                        int height,
+                                        std::vector<unsigned char> const &metadata,
+                                        Consensus::Params const &consensusParams) {
     if (height < consensusParams.DakotaHeight) {
         return Res::Err("New anchor TX type before Dakota fork. Height %d", height);
     }
@@ -3769,8 +3957,10 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction con
 
     auto rewardTx = mnview.GetRewardForAnchor(finMsg.btcTxHash);
     if (rewardTx) {
-        return Res::ErrDbg("bad-ar-exists", "reward for anchor %s already exists (tx: %s)",
-                           finMsg.btcTxHash.ToString(), (*rewardTx).ToString());
+        return Res::ErrDbg("bad-ar-exists",
+                           "reward for anchor %s already exists (tx: %s)",
+                           finMsg.btcTxHash.ToString(),
+                           (*rewardTx).ToString());
     }
 
     // Miner used confirm team at chain height when creating this TX, this is height - 1.
@@ -3787,25 +3977,28 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction con
 
     auto quorum = GetMinAnchorQuorum(*team);
     if (finMsg.sigs.size() < quorum) {
-        return Res::ErrDbg("bad-ar-sigs-quorum", "anchor sigs (%d) < min quorum (%) ",
-                           finMsg.sigs.size(), quorum);
+        return Res::ErrDbg("bad-ar-sigs-quorum", "anchor sigs (%d) < min quorum (%) ", finMsg.sigs.size(), quorum);
     }
 
     if (uniqueKeys < quorum) {
-        return Res::ErrDbg("bad-ar-sigs-quorum", "anchor unique keys (%d) < min quorum (%) ",
-                           uniqueKeys, quorum);
+        return Res::ErrDbg("bad-ar-sigs-quorum", "anchor unique keys (%d) < min quorum (%) ", uniqueKeys, quorum);
     }
 
     // Make sure anchor block height and hash exist in chain.
-    CBlockIndex* anchorIndex = ::ChainActive()[finMsg.anchorHeight];
+    CBlockIndex *anchorIndex = ::ChainActive()[finMsg.anchorHeight];
     if (!anchorIndex) {
-        return Res::ErrDbg("bad-ar-height", "Active chain does not contain block height %d. Chain height %d",
-                           finMsg.anchorHeight, ::ChainActive().Height());
+        return Res::ErrDbg("bad-ar-height",
+                           "Active chain does not contain block height %d. Chain height %d",
+                           finMsg.anchorHeight,
+                           ::ChainActive().Height());
     }
 
     if (anchorIndex->GetBlockHash() != finMsg.dfiBlockHash) {
-        return Res::ErrDbg("bad-ar-hash", "Anchor and blockchain mismatch at height %d. Expected %s found %s",
-                           finMsg.anchorHeight, anchorIndex->GetBlockHash().ToString(), finMsg.dfiBlockHash.ToString());
+        return Res::ErrDbg("bad-ar-hash",
+                           "Anchor and blockchain mismatch at height %d. Expected %s found %s",
+                           finMsg.anchorHeight,
+                           anchorIndex->GetBlockHash().ToString(),
+                           finMsg.dfiBlockHash.ToString());
     }
 
     // check reward sum
@@ -3815,27 +4008,33 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView & mnview, CTransaction con
 
     auto const anchorReward = mnview.GetCommunityBalance(CommunityAccountType::AnchorReward);
     if (cbValues.begin()->second != anchorReward) {
-        return Res::ErrDbg("bad-ar-amount", "anchor pays wrong amount (actual=%d vs expected=%d)",
-                           cbValues.begin()->second, anchorReward);
+        return Res::ErrDbg("bad-ar-amount",
+                           "anchor pays wrong amount (actual=%d vs expected=%d)",
+                           cbValues.begin()->second,
+                           anchorReward);
     }
 
-    CTxDestination destination = finMsg.rewardKeyType == 1 ? CTxDestination(PKHash(finMsg.rewardKeyID)) : CTxDestination(WitnessV0KeyHash(finMsg.rewardKeyID));
+    CTxDestination destination = finMsg.rewardKeyType == 1 ? CTxDestination(PKHash(finMsg.rewardKeyID))
+                                                           : CTxDestination(WitnessV0KeyHash(finMsg.rewardKeyID));
     if (tx.vout[1].scriptPubKey != GetScriptForDestination(destination)) {
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
 
-    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::AnchorReward), (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
-    mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0); // just reset
+    LogPrint(BCLog::ACCOUNTCHANGE,
+             "AccountChange: txid=%s fund=%s change=%s\n",
+             tx.GetHash().ToString(),
+             GetCommunityAccountName(CommunityAccountType::AnchorReward),
+             (CBalances{{{{0}, -mnview.GetCommunityBalance(CommunityAccountType::AnchorReward)}}}.ToString()));
+    mnview.SetCommunityBalance(CommunityAccountType::AnchorReward, 0);  // just reset
     mnview.AddRewardForAnchor(finMsg.btcTxHash, tx.GetHash());
 
     // Store reward data for RPC info
     mnview.AddAnchorConfirmData(CAnchorConfirmDataPlus{finMsg});
 
-    return { finMsg.btcTxHash, Res::Ok() };
+    return {finMsg.btcTxHash, Res::Ok()};
 }
 
-bool IsMempooledCustomTxCreate(const CTxMemPool & pool, const uint256 & txid)
-{
+bool IsMempooledCustomTxCreate(const CTxMemPool &pool, const uint256 &txid) {
     CTransactionRef ptx = pool.get(txid);
     if (ptx) {
         std::vector<unsigned char> dummy;
@@ -3845,16 +4044,14 @@ bool IsMempooledCustomTxCreate(const CTxMemPool & pool, const uint256 & txid)
     return false;
 }
 
-std::vector<DCT_ID> CPoolSwap::CalculateSwaps(CCustomCSView& view, bool testOnly) {
-
+std::vector<DCT_ID> CPoolSwap::CalculateSwaps(CCustomCSView &view, bool testOnly) {
     std::vector<std::vector<DCT_ID>> poolPaths = CalculatePoolPaths(view);
 
     // Record best pair
     std::pair<std::vector<DCT_ID>, CAmount> bestPair{{}, -1};
 
     // Loop through all common pairs
-    for (const auto& path : poolPaths) {
-
+    for (const auto &path : poolPaths) {
         // Test on copy of view
         CCustomCSView dummy(view);
 
@@ -3878,24 +4075,25 @@ std::vector<DCT_ID> CPoolSwap::CalculateSwaps(CCustomCSView& view, bool testOnly
     return bestPair.first;
 }
 
-std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& view) {
-
+std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView &view) {
     // For tokens to be traded get all pairs and pool IDs
     std::multimap<uint32_t, DCT_ID> fromPoolsID, toPoolsID;
-    view.ForEachPoolPair([&](DCT_ID const & id, const CPoolPair& pool) {
-        if (pool.idTokenA == obj.idTokenFrom) {
-            fromPoolsID.emplace(pool.idTokenB.v, id);
-        } else if (pool.idTokenB == obj.idTokenFrom) {
-            fromPoolsID.emplace(pool.idTokenA.v, id);
-        }
+    view.ForEachPoolPair(
+        [&](DCT_ID const &id, const CPoolPair &pool) {
+            if (pool.idTokenA == obj.idTokenFrom) {
+                fromPoolsID.emplace(pool.idTokenB.v, id);
+            } else if (pool.idTokenB == obj.idTokenFrom) {
+                fromPoolsID.emplace(pool.idTokenA.v, id);
+            }
 
-        if (pool.idTokenA == obj.idTokenTo) {
-            toPoolsID.emplace(pool.idTokenB.v, id);
-        } else if (pool.idTokenB == obj.idTokenTo) {
-            toPoolsID.emplace(pool.idTokenA.v, id);
-        }
-        return true;
-    }, {0});
+            if (pool.idTokenA == obj.idTokenTo) {
+                toPoolsID.emplace(pool.idTokenB.v, id);
+            } else if (pool.idTokenB == obj.idTokenTo) {
+                toPoolsID.emplace(pool.idTokenA.v, id);
+            }
+            return true;
+        },
+        {0});
 
     if (fromPoolsID.empty() || toPoolsID.empty()) {
         return {};
@@ -3903,24 +4101,22 @@ std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& vi
 
     // Find intersection on key
     std::map<uint32_t, DCT_ID> commonPairs;
-    set_intersection(fromPoolsID.begin(), fromPoolsID.end(), toPoolsID.begin(), toPoolsID.end(),
+    set_intersection(fromPoolsID.begin(),
+                     fromPoolsID.end(),
+                     toPoolsID.begin(),
+                     toPoolsID.end(),
                      std::inserter(commonPairs, commonPairs.begin()),
-                     [](std::pair<uint32_t, DCT_ID> a, std::pair<uint32_t, DCT_ID> b) {
-                         return a.first < b.first;
-                     });
+                     [](std::pair<uint32_t, DCT_ID> a, std::pair<uint32_t, DCT_ID> b) { return a.first < b.first; });
 
     // Loop through all common pairs and record direct pool to pool swaps
     std::vector<std::vector<DCT_ID>> poolPaths;
-    for (const auto& item : commonPairs) {
-
+    for (const auto &item : commonPairs) {
         // Loop through all source/intermediate pools matching common pairs
         const auto poolFromIDs = fromPoolsID.equal_range(item.first);
         for (auto fromID = poolFromIDs.first; fromID != poolFromIDs.second; ++fromID) {
-
             // Loop through all destination pools matching common pairs
             const auto poolToIDs = toPoolsID.equal_range(item.first);
             for (auto toID = poolToIDs.first; toID != poolToIDs.second; ++toID) {
-
                 // Add to pool paths
                 poolPaths.push_back({fromID->second, toID->second});
             }
@@ -3928,23 +4124,24 @@ std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& vi
     }
 
     // Look for pools that bridges token. Might be in addition to common token pairs paths.
-    view.ForEachPoolPair([&](DCT_ID const & id, const CPoolPair& pool) {
-
-        // Loop through from pool multimap on unique keys only
-        for (auto fromIt = fromPoolsID.begin(); fromIt != fromPoolsID.end(); fromIt = fromPoolsID.equal_range(fromIt->first).second) {
-
-            // Loop through to pool multimap on unique keys only
-            for (auto toIt = toPoolsID.begin(); toIt != toPoolsID.end(); toIt = toPoolsID.equal_range(toIt->first).second) {
-
-                // If a pool pairs matches from pair and to pair add it to the pool paths
-                if ((fromIt->first == pool.idTokenA.v && toIt->first == pool.idTokenB.v) ||
-                    (fromIt->first == pool.idTokenB.v && toIt->first == pool.idTokenA.v)) {
-                    poolPaths.push_back({fromIt->second, id, toIt->second});
+    view.ForEachPoolPair(
+        [&](DCT_ID const &id, const CPoolPair &pool) {
+            // Loop through from pool multimap on unique keys only
+            for (auto fromIt = fromPoolsID.begin(); fromIt != fromPoolsID.end();
+                 fromIt = fromPoolsID.equal_range(fromIt->first).second) {
+                // Loop through to pool multimap on unique keys only
+                for (auto toIt = toPoolsID.begin(); toIt != toPoolsID.end();
+                     toIt = toPoolsID.equal_range(toIt->first).second) {
+                    // If a pool pairs matches from pair and to pair add it to the pool paths
+                    if ((fromIt->first == pool.idTokenA.v && toIt->first == pool.idTokenB.v) ||
+                        (fromIt->first == pool.idTokenB.v && toIt->first == pool.idTokenA.v)) {
+                        poolPaths.push_back({fromIt->second, id, toIt->second});
+                    }
                 }
             }
-        }
-        return true;
-    }, {0});
+            return true;
+        },
+        {0});
 
     // return pool paths
     return poolPaths;
@@ -3953,8 +4150,7 @@ std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& vi
 // Note: `testOnly` doesn't update views, and as such can result in a previous price calculations
 // for a pool, if used multiple times (or duplicated pool IDs) with the same view.
 // testOnly is only meant for one-off tests per well defined view.
-Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, bool testOnly) {
-
+Res CPoolSwap::ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, bool testOnly) {
     Res poolResult = Res::Ok();
 
     // No composite swap allowed before Fort Canning
@@ -3968,7 +4164,7 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
 
     // Single swap if no pool IDs provided
     auto poolPrice = POOLPRICE_MAX;
-    std::optional<std::pair<DCT_ID, CPoolPair> > poolPair;
+    std::optional<std::pair<DCT_ID, CPoolPair>> poolPair;
     if (poolIDs.empty()) {
         poolPair = view.GetPoolPair(obj.idTokenFrom, obj.idTokenTo);
         if (!poolPair) {
@@ -3999,7 +4195,6 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
     CTokenAmount swapAmountResult{obj.idTokenFrom, obj.amountFrom};
 
     for (size_t i{0}; i < poolIDs.size(); ++i) {
-
         // Also used to generate pool specific error messages for RPC users
         currentID = poolIDs[i];
 
@@ -4007,8 +4202,7 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
         std::optional<CPoolPair> pool;
         if (poolPair) {
             pool = poolPair->second;
-        }
-        else // Or get pools from IDs provided for composite swap
+        } else  // Or get pools from IDs provided for composite swap
         {
             pool = view.GetPoolPair(currentID);
             if (!pool) {
@@ -4039,88 +4233,94 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
         const auto dirA = attributes->GetValue(dirAKey, CFeeDir{FeeDirValues::Both});
         const auto dirB = attributes->GetValue(dirBKey, CFeeDir{FeeDirValues::Both});
         const auto asymmetricFee = std::make_pair(dirA, dirB);
-      
+
         auto dexfeeInPct = view.GetDexFeeInPct(currentID, swapAmount.nTokenId);
-        auto& balances = dexBalances[currentID];
+        auto &balances = dexBalances[currentID];
         auto forward = swapAmount.nTokenId == pool->idTokenA;
 
-        auto& totalTokenA = forward ? balances.totalTokenA : balances.totalTokenB;
-        auto& totalTokenB = forward ? balances.totalTokenB : balances.totalTokenA;
+        auto &totalTokenA = forward ? balances.totalTokenA : balances.totalTokenB;
+        auto &totalTokenB = forward ? balances.totalTokenB : balances.totalTokenA;
 
-        const auto& reserveAmount = forward ? pool->reserveA : pool->reserveB;
-        const auto& blockCommission = forward ? pool->blockCommissionA : pool->blockCommissionB;
+        const auto &reserveAmount = forward ? pool->reserveA : pool->reserveB;
+        const auto &blockCommission = forward ? pool->blockCommissionA : pool->blockCommissionB;
 
         const auto initReserveAmount = reserveAmount;
         const auto initBlockCommission = blockCommission;
 
         // Perform swap
-        poolResult = pool->Swap(swapAmount, dexfeeInPct, poolPrice, asymmetricFee, [&] (const CTokenAmount& dexfeeInAmount, const CTokenAmount& tokenAmount) {
-            // Save swap amount for next loop
-            swapAmountResult = tokenAmount;
+        poolResult = pool->Swap(
+            swapAmount,
+            dexfeeInPct,
+            poolPrice,
+            asymmetricFee,
+            [&](const CTokenAmount &dexfeeInAmount, const CTokenAmount &tokenAmount) {
+                // Save swap amount for next loop
+                swapAmountResult = tokenAmount;
 
-            CTokenAmount dexfeeOutAmount{tokenAmount.nTokenId, 0};
+                CTokenAmount dexfeeOutAmount{tokenAmount.nTokenId, 0};
 
-            auto dexfeeOutPct = view.GetDexFeeOutPct(currentID, tokenAmount.nTokenId);
-            if (dexfeeOutPct > 0 && poolOutFee(swapAmount.nTokenId == pool->idTokenA, asymmetricFee)) {
-                dexfeeOutAmount.nValue = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
-                swapAmountResult.nValue -= dexfeeOutAmount.nValue;
-            }
+                auto dexfeeOutPct = view.GetDexFeeOutPct(currentID, tokenAmount.nTokenId);
+                if (dexfeeOutPct > 0 && poolOutFee(swapAmount.nTokenId == pool->idTokenA, asymmetricFee)) {
+                    dexfeeOutAmount.nValue = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
+                    swapAmountResult.nValue -= dexfeeOutAmount.nValue;
+                }
 
-            // If we're just testing, don't do any balance transfers.
-            // Just go over pools and return result. The only way this can
-            // cause inaccurate result is if we go over the same path twice,
-            // which shouldn't happen in the first place.
-            if (testOnly)
-                return Res::Ok();
+                // If we're just testing, don't do any balance transfers.
+                // Just go over pools and return result. The only way this can
+                // cause inaccurate result is if we go over the same path twice,
+                // which shouldn't happen in the first place.
+                if (testOnly)
+                    return Res::Ok();
 
-            auto res = view.SetPoolPair(currentID, height, *pool);
-            if (!res) {
-                return res;
-            }
-
-            CCustomCSView intermediateView(view);
-            // hide interemidiate swaps
-            auto& subView = i == 0 ? view : intermediateView;
-            res = subView.SubBalance(obj.from, swapAmount);
-            if (!res) {
-                return res;
-            }
-            intermediateView.Flush();
-
-            auto& addView = lastSwap ? view : intermediateView;
-            res = addView.AddBalance(lastSwap ? obj.to : obj.from, swapAmountResult);
-            if (!res) {
-                return res;
-            }
-            intermediateView.Flush();
-
-            // burn the dex in amount
-            if (dexfeeInAmount.nValue > 0) {
-                res = view.AddBalance(Params().GetConsensus().burnAddress, dexfeeInAmount);
+                auto res = view.SetPoolPair(currentID, height, *pool);
                 if (!res) {
                     return res;
                 }
-                totalTokenA.feeburn += dexfeeInAmount.nValue;
-            }
 
-            // burn the dex out amount
-            if (dexfeeOutAmount.nValue > 0) {
-                res = view.AddBalance(Params().GetConsensus().burnAddress, dexfeeOutAmount);
+                CCustomCSView intermediateView(view);
+                // hide interemidiate swaps
+                auto &subView = i == 0 ? view : intermediateView;
+                res = subView.SubBalance(obj.from, swapAmount);
                 if (!res) {
                     return res;
                 }
-                totalTokenB.feeburn += dexfeeOutAmount.nValue;
-            }
+                intermediateView.Flush();
 
-            totalTokenA.swaps += (reserveAmount - initReserveAmount);
-            totalTokenA.commissions += (blockCommission - initBlockCommission);
+                auto &addView = lastSwap ? view : intermediateView;
+                res = addView.AddBalance(lastSwap ? obj.to : obj.from, swapAmountResult);
+                if (!res) {
+                    return res;
+                }
+                intermediateView.Flush();
 
-            if (lastSwap && obj.to == Params().GetConsensus().burnAddress) {
-                totalTokenB.feeburn += swapAmountResult.nValue;
-            }
+                // burn the dex in amount
+                if (dexfeeInAmount.nValue > 0) {
+                    res = view.AddBalance(Params().GetConsensus().burnAddress, dexfeeInAmount);
+                    if (!res) {
+                        return res;
+                    }
+                    totalTokenA.feeburn += dexfeeInAmount.nValue;
+                }
 
-           return res;
-        }, static_cast<int>(height));
+                // burn the dex out amount
+                if (dexfeeOutAmount.nValue > 0) {
+                    res = view.AddBalance(Params().GetConsensus().burnAddress, dexfeeOutAmount);
+                    if (!res) {
+                        return res;
+                    }
+                    totalTokenB.feeburn += dexfeeOutAmount.nValue;
+                }
+
+                totalTokenA.swaps += (reserveAmount - initReserveAmount);
+                totalTokenA.commissions += (blockCommission - initBlockCommission);
+
+                if (lastSwap && obj.to == Params().GetConsensus().burnAddress) {
+                    totalTokenB.feeburn += swapAmountResult.nValue;
+                }
+
+                return res;
+            },
+            static_cast<int>(height));
 
         if (!poolResult) {
             return poolResult;
@@ -4147,8 +4347,13 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, boo
     return poolResult;
 }
 
-Res  SwapToDFIorDUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CScript const & from, CScript const & to, uint32_t height, bool forceLoanSwap)
-{
+Res SwapToDFIorDUSD(CCustomCSView &mnview,
+                    DCT_ID tokenId,
+                    CAmount amount,
+                    CScript const &from,
+                    CScript const &to,
+                    uint32_t height,
+                    bool forceLoanSwap) {
     CPoolSwapMessage obj;
 
     obj.from = from;
@@ -4176,8 +4381,7 @@ Res  SwapToDFIorDUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CSc
 
     // Direct swap from DUSD to DFI as defined in the CPoolSwapMessage.
     if (tokenId == dUsdToken->first) {
-        if (to == Params().GetConsensus().burnAddress && !forceLoanSwap && attributes->GetValue(directBurnKey, false))
-        {
+        if (to == Params().GetConsensus().burnAddress && !forceLoanSwap && attributes->GetValue(directBurnKey, false)) {
             // direct burn dUSD
             CTokenAmount dUSD{dUsdToken->first, amount};
 
@@ -4186,8 +4390,7 @@ Res  SwapToDFIorDUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CSc
                 return res;
 
             return mnview.AddBalance(to, dUSD);
-        }
-        else
+        } else
             // swap dUSD -> DFI and burn DFI
             return poolSwap.ExecuteSwap(mnview, {});
     }
@@ -4196,26 +4399,23 @@ Res  SwapToDFIorDUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CSc
     if (!pooldUSDDFI)
         return Res::Err("Cannot find pool pair DUSD-DFI!");
 
-    auto poolTokendUSD = mnview.GetPoolPair(tokenId,dUsdToken->first);
+    auto poolTokendUSD = mnview.GetPoolPair(tokenId, dUsdToken->first);
     if (!poolTokendUSD)
         return Res::Err("Cannot find pool pair %s-DUSD!", token->symbol);
 
-    if (to == Params().GetConsensus().burnAddress && !forceLoanSwap && attributes->GetValue(directBurnKey, false))
-    {
+    if (to == Params().GetConsensus().burnAddress && !forceLoanSwap && attributes->GetValue(directBurnKey, false)) {
         obj.idTokenTo = dUsdToken->first;
 
         // swap tokenID -> dUSD and burn dUSD
         return poolSwap.ExecuteSwap(mnview, {});
-    }
-    else
+    } else
         // swap tokenID -> dUSD -> DFI and burn DFI
         return poolSwap.ExecuteSwap(mnview, {poolTokendUSD->first, pooldUSDDFI->first});
 }
 
-bool IsVaultPriceValid(CCustomCSView& mnview, const CVaultId& vaultId, uint32_t height)
-{
+bool IsVaultPriceValid(CCustomCSView &mnview, const CVaultId &vaultId, uint32_t height) {
     if (auto collaterals = mnview.GetVaultCollaterals(vaultId))
-        for (const auto& collateral : collaterals->balances) {
+        for (const auto &collateral : collaterals->balances) {
             if (auto collateralToken = mnview.HasLoanCollateralToken({collateral.first, height})) {
                 if (auto fixedIntervalPrice = mnview.GetFixedIntervalPrice(collateralToken->fixedIntervalPriceId)) {
                     if (!fixedIntervalPrice.val->isLive(mnview.GetPriceDeviation())) {
@@ -4232,7 +4432,7 @@ bool IsVaultPriceValid(CCustomCSView& mnview, const CVaultId& vaultId, uint32_t 
         }
 
     if (auto loans = mnview.GetLoanTokens(vaultId))
-        for (const auto& loan : loans->balances) {
+        for (const auto &loan : loans->balances) {
             if (auto loanToken = mnview.GetLoanTokenByID(loan.first)) {
                 if (auto fixedIntervalPrice = mnview.GetFixedIntervalPrice(loanToken->fixedIntervalPriceId)) {
                     if (!fixedIntervalPrice.val->isLive(mnview.GetPriceDeviation())) {
@@ -4250,9 +4450,7 @@ bool IsVaultPriceValid(CCustomCSView& mnview, const CVaultId& vaultId, uint32_t 
     return true;
 }
 
-
-Res storeGovVars(const CGovernanceHeightMessage& obj, CCustomCSView& view) {
-
+Res storeGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view) {
     // Retrieve any stored GovVariables at startHeight
     auto storedGovVars = view.GetStoredVariables(obj.startHeight);
 

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -6,10 +6,10 @@
 #define DEFI_MASTERNODES_MN_CHECKS_H
 
 #include <consensus/params.h>
-#include <masternodes/masternodes.h>
 #include <consensus/tx_check.h>
-#include <vector>
+#include <masternodes/masternodes.h>
 #include <cstring>
+#include <vector>
 
 #include <variant>
 
@@ -27,88 +27,87 @@ class CHistoryErasers;
 
 enum CustomTxErrCodes : uint32_t {
     NotSpecified = 0,
-//    NotCustomTx  = 1,
+    //    NotCustomTx  = 1,
     NotEnoughBalance = 1024,
-    Fatal = uint32_t(1) << 31 // not allowed to fail
+    Fatal = uint32_t(1) << 31  // not allowed to fail
 };
 
-enum class CustomTxType : uint8_t
-{
+enum class CustomTxType : uint8_t {
     None = 0,
-    Reject = 1, // Invalid TX type. Returned by GuessCustomTxType on invalid custom TX.
+    Reject = 1,  // Invalid TX type. Returned by GuessCustomTxType on invalid custom TX.
 
     // masternodes:
-    CreateMasternode      = 'C',
-    ResignMasternode      = 'R',
-    UpdateMasternode      = 'm',
+    CreateMasternode = 'C',
+    ResignMasternode = 'R',
+    UpdateMasternode = 'm',
     SetForcedRewardAddress = 'F',
     RemForcedRewardAddress = 'f',
     // custom tokens:
-    CreateToken           = 'T',
-    MintToken             = 'M',
-    UpdateToken           = 'N', // previous type, only DAT flag triggers
-    UpdateTokenAny        = 'n', // new type of token's update with any flags/fields possible
+    CreateToken = 'T',
+    MintToken = 'M',
+    UpdateToken = 'N',     // previous type, only DAT flag triggers
+    UpdateTokenAny = 'n',  // new type of token's update with any flags/fields possible
     // dex orders - just not to overlap in future
-//    CreateOrder         = 'O',
-//    DestroyOrder        = 'E',
-//    MatchOrders         = 'A',
-    //poolpair
-    CreatePoolPair        = 'p',
-    UpdatePoolPair        = 'u',
-    PoolSwap              = 's',
-    PoolSwapV2            = 'i',
-    AddPoolLiquidity      = 'l',
-    RemovePoolLiquidity   = 'r',
+    //    CreateOrder         = 'O',
+    //    DestroyOrder        = 'E',
+    //    MatchOrders         = 'A',
+    // poolpair
+    CreatePoolPair = 'p',
+    UpdatePoolPair = 'u',
+    PoolSwap = 's',
+    PoolSwapV2 = 'i',
+    AddPoolLiquidity = 'l',
+    RemovePoolLiquidity = 'r',
     // accounts
-    UtxosToAccount        = 'U',
-    AccountToUtxos        = 'b',
-    AccountToAccount      = 'B',
+    UtxosToAccount = 'U',
+    AccountToUtxos = 'b',
+    AccountToAccount = 'B',
     AnyAccountsToAccounts = 'a',
-    SmartContract         = 'K',
-    FutureSwap            = 'Q',
-    //set governance variable
-    SetGovVariable        = 'G',
-    SetGovVariableHeight  = 'j',
+    SmartContract = 'K',
+    FutureSwap = 'Q',
+    // set governance variable
+    SetGovVariable = 'G',
+    SetGovVariableHeight = 'j',
     // Auto auth TX
-    AutoAuthPrep          = 'A',
+    AutoAuthPrep = 'A',
     // oracles
-    AppointOracle         = 'o',
-    RemoveOracleAppoint   = 'h',
-    UpdateOracleAppoint   = 't',
-    SetOracleData         = 'y',
+    AppointOracle = 'o',
+    RemoveOracleAppoint = 'h',
+    UpdateOracleAppoint = 't',
+    SetOracleData = 'y',
     // ICX
-    ICXCreateOrder      = '1',
-    ICXMakeOffer        = '2',
-    ICXSubmitDFCHTLC    = '3',
-    ICXSubmitEXTHTLC    = '4',
-    ICXClaimDFCHTLC     = '5',
-    ICXCloseOrder       = '6',
-    ICXCloseOffer       = '7',
+    ICXCreateOrder = '1',
+    ICXMakeOffer = '2',
+    ICXSubmitDFCHTLC = '3',
+    ICXSubmitEXTHTLC = '4',
+    ICXClaimDFCHTLC = '5',
+    ICXCloseOrder = '6',
+    ICXCloseOffer = '7',
     // Loans
     SetLoanCollateralToken = 'c',
-    SetLoanToken           = 'g',
-    UpdateLoanToken        = 'x',
-    LoanScheme             = 'L',
-    DefaultLoanScheme      = 'd',
-    DestroyLoanScheme      = 'D',
-    Vault                  = 'V',
-    CloseVault             = 'e',
-    UpdateVault            = 'v',
-    DepositToVault         = 'S',
-    WithdrawFromVault      = 'J',
-    TakeLoan               = 'X',
-    PaybackLoan            = 'H',
-    PaybackLoanV2          = 'k',
-    AuctionBid             = 'I',
+    SetLoanToken = 'g',
+    UpdateLoanToken = 'x',
+    LoanScheme = 'L',
+    DefaultLoanScheme = 'd',
+    DestroyLoanScheme = 'D',
+    Vault = 'V',
+    CloseVault = 'e',
+    UpdateVault = 'v',
+    DepositToVault = 'S',
+    WithdrawFromVault = 'J',
+    TakeLoan = 'X',
+    PaybackLoan = 'H',
+    PaybackLoanV2 = 'k',
+    AuctionBid = 'I',
     // Marker TXs
-    FutureSwapExecution    = 'q',
-    FutureSwapRefund       = 'w',
-    TokenSplit             = 'P',
+    FutureSwapExecution = 'q',
+    FutureSwapRefund = 'w',
+    TokenSplit = 'P',
 };
 
 inline CustomTxType CustomTxCodeToType(uint8_t ch) {
     auto type = static_cast<CustomTxType>(ch);
-    switch(type) {
+    switch (type) {
         case CustomTxType::CreateMasternode:
         case CustomTxType::ResignMasternode:
         case CustomTxType::SetForcedRewardAddress:
@@ -170,21 +169,21 @@ inline CustomTxType CustomTxCodeToType(uint8_t ch) {
 }
 
 std::string ToString(CustomTxType type);
-CustomTxType FromString(const std::string& str);
+CustomTxType FromString(const std::string &str);
 
 // it's disabled after Dakota height
 inline bool NotAllowedToFail(CustomTxType txType, int height) {
-    return (height < Params().GetConsensus().DakotaHeight
-        && (txType == CustomTxType::MintToken || txType == CustomTxType::AccountToUtxos));
+    return (height < Params().GetConsensus().DakotaHeight &&
+            (txType == CustomTxType::MintToken || txType == CustomTxType::AccountToUtxos));
 }
 
-template<typename Stream>
-inline void Serialize(Stream& s, CustomTxType txType) {
+template <typename Stream>
+inline void Serialize(Stream &s, CustomTxType txType) {
     Serialize(s, static_cast<unsigned char>(txType));
 }
 
-template<typename Stream>
-inline void Unserialize(Stream& s, CustomTxType & txType) {
+template <typename Stream>
+inline void Unserialize(Stream &s, CustomTxType &txType) {
     unsigned char ch;
     Unserialize(s, ch);
 
@@ -198,7 +197,7 @@ struct CCreateMasterNodeMessage {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(operatorType);
         READWRITE(operatorAuthAddress);
 
@@ -214,7 +213,7 @@ struct CResignMasterNodeMessage : public uint256 {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(uint256, *this);
     }
 };
@@ -227,8 +226,7 @@ struct CSetForcedRewardAddressMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(nodeId);
         READWRITE(rewardAddressType);
         READWRITE(rewardAddress);
@@ -241,8 +239,7 @@ struct CRemForcedRewardAddressMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(nodeId);
     }
 };
@@ -254,7 +251,7 @@ struct CUpdateMasterNodeMessage {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(mnId);
         READWRITE(operatorType);
         READWRITE(operatorAuthAddress);
@@ -266,7 +263,7 @@ struct CCreateTokenMessage : public CToken {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CToken, *this);
     }
 };
@@ -277,7 +274,7 @@ struct CUpdateTokenPreAMKMessage {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(tokenTx);
         READWRITE(isDAT);
     }
@@ -289,7 +286,7 @@ struct CUpdateTokenMessage {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(tokenTx);
         READWRITE(token);
     }
@@ -300,7 +297,7 @@ struct CMintTokensMessage : public CBalances {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CBalances, *this);
     }
 };
@@ -330,79 +327,112 @@ struct CGovernanceHeightMessage {
 
 struct CCustomTxMessageNone {};
 
-using CCustomTxMessage = std::variant<
-    CCustomTxMessageNone,
-    CCreateMasterNodeMessage,
-    CResignMasterNodeMessage,
-    CSetForcedRewardAddressMessage,
-    CRemForcedRewardAddressMessage,
-    CUpdateMasterNodeMessage,
-    CCreateTokenMessage,
-    CUpdateTokenPreAMKMessage,
-    CUpdateTokenMessage,
-    CMintTokensMessage,
-    CCreatePoolPairMessage,
-    CUpdatePoolPairMessage,
-    CPoolSwapMessage,
-    CPoolSwapMessageV2,
-    CLiquidityMessage,
-    CRemoveLiquidityMessage,
-    CUtxosToAccountMessage,
-    CAccountToUtxosMessage,
-    CAccountToAccountMessage,
-    CAnyAccountsToAccountsMessage,
-    CSmartContractMessage,
-    CFutureSwapMessage,
-    CGovernanceMessage,
-    CGovernanceHeightMessage,
-    CAppointOracleMessage,
-    CRemoveOracleAppointMessage,
-    CUpdateOracleAppointMessage,
-    CSetOracleDataMessage,
-    CICXCreateOrderMessage,
-    CICXMakeOfferMessage,
-    CICXSubmitDFCHTLCMessage,
-    CICXSubmitEXTHTLCMessage,
-    CICXClaimDFCHTLCMessage,
-    CICXCloseOrderMessage,
-    CICXCloseOfferMessage,
-    CLoanSetCollateralTokenMessage,
-    CLoanSetLoanTokenMessage,
-    CLoanUpdateLoanTokenMessage,
-    CLoanSchemeMessage,
-    CDefaultLoanSchemeMessage,
-    CDestroyLoanSchemeMessage,
-    CVaultMessage,
-    CCloseVaultMessage,
-    CUpdateVaultMessage,
-    CDepositToVaultMessage,
-    CWithdrawFromVaultMessage,
-    CLoanTakeLoanMessage,
-    CLoanPaybackLoanMessage,
-    CLoanPaybackLoanV2Message,
-    CAuctionBidMessage
->;
+using CCustomTxMessage = std::variant<CCustomTxMessageNone,
+                                      CCreateMasterNodeMessage,
+                                      CResignMasterNodeMessage,
+                                      CSetForcedRewardAddressMessage,
+                                      CRemForcedRewardAddressMessage,
+                                      CUpdateMasterNodeMessage,
+                                      CCreateTokenMessage,
+                                      CUpdateTokenPreAMKMessage,
+                                      CUpdateTokenMessage,
+                                      CMintTokensMessage,
+                                      CCreatePoolPairMessage,
+                                      CUpdatePoolPairMessage,
+                                      CPoolSwapMessage,
+                                      CPoolSwapMessageV2,
+                                      CLiquidityMessage,
+                                      CRemoveLiquidityMessage,
+                                      CUtxosToAccountMessage,
+                                      CAccountToUtxosMessage,
+                                      CAccountToAccountMessage,
+                                      CAnyAccountsToAccountsMessage,
+                                      CSmartContractMessage,
+                                      CFutureSwapMessage,
+                                      CGovernanceMessage,
+                                      CGovernanceHeightMessage,
+                                      CAppointOracleMessage,
+                                      CRemoveOracleAppointMessage,
+                                      CUpdateOracleAppointMessage,
+                                      CSetOracleDataMessage,
+                                      CICXCreateOrderMessage,
+                                      CICXMakeOfferMessage,
+                                      CICXSubmitDFCHTLCMessage,
+                                      CICXSubmitEXTHTLCMessage,
+                                      CICXClaimDFCHTLCMessage,
+                                      CICXCloseOrderMessage,
+                                      CICXCloseOfferMessage,
+                                      CLoanSetCollateralTokenMessage,
+                                      CLoanSetLoanTokenMessage,
+                                      CLoanUpdateLoanTokenMessage,
+                                      CLoanSchemeMessage,
+                                      CDefaultLoanSchemeMessage,
+                                      CDestroyLoanSchemeMessage,
+                                      CVaultMessage,
+                                      CCloseVaultMessage,
+                                      CUpdateVaultMessage,
+                                      CDepositToVaultMessage,
+                                      CWithdrawFromVaultMessage,
+                                      CLoanTakeLoanMessage,
+                                      CLoanPaybackLoanMessage,
+                                      CLoanPaybackLoanV2Message,
+                                      CAuctionBidMessage>;
 
 CCustomTxMessage customTypeToMessage(CustomTxType txType);
-bool IsMempooledCustomTxCreate(const CTxMemPool& pool, const uint256& txid);
-Res RpcInfo(const CTransaction& tx, uint32_t height, CustomTxType& type, UniValue& results);
-Res CustomMetadataParse(uint32_t height, const Consensus::Params& consensus, const std::vector<unsigned char>& metadata, CCustomTxMessage& txMessage);
-Res ApplyCustomTx(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, const Consensus::Params& consensus, uint32_t height, uint64_t time = 0, uint32_t txn = 0, CHistoryWriters* writers = nullptr);
-Res CustomTxVisit(CCustomCSView& mnview, const CCoinsViewCache& coins, const CTransaction& tx, uint32_t height, const Consensus::Params& consensus, const CCustomTxMessage& txMessage, uint64_t time, uint32_t txn = 0);
-ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView& mnview, const CTransaction& tx, int height, const uint256& prevStakeModifier, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
-ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView& mnview, const CTransaction& tx, int height, const std::vector<unsigned char>& metadata, const Consensus::Params& consensusParams);
-ResVal<CAmount> GetAggregatePrice(CCustomCSView& view, const std::string& token, const std::string& currency, uint64_t lastBlockTime);
-bool IsVaultPriceValid(CCustomCSView& mnview, const CVaultId& vaultId, uint32_t height);
-Res SwapToDFIorDUSD(CCustomCSView & mnview, DCT_ID tokenId, CAmount amount, CScript const & from, CScript const & to, uint32_t height, bool forceLoanSwap = false);
-Res storeGovVars(const CGovernanceHeightMessage& obj, CCustomCSView& view);
+bool IsMempooledCustomTxCreate(const CTxMemPool &pool, const uint256 &txid);
+Res RpcInfo(const CTransaction &tx, uint32_t height, CustomTxType &type, UniValue &results);
+Res CustomMetadataParse(uint32_t height,
+                        const Consensus::Params &consensus,
+                        const std::vector<unsigned char> &metadata,
+                        CCustomTxMessage &txMessage);
+Res ApplyCustomTx(CCustomCSView &mnview,
+                  const CCoinsViewCache &coins,
+                  const CTransaction &tx,
+                  const Consensus::Params &consensus,
+                  uint32_t height,
+                  uint64_t time = 0,
+                  uint32_t txn = 0,
+                  CHistoryWriters *writers = nullptr);
+Res CustomTxVisit(CCustomCSView &mnview,
+                  const CCoinsViewCache &coins,
+                  const CTransaction &tx,
+                  uint32_t height,
+                  const Consensus::Params &consensus,
+                  const CCustomTxMessage &txMessage,
+                  uint64_t time,
+                  uint32_t txn = 0);
+ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
+                                    const CTransaction &tx,
+                                    int height,
+                                    const uint256 &prevStakeModifier,
+                                    const std::vector<unsigned char> &metadata,
+                                    const Consensus::Params &consensusParams);
+ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView &mnview,
+                                        const CTransaction &tx,
+                                        int height,
+                                        const std::vector<unsigned char> &metadata,
+                                        const Consensus::Params &consensusParams);
+ResVal<CAmount> GetAggregatePrice(CCustomCSView &view,
+                                  const std::string &token,
+                                  const std::string &currency,
+                                  uint64_t lastBlockTime);
+bool IsVaultPriceValid(CCustomCSView &mnview, const CVaultId &vaultId, uint32_t height);
+Res SwapToDFIorDUSD(CCustomCSView &mnview,
+                    DCT_ID tokenId,
+                    CAmount amount,
+                    CScript const &from,
+                    CScript const &to,
+                    uint32_t height,
+                    bool forceLoanSwap = false);
+Res storeGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view);
 
-inline bool OraclePriceFeed(CCustomCSView& view, const CTokenCurrencyPair& priceFeed) {
+inline bool OraclePriceFeed(CCustomCSView &view, const CTokenCurrencyPair &priceFeed) {
     // Allow hard coded DUSD/USD
     if (priceFeed.first == "DUSD" && priceFeed.second == "USD") {
         return true;
     }
     bool found = false;
-    view.ForEachOracle([&](const COracleId&, COracle oracle) {
+    view.ForEachOracle([&](const COracleId &, COracle oracle) {
         return !(found = oracle.SupportsPair(priceFeed.first, priceFeed.second));
     });
     return found;
@@ -410,8 +440,10 @@ inline bool OraclePriceFeed(CCustomCSView& view, const CTokenCurrencyPair& price
 
 /*
  * Checks if given tx is probably one of 'CustomTx', returns tx type and serialized metadata in 'data'
-*/
-inline CustomTxType GuessCustomTxType(CTransaction const & tx, std::vector<unsigned char> & metadata, bool metadataValidation = false){
+ */
+inline CustomTxType GuessCustomTxType(CTransaction const &tx,
+                                      std::vector<unsigned char> &metadata,
+                                      bool metadataValidation = false) {
     if (tx.vout.empty()) {
         return CustomTxType::None;
     }
@@ -446,14 +478,12 @@ inline CustomTxType GuessCustomTxType(CTransaction const & tx, std::vector<unsig
     return txType;
 }
 
-inline bool IsMintTokenTx(const CTransaction& tx)
-{
+inline bool IsMintTokenTx(const CTransaction &tx) {
     std::vector<unsigned char> metadata;
     return GuessCustomTxType(tx, metadata) == CustomTxType::MintToken;
 }
 
-inline std::optional<std::vector<unsigned char>> GetAccountToUtxosMetadata(const CTransaction & tx)
-{
+inline std::optional<std::vector<unsigned char>> GetAccountToUtxosMetadata(const CTransaction &tx) {
     std::vector<unsigned char> metadata;
     if (GuessCustomTxType(tx, metadata) == CustomTxType::AccountToUtxos) {
         return metadata;
@@ -461,8 +491,7 @@ inline std::optional<std::vector<unsigned char>> GetAccountToUtxosMetadata(const
     return {};
 }
 
-inline std::optional<CAccountToUtxosMessage> GetAccountToUtxosMsg(const CTransaction & tx)
-{
+inline std::optional<CAccountToUtxosMessage> GetAccountToUtxosMsg(const CTransaction &tx) {
     const auto metadata = GetAccountToUtxosMetadata(tx);
     if (metadata) {
         CAccountToUtxosMessage msg;
@@ -477,8 +506,7 @@ inline std::optional<CAccountToUtxosMessage> GetAccountToUtxosMsg(const CTransac
     return {};
 }
 
-inline TAmounts GetNonMintedValuesOut(const CTransaction & tx)
-{
+inline TAmounts GetNonMintedValuesOut(const CTransaction &tx) {
     uint32_t mintingOutputsStart = std::numeric_limits<uint32_t>::max();
     const auto accountToUtxos = GetAccountToUtxosMsg(tx);
     if (accountToUtxos) {
@@ -487,8 +515,7 @@ inline TAmounts GetNonMintedValuesOut(const CTransaction & tx)
     return tx.GetValuesOut(mintingOutputsStart);
 }
 
-inline CAmount GetNonMintedValueOut(const CTransaction & tx, DCT_ID tokenID)
-{
+inline CAmount GetNonMintedValueOut(const CTransaction &tx, DCT_ID tokenID) {
     uint32_t mintingOutputsStart = std::numeric_limits<uint32_t>::max();
     const auto accountToUtxos = GetAccountToUtxosMsg(tx);
     if (accountToUtxos) {
@@ -498,21 +525,20 @@ inline CAmount GetNonMintedValueOut(const CTransaction & tx, DCT_ID tokenID)
 }
 
 class CPoolSwap {
-    const CPoolSwapMessage& obj;
+    const CPoolSwapMessage &obj;
     uint32_t height;
     CAmount result{0};
     DCT_ID currentID;
 
-public:
+   public:
     std::vector<std::pair<std::string, std::string>> errors;
 
-    CPoolSwap(const CPoolSwapMessage& obj, uint32_t height)
-    : obj(obj), height(height) {}
+    CPoolSwap(const CPoolSwapMessage &obj, uint32_t height) : obj(obj), height(height) {}
 
-    std::vector<DCT_ID> CalculateSwaps(CCustomCSView& view, bool testOnly = false);
-    Res ExecuteSwap(CCustomCSView& view, std::vector<DCT_ID> poolIDs, bool testOnly = false);
-    std::vector<std::vector<DCT_ID>> CalculatePoolPaths(CCustomCSView& view);
+    std::vector<DCT_ID> CalculateSwaps(CCustomCSView &view, bool testOnly = false);
+    Res ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, bool testOnly = false);
+    std::vector<std::vector<DCT_ID>> CalculatePoolPaths(CCustomCSView &view);
     CTokenAmount GetResult() { return CTokenAmount{obj.idTokenTo, result}; };
 };
 
-#endif // DEFI_MASTERNODES_MN_CHECKS_H
+#endif  // DEFI_MASTERNODES_MN_CHECKS_H

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -2,29 +2,30 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#include <regex>
-#include <masternodes/mn_rpc.h>
 #include <base58.h>
-#include <policy/settings.h>
 #include <masternodes/govvariables/attributes.h>
+#include <masternodes/mn_rpc.h>
+#include <policy/settings.h>
+#include <regex>
 
-extern bool EnsureWalletIsAvailable(bool avoidException); // in rpcwallet.cpp
-extern bool DecodeHexTx(CTransaction& tx, std::string const& strHexTx); // in core_io.h
+extern bool EnsureWalletIsAvailable(bool avoidException);                // in rpcwallet.cpp
+extern bool DecodeHexTx(CTransaction &tx, std::string const &strHexTx);  // in core_io.h
 
-CAccounts GetAllMineAccounts(CWallet * const pwallet) {
-
+CAccounts GetAllMineAccounts(CWallet *const pwallet) {
     CAccounts walletAccounts;
 
     LOCK(cs_main);
     CCustomCSView mnview(*pcustomcsview);
     auto targetHeight = ::ChainActive().Height() + 1;
 
-    mnview.ForEachAccount([&](CScript const & account) {
+    mnview.ForEachAccount([&](CScript const &account) {
         if (IsMineCached(*pwallet, account) == ISMINE_SPENDABLE) {
             mnview.CalculateOwnerRewards(account, targetHeight);
-            mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
-                return account == owner && walletAccounts[owner].Add(balance);
-            }, {account, DCT_ID{}});
+            mnview.ForEachBalance(
+                [&](CScript const &owner, CTokenAmount balance) {
+                    return account == owner && walletAccounts[owner].Add(balance);
+                },
+                {account, DCT_ID{}});
         }
         return true;
     });
@@ -32,18 +33,19 @@ CAccounts GetAllMineAccounts(CWallet * const pwallet) {
     return walletAccounts;
 }
 
-CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalances& targetBalances, AccountSelectionMode selectionMode) {
-
+CAccounts SelectAccountsByTargetBalances(const CAccounts &accounts,
+                                         const CBalances &targetBalances,
+                                         AccountSelectionMode selectionMode) {
     std::set<DCT_ID> tokenIds;
     std::vector<std::pair<CScript, CBalances>> foundAccountsBalances;
     // iterate at all accounts to finding all accounts with neccessaru token balances
-    for (const auto& account : accounts) {
+    for (const auto &account : accounts) {
         // selectedBalances accumulates overlap between account balances and residual balances
         CBalances selectedBalances;
         // iterate at residual balances to find neccessary tokens in account
-        for (const auto& balance : targetBalances.balances) {
+        for (const auto &balance : targetBalances.balances) {
             // find neccessary token amount from current account
-            const auto& accountBalances = account.second.balances;
+            const auto &accountBalances = account.second.balances;
             auto foundTokenAmount = accountBalances.find(balance.first);
             // account balance has neccessary token
             if (foundTokenAmount != accountBalances.end()) {
@@ -58,15 +60,15 @@ CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalan
         }
     }
 
-    auto sortByTokenAmount = [selectionMode](const std::pair<CScript, CBalances>& p1,
-                                             const std::pair<CScript, CBalances>& p2,
+    auto sortByTokenAmount = [selectionMode](const std::pair<CScript, CBalances> &p1,
+                                             const std::pair<CScript, CBalances> &p2,
                                              const DCT_ID id) {
         auto it1 = p1.second.balances.find(id);
         auto it2 = p2.second.balances.find(id);
         if (it1 != p1.second.balances.end() && it2 != p2.second.balances.end()) {
             return selectionMode == SelectionCrumbs ? it1->second < it2->second : it1->second > it2->second;
         } else {
-            return false; // should never happen
+            return false;  // should never happen
         }
     };
 
@@ -75,10 +77,11 @@ CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalan
     // selecting accounts balances
     for (const auto tokenId : tokenIds) {
         if (selectionMode != SelectionForward) {
-            std::sort(foundAccountsBalances.begin(), foundAccountsBalances.end(),
+            std::sort(foundAccountsBalances.begin(),
+                      foundAccountsBalances.end(),
                       std::bind(sortByTokenAmount, std::placeholders::_1, std::placeholders::_2, tokenId));
         }
-        for (const auto& accountBalances : foundAccountsBalances) {
+        for (const auto &accountBalances : foundAccountsBalances) {
             // Substract residualBalances and tokenBalance with remainder.
             // Substraction with remainder will remove tokenAmount from balances if remainder
             // of token's amount is not zero (we got negative result of substraction)
@@ -108,7 +111,10 @@ CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalan
     return selectedAccountsBalances;
 }
 
-CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx, CCoinControl* coin_control) {
+CMutableTransaction fund(CMutableTransaction &mtx,
+                         CWalletCoinsUnlocker &pwallet,
+                         CTransactionRef optAuthTx,
+                         CCoinControl *coin_control) {
     CAmount fee_out;
     int change_position = mtx.vout.size();
 
@@ -120,8 +126,8 @@ CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwalle
     // add outputs from possible linked auth tx into 'linkedCoins' pool
     if (optAuthTx) {
         for (size_t i = 0; i < optAuthTx->vout.size(); ++i) {
-            CTxOut const & out = optAuthTx->vout[i];
-            if (!out.scriptPubKey.IsUnspendable()) { // skip for possible metadata
+            CTxOut const &out = optAuthTx->vout[i];
+            if (!out.scriptPubKey.IsUnspendable()) {  // skip for possible metadata
                 coinControl.m_linkedCoins.emplace(COutPoint(optAuthTx->GetHash(), i), out);
             }
         }
@@ -130,22 +136,27 @@ CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwalle
     // we does not honor non locking spends anymore
     // it ensures auto auth not overlap regular tx inputs
     const bool lockUnspents = true;
-    if (!pwallet->FundTransaction(mtx, fee_out, change_position, strFailReason, lockUnspents, {} /*setSubtractFeeFromOutputs*/, coinControl)) {
+    if (!pwallet->FundTransaction(mtx,
+                                  fee_out,
+                                  change_position,
+                                  strFailReason,
+                                  lockUnspents,
+                                  {} /*setSubtractFeeFromOutputs*/,
+                                  coinControl)) {
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }
-    for (auto& txin : mtx.vin) {
+    for (auto &txin : mtx.vin) {
         if (!coinControl.IsSelected(txin.prevout)) {
             pwallet.AddLockedCoin(txin.prevout);
         }
     }
-    for (const auto& coin : coinControl.m_linkedCoins) {
+    for (const auto &coin : coinControl.m_linkedCoins) {
         pwallet.AddLockedCoin(coin.first);
     }
     return mtx;
 }
 
-static CTransactionRef sign(CMutableTransaction& mtx, CWallet* const pwallet, CTransactionRef optAuthTx) {
-
+static CTransactionRef sign(CMutableTransaction &mtx, CWallet *const pwallet, CTransactionRef optAuthTx) {
     // assemble prevouts from optional linked tx
     UniValue prevtxs(UniValue::VARR);
     if (optAuthTx) {
@@ -155,8 +166,8 @@ static CTransactionRef sign(CMutableTransaction& mtx, CWallet* const pwallet, CT
                 prevout.pushKV("txid", optAuthTx->GetHash().GetHex());
                 prevout.pushKV("vout", (uint64_t)i);
                 prevout.pushKV("scriptPubKey", optAuthTx->vout[i].scriptPubKey.GetHex());
-                //prevout.pushKV("redeemScript", );
-                //prevout.pushKV("witnessScript", );
+                // prevout.pushKV("redeemScript", );
+                // prevout.pushKV("witnessScript", );
                 prevout.pushKV("amount", ValueFromAmount(optAuthTx->vout[i].nValue));
                 prevtxs.push_back(prevout);
             }
@@ -167,8 +178,8 @@ static CTransactionRef sign(CMutableTransaction& mtx, CWallet* const pwallet, CT
 
     // Fetch previous transactions (inputs):
     std::map<COutPoint, Coin> coins;
-    for (const CTxIn& txin : mtx.vin) {
-        coins[txin.prevout]; // Create empty map entry keyed by prevout.
+    for (const CTxIn &txin : mtx.vin) {
+        coins[txin.prevout];  // Create empty map entry keyed by prevout.
     }
     pwallet->chain().findCoins(coins);  // LOCK2(cs_main, ::mempool.cs);
 
@@ -177,67 +188,66 @@ static CTransactionRef sign(CMutableTransaction& mtx, CWallet* const pwallet, CT
         if (!DecodeHexTx(mtx, signedVal["hex"].get_str(), true)) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Can't decode signed auth TX");
         }
-    }
-    else {
+    } else {
         throw JSONRPCError(RPC_VERIFY_ERROR, "Can't sign TX: " + signedVal["errors"].write());
     }
     return MakeTransactionRef(std::move(mtx));
 }
 
 static CTransactionRef send(CTransactionRef tx, CTransactionRef optAuthTx) {
-
     if (optAuthTx) {
         send(optAuthTx, {});
     }
 
     // from "sendrawtransaction":
-    CAmount max_raw_tx_fee = {COIN / 10}; /// @todo check it with 0
+    CAmount max_raw_tx_fee = {COIN / 10};  /// @todo check it with 0
 
     std::string err_string;
     AssertLockNotHeld(cs_main);
-    const TransactionError err = BroadcastTransaction(tx, err_string, max_raw_tx_fee, /*relay*/
-                                                      true, /*wait_callback*/ true);
+    const TransactionError err = BroadcastTransaction(tx,
+                                                      err_string,
+                                                      max_raw_tx_fee, /*relay*/
+                                                      true,
+                                                      /*wait_callback*/ true);
     if (TransactionError::OK != err) {
         throw JSONRPCTransactionError(err, err_string);
     }
     return tx;
 }
 
-CWalletCoinsUnlocker::CWalletCoinsUnlocker(std::shared_ptr<CWallet> pwallet) : 
-    pwallet(std::move(pwallet)) {
-}
+CWalletCoinsUnlocker::CWalletCoinsUnlocker(std::shared_ptr<CWallet> pwallet) : pwallet(std::move(pwallet)) {}
 
 CWalletCoinsUnlocker::~CWalletCoinsUnlocker() {
     if (!coins.empty()) {
         LOCK(pwallet->cs_wallet);
-        for (auto& coin : coins) {
+        for (auto &coin : coins) {
             pwallet->UnlockCoin(coin);
         }
     }
 }
 
-CWallet* CWalletCoinsUnlocker::operator->() {
+CWallet *CWalletCoinsUnlocker::operator->() {
     return pwallet.get();
 }
 
-CWallet& CWalletCoinsUnlocker::operator*() {
+CWallet &CWalletCoinsUnlocker::operator*() {
     return *pwallet;
 }
 
-CWalletCoinsUnlocker::operator CWallet*() {
+CWalletCoinsUnlocker::operator CWallet *() {
     return pwallet.get();
 }
 
-void CWalletCoinsUnlocker::AddLockedCoin(const COutPoint& coin) {
+void CWalletCoinsUnlocker::AddLockedCoin(const COutPoint &coin) {
     coins.push_back(coin);
 }
 
-CTransactionRef signsend(CMutableTransaction& mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx) {
+CTransactionRef signsend(CMutableTransaction &mtx, CWalletCoinsUnlocker &pwallet, CTransactionRef optAuthTx) {
     return send(sign(mtx, pwallet, optAuthTx), optAuthTx);
 }
 
 // returns either base58/bech32 address, or hex if format is unknown
-std::string ScriptToString(CScript const& script) {
+std::string ScriptToString(CScript const &script) {
     CTxDestination dest;
     if (!ExtractDestination(script, dest)) {
         return script.GetHex();
@@ -245,23 +255,22 @@ std::string ScriptToString(CScript const& script) {
     return EncodeDestination(dest);
 }
 
-int chainHeight(interfaces::Chain::Lock& locked_chain)
-{
+int chainHeight(interfaces::Chain::Lock &locked_chain) {
     LOCK(locked_chain.mutex());
     if (auto height = locked_chain.getHeight())
         return *height;
     return 0;
 }
 
-static std::vector<CTxIn> GetInputs(UniValue const& inputs) {
+static std::vector<CTxIn> GetInputs(UniValue const &inputs) {
     std::vector<CTxIn> vin{};
     for (unsigned int idx = 0; idx < inputs.size(); idx++) {
-        const UniValue& input = inputs[idx];
-        const UniValue& o = input.get_obj();
+        const UniValue &input = inputs[idx];
+        const UniValue &o = input.get_obj();
 
         uint256 txid = ParseHashO(o, "txid");
 
-        const UniValue& vout_v = find_value(o, "vout");
+        const UniValue &vout_v = find_value(o, "vout");
         if (!vout_v.isNum())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing vout key");
         int nOutput = vout_v.get_int();
@@ -273,16 +282,15 @@ static std::vector<CTxIn> GetInputs(UniValue const& inputs) {
     return vin;
 }
 
-std::optional<CScript> AmIFounder(CWallet* const pwallet) {
-    for(auto const & script : Params().GetConsensus().foundationMembers) {
-        if(IsMineCached(*pwallet, script) == ISMINE_SPENDABLE)
-            return { script };
+std::optional<CScript> AmIFounder(CWallet *const pwallet) {
+    for (auto const &script : Params().GetConsensus().foundationMembers) {
+        if (IsMineCached(*pwallet, script) == ISMINE_SPENDABLE)
+            return {script};
     }
     return {};
 }
 
-static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxDestination const& auth) {
-
+static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker &pwallet, CTxDestination const &auth) {
     std::vector<COutput> vecOutputs;
     CCoinControl cctl;
     cctl.m_min_depth = 1;
@@ -304,7 +312,7 @@ static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxD
     return txin;
 }
 
-static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker& pwallet, std::set<CScript> const & auths, int32_t txVersion) {
+static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker &pwallet, std::set<CScript> const &auths, int32_t txVersion) {
     CMutableTransaction mtx(txVersion);
     CCoinControl coinControl;
 
@@ -318,7 +326,6 @@ static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker& pwallet, std::set<CScr
 
     // Only set change to auth on single auth TXs
     if (auths.size() == 1) {
-
         // Get auth ScriptPubkey
         auto auth = *auths.cbegin();
 
@@ -329,16 +336,16 @@ static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker& pwallet, std::set<CScr
 
         // AutoAuthPrep, auth output and change
         if (mtx.vout.size() == 3) {
-            mtx.vout[1].nValue += mtx.vout[2].nValue; // Combine values
+            mtx.vout[1].nValue += mtx.vout[2].nValue;  // Combine values
             mtx.vout[1].scriptPubKey = auth;
-            mtx.vout.erase(mtx.vout.begin() + 2); // Delete "change" output
+            mtx.vout.erase(mtx.vout.begin() + 2);  // Delete "change" output
         }
 
         return sign(mtx, pwallet, {});
     }
 
     // create tx with one dust output per script
-    for (auto const & auth : auths) {
+    for (auto const &auth : auths) {
         CTxOut authOut(1, auth);
         authOut.nValue = GetDustThreshold(authOut, mtx.nVersion, ::dustRelayFee);
         mtx.vout.push_back(authOut);
@@ -347,8 +354,8 @@ static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker& pwallet, std::set<CScr
     return fund(mtx, pwallet, {}, &coinControl), sign(mtx, pwallet, {});
 }
 
-static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker& pwallet) {
-    for (auto const & founderScript : Params().GetConsensus().foundationMembers) {
+static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker &pwallet) {
+    for (auto const &founderScript : Params().GetConsensus().foundationMembers) {
         if (IsMineCached(*pwallet, founderScript) == ISMINE_SPENDABLE) {
             CTxDestination destination;
             if (ExtractDestination(founderScript, destination)) {
@@ -361,8 +368,12 @@ static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker& pwal
     return {};
 }
 
-std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txVersion, std::set<CScript>& auths, bool needFounderAuth, CTransactionRef & optAuthTx, UniValue const& explicitInputs) {
-
+std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker &pwallet,
+                                      int32_t txVersion,
+                                      std::set<CScript> &auths,
+                                      bool needFounderAuth,
+                                      CTransactionRef &optAuthTx,
+                                      UniValue const &explicitInputs) {
     if (!explicitInputs.isNull() && !explicitInputs.empty()) {
         return GetInputs(explicitInputs);
     }
@@ -370,19 +381,19 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
     std::vector<CTxIn> result;
     std::set<CScript> notFoundYet;
     // first, look for "common" auth inputs, tracking missed
-    for (auto const & auth : auths) {
+    for (auto const &auth : auths) {
         CTxDestination destination;
         if (!ExtractDestination(auth, destination)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Can't extract destination for " + auth.GetHex());
         }
         if (IsMineCached(*pwallet, auth) != ISMINE_SPENDABLE) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Incorrect authorization for " + EncodeDestination(destination));
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
+                               "Incorrect authorization for " + EncodeDestination(destination));
         }
         auto authInput = GetAuthInputOnly(pwallet, destination);
         if (authInput) {
             result.push_back(authInput.value());
-        }
-        else {
+        } else {
             notFoundYet.insert(auth);
         }
     }
@@ -399,8 +410,7 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
             auto authInput = GetAnyFoundationAuthInput(pwallet);
             if (authInput) {
                 result.push_back(authInput.value());
-            }
-            else {
+            } else {
                 notFoundYet.insert(anyFounder.value());
             }
         }
@@ -409,11 +419,12 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
     // at last, create additional tx for missed
     if (!notFoundYet.empty()) {
         try {
-            optAuthTx = CreateAuthTx(pwallet, notFoundYet, txVersion); // success or throw
-        } catch (const UniValue& objError) {
+            optAuthTx = CreateAuthTx(pwallet, notFoundYet, txVersion);  // success or throw
+        } catch (const UniValue &objError) {
             throw JSONRPCError(objError["code"].get_int(), "Add-on auth TX failed: " + objError["message"].getValStr());
         }
-        // if we are here - we've got signed optional auth tx - add all of the outputs into inputs (to do not miss any coins for sure)
+        // if we are here - we've got signed optional auth tx - add all of the outputs into inputs (to do not miss any
+        // coins for sure)
         for (size_t i = 0; i < optAuthTx->vout.size(); ++i) {
             if (!optAuthTx->vout[i].scriptPubKey.IsUnspendable())
                 result.push_back(CTxIn(optAuthTx->GetHash(), i));
@@ -423,7 +434,7 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
     return result;
 }
 
-void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuthTx) {
+void execTestTx(const CTransaction &tx, uint32_t height, CTransactionRef optAuthTx) {
     std::vector<unsigned char> metadata;
     auto txType = GuessCustomTxType(tx, metadata);
     auto txMessage = customTypeToMessage(txType);
@@ -439,21 +450,24 @@ void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuth
     if (!res) {
         if (res.code == CustomTxErrCodes::NotEnoughBalance) {
             throw JSONRPCError(RPC_INVALID_REQUEST,
-                               strprintf("Test %sTx execution failed: not enough balance on owner's account, call utxostoaccount to increase it.\n%s", ToString(txType), res.msg));
+                               strprintf("Test %sTx execution failed: not enough balance on owner's account, call "
+                                         "utxostoaccount to increase it.\n%s",
+                                         ToString(txType),
+                                         res.msg));
         }
-        throw JSONRPCError(RPC_INVALID_REQUEST, strprintf("Test %sTx execution failed:\n%s", ToString(txType), res.msg));
+        throw JSONRPCError(RPC_INVALID_REQUEST,
+                           strprintf("Test %sTx execution failed:\n%s", ToString(txType), res.msg));
     }
 }
 
-CWalletCoinsUnlocker GetWallet(const JSONRPCRequest& request) {
+CWalletCoinsUnlocker GetWallet(const JSONRPCRequest &request) {
     auto wallet = GetWalletForJSONRPCRequest(request);
 
     EnsureWalletIsAvailable(wallet.get(), request.fHelp);
     return CWalletCoinsUnlocker{std::move(wallet)};
 }
 
-std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId)
-{
+std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId) {
     LOCK(cs_main);
 
     const auto attributes = pcustomcsview->GetAttributes();
@@ -478,39 +492,54 @@ std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId)
     return FutureSwapHeightInfo{attributes->GetValue(startKey, CAmount{}), attributes->GetValue(blockKey, CAmount{})};
 }
 
-UniValue setgov(const JSONRPCRequest& request) {
+UniValue setgov(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"setgov",
-               "\nSet special 'governance' variables:: ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_LOAN_TOKEN_SPLITS, LP_SPLITS, ORACLE_BLOCK_INTERVAL, ORACLE_DEVIATION\n",
-               {
-                    {"variables", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Object with variables",
+    RPCHelpMan{
+        "setgov",
+        "\nSet special 'governance' variables:: ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_LOAN_TOKEN_SPLITS, LP_SPLITS, "
+        "ORACLE_BLOCK_INTERVAL, ORACLE_DEVIATION\n",
+        {
+            {
+                "variables",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "Object with variables",
+                {
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Variable's name is the key, value is the data. Exact data type depends on variable's name."},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "Variable's name is the key, value is the data. Exact data type depends on variable's name."},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("setgov", "'{\"LP_SPLITS\": {\"2\":0.2,\"3\":0.8}'")
-                       + HelpExampleRpc("setgov", "'{\"ICX_TAKERFEE_PER_BTC\":109440}'")
-               },
-    }.Check(request);
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("setgov", "'{\"LP_SPLITS\": {\"2\":0.2,\"3\":0.8}'") +
+                    HelpExampleRpc("setgov", "'{\"ICX_TAKERFEE_PER_BTC\":109440}'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -518,7 +547,7 @@ UniValue setgov(const JSONRPCRequest& request) {
 
     CDataStream varStream(SER_NETWORK, PROTOCOL_VERSION);
     if (request.params.size() > 0 && request.params[0].isObject()) {
-        for (const std::string& name : request.params[0].getKeys()) {
+        for (const std::string &name : request.params[0].getKeys()) {
             auto gv = GovVariable::Create(name);
             if (!gv) {
                 throw JSONRPCError(RPC_INVALID_REQUEST, "Variable " + name + " not registered");
@@ -532,8 +561,7 @@ UniValue setgov(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::SetGovVariable)
-             << varStream;
+    metadata << static_cast<unsigned char>(CustomTxType::SetGovVariable) << varStream;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -544,7 +572,7 @@ UniValue setgov(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, true /*needFoundersAuth*/, optAuthTx, txInputs);
@@ -566,40 +594,55 @@ UniValue setgov(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue setgovheight(const JSONRPCRequest& request) {
+UniValue setgovheight(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"setgovheight",
-               "\nChange governance variable at height: ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_LOAN_TOKEN_SPLITS, LP_SPLITS, ORACLE_DEVIATION\n",
-               {
-                       {"variables", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Object with variable",
+    RPCHelpMan{
+        "setgovheight",
+        "\nChange governance variable at height: ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_LOAN_TOKEN_SPLITS, LP_SPLITS, "
+        "ORACLE_DEVIATION\n",
+        {
+            {
+                "variables",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "Object with variable",
+                {
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Variable name is the key, value is the data. Exact data type depends on variable name."},
+                },
+            },
+            {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "Start height for the changes to take effect."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                                {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "Variable name is the key, value is the data. Exact data type depends on variable name."},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                       },
-                       {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "Start height for the changes to take effect."},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                        {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
-                                },
-                        },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("setgovheight", "'{\"LP_SPLITS\": {\"2\":0.2,\"3\":0.8}' 100000")
-                       + HelpExampleRpc("setgovheight", "'{\"ICX_TAKERFEE_PER_BTC\":109440}', 100000")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("setgovheight", "'{\"LP_SPLITS\": {\"2\":0.2,\"3\":0.8}' 100000") +
+                    HelpExampleRpc("setgovheight", "'{\"ICX_TAKERFEE_PER_BTC\":109440}', 100000")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -608,7 +651,7 @@ UniValue setgovheight(const JSONRPCRequest& request) {
     CDataStream varStream(SER_NETWORK, PROTOCOL_VERSION);
     const auto keys = request.params[0].getKeys();
     if (!keys.empty()) {
-        const std::string& name = request.params[0].getKeys()[0];
+        const std::string &name = request.params[0].getKeys()[0];
         auto gv = GovVariable::Create(name);
         if (!gv) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "Variable " + name + " not registered");
@@ -625,9 +668,7 @@ UniValue setgovheight(const JSONRPCRequest& request) {
     const uint32_t startHeight = request.params[1].get_int();
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::SetGovVariableHeight)
-             << varStream
-             << startHeight;
+    metadata << static_cast<unsigned char>(CustomTxType::SetGovVariableHeight) << varStream << startHeight;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -638,7 +679,7 @@ UniValue setgovheight(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.emplace_back(0, scriptMeta);
 
-    UniValue const & txInputs = request.params[2];
+    UniValue const &txInputs = request.params[2];
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, true /*needFoundersAuth*/, optAuthTx, txInputs);
@@ -660,24 +701,21 @@ UniValue setgovheight(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue getgov(const JSONRPCRequest& request) {
-    RPCHelpMan{"getgov",
-               "\nReturns information about governance variable:\n"
-               "ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_DAILY_LOAN_TOKEN_REWARD, LP_LOAN_TOKEN_SPLITS, LP_DAILY_DFI_REWARD,\n"
-               "LOAN_LIQUIDATION_PENALTY, LP_SPLITS, ORACLE_BLOCK_INTERVAL, ORACLE_DEVIATION\n",
-               {
-                       {"name", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "Variable name"},
-               },
-               RPCResult{
-                       "{id:{...}}     (array) Json object with variable information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("getgov", "LP_SPLITS")
-                       + HelpExampleRpc("getgov", "LP_DAILY_DFI_REWARD")
-               },
-    }.Check(request);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+UniValue getgov(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getgov",
+        "\nReturns information about governance variable:\n"
+        "ATTRIBUTES, ICX_TAKERFEE_PER_BTC, LP_DAILY_LOAN_TOKEN_REWARD, LP_LOAN_TOKEN_SPLITS, LP_DAILY_DFI_REWARD,\n"
+        "LOAN_LIQUIDATION_PENALTY, LP_SPLITS, ORACLE_BLOCK_INTERVAL, ORACLE_DEVIATION\n",
+        {
+            {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "Variable name"},
+        },
+        RPCResult{"{id:{...}}     (array) Json object with variable information\n"},
+        RPCExamples{HelpExampleCli("getgov", "LP_SPLITS") + HelpExampleRpc("getgov", "LP_DAILY_DFI_REWARD")},
+    }
+        .Check(request);
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     LOCK(cs_main);
 
@@ -685,37 +723,35 @@ UniValue getgov(const JSONRPCRequest& request) {
     auto var = pcustomcsview->GetVariable(name);
     if (var) {
         UniValue ret(UniValue::VOBJ);
-        ret.pushKV(var->GetName(),var->Export());
+        ret.pushKV(var->GetName(), var->Export());
         return GetRPCResultCache().Set(request, ret);
     }
     throw JSONRPCError(RPC_INVALID_REQUEST, "Variable '" + name + "' not registered");
 }
 
-UniValue listgovs(const JSONRPCRequest& request) {
-    RPCHelpMan{"listgovs",
-               "\nReturns information about all governance variables including pending changes\n",
-               {
-                   {"prefix", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                       "One of all, gov, attrs, live. Defaults to the all view. Any other string is treated as\n"
-                       "a prefix of attributes to filter with. `v0/` is assumed if not explicitly provided."},
-               },
-               RPCResult{
-                       "[[{id:{...}},{height:{...}},...], ...]     (array) Json array with JSON objects with variable information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listgovs", "")
-                       + HelpExampleCli("listgovs", "gov")
-                       + HelpExampleCli("listgovs", "live")
-                       + HelpExampleCli("listgovs", "token/")
-                       + HelpExampleCli("listgovs", "token/15")
-                       + HelpExampleRpc("listgovs", "")
-                       + HelpExampleRpc("listgovs", "live")
-                       + HelpExampleCli("listgovs", "token/")
-                       + HelpExampleRpc("listgovs", "token/15")
-               },
-    }.Check(request);
+UniValue listgovs(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listgovs",
+        "\nReturns information about all governance variables including pending changes\n",
+        {
+            {"prefix",
+             RPCArg::Type::STR,
+             RPCArg::Optional::OMITTED,
+             "One of all, gov, attrs, live. Defaults to the all view. Any other string is treated as\n"
+             "a prefix of attributes to filter with. `v0/` is assumed if not explicitly provided."},
+        },
+        RPCResult{"[[{id:{...}},{height:{...}},...], ...]     (array) Json array with JSON objects with variable "
+                  "information\n"},
+        RPCExamples{HelpExampleCli("listgovs", "") + HelpExampleCli("listgovs", "gov") +
+                    HelpExampleCli("listgovs", "live") + HelpExampleCli("listgovs", "token/") +
+                    HelpExampleCli("listgovs", "token/15") + HelpExampleRpc("listgovs", "") +
+                    HelpExampleRpc("listgovs", "live") + HelpExampleCli("listgovs", "token/") +
+                    HelpExampleRpc("listgovs", "token/15")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     GovVarsFilter mode{GovVarsFilter::All};
     std::string prefix;
@@ -730,7 +766,7 @@ UniValue listgovs(const JSONRPCRequest& request) {
         } else if (prefix == "attrs") {
             mode = GovVarsFilter::AttributesOnly;
         } else if (prefix == "v/2.7") {
-            // Undocumented. Make be removed or deprecated without notice. 
+            // Undocumented. Make be removed or deprecated without notice.
             // Only here for unforeseen compatibility concern downstream
             // for transitions.
             mode = GovVarsFilter::Version2Dot7;
@@ -745,8 +781,15 @@ UniValue listgovs(const JSONRPCRequest& request) {
         }
     }
 
-    std::vector<std::string> vars{"ICX_TAKERFEE_PER_BTC", "LP_DAILY_LOAN_TOKEN_REWARD", "LP_LOAN_TOKEN_SPLITS", "LP_DAILY_DFI_REWARD",
-                                  "LOAN_LIQUIDATION_PENALTY", "LP_SPLITS", "ORACLE_BLOCK_INTERVAL", "ORACLE_DEVIATION", "ATTRIBUTES"};
+    std::vector<std::string> vars{"ICX_TAKERFEE_PER_BTC",
+                                  "LP_DAILY_LOAN_TOKEN_REWARD",
+                                  "LP_LOAN_TOKEN_SPLITS",
+                                  "LP_DAILY_DFI_REWARD",
+                                  "LOAN_LIQUIDATION_PENALTY",
+                                  "LP_SPLITS",
+                                  "ORACLE_BLOCK_INTERVAL",
+                                  "ORACLE_DEVIATION",
+                                  "ATTRIBUTES"};
 
     LOCK(cs_main);
 
@@ -754,7 +797,7 @@ UniValue listgovs(const JSONRPCRequest& request) {
     auto pending = pcustomcsview->GetAllStoredVariables();
 
     UniValue result(UniValue::VARR);
-    for (const auto& name : vars) {
+    for (const auto &name : vars) {
         UniValue innerResult(UniValue::VARR);
         auto var = pcustomcsview->GetVariable(name);
         if (var) {
@@ -770,23 +813,22 @@ UniValue listgovs(const JSONRPCRequest& request) {
                     val = a->ExportFiltered(mode, prefix);
                 }
             } else {
-                if (mode == GovVarsFilter::LiveAttributes || 
-                    mode == GovVarsFilter::PrefixedAttributes ||
-                    mode == GovVarsFilter::AttributesOnly){
+                if (mode == GovVarsFilter::LiveAttributes || mode == GovVarsFilter::PrefixedAttributes ||
+                    mode == GovVarsFilter::AttributesOnly) {
                     continue;
                 }
                 val = var->Export();
             }
             if (!skip) {
-                ret.pushKV(name,val);
+                ret.pushKV(name, val);
                 innerResult.push_back(ret);
             }
         }
 
         // Get and add any pending changes
-        for (const auto& items : pending[name]) {
+        for (const auto &items : pending[name]) {
             UniValue ret(UniValue::VOBJ);
-            ret.pushKV(std::to_string(items.first),items.second->Export());
+            ret.pushKV(std::to_string(items.first), items.second->Export());
             innerResult.push_back(ret);
         }
         result.push_back(innerResult);
@@ -795,22 +837,19 @@ UniValue listgovs(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, result);
 }
 
-
-UniValue isappliedcustomtx(const JSONRPCRequest& request) {
-    RPCHelpMan{"isappliedcustomtx",
-               "\nChecks that custom transaction was affected on chain\n",
-               {
-                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A transaction hash"},
-                    {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of block which contain tx"}
-               },
-               RPCResult{
-                       "(bool) The boolean indicate that custom transaction was affected on chain\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("isappliedcustomtx", "b2bb09ffe9f9b292f13d23bafa1225ef26d0b9906da7af194c5738b63839b235 1005")
-                       + HelpExampleRpc("isappliedcustomtx", "b2bb09ffe9f9b292f13d23bafa1225ef26d0b9906da7af194c5738b63839b235 1005")
-               },
-    }.Check(request);
+UniValue isappliedcustomtx(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "isappliedcustomtx",
+        "\nChecks that custom transaction was affected on chain\n",
+        {{"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A transaction hash"},
+         {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of block which contain tx"}},
+        RPCResult{"(bool) The boolean indicate that custom transaction was affected on chain\n"},
+        RPCExamples{HelpExampleCli("isappliedcustomtx",
+                                   "b2bb09ffe9f9b292f13d23bafa1225ef26d0b9906da7af194c5738b63839b235 1005") +
+                    HelpExampleRpc("isappliedcustomtx",
+                                   "b2bb09ffe9f9b292f13d23bafa1225ef26d0b9906da7af194c5738b63839b235 1005")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VNUM}, false);
 
@@ -854,8 +893,7 @@ UniValue isappliedcustomtx(const JSONRPCRequest& request) {
     return result;
 }
 
-
-static std::string GetContractCall(const std::string& str) {
+static std::string GetContractCall(const std::string &str) {
     if (str == "DFIP2201") {
         return "dbtcdfiswap";
     }
@@ -863,25 +901,21 @@ static std::string GetContractCall(const std::string& str) {
     return str;
 }
 
-UniValue listsmartcontracts(const JSONRPCRequest& request) {
-    RPCHelpMan{"listsmartcontracts",
-               "\nReturns information on smart contracts\n",
-               {
-               },
-               RPCResult{
-                       "(array) JSON array with smart contract information\n"
-                       "\"name\":\"name\"         smart contract name\n"
-                       "\"address\":\"address\"   smart contract address\n"
-                       "\"token id\":x.xxxxxxxx   smart contract balance per token\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listsmartcontracts", "")
-                       + HelpExampleRpc("listsmartcontracts", "")
-               },
-    }.Check(request);
+UniValue listsmartcontracts(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listsmartcontracts",
+        "\nReturns information on smart contracts\n",
+        {},
+        RPCResult{"(array) JSON array with smart contract information\n"
+                  "\"name\":\"name\"         smart contract name\n"
+                  "\"address\":\"address\"   smart contract address\n"
+                  "\"token id\":x.xxxxxxxx   smart contract balance per token\n"},
+        RPCExamples{HelpExampleCli("listsmartcontracts", "") + HelpExampleRpc("listsmartcontracts", "")},
+    }
+        .Check(request);
 
     UniValue arr(UniValue::VARR);
-    for (const auto& item : Params().GetConsensus().smartContracts) {
+    for (const auto &item : Params().GetConsensus().smartContracts) {
         UniValue obj(UniValue::VOBJ);
         CTxDestination dest;
         ExtractDestination(item.second, dest);
@@ -889,38 +923,33 @@ UniValue listsmartcontracts(const JSONRPCRequest& request) {
         obj.pushKV("call", GetContractCall(item.first));
         obj.pushKV("address", EncodeDestination(dest));
 
-        pcustomcsview->ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
-            if (owner != item.second) {
-                return false;
-            }
-            obj.pushKV(balance.nTokenId.ToString(), ValueFromAmount(balance.nValue));
-            return true;
-        }, BalanceKey{item.second, {0}});
+        pcustomcsview->ForEachBalance(
+            [&](CScript const &owner, CTokenAmount balance) {
+                if (owner != item.second) {
+                    return false;
+                }
+                obj.pushKV(balance.nTokenId.ToString(), ValueFromAmount(balance.nValue));
+                return true;
+            },
+            BalanceKey{item.second, {0}});
 
         arr.push_back(obj);
     }
     return arr;
 }
 
-
-static UniValue clearmempool(const JSONRPCRequest& request)
-{
+static UniValue clearmempool(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
     RPCHelpMan("clearmempool",
                "\nClears the memory pool and returns a list of the removed transactions.\n",
                {},
-               RPCResult{
-                       "[                     (json array of string)\n"
-                       "  \"hash\"              (string) The transaction hash\n"
-                       "  ,...\n"
-                       "]\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("clearmempool", "")
-                       + HelpExampleRpc("clearmempool", "")
-               }
-    ).Check(request);
+               RPCResult{"[                     (json array of string)\n"
+                         "  \"hash\"              (string) The transaction hash\n"
+                         "  ,...\n"
+                         "]\n"},
+               RPCExamples{HelpExampleCli("clearmempool", "") + HelpExampleRpc("clearmempool", "")})
+        .Check(request);
 
     SyncWithValidationInterfaceQueue();
 
@@ -942,28 +971,26 @@ static UniValue clearmempool(const JSONRPCRequest& request)
     }
 
     UniValue removed(UniValue::VARR);
-    for (const uint256& hash : vtxid) {
+    for (const uint256 &hash : vtxid) {
         removed.push_back(hash.ToString());
     }
 
     return removed;
 }
 
-
-static const CRPCCommand commands[] =
-{
-//  category        name                     actor (function)        params
-//  --------------  ----------------------   --------------------    ----------,
-    {"blockchain",  "setgov",                &setgov,                {"variables", "inputs"}},
-    {"blockchain",  "setgovheight",          &setgovheight,          {"variables", "height", "inputs"}},
-    {"blockchain",  "getgov",                &getgov,                {"name"}},
-    {"blockchain",  "listgovs",              &listgovs,              {"prefix"}},
-    {"blockchain",  "isappliedcustomtx",     &isappliedcustomtx,     {"txid", "blockHeight"}},
-    {"blockchain",  "listsmartcontracts",    &listsmartcontracts,    {}},
-    {"blockchain",  "clearmempool",          &clearmempool,          {} },
+static const CRPCCommand commands[] = {
+    //  category        name                     actor (function)        params
+    //  --------------  ----------------------   --------------------    ----------,
+    {"blockchain", "setgov", &setgov, {"variables", "inputs"}},
+    {"blockchain", "setgovheight", &setgovheight, {"variables", "height", "inputs"}},
+    {"blockchain", "getgov", &getgov, {"name"}},
+    {"blockchain", "listgovs", &listgovs, {"prefix"}},
+    {"blockchain", "isappliedcustomtx", &isappliedcustomtx, {"txid", "blockHeight"}},
+    {"blockchain", "listsmartcontracts", &listsmartcontracts, {}},
+    {"blockchain", "clearmempool", &clearmempool, {}},
 };
 
-void RegisterMNBlockchainRPCCommands(CRPCTable& tableRPC) {
+void RegisterMNBlockchainRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -12,8 +12,8 @@
 #include <masternodes/mn_checks.h>
 
 #include <rpc/rawtransaction_util.h>
-#include <rpc/server.h>
 #include <rpc/resultcache.h>
+#include <rpc/server.h>
 #include <rpc/util.h>
 
 //#ifdef ENABLE_WALLET
@@ -36,27 +36,28 @@ typedef enum {
 } AccountSelectionMode;
 
 enum class AmountFormat : uint8_t {
-        Unknown,
-        // amount@0
-        Id,
-        // amount@DFI
-        Symbol,
-        // amount@0#DFI
-        Combined,
+    Unknown,
+    // amount@0
+    Id,
+    // amount@DFI
+    Symbol,
+    // amount@0#DFI
+    Combined,
 };
 
 class CWalletCoinsUnlocker {
     std::shared_ptr<CWallet> pwallet;
     std::vector<COutPoint> coins;
-public:
+
+   public:
     explicit CWalletCoinsUnlocker(std::shared_ptr<CWallet> pwallet);
-    CWalletCoinsUnlocker(const CWalletCoinsUnlocker&) = delete;
-    CWalletCoinsUnlocker(CWalletCoinsUnlocker&&) = default;
+    CWalletCoinsUnlocker(const CWalletCoinsUnlocker &) = delete;
+    CWalletCoinsUnlocker(CWalletCoinsUnlocker &&) = default;
     ~CWalletCoinsUnlocker();
-    CWallet* operator->();
-    CWallet& operator*();
-    operator CWallet*();
-    void AddLockedCoin(const COutPoint& coin);
+    CWallet *operator->();
+    CWallet &operator*();
+    operator CWallet *();
+    void AddLockedCoin(const COutPoint &coin);
 };
 
 struct FutureSwapHeightInfo {
@@ -65,18 +66,28 @@ struct FutureSwapHeightInfo {
 };
 
 // common functions
-bool IsSkippedTx(const uint256& hash);
-int chainHeight(interfaces::Chain::Lock& locked_chain);
-CMutableTransaction fund(CMutableTransaction& mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx, CCoinControl* coin_control = nullptr);
-CTransactionRef signsend(CMutableTransaction& mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx);
-CWalletCoinsUnlocker GetWallet(const JSONRPCRequest& request);
-std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txVersion, std::set<CScript>& auths, bool needFounderAuth, CTransactionRef& optAuthTx, UniValue const& explicitInputs);
-std::string ScriptToString(CScript const& script);
-CAccounts GetAllMineAccounts(CWallet* const pwallet);
-CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalances& targetBalances, AccountSelectionMode selectionMode);
-void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuthTx = {});
-CScript CreateScriptForHTLC(const JSONRPCRequest& request, uint32_t &blocks, std::vector<unsigned char>& image);
+bool IsSkippedTx(const uint256 &hash);
+int chainHeight(interfaces::Chain::Lock &locked_chain);
+CMutableTransaction fund(CMutableTransaction &mtx,
+                         CWalletCoinsUnlocker &pwallet,
+                         CTransactionRef optAuthTx,
+                         CCoinControl *coin_control = nullptr);
+CTransactionRef signsend(CMutableTransaction &mtx, CWalletCoinsUnlocker &pwallet, CTransactionRef optAuthTx);
+CWalletCoinsUnlocker GetWallet(const JSONRPCRequest &request);
+std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker &pwallet,
+                                      int32_t txVersion,
+                                      std::set<CScript> &auths,
+                                      bool needFounderAuth,
+                                      CTransactionRef &optAuthTx,
+                                      UniValue const &explicitInputs);
+std::string ScriptToString(CScript const &script);
+CAccounts GetAllMineAccounts(CWallet *const pwallet);
+CAccounts SelectAccountsByTargetBalances(const CAccounts &accounts,
+                                         const CBalances &targetBalances,
+                                         AccountSelectionMode selectionMode);
+void execTestTx(const CTransaction &tx, uint32_t height, CTransactionRef optAuthTx = {});
+CScript CreateScriptForHTLC(const JSONRPCRequest &request, uint32_t &blocks, std::vector<unsigned char> &image);
 CPubKey PublickeyFromString(const std::string &pubkey);
 std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId);
 
-#endif // DEFI_MASTERNODES_MN_RPC_H
+#endif  // DEFI_MASTERNODES_MN_RPC_H

--- a/src/masternodes/oracles.cpp
+++ b/src/masternodes/oracles.cpp
@@ -8,13 +8,11 @@
 
 #include <algorithm>
 
-bool COracle::SupportsPair(const std::string& token, const std::string& currency) const
-{
+bool COracle::SupportsPair(const std::string &token, const std::string &currency) const {
     return availablePairs.count(std::make_pair(token, currency)) > 0;
 }
 
-Res COracle::SetTokenPrice(const std::string& token, const std::string& currency, CAmount amount, int64_t timestamp)
-{
+Res COracle::SetTokenPrice(const std::string &token, const std::string &currency, CAmount amount, int64_t timestamp) {
     if (!SupportsPair(token, currency)) {
         return Res::Err("token <%s> - currency <%s> is not allowed", token, currency);
     }
@@ -24,8 +22,7 @@ Res COracle::SetTokenPrice(const std::string& token, const std::string& currency
     return Res::Ok();
 }
 
-ResVal<CAmount> COracle::GetTokenPrice(const std::string& token, const std::string& currency)
-{
+ResVal<CAmount> COracle::GetTokenPrice(const std::string &token, const std::string &currency) {
     if (!SupportsPair(token, currency)) {
         return Res::Err("token <%s> - currency <%s> is not allowed", token, currency);
     }
@@ -33,8 +30,7 @@ ResVal<CAmount> COracle::GetTokenPrice(const std::string& token, const std::stri
     return ResVal<CAmount>(tokenPrices[token][currency].first, Res::Ok());
 }
 
-Res COracleView::AppointOracle(const COracleId& oracleId, const COracle& oracle)
-{
+Res COracleView::AppointOracle(const COracleId &oracleId, const COracle &oracle) {
     if (!WriteBy<ByName>(oracleId, oracle)) {
         return Res::Err("failed to appoint the new oracle <%s>", oracleId.GetHex());
     }
@@ -42,8 +38,7 @@ Res COracleView::AppointOracle(const COracleId& oracleId, const COracle& oracle)
     return Res::Ok();
 }
 
-Res COracleView::UpdateOracle(const COracleId& oracleId, COracle&& newOracle)
-{
+Res COracleView::UpdateOracle(const COracleId &oracleId, COracle &&newOracle) {
     COracle oracle;
     if (!ReadBy<ByName>(oracleId, oracle)) {
         return Res::Err("oracle <%s> not found", oracleId.GetHex());
@@ -57,10 +52,10 @@ Res COracleView::UpdateOracle(const COracleId& oracleId, COracle&& newOracle)
     oracle.oracleAddress = std::move(newOracle.oracleAddress);
 
     CTokenPricePoints allowedPrices;
-    for (const auto& tokenPrice : oracle.tokenPrices) {
-        const auto& token = tokenPrice.first;
-        for (const auto& price : tokenPrice.second) {
-            const auto& currency = price.first;
+    for (const auto &tokenPrice : oracle.tokenPrices) {
+        const auto &token = tokenPrice.first;
+        for (const auto &price : tokenPrice.second) {
+            const auto &currency = price.first;
             if (!newOracle.SupportsPair(token, currency)) {
                 continue;
             }
@@ -79,8 +74,7 @@ Res COracleView::UpdateOracle(const COracleId& oracleId, COracle&& newOracle)
     return Res::Ok();
 }
 
-Res COracleView::RemoveOracle(const COracleId& oracleId)
-{
+Res COracleView::RemoveOracle(const COracleId &oracleId) {
     if (!ExistsBy<ByName>(oracleId)) {
         return Res::Err("oracle <%s> not found", oracleId.GetHex());
     }
@@ -93,17 +87,16 @@ Res COracleView::RemoveOracle(const COracleId& oracleId)
     return Res::Ok();
 }
 
-Res COracleView::SetOracleData(const COracleId& oracleId, int64_t timestamp, const CTokenPrices& tokenPrices)
-{
+Res COracleView::SetOracleData(const COracleId &oracleId, int64_t timestamp, const CTokenPrices &tokenPrices) {
     COracle oracle;
     if (!ReadBy<ByName>(oracleId, oracle)) {
         return Res::Err("failed to read oracle %s from database", oracleId.GetHex());
     }
 
-    for (const auto& tokenPrice : tokenPrices) {
-        const auto& token = tokenPrice.first;
-        for (const auto& price : tokenPrice.second) {
-            const auto& currency = price.first;
+    for (const auto &tokenPrice : tokenPrices) {
+        const auto &token = tokenPrice.first;
+        for (const auto &price : tokenPrice.second) {
+            const auto &currency = price.first;
             auto res = oracle.SetTokenPrice(token, currency, price.second, timestamp);
             if (!res.ok) {
                 return res;
@@ -118,8 +111,7 @@ Res COracleView::SetOracleData(const COracleId& oracleId, int64_t timestamp, con
     return Res::Ok();
 }
 
-ResVal<COracle> COracleView::GetOracleData(const COracleId& oracleId) const
-{
+ResVal<COracle> COracleView::GetOracleData(const COracleId &oracleId) const {
     COracle oracle;
     if (!ReadBy<ByName>(oracleId, oracle)) {
         return Res::Err("oracle <%s> not found", oracleId.GetHex());
@@ -128,35 +120,38 @@ ResVal<COracle> COracleView::GetOracleData(const COracleId& oracleId) const
     return ResVal<COracle>(oracle, Res::Ok());
 }
 
-void COracleView::ForEachOracle(std::function<bool(const COracleId&, CLazySerialize<COracle>)> callback, const COracleId& start)
-{
+void COracleView::ForEachOracle(std::function<bool(const COracleId &, CLazySerialize<COracle>)> callback,
+                                const COracleId &start) {
     ForEach<ByName, COracleId, COracle>(callback, start);
 }
 
-bool CFixedIntervalPrice::isLive(const CAmount deviationThreshold) const
-{
-    return (
-        priceRecord[0] > 0 &&
-        priceRecord[1] > 0 &&
-        (std::abs(priceRecord[1] - priceRecord[0]) < MultiplyAmounts(priceRecord[0], deviationThreshold))
-    );
+bool CFixedIntervalPrice::isLive(const CAmount deviationThreshold) const {
+    return (priceRecord[0] > 0 && priceRecord[1] > 0 &&
+            (std::abs(priceRecord[1] - priceRecord[0]) < MultiplyAmounts(priceRecord[0], deviationThreshold)));
 }
 
-Res COracleView::SetFixedIntervalPrice(const CFixedIntervalPrice& fixedIntervalPrice){
-
+Res COracleView::SetFixedIntervalPrice(const CFixedIntervalPrice &fixedIntervalPrice) {
     if (!WriteBy<FixedIntervalPriceKey>(fixedIntervalPrice.priceFeedId, fixedIntervalPrice)) {
-        return Res::Err("failed to set new price feed <%s/%s>", fixedIntervalPrice.priceFeedId.first, fixedIntervalPrice.priceFeedId.second);
+        return Res::Err("failed to set new price feed <%s/%s>",
+                        fixedIntervalPrice.priceFeedId.first,
+                        fixedIntervalPrice.priceFeedId.second);
     }
-    LogPrint(BCLog::ORACLE, "%s(): %s/%s, active - %lld, next - %lld\n", __func__, fixedIntervalPrice.priceFeedId.first, fixedIntervalPrice.priceFeedId.second, fixedIntervalPrice.priceRecord[0], fixedIntervalPrice.priceRecord[1]);
+    LogPrint(BCLog::ORACLE,
+             "%s(): %s/%s, active - %lld, next - %lld\n",
+             __func__,
+             fixedIntervalPrice.priceFeedId.first,
+             fixedIntervalPrice.priceFeedId.second,
+             fixedIntervalPrice.priceRecord[0],
+             fixedIntervalPrice.priceRecord[1]);
 
     return Res::Ok();
 }
 
-ResVal<CFixedIntervalPrice> COracleView::GetFixedIntervalPrice(const CTokenCurrencyPair& fixedIntervalPriceId)
-{
+ResVal<CFixedIntervalPrice> COracleView::GetFixedIntervalPrice(const CTokenCurrencyPair &fixedIntervalPriceId) {
     CFixedIntervalPrice fixedIntervalPrice;
     if (!ReadBy<FixedIntervalPriceKey>(fixedIntervalPriceId, fixedIntervalPrice)) {
-        return Res::Err("fixedIntervalPrice with id <%s/%s> not found", fixedIntervalPriceId.first, fixedIntervalPriceId.second);
+        return Res::Err(
+            "fixedIntervalPrice with id <%s/%s> not found", fixedIntervalPriceId.first, fixedIntervalPriceId.second);
     }
 
     DCT_ID firstID{}, secondID{};
@@ -176,23 +171,28 @@ ResVal<CFixedIntervalPrice> COracleView::GetFixedIntervalPrice(const CTokenCurre
         return Res::Err("Fixed interval price currently disabled due to locked token");
     }
 
-    LogPrint(BCLog::ORACLE, "%s(): %s/%s, active - %lld, next - %lld\n", __func__, fixedIntervalPrice.priceFeedId.first, fixedIntervalPrice.priceFeedId.second, fixedIntervalPrice.priceRecord[0], fixedIntervalPrice.priceRecord[1]);
+    LogPrint(BCLog::ORACLE,
+             "%s(): %s/%s, active - %lld, next - %lld\n",
+             __func__,
+             fixedIntervalPrice.priceFeedId.first,
+             fixedIntervalPrice.priceFeedId.second,
+             fixedIntervalPrice.priceRecord[0],
+             fixedIntervalPrice.priceRecord[1]);
     return ResVal<CFixedIntervalPrice>(fixedIntervalPrice, Res::Ok());
 }
 
-void COracleView::ForEachFixedIntervalPrice(std::function<bool(const CTokenCurrencyPair&, CLazySerialize<CFixedIntervalPrice>)> callback, const CTokenCurrencyPair& start)
-{
+void COracleView::ForEachFixedIntervalPrice(
+    std::function<bool(const CTokenCurrencyPair &, CLazySerialize<CFixedIntervalPrice>)> callback,
+    const CTokenCurrencyPair &start) {
     ForEach<FixedIntervalPriceKey, CTokenCurrencyPair, CFixedIntervalPrice>(callback, start);
 }
 
-Res COracleView::SetPriceDeviation(const uint32_t deviation)
-{
+Res COracleView::SetPriceDeviation(const uint32_t deviation) {
     Write(PriceDeviation::prefix(), deviation);
     return Res::Ok();
 }
 
-CAmount COracleView::GetPriceDeviation() const
-{
+CAmount COracleView::GetPriceDeviation() const {
     uint32_t deviation;
     if (Read(PriceDeviation::prefix(), deviation)) {
         return deviation;
@@ -202,14 +202,12 @@ CAmount COracleView::GetPriceDeviation() const
     return 3 * COIN / 10;
 }
 
-Res COracleView::SetIntervalBlock(const uint32_t blockInterval)
-{
+Res COracleView::SetIntervalBlock(const uint32_t blockInterval) {
     Write(FixedIntervalBlockKey::prefix(), blockInterval);
     return Res::Ok();
 }
 
-uint32_t COracleView::GetIntervalBlock() const
-{
+uint32_t COracleView::GetIntervalBlock() const {
     uint32_t blockInterval;
     if (Read(FixedIntervalBlockKey::prefix(), blockInterval)) {
         return blockInterval;

--- a/src/masternodes/oracles.h
+++ b/src/masternodes/oracles.h
@@ -33,8 +33,7 @@ struct CAppointOracleMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(oracleAddress);
         READWRITE(weightage);
         READWRITE(availablePairs);
@@ -47,8 +46,7 @@ struct CRemoveOracleAppointMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(oracleId);
     }
 };
@@ -60,8 +58,7 @@ struct CUpdateOracleAppointMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(oracleId);
         READWRITE(newOracleAppoint);
     }
@@ -75,8 +72,7 @@ struct CSetOracleDataMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(oracleId);
         READWRITE(timestamp);
         READWRITE(tokenPrices);
@@ -87,71 +83,70 @@ struct CSetOracleDataMessage {
 struct COracle : public CAppointOracleMessage {
     CTokenPricePoints tokenPrices;
 
-    bool SupportsPair(const std::string& token, const std::string& currency) const;
-    Res SetTokenPrice(const std::string& token, const std::string& currency, CAmount amount, int64_t timestamp);
-    ResVal<CAmount> GetTokenPrice(const std::string& token, const std::string& currency);
+    bool SupportsPair(const std::string &token, const std::string &currency) const;
+    Res SetTokenPrice(const std::string &token, const std::string &currency, CAmount amount, int64_t timestamp);
+    ResVal<CAmount> GetTokenPrice(const std::string &token, const std::string &currency);
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CAppointOracleMessage, *this);
         READWRITE(tokenPrices);
     }
 };
 
-struct CFixedIntervalPrice
-{
+struct CFixedIntervalPrice {
     CTokenCurrencyPair priceFeedId;
     int64_t timestamp;
-    std::vector<CAmount> priceRecord{0, 0}; // priceHistory[0] = active price, priceHistory[1] = next price
+    std::vector<CAmount> priceRecord{0, 0};  // priceHistory[0] = active price, priceHistory[1] = next price
     bool isLive(const CAmount deviationThreshold) const;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(priceFeedId);
         READWRITE(timestamp);
         READWRITE(priceRecord);
     }
 };
 
-struct CFuturesPrice
-{
+struct CFuturesPrice {
     CAmount discount;
     CAmount premium;
 };
 
 /// View for managing oracles and their data
-class COracleView : public virtual CStorageView
-{
-public:
+class COracleView : public virtual CStorageView {
+   public:
     ~COracleView() override = default;
 
     /// register new oracle instance
-    Res AppointOracle(const COracleId& oracleId, const COracle& oracle);
+    Res AppointOracle(const COracleId &oracleId, const COracle &oracle);
 
     /// updates oracle info
-    Res UpdateOracle(const COracleId& oracleId, COracle&& newOracle);
+    Res UpdateOracle(const COracleId &oracleId, COracle &&newOracle);
 
     /// remove oracle instancefrom database
-    Res RemoveOracle(const COracleId& oracleId);
+    Res RemoveOracle(const COracleId &oracleId);
 
     /// store registered oracle data
-    Res SetOracleData(const COracleId& oracleId, int64_t timestamp, const CTokenPrices& tokenPrices);
+    Res SetOracleData(const COracleId &oracleId, int64_t timestamp, const CTokenPrices &tokenPrices);
 
     /// deserialize oracle instance from database
-    ResVal<COracle> GetOracleData(const COracleId& oracleId) const;
+    ResVal<COracle> GetOracleData(const COracleId &oracleId) const;
 
-    void ForEachOracle(std::function<bool(const COracleId&, CLazySerialize<COracle>)> callback, const COracleId& start = {});
+    void ForEachOracle(std::function<bool(const COracleId &, CLazySerialize<COracle>)> callback,
+                       const COracleId &start = {});
 
-    Res SetFixedIntervalPrice(const CFixedIntervalPrice& PriceFeed);
+    Res SetFixedIntervalPrice(const CFixedIntervalPrice &PriceFeed);
 
-    ResVal<CFixedIntervalPrice> GetFixedIntervalPrice(const CTokenCurrencyPair& priceFeedId);
+    ResVal<CFixedIntervalPrice> GetFixedIntervalPrice(const CTokenCurrencyPair &priceFeedId);
 
-    void ForEachFixedIntervalPrice(std::function<bool(const CTokenCurrencyPair&, CLazySerialize<CFixedIntervalPrice>)> callback, const CTokenCurrencyPair& start = {});
+    void ForEachFixedIntervalPrice(
+        std::function<bool(const CTokenCurrencyPair &, CLazySerialize<CFixedIntervalPrice>)> callback,
+        const CTokenCurrencyPair &start = {});
 
     Res SetPriceDeviation(const uint32_t deviation);
     CAmount GetPriceDeviation() const;
@@ -159,14 +154,23 @@ public:
     Res SetIntervalBlock(const uint32_t blockInterval);
     uint32_t GetIntervalBlock() const;
 
-    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t>& tokenIds) const = 0;
-    [[nodiscard]] virtual std::optional<CTokenImplementation> GetTokenGuessId(const std::string & str, DCT_ID & id) const = 0;
-    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenByID(DCT_ID const & id) const = 0;
+    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) const = 0;
+    [[nodiscard]] virtual std::optional<CTokenImplementation> GetTokenGuessId(const std::string &str,
+                                                                              DCT_ID &id) const = 0;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenByID(DCT_ID const &id) const = 0;
 
-    struct ByName { static constexpr uint8_t prefix() { return 'O'; } };
-    struct PriceDeviation { static constexpr uint8_t prefix() { return 'Y'; } };
-    struct FixedIntervalBlockKey { static constexpr uint8_t prefix() { return 'z'; } };
-    struct FixedIntervalPriceKey { static constexpr uint8_t prefix() { return 'y'; } };
+    struct ByName {
+        static constexpr uint8_t prefix() { return 'O'; }
+    };
+    struct PriceDeviation {
+        static constexpr uint8_t prefix() { return 'Y'; }
+    };
+    struct FixedIntervalBlockKey {
+        static constexpr uint8_t prefix() { return 'z'; }
+    };
+    struct FixedIntervalPriceKey {
+        static constexpr uint8_t prefix() { return 'y'; }
+    };
 };
 
-#endif // DEFI_MASTERNODES_ORACLES_H
+#endif  // DEFI_MASTERNODES_ORACLES_H

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -3,10 +3,10 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 #include <arith_uint256.h>
-#include <masternodes/poolpairs.h>
 #include <core_io.h>
-#include <primitives/transaction.h>
 #include <masternodes/govvariables/attributes.h>
+#include <masternodes/poolpairs.h>
+#include <primitives/transaction.h>
 
 struct PoolSwapValue {
     bool swapEvent;
@@ -16,7 +16,7 @@ struct PoolSwapValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(swapEvent);
         READWRITE(blockCommissionA);
         READWRITE(blockCommissionB);
@@ -30,14 +30,13 @@ struct PoolReservesValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(reserveA);
         READWRITE(reserveB);
     }
 };
 
-std::string RewardToString(RewardType type)
-{
+std::string RewardToString(RewardType type) {
     if (type & RewardType::Rewards) {
         return "Rewards";
     } else if (type == RewardType::Commission) {
@@ -46,18 +45,21 @@ std::string RewardToString(RewardType type)
     return "Unknown";
 }
 
-std::string RewardTypeToString(RewardType type)
-{
-    switch(type) {
-        case RewardType::Coinbase: return "Coinbase";
-        case RewardType::Pool: return "Pool";
-        case RewardType::LoanTokenDEXReward: return "LoanTokenDEXReward";
-        default: return "Unknown";
+std::string RewardTypeToString(RewardType type) {
+    switch (type) {
+        case RewardType::Coinbase:
+            return "Coinbase";
+        case RewardType::Pool:
+            return "Pool";
+        case RewardType::LoanTokenDEXReward:
+            return "LoanTokenDEXReward";
+        default:
+            return "Unknown";
     }
 }
 
 template <typename By, typename ReturnType>
-ReturnType ReadValueAt(CPoolPairView * poolView, PoolHeightKey const & poolKey) {
+ReturnType ReadValueAt(CPoolPairView *poolView, PoolHeightKey const &poolKey) {
     auto it = poolView->LowerBound<By>(poolKey);
     if (it.Valid() && it.Key().poolID == poolKey.poolID) {
         return it.Value();
@@ -65,8 +67,7 @@ ReturnType ReadValueAt(CPoolPairView * poolView, PoolHeightKey const & poolKey) 
     return {};
 }
 
-Res CPoolPairView::SetPoolPair(DCT_ID const & poolId, uint32_t height, CPoolPair const & pool)
-{
+Res CPoolPairView::SetPoolPair(DCT_ID const &poolId, uint32_t height, CPoolPair const &pool) {
     if (pool.idTokenA == pool.idTokenB) {
         return Res::Err("Error: tokens IDs are the same.");
     }
@@ -74,8 +75,7 @@ Res CPoolPairView::SetPoolPair(DCT_ID const & poolId, uint32_t height, CPoolPair
     auto poolPairByID = GetPoolPair(poolId);
     auto poolIdByTokens = ReadBy<ByPair, DCT_ID>(ByPairKey{pool.idTokenA, pool.idTokenB});
 
-    if ((!poolPairByID && poolIdByTokens)
-    || (poolPairByID && !poolIdByTokens)) {
+    if ((!poolPairByID && poolIdByTokens) || (poolPairByID && !poolIdByTokens)) {
         return Res::Err("Error, there is already a poolpair with same tokens, but different poolId");
     }
 
@@ -96,12 +96,9 @@ Res CPoolPairView::SetPoolPair(DCT_ID const & poolId, uint32_t height, CPoolPair
     assert(poolPairByTokens);
 
     // update
-    if(poolPairByID->idTokenA == pool.idTokenA
-    && poolPairByID->idTokenB == pool.idTokenB
-    && poolPairByTokens->idTokenA == pool.idTokenA
-    && poolPairByTokens->idTokenB == pool.idTokenB) {
-        if (poolPairByID->reserveA != pool.reserveA
-        || poolPairByID->reserveB != pool.reserveB) {
+    if (poolPairByID->idTokenA == pool.idTokenA && poolPairByID->idTokenB == pool.idTokenB &&
+        poolPairByTokens->idTokenA == pool.idTokenA && poolPairByTokens->idTokenB == pool.idTokenB) {
+        if (poolPairByID->reserveA != pool.reserveA || poolPairByID->reserveB != pool.reserveB) {
             WriteBy<ByReserves>(poolId, PoolReservesValue{pool.reserveA, pool.reserveB});
         }
         PoolHeightKey poolKey = {poolId, height};
@@ -117,20 +114,24 @@ Res CPoolPairView::SetPoolPair(DCT_ID const & poolId, uint32_t height, CPoolPair
     return Res::Err("Error, idTokenA or idTokenB is incorrect.");
 }
 
-Res CPoolPairView::UpdatePoolPair(DCT_ID const & poolId, uint32_t height, bool status, CAmount const & commission, CScript const & ownerAddress, CBalances const & rewards)
-{
+Res CPoolPairView::UpdatePoolPair(DCT_ID const &poolId,
+                                  uint32_t height,
+                                  bool status,
+                                  CAmount const &commission,
+                                  CScript const &ownerAddress,
+                                  CBalances const &rewards) {
     auto poolPair = GetPoolPair(poolId);
     if (!poolPair) {
         return Res::Err("Pool with poolId %s does not exist", poolId.ToString());
     }
 
-    CPoolPair & pool = poolPair.value();
+    CPoolPair &pool = poolPair.value();
 
     if (pool.status != status) {
         pool.status = status;
     }
 
-    if (commission >= 0) { // default/not set is -1
+    if (commission >= 0) {  // default/not set is -1
         if (commission > COIN) {
             return Res::Err("commission > 100%%");
         }
@@ -144,8 +145,9 @@ Res CPoolPairView::UpdatePoolPair(DCT_ID const & poolId, uint32_t height, bool s
     if (!rewards.balances.empty()) {
         auto customRewards = rewards;
         // Check for special case to wipe rewards
-        if (rewards.balances.size() == 1 && rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()}
-        && rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max()) {
+        if (rewards.balances.size() == 1 &&
+            rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()} &&
+            rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max()) {
             customRewards.balances.clear();
         }
         if (pool.rewards != customRewards) {
@@ -158,8 +160,7 @@ Res CPoolPairView::UpdatePoolPair(DCT_ID const & poolId, uint32_t height, bool s
     return Res::Ok();
 }
 
-std::optional<CPoolPair> CPoolPairView::GetPoolPair(const DCT_ID &poolId) const
-{
+std::optional<CPoolPair> CPoolPairView::GetPoolPair(const DCT_ID &poolId) const {
     auto pool = ReadBy<ByID, CPoolPair>(poolId);
     if (!pool) {
         return {};
@@ -185,11 +186,11 @@ std::optional<CPoolPair> CPoolPairView::GetPoolPair(const DCT_ID &poolId) const
     return pool;
 }
 
-std::optional<std::pair<DCT_ID, CPoolPair> > CPoolPairView::GetPoolPair(const DCT_ID &tokenA, const DCT_ID &tokenB) const
-{
+std::optional<std::pair<DCT_ID, CPoolPair> > CPoolPairView::GetPoolPair(const DCT_ID &tokenA,
+                                                                        const DCT_ID &tokenB) const {
     DCT_ID poolId;
-    ByPairKey key {tokenA, tokenB};
-    if(ReadBy<ByPair, ByPairKey>(key, poolId)) {
+    ByPairKey key{tokenA, tokenB};
+    if (ReadBy<ByPair, ByPairKey>(key, poolId)) {
         if (auto poolPair = GetPoolPair(poolId)) {
             return std::make_pair(poolId, std::move(*poolPair));
         }
@@ -198,12 +199,12 @@ std::optional<std::pair<DCT_ID, CPoolPair> > CPoolPairView::GetPoolPair(const DC
 }
 
 inline CAmount liquidityReward(CAmount reward, CAmount liquidity, CAmount totalLiquidity) {
-    return static_cast<CAmount>((arith_uint256(reward) * arith_uint256(liquidity) / arith_uint256(totalLiquidity)).GetLow64());
+    return static_cast<CAmount>(
+        (arith_uint256(reward) * arith_uint256(liquidity) / arith_uint256(totalLiquidity)).GetLow64());
 }
 
-template<typename TIterator, typename ValueType>
-void ReadValueMoveToNext(TIterator & it, DCT_ID poolId, ValueType & value, uint32_t & height) {
-
+template <typename TIterator, typename ValueType>
+void ReadValueMoveToNext(TIterator &it, DCT_ID poolId, ValueType &value, uint32_t &height) {
     if (it.Valid() && it.Key().poolID == poolId) {
         value = it.Value();
         /// @Note we store keys in desc order so Prev is actually go in forward
@@ -219,7 +220,11 @@ void ReadValueMoveToNext(TIterator & it, DCT_ID poolId, ValueType & value, uint3
     }
 }
 
-void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CAmount()> onLiquidity, uint32_t begin, uint32_t end, std::function<void(RewardType, CTokenAmount, uint32_t)> onReward) {
+void CPoolPairView::CalculatePoolRewards(DCT_ID const &poolId,
+                                         std::function<CAmount()> onLiquidity,
+                                         uint32_t begin,
+                                         uint32_t end,
+                                         std::function<void(RewardType, CTokenAmount, uint32_t)> onReward) {
     if (begin >= end) {
         return;
     }
@@ -227,7 +232,7 @@ void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CA
     const auto newCalcHeight = uint32_t(Params().GetConsensus().BayfrontGardensHeight);
 
     auto tokenIds = ReadBy<ByIDPair, ByPairKey>(poolId);
-    assert(tokenIds); // contract to verify pool data
+    assert(tokenIds);  // contract to verify pool data
 
     PoolHeightKey poolKey = {poolId, begin};
 
@@ -279,10 +284,10 @@ void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CA
         // daily rewards
         if (poolReward != 0) {
             CAmount providerReward = 0;
-            if (height < newCalcHeight) { // old calculation
+            if (height < newCalcHeight) {  // old calculation
                 uint32_t liqWeight = liquidity * PRECISION / totalLiquidity;
                 providerReward = poolReward * liqWeight / PRECISION;
-            } else { // new calculation
+            } else {  // new calculation
                 providerReward = liquidityReward(poolReward, liquidity, totalLiquidity);
             }
             onReward(RewardType::Coinbase, {DCT_ID{0}, providerReward}, height);
@@ -310,7 +315,7 @@ void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CA
             }
         }
         // custom rewards
-        for (const auto& reward : customRewards.balances) {
+        for (const auto &reward : customRewards.balances) {
             if (auto providerReward = liquidityReward(reward.second, liquidity, totalLiquidity)) {
                 onReward(RewardType::Pool, {reward.first, providerReward}, height);
             }
@@ -319,7 +324,10 @@ void CPoolPairView::CalculatePoolRewards(DCT_ID const & poolId, std::function<CA
     }
 }
 
-Res CPoolPair::AddLiquidity(CAmount amountA, CAmount amountB, std::function<Res(CAmount)> onMint, bool slippageProtection) {
+Res CPoolPair::AddLiquidity(CAmount amountA,
+                            CAmount amountB,
+                            std::function<Res(CAmount)> onMint,
+                            bool slippageProtection) {
     // instead of assertion due to tests
     if (amountA <= 0 || amountB <= 0) {
         return Res::Err("amounts should be positive");
@@ -327,8 +335,10 @@ Res CPoolPair::AddLiquidity(CAmount amountA, CAmount amountB, std::function<Res(
 
     CAmount liquidity{0};
     if (totalLiquidity == 0) {
-        liquidity = (CAmount) (arith_uint256(amountA) * arith_uint256(amountB)).sqrt().GetLow64(); // sure this is below std::numeric_limits<CAmount>::max() due to sqrt natue
-        if (liquidity <= MINIMUM_LIQUIDITY) { // ensure that it'll be non-zero
+        liquidity = (CAmount)(arith_uint256(amountA) * arith_uint256(amountB))
+                        .sqrt()
+                        .GetLow64();  // sure this is below std::numeric_limits<CAmount>::max() due to sqrt natue
+        if (liquidity <= MINIMUM_LIQUIDITY) {  // ensure that it'll be non-zero
             return Res::Err("liquidity too low");
         }
         liquidity -= MINIMUM_LIQUIDITY;
@@ -343,7 +353,7 @@ Res CPoolPair::AddLiquidity(CAmount amountA, CAmount amountB, std::function<Res(
             return Res::Err("amounts too low, zero liquidity");
         }
 
-        if(slippageProtection) {
+        if (slippageProtection) {
             if ((std::max(liqA, liqB) - liquidity) * 100 / liquidity >= 3) {
                 return Res::Err("Exceeds max ratio slippage protection of 3%%");
             }
@@ -372,7 +382,8 @@ Res CPoolPair::AddLiquidity(CAmount amountA, CAmount amountB, std::function<Res(
 
 Res CPoolPair::RemoveLiquidity(CAmount liqAmount, std::function<Res(CAmount, CAmount)> onReclaim) {
     // instead of assertion due to tests
-    // IRL it can't be more than "total-1000", and was checked indirectly by balances before. but for tests and incapsulation:
+    // IRL it can't be more than "total-1000", and was checked indirectly by balances before. but for tests and
+    // incapsulation:
     if (liqAmount <= 0 || liqAmount >= totalLiquidity) {
         return Res::Err("incorrect liquidity");
     }
@@ -381,33 +392,39 @@ Res CPoolPair::RemoveLiquidity(CAmount liqAmount, std::function<Res(CAmount, CAm
     resAmountA = (arith_uint256(liqAmount) * arith_uint256(reserveA) / totalLiquidity).GetLow64();
     resAmountB = (arith_uint256(liqAmount) * arith_uint256(reserveB) / totalLiquidity).GetLow64();
 
-    reserveA -= resAmountA; // safe due to previous math
+    reserveA -= resAmountA;  // safe due to previous math
     reserveB -= resAmountB;
     totalLiquidity -= liqAmount;
 
     return onReclaim(resAmountA, resAmountB);
 }
 
-Res CPoolPair::Swap(CTokenAmount in, CAmount dexfeeInPct, PoolPrice const & maxPrice, const std::pair<CFeeDir, CFeeDir>& asymmetricFee, std::function<Res (const CTokenAmount &, const CTokenAmount &)> onTransfer, int height) {
+Res CPoolPair::Swap(CTokenAmount in,
+                    CAmount dexfeeInPct,
+                    PoolPrice const &maxPrice,
+                    const std::pair<CFeeDir, CFeeDir> &asymmetricFee,
+                    std::function<Res(const CTokenAmount &, const CTokenAmount &)> onTransfer,
+                    int height) {
     if (in.nTokenId != idTokenA && in.nTokenId != idTokenB)
-        return Res::Err("Error, input token ID (" + in.nTokenId.ToString() + ") doesn't match pool tokens (" + idTokenA.ToString() + "," + idTokenB.ToString() + ")");
+        return Res::Err("Error, input token ID (" + in.nTokenId.ToString() + ") doesn't match pool tokens (" +
+                        idTokenA.ToString() + "," + idTokenB.ToString() + ")");
 
     if (!status)
         return Res::Err("Pool trading is turned off!");
 
     bool const forward = in.nTokenId == idTokenA;
-    auto& reserveF = forward ? reserveA : reserveB;
-    auto& reserveT = forward ? reserveB : reserveA;
+    auto &reserveF = forward ? reserveA : reserveB;
+    auto &reserveT = forward ? reserveB : reserveA;
 
-    // it is important that reserves are at least SLOPE_SWAP_RATE (1000) to be able to slide, otherwise it can lead to underflow
+    // it is important that reserves are at least SLOPE_SWAP_RATE (1000) to be able to slide, otherwise it can lead to
+    // underflow
     if (reserveA < SLOPE_SWAP_RATE || reserveB < SLOPE_SWAP_RATE)
         return Res::Err("Lack of liquidity.");
 
     auto const maxPrice256 = arith_uint256(maxPrice.integer) * PRECISION + maxPrice.fraction;
     // NOTE it has a bug prior Dakota hardfork
-    auto const price = height < Params().GetConsensus().DakotaHeight
-                              ? arith_uint256(reserveT) * PRECISION / reserveF
-                              : arith_uint256(reserveF) * PRECISION / reserveT;
+    auto const price = height < Params().GetConsensus().DakotaHeight ? arith_uint256(reserveT) * PRECISION / reserveF
+                                                                     : arith_uint256(reserveF) * PRECISION / reserveT;
     if (price > maxPrice256)
         return Res::Err("Price is higher than indicated.");
 
@@ -438,23 +455,23 @@ Res CPoolPair::Swap(CTokenAmount in, CAmount dexfeeInPct, PoolPrice const & maxP
 
     CAmount result = slopeSwap(in.nValue, reserveF, reserveT, height);
 
-    swapEvent = true; // (!!!)
+    swapEvent = true;  // (!!!)
 
-    return onTransfer(dexfeeInAmount, { forward ? idTokenB : idTokenA, result });
+    return onTransfer(dexfeeInAmount, {forward ? idTokenB : idTokenA, result});
 }
 
 CAmount CPoolPair::slopeSwap(CAmount unswapped, CAmount &poolFrom, CAmount &poolTo, int height) {
-    assert (unswapped >= 0);
-    assert (SafeAdd(unswapped, poolFrom).ok);
+    assert(unswapped >= 0);
+    assert(SafeAdd(unswapped, poolFrom).ok);
 
     arith_uint256 poolF = arith_uint256(poolFrom);
     arith_uint256 poolT = arith_uint256(poolTo);
 
     arith_uint256 swapped = 0;
     if (height < Params().GetConsensus().BayfrontGardensHeight) {
-        CAmount chunk = poolFrom/SLOPE_SWAP_RATE < unswapped ? poolFrom/SLOPE_SWAP_RATE : unswapped;
+        CAmount chunk = poolFrom / SLOPE_SWAP_RATE < unswapped ? poolFrom / SLOPE_SWAP_RATE : unswapped;
         while (unswapped > 0) {
-            //arith_uint256 stepFrom = std::min(poolFrom/1000, unswapped); // 0.1%
+            // arith_uint256 stepFrom = std::min(poolFrom/1000, unswapped); // 0.1%
             CAmount stepFrom = std::min(chunk, unswapped);
             arith_uint256 stepFrom256(stepFrom);
             arith_uint256 stepTo = poolT * stepFrom256 / poolF;
@@ -480,18 +497,19 @@ CAmount CPoolPair::slopeSwap(CAmount unswapped, CAmount &poolFrom, CAmount &pool
     return swapped.GetLow64();
 }
 
-std::pair<CAmount, CAmount> CPoolPairView::UpdatePoolRewards(std::function<CTokenAmount(CScript const &, DCT_ID)> onGetBalance, std::function<Res(CScript const &, CScript const &, CTokenAmount)> onTransfer, int nHeight) {
-
+std::pair<CAmount, CAmount> CPoolPairView::UpdatePoolRewards(
+    std::function<CTokenAmount(CScript const &, DCT_ID)> onGetBalance,
+    std::function<Res(CScript const &, CScript const &, CTokenAmount)> onTransfer,
+    int nHeight) {
     bool newRewardCalc = nHeight >= Params().GetConsensus().BayfrontGardensHeight;
     bool newRewardLogic = nHeight >= Params().GetConsensus().EunosHeight;
     bool newCustomRewards = nHeight >= Params().GetConsensus().ClarkeQuayHeight;
 
-    constexpr uint32_t const PRECISION = 10000; // (== 100%) just searching the way to avoid arith256 inflating
+    constexpr uint32_t const PRECISION = 10000;  // (== 100%) just searching the way to avoid arith256 inflating
     CAmount totalDistributed = 0;
     CAmount totalLoanDistributed = 0;
 
-    ForEachPoolId([&] (DCT_ID const & poolId) {
-
+    ForEachPoolId([&](DCT_ID const &poolId) {
         CAmount distributedFeeA = 0;
         CAmount distributedFeeB = 0;
         std::optional<CScript> ownerAddress;
@@ -532,7 +550,6 @@ std::pair<CAmount, CAmount> CPoolPairView::UpdatePoolRewards(std::function<CToke
         auto poolReward = ReadValueAt<ByPoolReward, CAmount>(this, poolKey);
 
         if (newRewardLogic) {
-
             if (swapEvent) {
                 // it clears block commission
                 distributedFeeA = swapValue->blockCommissionA;
@@ -546,90 +563,93 @@ std::pair<CAmount, CAmount> CPoolPairView::UpdatePoolRewards(std::function<CToke
             totalDistributed += poolReward;
             totalLoanDistributed += poolLoanReward;
 
-            for (const auto& reward : rewards.balances) {
+            for (const auto &reward : rewards.balances) {
                 // subtract pool's owner account by custom block reward
                 onTransfer(*ownerAddress, {}, {reward.first, reward.second});
             }
 
         } else {
             if (!swapEvent && poolReward == 0 && rewards.balances.empty()) {
-                return true; // no events, skip to the next pool
+                return true;  // no events, skip to the next pool
             }
 
-            ForEachPoolShare([&] (DCT_ID const & currentId, CScript const & provider, uint32_t) {
-                if (currentId != poolId) {
-                    return false; // stop
-                }
-                CAmount const liquidity = onGetBalance(provider, poolId).nValue;
+            ForEachPoolShare(
+                [&](DCT_ID const &currentId, CScript const &provider, uint32_t) {
+                    if (currentId != poolId) {
+                        return false;  // stop
+                    }
+                    CAmount const liquidity = onGetBalance(provider, poolId).nValue;
 
-                uint32_t const liqWeight = liquidity * PRECISION / totalLiquidity;
-                assert (liqWeight < PRECISION);
+                    uint32_t const liqWeight = liquidity * PRECISION / totalLiquidity;
+                    assert(liqWeight < PRECISION);
 
-                // distribute trading fees
-                if (swapEvent) {
-                    CAmount feeA, feeB;
-                    if (newRewardCalc) {
-                        feeA = liquidityReward(swapValue->blockCommissionA, liquidity, totalLiquidity);
-                        feeB = liquidityReward(swapValue->blockCommissionB, liquidity, totalLiquidity);
-                    } else {
-                        feeA = swapValue->blockCommissionA * liqWeight / PRECISION;
-                        feeB = swapValue->blockCommissionB * liqWeight / PRECISION;
+                    // distribute trading fees
+                    if (swapEvent) {
+                        CAmount feeA, feeB;
+                        if (newRewardCalc) {
+                            feeA = liquidityReward(swapValue->blockCommissionA, liquidity, totalLiquidity);
+                            feeB = liquidityReward(swapValue->blockCommissionB, liquidity, totalLiquidity);
+                        } else {
+                            feeA = swapValue->blockCommissionA * liqWeight / PRECISION;
+                            feeB = swapValue->blockCommissionB * liqWeight / PRECISION;
+                        }
+                        auto tokenIds = ReadBy<ByIDPair, ByPairKey>(poolId);
+                        assert(tokenIds);
+                        if (onTransfer({}, provider, {tokenIds->idTokenA, feeA})) {
+                            distributedFeeA += feeA;
+                        }
+                        if (onTransfer({}, provider, {tokenIds->idTokenB, feeB})) {
+                            distributedFeeB += feeB;
+                        }
                     }
-                    auto tokenIds = ReadBy<ByIDPair, ByPairKey>(poolId);
-                    assert(tokenIds);
-                    if (onTransfer({}, provider, {tokenIds->idTokenA, feeA})) {
-                        distributedFeeA += feeA;
-                    }
-                    if (onTransfer({}, provider, {tokenIds->idTokenB, feeB})) {
-                        distributedFeeB += feeB;
-                    }
-                }
 
-                // distribute yield farming
-                if (poolReward) {
-                    CAmount providerReward;
-                    if (newRewardCalc) {
-                        providerReward = liquidityReward(poolReward, liquidity, totalLiquidity);
-                    } else {
-                        providerReward = poolReward * liqWeight / PRECISION;
+                    // distribute yield farming
+                    if (poolReward) {
+                        CAmount providerReward;
+                        if (newRewardCalc) {
+                            providerReward = liquidityReward(poolReward, liquidity, totalLiquidity);
+                        } else {
+                            providerReward = poolReward * liqWeight / PRECISION;
+                        }
+                        if (onTransfer({}, provider, {DCT_ID{0}, providerReward})) {
+                            totalDistributed += providerReward;
+                        }
                     }
-                    if (onTransfer({}, provider, {DCT_ID{0}, providerReward})) {
-                        totalDistributed += providerReward;
-                    }
-                }
 
-                for (const auto& reward : rewards.balances) {
-                    if (auto providerReward = liquidityReward(reward.second, liquidity, totalLiquidity)) {
-                        onTransfer(*ownerAddress, provider, {reward.first, providerReward});
+                    for (const auto &reward : rewards.balances) {
+                        if (auto providerReward = liquidityReward(reward.second, liquidity, totalLiquidity)) {
+                            onTransfer(*ownerAddress, provider, {reward.first, providerReward});
+                        }
                     }
-                }
 
-                return true;
-            }, PoolShareKey{poolId, CScript{}});
+                    return true;
+                },
+                PoolShareKey{poolId, CScript{}});
         }
 
         if (swapEvent) {
             swapValue->blockCommissionA -= distributedFeeA;
             swapValue->blockCommissionB -= distributedFeeB;
-            poolKey.height++; // block commissions to next block
-            WriteBy<ByPoolSwap>(poolKey, PoolSwapValue{false, swapValue->blockCommissionA, swapValue->blockCommissionB});
+            poolKey.height++;  // block commissions to next block
+            WriteBy<ByPoolSwap>(poolKey,
+                                PoolSwapValue{false, swapValue->blockCommissionA, swapValue->blockCommissionB});
         }
         return true;
     });
     return {totalDistributed, totalLoanDistributed};
 }
 
-Res CPoolPairView::SetShare(DCT_ID const & poolId, CScript const & provider, uint32_t height) {
+Res CPoolPairView::SetShare(DCT_ID const &poolId, CScript const &provider, uint32_t height) {
     WriteBy<ByShare>(PoolShareKey{poolId, provider}, height);
     return Res::Ok();
 }
 
-Res CPoolPairView::DelShare(DCT_ID const & poolId, CScript const & provider) {
+Res CPoolPairView::DelShare(DCT_ID const &poolId, CScript const &provider) {
     EraseBy<ByShare>(PoolShareKey{poolId, provider});
     return Res::Ok();
 }
 
-std::optional<uint32_t> CPoolPairView::GetShare(DCT_ID const & poolId, CScript const & provider) {
+std::optional<uint32_t> CPoolPairView::GetShare(DCT_ID const &poolId, CScript const &provider) {
     if (const auto res = ReadBy<ByShare, uint32_t>(PoolShareKey{poolId, provider}))
         return res;
     return {};
@@ -639,7 +659,7 @@ inline CAmount PoolRewardPerBlock(CAmount dailyReward, CAmount rewardPct) {
     return dailyReward / Params().GetConsensus().blocksPerDay() * rewardPct / COIN;
 }
 
-Res CPoolPairView::SetRewardPct(DCT_ID const & poolId, uint32_t height, CAmount rewardPct) {
+Res CPoolPairView::SetRewardPct(DCT_ID const &poolId, uint32_t height, CAmount rewardPct) {
     if (!HasPoolPair(poolId)) {
         return Res::Err("No such pool pair");
     }
@@ -650,7 +670,7 @@ Res CPoolPairView::SetRewardPct(DCT_ID const & poolId, uint32_t height, CAmount 
     return Res::Ok();
 }
 
-Res CPoolPairView::SetRewardLoanPct(DCT_ID const & poolId, uint32_t height, CAmount rewardLoanPct) {
+Res CPoolPairView::SetRewardLoanPct(DCT_ID const &poolId, uint32_t height, CAmount rewardLoanPct) {
     if (!HasPoolPair(poolId)) {
         return Res::Err("No such pool pair");
     }
@@ -662,7 +682,7 @@ Res CPoolPairView::SetRewardLoanPct(DCT_ID const & poolId, uint32_t height, CAmo
 }
 
 Res CPoolPairView::SetDailyReward(uint32_t height, CAmount reward) {
-    ForEachPoolId([&](DCT_ID const & poolId) {
+    ForEachPoolId([&](DCT_ID const &poolId) {
         if (auto rewardPct = ReadBy<ByRewardPct, CAmount>(poolId)) {
             WriteBy<ByPoolReward>(PoolHeightKey{poolId, height}, PoolRewardPerBlock(reward, *rewardPct));
         }
@@ -672,9 +692,8 @@ Res CPoolPairView::SetDailyReward(uint32_t height, CAmount reward) {
     return Res::Ok();
 }
 
-Res CPoolPairView::SetLoanDailyReward(const uint32_t height, const CAmount reward)
-{
-    ForEachPoolId([&](DCT_ID const & poolId) {
+Res CPoolPairView::SetLoanDailyReward(const uint32_t height, const CAmount reward) {
+    ForEachPoolId([&](DCT_ID const &poolId) {
         if (auto rewardLoanPct = ReadBy<ByRewardLoanPct, CAmount>(poolId)) {
             WriteBy<ByPoolLoanReward>(PoolHeightKey{poolId, height}, PoolRewardPerBlock(reward, *rewardLoanPct));
         }
@@ -684,26 +703,27 @@ Res CPoolPairView::SetLoanDailyReward(const uint32_t height, const CAmount rewar
     return Res::Ok();
 }
 
-bool CPoolPairView::HasPoolPair(DCT_ID const & poolId) const {
+bool CPoolPairView::HasPoolPair(DCT_ID const &poolId) const {
     return ExistsBy<ByID>(poolId);
 }
 
-void CPoolPairView::ForEachPoolId(std::function<bool(const DCT_ID &)> callback, DCT_ID const & start) {
-    ForEach<ByID, DCT_ID, CPoolPair>([&callback](const DCT_ID & poolId, CLazySerialize<CPoolPair>) {
-        return callback(poolId);
-    }, start);
+void CPoolPairView::ForEachPoolId(std::function<bool(const DCT_ID &)> callback, DCT_ID const &start) {
+    ForEach<ByID, DCT_ID, CPoolPair>(
+        [&callback](const DCT_ID &poolId, CLazySerialize<CPoolPair>) { return callback(poolId); }, start);
 }
 
-void CPoolPairView::ForEachPoolPair(std::function<bool(const DCT_ID &, CPoolPair)> callback, DCT_ID const & start) {
-    ForEach<ByID, DCT_ID, CPoolPair>([&](const DCT_ID & poolId, CLazySerialize<CPoolPair>) {
-        return callback(poolId, *GetPoolPair(poolId));
-    }, start);
+void CPoolPairView::ForEachPoolPair(std::function<bool(const DCT_ID &, CPoolPair)> callback, DCT_ID const &start) {
+    ForEach<ByID, DCT_ID, CPoolPair>(
+        [&](const DCT_ID &poolId, CLazySerialize<CPoolPair>) { return callback(poolId, *GetPoolPair(poolId)); }, start);
 }
 
-void CPoolPairView::ForEachPoolShare(std::function<bool (DCT_ID const &, CScript const &, uint32_t)> callback, const PoolShareKey &startKey) {
-    ForEach<ByShare, PoolShareKey, uint32_t>([&callback] (PoolShareKey const & poolShareKey, uint32_t height) {
-        return callback(poolShareKey.poolID, poolShareKey.owner, height);
-    }, startKey);
+void CPoolPairView::ForEachPoolShare(std::function<bool(DCT_ID const &, CScript const &, uint32_t)> callback,
+                                     const PoolShareKey &startKey) {
+    ForEach<ByShare, PoolShareKey, uint32_t>(
+        [&callback](PoolShareKey const &poolShareKey, uint32_t height) {
+            return callback(poolShareKey.poolID, poolShareKey.owner, height);
+        },
+        startKey);
 }
 
 Res CPoolPairView::SetDexFeePct(DCT_ID poolId, DCT_ID tokenId, CAmount feePct) {
@@ -720,29 +740,33 @@ void CPoolPairView::EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId) {
 
 CAmount CPoolPairView::GetDexFeeInPct(DCT_ID poolId, DCT_ID tokenId) const {
     uint32_t feePct;
-    return ReadBy<ByTokenDexFeePct>(std::make_pair(poolId, tokenId), feePct)
-        || ReadBy<ByTokenDexFeePct>(std::make_pair(tokenId, DCT_ID{~0u}), feePct)
-        ? feePct : 0;
+    return ReadBy<ByTokenDexFeePct>(std::make_pair(poolId, tokenId), feePct) ||
+                   ReadBy<ByTokenDexFeePct>(std::make_pair(tokenId, DCT_ID{~0u}), feePct)
+               ? feePct
+               : 0;
 }
 
 CAmount CPoolPairView::GetDexFeeOutPct(DCT_ID poolId, DCT_ID tokenId) const {
     uint32_t feePct;
-    return ReadBy<ByTokenDexFeePct>(std::make_pair(poolId, tokenId), feePct)
-        || ReadBy<ByTokenDexFeePct>(std::make_pair(DCT_ID{~0u}, tokenId), feePct)
-        ? feePct : 0;
+    return ReadBy<ByTokenDexFeePct>(std::make_pair(poolId, tokenId), feePct) ||
+                   ReadBy<ByTokenDexFeePct>(std::make_pair(DCT_ID{~0u}, tokenId), feePct)
+               ? feePct
+               : 0;
 }
 
-bool poolInFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee) {
-    const auto& [dirA, dirB] = asymmetricFee;
-    if ((forward && (dirA.feeDir == FeeDirValues::Both || dirA.feeDir == FeeDirValues::In)) || (!forward && (dirB.feeDir == FeeDirValues::Both || dirB.feeDir == FeeDirValues::In))) {
+bool poolInFee(const bool forward, const std::pair<CFeeDir, CFeeDir> &asymmetricFee) {
+    const auto &[dirA, dirB] = asymmetricFee;
+    if ((forward && (dirA.feeDir == FeeDirValues::Both || dirA.feeDir == FeeDirValues::In)) ||
+        (!forward && (dirB.feeDir == FeeDirValues::Both || dirB.feeDir == FeeDirValues::In))) {
         return true;
     }
     return false;
 }
 
-bool poolOutFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee) {
-    const auto& [dirA, dirB] = asymmetricFee;
-    if ((forward && (dirB.feeDir == FeeDirValues::Both || dirB.feeDir == FeeDirValues::Out)) || (!forward && (dirA.feeDir == FeeDirValues::Both || dirA.feeDir == FeeDirValues::Out))) {
+bool poolOutFee(const bool forward, const std::pair<CFeeDir, CFeeDir> &asymmetricFee) {
+    const auto &[dirA, dirB] = asymmetricFee;
+    if ((forward && (dirB.feeDir == FeeDirValues::Both || dirB.feeDir == FeeDirValues::Out)) ||
+        (!forward && (dirA.feeDir == FeeDirValues::Both || dirA.feeDir == FeeDirValues::Out))) {
         return true;
     }
     return false;

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -10,11 +10,11 @@
 #include <amount.h>
 #include <arith_uint256.h>
 #include <chainparams.h>
+#include <masternodes/balances.h>
 #include <masternodes/res.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
-#include <masternodes/balances.h>
 
 struct CFeeDir;
 
@@ -25,7 +25,7 @@ struct ByPairKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(idTokenA);
         READWRITE(idTokenB);
     }
@@ -37,17 +37,16 @@ struct PoolPrice {
 
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(integer);
         READWRITE(fraction);
     }
 
-    bool operator!=(const PoolPrice& rhs) const {
-        return integer != rhs.integer || fraction != rhs.fraction;
-    }
+    bool operator!=(const PoolPrice &rhs) const { return integer != rhs.integer || fraction != rhs.fraction; }
 };
 
-static constexpr auto POOLPRICE_MAX = PoolPrice{std::numeric_limits<CAmount>::max(), std::numeric_limits<CAmount>::max()};
+static constexpr auto POOLPRICE_MAX =
+    PoolPrice{std::numeric_limits<CAmount>::max(), std::numeric_limits<CAmount>::max()};
 
 struct CPoolSwapMessage {
     CScript from, to;
@@ -58,7 +57,7 @@ struct CPoolSwapMessage {
     ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(idTokenFrom);
         READWRITE(amountFrom);
@@ -75,7 +74,7 @@ struct CPoolSwapMessageV2 {
     ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(swapInfo);
         READWRITE(poolIDs);
     }
@@ -83,14 +82,14 @@ struct CPoolSwapMessageV2 {
 
 struct CPoolPairMessage {
     DCT_ID idTokenA, idTokenB;
-    CAmount commission;   // comission %% for traders
+    CAmount commission;  // comission %% for traders
     CScript ownerAddress;
     bool status = true;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(idTokenA);
         READWRITE(idTokenB);
         READWRITE(commission);
@@ -99,13 +98,12 @@ struct CPoolPairMessage {
     }
 };
 
-class CPoolPair : public CPoolPairMessage
-{
-public:
+class CPoolPair : public CPoolPairMessage {
+   public:
     static const CAmount MINIMUM_LIQUIDITY = 1000;
     static const CAmount SLOPE_SWAP_RATE = 1000;
-    static const uint32_t PRECISION = (uint32_t) COIN; // or just PRECISION_BITS for "<<" and ">>"
-    CPoolPair(CPoolPairMessage const & msg = {}) : CPoolPairMessage(msg) {}
+    static const uint32_t PRECISION = (uint32_t)COIN;  // or just PRECISION_BITS for "<<" and ">>"
+    CPoolPair(CPoolPairMessage const &msg = {}) : CPoolPairMessage(msg) {}
     virtual ~CPoolPair() = default;
 
     // temporary values, not serialized
@@ -115,7 +113,7 @@ public:
     CAmount blockCommissionA = 0;
     CAmount blockCommissionB = 0;
 
-    CAmount rewardPct = 0;       // pool yield farming reward %%
+    CAmount rewardPct = 0;  // pool yield farming reward %%
     CAmount rewardLoanPct = 0;
     bool swapEvent = false;
 
@@ -125,40 +123,47 @@ public:
     uint32_t creationHeight = -1;
 
     // 'amountA' && 'amountB' should be normalized (correspond) to actual 'tokenA' and 'tokenB' ids in the pair!!
-    // otherwise, 'AddLiquidity' should be () external to 'CPairPool' (i.e. CPoolPairView::AddLiquidity(TAmount a,b etc) with internal lookup of pool by TAmount a,b)
-    Res AddLiquidity(CAmount amountA, CAmount amountB, std::function<Res(CAmount)> onMint, bool slippageProtection = false);
+    // otherwise, 'AddLiquidity' should be () external to 'CPairPool' (i.e. CPoolPairView::AddLiquidity(TAmount a,b etc)
+    // with internal lookup of pool by TAmount a,b)
+    Res AddLiquidity(CAmount amountA,
+                     CAmount amountB,
+                     std::function<Res(CAmount)> onMint,
+                     bool slippageProtection = false);
     Res RemoveLiquidity(CAmount liqAmount, std::function<Res(CAmount, CAmount)> onReclaim);
 
-    Res Swap(CTokenAmount in, CAmount dexfeeInPct, PoolPrice const & maxPrice, const std::pair<CFeeDir, CFeeDir>& asymmetricFee, std::function<Res(CTokenAmount const &, CTokenAmount const &)> onTransfer, int height = INT_MAX);
+    Res Swap(CTokenAmount in,
+             CAmount dexfeeInPct,
+             PoolPrice const &maxPrice,
+             const std::pair<CFeeDir, CFeeDir> &asymmetricFee,
+             std::function<Res(CTokenAmount const &, CTokenAmount const &)> onTransfer,
+             int height = INT_MAX);
 
-private:
-    CAmount slopeSwap(CAmount unswapped, CAmount & poolFrom, CAmount & poolTo, int height);
+   private:
+    CAmount slopeSwap(CAmount unswapped, CAmount &poolFrom, CAmount &poolTo, int height);
 
-    inline void ioProofer() const { // Maybe it's more reasonable to use unsigned everywhere, but for basic CAmount compatibility
-        if (reserveA < 0 || reserveB < 0 ||
-            totalLiquidity < 0 ||
-            blockCommissionA < 0 || blockCommissionB < 0 ||
-            rewardPct < 0 || commission < 0 ||
-            rewardLoanPct < 0
-            ) {
+    inline void ioProofer()
+        const {  // Maybe it's more reasonable to use unsigned everywhere, but for basic CAmount compatibility
+        if (reserveA < 0 || reserveB < 0 || totalLiquidity < 0 || blockCommissionA < 0 || blockCommissionB < 0 ||
+            rewardPct < 0 || commission < 0 || rewardLoanPct < 0) {
             throw std::ios_base::failure("negative pool's 'CAmounts'");
         }
     }
 
-public:
-
+   public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        if (!ser_action.ForRead()) ioProofer();
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        if (!ser_action.ForRead())
+            ioProofer();
 
         READWRITEAS(CPoolPairMessage, *this);
         READWRITE(rewards);
         READWRITE(creationTx);
         READWRITE(creationHeight);
 
-        if (ser_action.ForRead()) ioProofer();
+        if (ser_action.ForRead())
+            ioProofer();
     }
 };
 
@@ -169,7 +174,7 @@ struct PoolShareKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(WrapBigEndian(poolID.v));
         READWRITE(owner);
     }
@@ -182,7 +187,7 @@ struct PoolHeightKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(poolID);
 
         if (ser_action.ForRead()) {
@@ -195,8 +200,7 @@ struct PoolHeightKey {
     }
 };
 
-enum RewardType
-{
+enum RewardType {
     Commission = 127,
     Rewards = 128,
     Coinbase = Rewards | 1,
@@ -207,65 +211,107 @@ enum RewardType
 std::string RewardToString(RewardType type);
 std::string RewardTypeToString(RewardType type);
 
-class CPoolPairView : public virtual CStorageView
-{
-public:
-    Res SetPoolPair(const DCT_ID &poolId, uint32_t height, CPoolPair const & pool);
-    Res UpdatePoolPair(DCT_ID const & poolId, uint32_t height, bool status, CAmount const & commission, CScript const & ownerAddress, CBalances const & rewards);
+class CPoolPairView : public virtual CStorageView {
+   public:
+    Res SetPoolPair(const DCT_ID &poolId, uint32_t height, CPoolPair const &pool);
+    Res UpdatePoolPair(DCT_ID const &poolId,
+                       uint32_t height,
+                       bool status,
+                       CAmount const &commission,
+                       CScript const &ownerAddress,
+                       CBalances const &rewards);
 
     std::optional<CPoolPair> GetPoolPair(const DCT_ID &poolId) const;
-    std::optional<std::pair<DCT_ID, CPoolPair> > GetPoolPair(DCT_ID const & tokenA, DCT_ID const & tokenB) const;
+    std::optional<std::pair<DCT_ID, CPoolPair> > GetPoolPair(DCT_ID const &tokenA, DCT_ID const &tokenB) const;
 
-    void ForEachPoolId(std::function<bool(DCT_ID const &)> callback, DCT_ID const & start = DCT_ID{0});
-    void ForEachPoolPair(std::function<bool(DCT_ID const &, CPoolPair)> callback, DCT_ID const & start = DCT_ID{0});
-    void ForEachPoolShare(std::function<bool(DCT_ID const &, CScript const &, uint32_t)> callback, PoolShareKey const &startKey = {});
+    void ForEachPoolId(std::function<bool(DCT_ID const &)> callback, DCT_ID const &start = DCT_ID{0});
+    void ForEachPoolPair(std::function<bool(DCT_ID const &, CPoolPair)> callback, DCT_ID const &start = DCT_ID{0});
+    void ForEachPoolShare(std::function<bool(DCT_ID const &, CScript const &, uint32_t)> callback,
+                          PoolShareKey const &startKey = {});
 
-    Res SetShare(DCT_ID const & poolId, CScript const & provider, uint32_t height);
-    Res DelShare(DCT_ID const & poolId, CScript const & provider);
+    Res SetShare(DCT_ID const &poolId, CScript const &provider, uint32_t height);
+    Res DelShare(DCT_ID const &poolId, CScript const &provider);
 
-    std::optional<uint32_t> GetShare(DCT_ID const & poolId, CScript const & provider);
+    std::optional<uint32_t> GetShare(DCT_ID const &poolId, CScript const &provider);
 
-    void CalculatePoolRewards(DCT_ID const & poolId, std::function<CAmount()> onLiquidity, uint32_t begin, uint32_t end, std::function<void(RewardType, CTokenAmount, uint32_t)> onReward);
+    void CalculatePoolRewards(DCT_ID const &poolId,
+                              std::function<CAmount()> onLiquidity,
+                              uint32_t begin,
+                              uint32_t end,
+                              std::function<void(RewardType, CTokenAmount, uint32_t)> onReward);
 
     Res SetLoanDailyReward(const uint32_t height, const CAmount reward);
     Res SetDailyReward(uint32_t height, CAmount reward);
-    Res SetRewardPct(DCT_ID const & poolId, uint32_t height, CAmount rewardPct);
-    Res SetRewardLoanPct(DCT_ID const & poolId, uint32_t height, CAmount rewardLoanPct);
-    bool HasPoolPair(DCT_ID const & poolId) const;
+    Res SetRewardPct(DCT_ID const &poolId, uint32_t height, CAmount rewardPct);
+    Res SetRewardLoanPct(DCT_ID const &poolId, uint32_t height, CAmount rewardLoanPct);
+    bool HasPoolPair(DCT_ID const &poolId) const;
 
     Res SetDexFeePct(DCT_ID poolId, DCT_ID tokenId, CAmount feePct);
     void EraseDexFeePct(DCT_ID poolId, DCT_ID tokenId);
     CAmount GetDexFeeInPct(DCT_ID poolId, DCT_ID tokenId) const;
     CAmount GetDexFeeOutPct(DCT_ID poolId, DCT_ID tokenId) const;
 
-    std::pair<CAmount, CAmount> UpdatePoolRewards(std::function<CTokenAmount(CScript const &, DCT_ID)> onGetBalance, std::function<Res(CScript const &, CScript const &, CTokenAmount)> onTransfer, int nHeight = 0);
+    std::pair<CAmount, CAmount> UpdatePoolRewards(
+        std::function<CTokenAmount(CScript const &, DCT_ID)> onGetBalance,
+        std::function<Res(CScript const &, CScript const &, CTokenAmount)> onTransfer,
+        int nHeight = 0);
 
     // tags
-    struct ByID             { static constexpr uint8_t prefix() { return 'i'; } };
-    struct ByPair           { static constexpr uint8_t prefix() { return 'j'; } };
-    struct ByShare          { static constexpr uint8_t prefix() { return 'k'; } };
-    struct ByIDPair         { static constexpr uint8_t prefix() { return 'C'; } };
-    struct ByPoolSwap       { static constexpr uint8_t prefix() { return 'P'; } };
-    struct ByReserves       { static constexpr uint8_t prefix() { return 'R'; } };
-    struct ByRewardPct      { static constexpr uint8_t prefix() { return 'Q'; } };
-    struct ByPoolReward     { static constexpr uint8_t prefix() { return 'I'; } };
-    struct ByDailyReward    { static constexpr uint8_t prefix() { return 'B'; } };
-    struct ByCustomReward   { static constexpr uint8_t prefix() { return 'A'; } };
-    struct ByTotalLiquidity { static constexpr uint8_t prefix() { return 'f'; } };
-    struct ByDailyLoanReward{ static constexpr uint8_t prefix() { return 'q'; } };
-    struct ByRewardLoanPct  { static constexpr uint8_t prefix() { return 'U'; } };
-    struct ByPoolLoanReward { static constexpr uint8_t prefix() { return 'W'; } };
-    struct ByTokenDexFeePct { static constexpr uint8_t prefix() { return 'l'; } };
+    struct ByID {
+        static constexpr uint8_t prefix() { return 'i'; }
+    };
+    struct ByPair {
+        static constexpr uint8_t prefix() { return 'j'; }
+    };
+    struct ByShare {
+        static constexpr uint8_t prefix() { return 'k'; }
+    };
+    struct ByIDPair {
+        static constexpr uint8_t prefix() { return 'C'; }
+    };
+    struct ByPoolSwap {
+        static constexpr uint8_t prefix() { return 'P'; }
+    };
+    struct ByReserves {
+        static constexpr uint8_t prefix() { return 'R'; }
+    };
+    struct ByRewardPct {
+        static constexpr uint8_t prefix() { return 'Q'; }
+    };
+    struct ByPoolReward {
+        static constexpr uint8_t prefix() { return 'I'; }
+    };
+    struct ByDailyReward {
+        static constexpr uint8_t prefix() { return 'B'; }
+    };
+    struct ByCustomReward {
+        static constexpr uint8_t prefix() { return 'A'; }
+    };
+    struct ByTotalLiquidity {
+        static constexpr uint8_t prefix() { return 'f'; }
+    };
+    struct ByDailyLoanReward {
+        static constexpr uint8_t prefix() { return 'q'; }
+    };
+    struct ByRewardLoanPct {
+        static constexpr uint8_t prefix() { return 'U'; }
+    };
+    struct ByPoolLoanReward {
+        static constexpr uint8_t prefix() { return 'W'; }
+    };
+    struct ByTokenDexFeePct {
+        static constexpr uint8_t prefix() { return 'l'; }
+    };
 };
 
 struct CLiquidityMessage {
-    CAccounts from; // from -> balances
+    CAccounts from;  // from -> balances
     CScript shareAddress;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(shareAddress);
     }
@@ -278,13 +324,13 @@ struct CRemoveLiquidityMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(from);
         READWRITE(amount);
     }
 };
 
-bool poolInFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee);
-bool poolOutFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee);
+bool poolInFee(const bool forward, const std::pair<CFeeDir, CFeeDir> &asymmetricFee);
+bool poolOutFee(const bool forward, const std::pair<CFeeDir, CFeeDir> &asymmetricFee);
 
-#endif // DEFI_MASTERNODES_POOLPAIRS_H
+#endif  // DEFI_MASTERNODES_POOLPAIRS_H

--- a/src/masternodes/res.h
+++ b/src/masternodes/res.h
@@ -1,84 +1,76 @@
 #ifndef DEFI_MASTERNODES_RES_H
 #define DEFI_MASTERNODES_RES_H
 
+#include <tinyformat.h>
 #include <optional>
 #include <string>
-#include <tinyformat.h>
 
-struct Res
-{
+struct Res {
     bool ok;
     std::string msg;
     uint32_t code;
-    std::string dbgMsg; // CValidationState support
+    std::string dbgMsg;  // CValidationState support
 
     Res() = delete;
 
-    operator bool() const {
-        return ok;
+    operator bool() const { return ok; }
+
+    template <typename... Args>
+    static Res Err(std::string const &err, const Args &...args) {
+        return Res{false, tfm::format(err, args...), 0, {}};
     }
 
-    template<typename... Args>
-    static Res Err(std::string const & err, const Args&... args) {
-        return Res{false, tfm::format(err, args...), 0, {} };
-    }
-
-    template<typename... Args>
-    static Res ErrCode(uint32_t code, std::string const & err, const Args&... args) {
-        return Res{false, tfm::format(err, args...), code, {} };
+    template <typename... Args>
+    static Res ErrCode(uint32_t code, std::string const &err, const Args &...args) {
+        return Res{false, tfm::format(err, args...), code, {}};
     }
 
     // extended version just for CValidationState support
-    template<typename... Args>
-    static Res ErrDbg(std::string const & debugMsg, std::string const & err, const Args&... args) {
-        return {false, tfm::format(err, args...), 0, debugMsg };
+    template <typename... Args>
+    static Res ErrDbg(std::string const &debugMsg, std::string const &err, const Args &...args) {
+        return {false, tfm::format(err, args...), 0, debugMsg};
     }
 
-    template<typename... Args>
-    static Res Ok(std::string const & msg, const Args&... args) {
-        return Res{true, tfm::format(msg, args...), 0, {} };
+    template <typename... Args>
+    static Res Ok(std::string const &msg, const Args &...args) {
+        return Res{true, tfm::format(msg, args...), 0, {}};
     }
 
-    static Res Ok() {
-        return Res{true, {}, 0, {} };
-    }
+    static Res Ok() { return Res{true, {}, 0, {}}; }
 };
 
 template <typename T>
-struct ResVal : public Res
-{
+struct ResVal : public Res {
     std::optional<T> val{};
 
     ResVal() = delete;
 
-    ResVal(Res const & errRes) : Res(errRes) {
-        assert(!this->ok); // if value is not provided, then it's always an error
+    ResVal(Res const &errRes) : Res(errRes) {
+        assert(!this->ok);  // if value is not provided, then it's always an error
     }
-    ResVal(T value, Res const & okRes) : Res(okRes), val(std::move(value)) {
-        assert(this->ok); // if value if provided, then it's never an error
+    ResVal(T value, Res const &okRes) : Res(okRes), val(std::move(value)) {
+        assert(this->ok);  // if value if provided, then it's never an error
     }
 
-    operator bool() const {
-        return ok;
-    }
+    operator bool() const { return ok; }
 
     operator T() const {
         assert(ok);
         return *val;
     }
 
-    const T& operator*() const {
+    const T &operator*() const {
         assert(ok);
         return *val;
     }
 
-    T& operator*() {
+    T &operator*() {
         assert(ok);
         return *val;
     }
 
     template <typename F>
-    T ValOrException(F&& func) const {
+    T ValOrException(F &&func) const {
         if (!ok) {
             throw func(code, msg);
         }
@@ -93,4 +85,4 @@ struct ResVal : public Res
     }
 };
 
-#endif //DEFI_MASTERNODES_RES_H
+#endif  // DEFI_MASTERNODES_RES_H

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -1,23 +1,22 @@
 
 #include <core_io.h>
 #include <key_io.h>
-#include <masternodes/res.h>
 #include <masternodes/mn_checks.h>
+#include <masternodes/res.h>
 #include <primitives/transaction.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <univalue.h>
 
-extern std::string ScriptToString(CScript const& script);
+extern std::string ScriptToString(CScript const &script);
 
-class CCustomTxRpcVisitor
-{
+class CCustomTxRpcVisitor {
     uint32_t height;
-    UniValue& rpcInfo;
-    CCustomCSView& mnview;
-    const CTransaction& tx;
+    UniValue &rpcInfo;
+    CCustomCSView &mnview;
+    const CTransaction &tx;
 
-    void tokenInfo(const CToken& token) const {
+    void tokenInfo(const CToken &token) const {
         rpcInfo.pushKV("name", token.name);
         rpcInfo.pushKV("symbol", token.symbol);
         rpcInfo.pushKV("isDAT", token.IsDAT());
@@ -26,9 +25,9 @@ class CCustomTxRpcVisitor
         rpcInfo.pushKV("finalized", token.IsFinalized());
     }
 
-    void customRewardsInfo(const CBalances& rewards) const {
+    void customRewardsInfo(const CBalances &rewards) const {
         UniValue rewardArr(UniValue::VARR);
-        for (const auto& reward : rewards.balances) {
+        for (const auto &reward : rewards.balances) {
             if (reward.second > 0) {
                 rewardArr.push_back(CTokenAmount{reward.first, reward.second}.ToString());
             }
@@ -38,17 +37,17 @@ class CCustomTxRpcVisitor
         }
     }
 
-    UniValue accountsInfo(const CAccounts& accounts) const {
+    UniValue accountsInfo(const CAccounts &accounts) const {
         UniValue info(UniValue::VOBJ);
-        for (const auto& account : accounts) {
+        for (const auto &account : accounts) {
             info.pushKV(ScriptToString(account.first), account.second.ToString());
         }
         return info;
     }
 
-    void tokenCurrencyPairInfo(const std::set<CTokenCurrencyPair>& pairs) const {
+    void tokenCurrencyPairInfo(const std::set<CTokenCurrencyPair> &pairs) const {
         UniValue availablePairs(UniValue::VARR);
-        for (const auto& pair : pairs) {
+        for (const auto &pair : pairs) {
             UniValue uniPair(UniValue::VOBJ);
             uniPair.pushKV("token", pair.first);
             uniPair.pushKV("currency", pair.second);
@@ -57,60 +56,52 @@ class CCustomTxRpcVisitor
         rpcInfo.pushKV("availablePairs", availablePairs);
     }
 
-public:
-    CCustomTxRpcVisitor(const CTransaction& tx, uint32_t height, CCustomCSView& mnview, UniValue& rpcInfo)
-        : height(height), rpcInfo(rpcInfo), mnview(mnview), tx(tx) {
-    }
+   public:
+    CCustomTxRpcVisitor(const CTransaction &tx, uint32_t height, CCustomCSView &mnview, UniValue &rpcInfo)
+        : height(height), rpcInfo(rpcInfo), mnview(mnview), tx(tx) {}
 
-    void operator()(const CCreateMasterNodeMessage& obj) const {
+    void operator()(const CCreateMasterNodeMessage &obj) const {
         rpcInfo.pushKV("collateralamount", ValueFromAmount(GetMnCollateralAmount(height)));
-        rpcInfo.pushKV("masternodeoperator", EncodeDestination(obj.operatorType == PKHashType ?
-                                                CTxDestination(PKHash(obj.operatorAuthAddress)) :
-                                                CTxDestination(WitnessV0KeyHash(obj.operatorAuthAddress))));
+        rpcInfo.pushKV("masternodeoperator",
+                       EncodeDestination(obj.operatorType == PKHashType
+                                             ? CTxDestination(PKHash(obj.operatorAuthAddress))
+                                             : CTxDestination(WitnessV0KeyHash(obj.operatorAuthAddress))));
         rpcInfo.pushKV("timelock", CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(obj.timelock)));
     }
 
-    void operator()(const CResignMasterNodeMessage& obj) const {
-        rpcInfo.pushKV("id", obj.GetHex());
-    }
+    void operator()(const CResignMasterNodeMessage &obj) const { rpcInfo.pushKV("id", obj.GetHex()); }
 
-    void operator()(const CSetForcedRewardAddressMessage& obj) const {
+    void operator()(const CSetForcedRewardAddressMessage &obj) const {
         rpcInfo.pushKV("mc_id", obj.nodeId.GetHex());
-        rpcInfo.pushKV("rewardAddress", EncodeDestination(
-                obj.rewardAddressType == 1 ?
-                    CTxDestination(PKHash(obj.rewardAddress)) :
-                    CTxDestination(WitnessV0KeyHash(obj.rewardAddress)))
-        );
+        rpcInfo.pushKV(
+            "rewardAddress",
+            EncodeDestination(obj.rewardAddressType == 1 ? CTxDestination(PKHash(obj.rewardAddress))
+                                                         : CTxDestination(WitnessV0KeyHash(obj.rewardAddress))));
     }
 
-    void operator()(const CRemForcedRewardAddressMessage& obj) const {
-        rpcInfo.pushKV("mc_id", obj.nodeId.GetHex());
-    }
+    void operator()(const CRemForcedRewardAddressMessage &obj) const { rpcInfo.pushKV("mc_id", obj.nodeId.GetHex()); }
 
-    void operator()(const CUpdateMasterNodeMessage& obj) const {
+    void operator()(const CUpdateMasterNodeMessage &obj) const {
         rpcInfo.pushKV("id", obj.mnId.GetHex());
-        rpcInfo.pushKV("masternodeoperator", EncodeDestination(obj.operatorType == PKHashType ?
-                                                CTxDestination(PKHash(obj.operatorAuthAddress)) :
-                                                CTxDestination(WitnessV0KeyHash(obj.operatorAuthAddress))));
+        rpcInfo.pushKV("masternodeoperator",
+                       EncodeDestination(obj.operatorType == PKHashType
+                                             ? CTxDestination(PKHash(obj.operatorAuthAddress))
+                                             : CTxDestination(WitnessV0KeyHash(obj.operatorAuthAddress))));
     }
 
-    void operator()(const CCreateTokenMessage& obj) const {
+    void operator()(const CCreateTokenMessage &obj) const {
         rpcInfo.pushKV("creationTx", tx.GetHash().GetHex());
         tokenInfo(obj);
     }
 
-    void operator()(const CUpdateTokenPreAMKMessage& obj) const {
-        rpcInfo.pushKV("isDAT", obj.isDAT);
-    }
+    void operator()(const CUpdateTokenPreAMKMessage &obj) const { rpcInfo.pushKV("isDAT", obj.isDAT); }
 
-    void operator()(const CUpdateTokenMessage& obj) const {
-        tokenInfo(obj.token);
-    }
+    void operator()(const CUpdateTokenMessage &obj) const { tokenInfo(obj.token); }
 
-    void operator()(const CMintTokensMessage& obj) const {
-        for (auto const & kv : obj.balances) {
+    void operator()(const CMintTokensMessage &obj) const {
+        for (auto const &kv : obj.balances) {
             if (auto token = mnview.GetToken(kv.first)) {
-                auto tokenImpl = static_cast<CTokenImplementation const&>(*token);
+                auto tokenImpl = static_cast<CTokenImplementation const &>(*token);
                 if (auto tokenPair = mnview.GetTokenByCreationTx(tokenImpl.creationTx)) {
                     rpcInfo.pushKV(tokenPair->first.ToString(), ValueFromAmount(kv.second));
                 }
@@ -118,7 +109,7 @@ public:
         }
     }
 
-    void operator()(const CLiquidityMessage& obj) const {
+    void operator()(const CLiquidityMessage &obj) const {
         CBalances sumTx = SumAllTransfers(obj.from);
         if (sumTx.balances.size() == 2) {
             auto amountA = *sumTx.balances.begin();
@@ -129,41 +120,39 @@ public:
         }
     }
 
-    void operator()(const CRemoveLiquidityMessage& obj) const {
+    void operator()(const CRemoveLiquidityMessage &obj) const {
         rpcInfo.pushKV("from", ScriptToString(obj.from));
         rpcInfo.pushKV("amount", obj.amount.ToString());
     }
 
-    void operator()(const CUtxosToAccountMessage& obj) const {
-        rpcInfo.pushKVs(accountsInfo(obj.to));
-    }
+    void operator()(const CUtxosToAccountMessage &obj) const { rpcInfo.pushKVs(accountsInfo(obj.to)); }
 
-    void operator()(const CAccountToUtxosMessage& obj) const {
+    void operator()(const CAccountToUtxosMessage &obj) const {
         rpcInfo.pushKV("from", ScriptToString(obj.from));
 
         UniValue dest(UniValue::VOBJ);
-        for (uint32_t i = obj.mintingOutputsStart; i <  static_cast<uint32_t>(tx.vout.size()); i++) {
+        for (uint32_t i = obj.mintingOutputsStart; i < static_cast<uint32_t>(tx.vout.size()); i++) {
             dest.pushKV(ScriptToString(tx.vout[i].scriptPubKey), tx.vout[i].TokenAmount().ToString());
         }
         rpcInfo.pushKV("to", dest);
     }
 
-    void operator()(const CAccountToAccountMessage& obj) const {
+    void operator()(const CAccountToAccountMessage &obj) const {
         rpcInfo.pushKV("from", ScriptToString(obj.from));
         rpcInfo.pushKV("to", accountsInfo(obj.to));
     }
 
-    void operator()(const CAnyAccountsToAccountsMessage& obj) const {
+    void operator()(const CAnyAccountsToAccountsMessage &obj) const {
         rpcInfo.pushKV("from", accountsInfo(obj.from));
         rpcInfo.pushKV("to", accountsInfo(obj.to));
     }
 
-    void operator()(const CSmartContractMessage& obj) const {
+    void operator()(const CSmartContractMessage &obj) const {
         rpcInfo.pushKV("name", obj.name);
         rpcInfo.pushKV("accounts", accountsInfo(obj.accounts));
     }
 
-    void operator()(const CFutureSwapMessage& obj) const {
+    void operator()(const CFutureSwapMessage &obj) const {
         CTxDestination dest;
         if (ExtractDestination(obj.owner, dest)) {
             rpcInfo.pushKV("owner", EncodeDestination(dest));
@@ -175,7 +164,7 @@ public:
         rpcInfo.pushKV("destination", std::to_string(obj.destination));
     }
 
-    void operator()(const CCreatePoolPairMessage& obj) const {
+    void operator()(const CCreatePoolPairMessage &obj) const {
         rpcInfo.pushKV("creationTx", tx.GetHash().GetHex());
         if (auto tokenPair = mnview.GetTokenByCreationTx(tx.GetHash()))
             tokenInfo(tokenPair->second);
@@ -189,7 +178,7 @@ public:
         customRewardsInfo(obj.rewards);
     }
 
-    void operator()(const CUpdatePoolPairMessage& obj) const {
+    void operator()(const CUpdatePoolPairMessage &obj) const {
         rpcInfo.pushKV("commission", ValueFromAmount(obj.commission));
         rpcInfo.pushKV("status", obj.status);
         rpcInfo.pushKV("ownerAddress", ScriptToString(obj.ownerAddress));
@@ -197,10 +186,11 @@ public:
         // Add rewards here before processing them below to avoid adding current rewards
         if (!obj.rewards.balances.empty()) {
             UniValue rewardArr(UniValue::VARR);
-            auto& rewards = obj.rewards;
+            auto &rewards = obj.rewards;
             // Check for special case to wipe rewards
-            if (rewards.balances.size() == 1 && rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()}
-            && rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max()) {
+            if (rewards.balances.size() == 1 &&
+                rewards.balances.cbegin()->first == DCT_ID{std::numeric_limits<uint32_t>::max()} &&
+                rewards.balances.cbegin()->second == std::numeric_limits<CAmount>::max()) {
                 rpcInfo.pushKV("customRewards", rewardArr);
             } else {
                 customRewardsInfo(rewards);
@@ -208,7 +198,7 @@ public:
         }
     }
 
-    void operator()(const CPoolSwapMessage& obj) const {
+    void operator()(const CPoolSwapMessage &obj) const {
         rpcInfo.pushKV("fromAddress", ScriptToString(obj.from));
         rpcInfo.pushKV("fromToken", obj.idTokenFrom.ToString());
         rpcInfo.pushKV("fromAmount", ValueFromAmount(obj.amountFrom));
@@ -217,10 +207,10 @@ public:
         rpcInfo.pushKV("maxPrice", ValueFromAmount((obj.maxPrice.integer * COIN) + obj.maxPrice.fraction));
     }
 
-    void operator()(const CPoolSwapMessageV2& obj) const {
+    void operator()(const CPoolSwapMessageV2 &obj) const {
         (*this)(obj.swapInfo);
         std::string str;
-        for (auto& id : obj.poolIDs) {
+        for (auto &id : obj.poolIDs) {
             if (auto token = mnview.GetToken(id)) {
                 if (!str.empty()) {
                     str += '/';
@@ -233,43 +223,43 @@ public:
         }
     }
 
-    void operator()(const CGovernanceMessage& obj) const {
-        for (const auto& var : obj.govs) {
+    void operator()(const CGovernanceMessage &obj) const {
+        for (const auto &var : obj.govs) {
             rpcInfo.pushKV(var->GetName(), var->Export());
         }
     }
 
-    void operator()(const CGovernanceHeightMessage& obj) const {
+    void operator()(const CGovernanceHeightMessage &obj) const {
         rpcInfo.pushKV(obj.govVar->GetName(), obj.govVar->Export());
         rpcInfo.pushKV("startHeight", static_cast<uint64_t>(obj.startHeight));
     }
 
-    void operator()(const CAppointOracleMessage& obj) const {
+    void operator()(const CAppointOracleMessage &obj) const {
         rpcInfo.pushKV("oracleAddress", ScriptToString(obj.oracleAddress));
         rpcInfo.pushKV("weightage", obj.weightage);
         tokenCurrencyPairInfo(obj.availablePairs);
     }
 
-    void operator()(const CUpdateOracleAppointMessage& obj) const {
+    void operator()(const CUpdateOracleAppointMessage &obj) const {
         rpcInfo.pushKV("oracleId", obj.oracleId.ToString());
         rpcInfo.pushKV("oracleAddress", ScriptToString(obj.newOracleAppoint.oracleAddress));
         rpcInfo.pushKV("weightage", obj.newOracleAppoint.weightage);
         tokenCurrencyPairInfo(obj.newOracleAppoint.availablePairs);
     }
 
-    void operator()(const CRemoveOracleAppointMessage& obj) const {
+    void operator()(const CRemoveOracleAppointMessage &obj) const {
         rpcInfo.pushKV("oracleId", obj.oracleId.ToString());
     }
 
-    void operator()(const CSetOracleDataMessage& obj) const {
+    void operator()(const CSetOracleDataMessage &obj) const {
         rpcInfo.pushKV("oracleId", obj.oracleId.ToString());
         rpcInfo.pushKV("timestamp", obj.timestamp);
 
         UniValue tokenPrices(UniValue::VARR);
-        for (const auto& tokenPice : obj.tokenPrices) {
-            const auto& token = tokenPice.first;
-            for (const auto& price : tokenPice.second) {
-                const auto& currency = price.first;
+        for (const auto &tokenPice : obj.tokenPrices) {
+            const auto &token = tokenPice.first;
+            for (const auto &price : tokenPice.second) {
+                const auto &currency = price.first;
                 auto amount = price.second;
 
                 UniValue uniPair(UniValue::VOBJ);
@@ -281,17 +271,14 @@ public:
         rpcInfo.pushKV("tokenPrices", tokenPrices);
     }
 
-    void operator()(const CICXCreateOrderMessage& obj) const {
-        if (obj.orderType == CICXOrder::TYPE_INTERNAL)
-        {
-            rpcInfo.pushKV("type","DFC");
+    void operator()(const CICXCreateOrderMessage &obj) const {
+        if (obj.orderType == CICXOrder::TYPE_INTERNAL) {
+            rpcInfo.pushKV("type", "DFC");
             if (auto token = mnview.GetToken(obj.idToken))
                 rpcInfo.pushKV("tokenFrom", token->CreateSymbolKey(obj.idToken));
             rpcInfo.pushKV("chainto", CICXOrder::CHAIN_BTC);
-        }
-        else if (obj.orderType == CICXOrder::TYPE_EXTERNAL)
-        {
-            rpcInfo.pushKV("type","EXTERNAL");
+        } else if (obj.orderType == CICXOrder::TYPE_EXTERNAL) {
+            rpcInfo.pushKV("type", "EXTERNAL");
             rpcInfo.pushKV("chainFrom", CICXOrder::CHAIN_BTC);
             if (auto token = mnview.GetToken(obj.idToken))
                 rpcInfo.pushKV("tokenTo", token->CreateSymbolKey(obj.idToken));
@@ -302,12 +289,13 @@ public:
         rpcInfo.pushKV("amountFrom", ValueFromAmount(obj.amountFrom));
         rpcInfo.pushKV("amountToFill", ValueFromAmount(obj.amountToFill));
         rpcInfo.pushKV("orderPrice", ValueFromAmount(obj.orderPrice));
-        CAmount calcedAmount(static_cast<CAmount>((arith_uint256(obj.amountToFill) * arith_uint256(obj.orderPrice) / arith_uint256(COIN)).GetLow64()));
+        CAmount calcedAmount(static_cast<CAmount>(
+            (arith_uint256(obj.amountToFill) * arith_uint256(obj.orderPrice) / arith_uint256(COIN)).GetLow64()));
         rpcInfo.pushKV("amountToFillInToAsset", ValueFromAmount(calcedAmount));
         rpcInfo.pushKV("expiry", static_cast<int>(obj.expiry));
     }
 
-    void operator()(const CICXMakeOfferMessage& obj) const {
+    void operator()(const CICXMakeOfferMessage &obj) const {
         rpcInfo.pushKV("orderTx", obj.orderTx.GetHex());
         rpcInfo.pushKV("amount", ValueFromAmount(obj.amount));
         rpcInfo.pushKV("ownerAddress", ScriptToString(obj.ownerAddress));
@@ -317,7 +305,7 @@ public:
         rpcInfo.pushKV("expiry", static_cast<int>(obj.expiry));
     }
 
-    void operator()(const CICXSubmitDFCHTLCMessage& obj) const {
+    void operator()(const CICXSubmitDFCHTLCMessage &obj) const {
         rpcInfo.pushKV("type", "DFC");
         rpcInfo.pushKV("offerTx", obj.offerTx.GetHex());
         rpcInfo.pushKV("amount", ValueFromAmount(obj.amount));
@@ -325,7 +313,7 @@ public:
         rpcInfo.pushKV("timeout", static_cast<int>(obj.timeout));
     }
 
-    void operator()(const CICXSubmitEXTHTLCMessage& obj) const {
+    void operator()(const CICXSubmitEXTHTLCMessage &obj) const {
         rpcInfo.pushKV("type", "EXTERNAL");
         rpcInfo.pushKV("offerTx", obj.offerTx.GetHex());
         rpcInfo.pushKV("amount", ValueFromAmount(obj.amount));
@@ -335,21 +323,17 @@ public:
         rpcInfo.pushKV("timeout", static_cast<int>(obj.timeout));
     }
 
-    void operator()(const CICXClaimDFCHTLCMessage& obj) const {
+    void operator()(const CICXClaimDFCHTLCMessage &obj) const {
         rpcInfo.pushKV("type", "CLAIM DFC");
         rpcInfo.pushKV("dfchtlcTx", obj.dfchtlcTx.GetHex());
         rpcInfo.pushKV("seed", HexStr(obj.seed));
     }
 
-    void operator()(const CICXCloseOrderMessage& obj) const {
-        rpcInfo.pushKV("orderTx", obj.orderTx.GetHex());
-    }
+    void operator()(const CICXCloseOrderMessage &obj) const { rpcInfo.pushKV("orderTx", obj.orderTx.GetHex()); }
 
-    void operator()(const CICXCloseOfferMessage& obj) const {
-        rpcInfo.pushKV("offerTx", obj.offerTx.GetHex());
-    }
+    void operator()(const CICXCloseOfferMessage &obj) const { rpcInfo.pushKV("offerTx", obj.offerTx.GetHex()); }
 
-    void operator()(const CLoanSetCollateralTokenMessage& obj) const {
+    void operator()(const CLoanSetCollateralTokenMessage &obj) const {
         if (auto token = mnview.GetToken(obj.idToken))
             rpcInfo.pushKV("token", token->CreateSymbolKey(obj.idToken));
         rpcInfo.pushKV("factor", ValueFromAmount(obj.factor));
@@ -358,7 +342,7 @@ public:
             rpcInfo.pushKV("activateAfterBlock", static_cast<int>(obj.activateAfterBlock));
     }
 
-    void operator()(const CLoanSetLoanTokenMessage& obj) const {
+    void operator()(const CLoanSetLoanTokenMessage &obj) const {
         rpcInfo.pushKV("symbol", obj.symbol);
         rpcInfo.pushKV("name", obj.name);
         rpcInfo.pushKV("fixedIntervalPriceId", obj.fixedIntervalPriceId.first + "/" + obj.fixedIntervalPriceId.second);
@@ -366,7 +350,7 @@ public:
         rpcInfo.pushKV("interest", ValueFromAmount(obj.interest));
     }
 
-    void operator()(const CLoanUpdateLoanTokenMessage& obj) const {
+    void operator()(const CLoanUpdateLoanTokenMessage &obj) const {
         rpcInfo.pushKV("id", obj.tokenTx.ToString());
         rpcInfo.pushKV("symbol", obj.symbol);
         rpcInfo.pushKV("name", obj.name);
@@ -375,59 +359,57 @@ public:
         rpcInfo.pushKV("interest", ValueFromAmount(obj.interest));
     }
 
-    void operator()(const CLoanSchemeMessage& obj) const {
+    void operator()(const CLoanSchemeMessage &obj) const {
         rpcInfo.pushKV("id", obj.identifier);
         rpcInfo.pushKV("mincolratio", static_cast<uint64_t>(obj.ratio));
         rpcInfo.pushKV("interestrate", ValueFromAmount(obj.rate));
         rpcInfo.pushKV("updateHeight", obj.updateHeight);
     }
 
-    void operator()(const CDefaultLoanSchemeMessage& obj) const {
-        rpcInfo.pushKV("id", obj.identifier);
-    }
+    void operator()(const CDefaultLoanSchemeMessage &obj) const { rpcInfo.pushKV("id", obj.identifier); }
 
-    void operator()(const CDestroyLoanSchemeMessage& obj) const {
+    void operator()(const CDestroyLoanSchemeMessage &obj) const {
         rpcInfo.pushKV("id", obj.identifier);
         rpcInfo.pushKV("destroyHeight", obj.destroyHeight);
     }
 
-    void operator()(const CVaultMessage& obj) const {
+    void operator()(const CVaultMessage &obj) const {
         // Add Vault attributes
         rpcInfo.pushKV("ownerAddress", ScriptToString(obj.ownerAddress));
         rpcInfo.pushKV("loanSchemeId", obj.schemeId);
     }
 
-    void operator()(const CCloseVaultMessage& obj) const {
+    void operator()(const CCloseVaultMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("to", ScriptToString(obj.to));
     }
 
-    void operator()(const CUpdateVaultMessage& obj) const {
+    void operator()(const CUpdateVaultMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("ownerAddress", ScriptToString(obj.ownerAddress));
         rpcInfo.pushKV("loanSchemeId", obj.schemeId);
     }
 
-    void operator()(const CDepositToVaultMessage& obj) const {
+    void operator()(const CDepositToVaultMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("from", ScriptToString(obj.from));
         rpcInfo.pushKV("amount", obj.amount.ToString());
     }
 
-    void operator()(const CWithdrawFromVaultMessage& obj) const {
+    void operator()(const CWithdrawFromVaultMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("to", ScriptToString(obj.to));
         rpcInfo.pushKV("amount", obj.amount.ToString());
     }
 
-    void operator()(const CLoanTakeLoanMessage& obj) const {
+    void operator()(const CLoanTakeLoanMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         if (!obj.to.empty())
             rpcInfo.pushKV("to", ScriptToString(obj.to));
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
-        for (auto const & kv : obj.amounts.balances) {
+        for (auto const &kv : obj.amounts.balances) {
             if (auto token = mnview.GetToken(kv.first)) {
-                auto tokenImpl = static_cast<CTokenImplementation const&>(*token);
+                auto tokenImpl = static_cast<CTokenImplementation const &>(*token);
                 if (auto tokenPair = mnview.GetTokenByCreationTx(tokenImpl.creationTx)) {
                     rpcInfo.pushKV(tokenPair->first.ToString(), ValueFromAmount(kv.second));
                 }
@@ -435,12 +417,12 @@ public:
         }
     }
 
-    void operator()(const CLoanPaybackLoanMessage& obj) const {
+    void operator()(const CLoanPaybackLoanMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("from", ScriptToString(obj.from));
-        for (auto const & kv : obj.amounts.balances) {
+        for (auto const &kv : obj.amounts.balances) {
             if (auto token = mnview.GetToken(kv.first)) {
-                auto tokenImpl = static_cast<CTokenImplementation const&>(*token);
+                auto tokenImpl = static_cast<CTokenImplementation const &>(*token);
                 if (auto tokenPair = mnview.GetTokenByCreationTx(tokenImpl.creationTx)) {
                     rpcInfo.pushKV(tokenPair->first.ToString(), ValueFromAmount(kv.second));
                 }
@@ -448,21 +430,21 @@ public:
         }
     }
 
-    void operator()(const CLoanPaybackLoanV2Message& obj) const {
+    void operator()(const CLoanPaybackLoanV2Message &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("from", ScriptToString(obj.from));
         UniValue loans{UniValue::VARR};
-        for (auto const & idx : obj.loans) {
+        for (auto const &idx : obj.loans) {
             UniValue loan{UniValue::VOBJ};
             if (auto dtoken = mnview.GetToken(idx.first)) {
-                auto dtokenImpl = static_cast<CTokenImplementation const&>(*dtoken);
+                auto dtokenImpl = static_cast<CTokenImplementation const &>(*dtoken);
                 if (auto dtokenPair = mnview.GetTokenByCreationTx(dtokenImpl.creationTx)) {
-                    loan.pushKV("dTokens",dtokenPair->first.ToString());
+                    loan.pushKV("dTokens", dtokenPair->first.ToString());
                 }
             }
-            for (auto const & kv : idx.second.balances) {
+            for (auto const &kv : idx.second.balances) {
                 if (auto token = mnview.GetToken(kv.first)) {
-                    auto tokenImpl = static_cast<CTokenImplementation const&>(*token);
+                    auto tokenImpl = static_cast<CTokenImplementation const &>(*token);
                     if (auto tokenPair = mnview.GetTokenByCreationTx(tokenImpl.creationTx)) {
                         loan.pushKV(tokenPair->first.ToString(), ValueFromAmount(kv.second));
                     }
@@ -470,21 +452,20 @@ public:
             }
             loans.push_back(loan);
         }
-        rpcInfo.pushKV("dToken",loans);
+        rpcInfo.pushKV("dToken", loans);
     }
 
-    void operator()(const CAuctionBidMessage& obj) const {
+    void operator()(const CAuctionBidMessage &obj) const {
         rpcInfo.pushKV("vaultId", obj.vaultId.GetHex());
         rpcInfo.pushKV("index", int64_t(obj.index));
         rpcInfo.pushKV("from", ScriptToString(obj.from));
         rpcInfo.pushKV("amount", obj.amount.ToString());
     }
 
-    void operator()(const CCustomTxMessageNone&) const {
-    }
+    void operator()(const CCustomTxMessageNone &) const {}
 };
 
-Res RpcInfo(const CTransaction& tx, uint32_t height, CustomTxType& txType, UniValue& results) {
+Res RpcInfo(const CTransaction &tx, uint32_t height, CustomTxType &txType, UniValue &results) {
     std::vector<unsigned char> metadata;
     txType = GuessCustomTxType(tx, metadata);
     if (txType == CustomTxType::None) {

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -1,51 +1,50 @@
 #include <masternodes/mn_rpc.h>
 
-UniValue icxOrderToJSON(CICXOrderImplemetation const& order, uint8_t const status) {
+UniValue icxOrderToJSON(CICXOrderImplemetation const &order, uint8_t const status) {
     UniValue orderObj(UniValue::VOBJ);
 
     auto token = pcustomcsview->GetToken(order.idToken);
-        if (!token)
-            return (UniValue::VNULL);
+    if (!token)
+        return (UniValue::VNULL);
 
-    switch (status)
-    {
-        case 0: orderObj.pushKV("status", "OPEN");
-                break;
-        case 1: orderObj.pushKV("status", "CLOSED");
-                break;
-        case 2: orderObj.pushKV("status", "FILLED");
-                break;
-        case 3: orderObj.pushKV("status", "EXPIRED");
-                break;
+    switch (status) {
+        case 0:
+            orderObj.pushKV("status", "OPEN");
+            break;
+        case 1:
+            orderObj.pushKV("status", "CLOSED");
+            break;
+        case 2:
+            orderObj.pushKV("status", "FILLED");
+            break;
+        case 3:
+            orderObj.pushKV("status", "EXPIRED");
+            break;
     }
-    if (order.orderType == CICXOrder::TYPE_INTERNAL)
-    {
+    if (order.orderType == CICXOrder::TYPE_INTERNAL) {
         orderObj.pushKV("type", "INTERNAL");
         orderObj.pushKV("tokenFrom", token->CreateSymbolKey(order.idToken));
         orderObj.pushKV("chainTo", CICXOrder::CHAIN_BTC);
         orderObj.pushKV("receivePubkey", HexStr(order.receivePubkey));
-    }
-    else if (order.orderType == CICXOrder::TYPE_EXTERNAL)
-    {
+    } else if (order.orderType == CICXOrder::TYPE_EXTERNAL) {
         orderObj.pushKV("type", "EXTERNAL");
-        orderObj.pushKV("chainFrom",CICXOrder::CHAIN_BTC);
+        orderObj.pushKV("chainFrom", CICXOrder::CHAIN_BTC);
         orderObj.pushKV("tokenTo", token->CreateSymbolKey(order.idToken));
     }
     orderObj.pushKV("ownerAddress", ScriptToString(order.ownerAddress));
     orderObj.pushKV("amountFrom", ValueFromAmount(order.amountFrom));
     orderObj.pushKV("amountToFill", ValueFromAmount(order.amountToFill));
     orderObj.pushKV("orderPrice", ValueFromAmount(order.orderPrice));
-    CAmount calcedAmount(static_cast<CAmount>((arith_uint256(order.amountToFill) * arith_uint256(order.orderPrice) / arith_uint256(COIN)).GetLow64()));
+    CAmount calcedAmount(static_cast<CAmount>(
+        (arith_uint256(order.amountToFill) * arith_uint256(order.orderPrice) / arith_uint256(COIN)).GetLow64()));
     orderObj.pushKV("amountToFillInToAsset", ValueFromAmount(calcedAmount));
     orderObj.pushKV("height", static_cast<int>(order.creationHeight));
     orderObj.pushKV("expireHeight", static_cast<int>(order.creationHeight + order.expiry));
-    if (order.closeHeight > -1)
-    {
+    if (order.closeHeight > -1) {
         orderObj.pushKV("closeHeight", static_cast<int>(order.closeHeight));
-        if (!order.closeTx.IsNull()) orderObj.pushKV("closeTx", order.closeTx.GetHex());
-    }
-    else if (order.creationHeight + order.expiry <= static_cast<uint32_t>(pcustomcsview->GetLastHeight()))
-    {
+        if (!order.closeTx.IsNull())
+            orderObj.pushKV("closeTx", order.closeTx.GetHex());
+    } else if (order.creationHeight + order.expiry <= static_cast<uint32_t>(pcustomcsview->GetLastHeight())) {
         orderObj.pushKV("expired", true);
     }
 
@@ -54,18 +53,22 @@ UniValue icxOrderToJSON(CICXOrderImplemetation const& order, uint8_t const statu
     return (ret);
 }
 
-UniValue icxMakeOfferToJSON(CICXMakeOfferImplemetation const& makeoffer, uint8_t const status) {
+UniValue icxMakeOfferToJSON(CICXMakeOfferImplemetation const &makeoffer, uint8_t const status) {
     UniValue orderObj(UniValue::VOBJ);
 
     auto order = pcustomcsview->GetICXOrderByCreationTx(makeoffer.orderTx);
     if (!order)
         return (UniValue::VNULL);
     orderObj.pushKV("orderTx", makeoffer.orderTx.GetHex());
-    orderObj.pushKV("status", status == CICXMakeOffer::STATUS_OPEN ? "OPEN" : status == CICXMakeOffer::STATUS_CLOSED ? "CLOSED" : "EXPIRED");
+    orderObj.pushKV("status",
+                    status == CICXMakeOffer::STATUS_OPEN     ? "OPEN"
+                    : status == CICXMakeOffer::STATUS_CLOSED ? "CLOSED"
+                                                             : "EXPIRED");
     orderObj.pushKV("amount", ValueFromAmount(makeoffer.amount));
-    CAmount calcedAmount(static_cast<CAmount>((arith_uint256(makeoffer.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice) ).GetLow64()));
+    CAmount calcedAmount(static_cast<CAmount>(
+        (arith_uint256(makeoffer.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
     orderObj.pushKV("amountInFromAsset", ValueFromAmount(calcedAmount));
-    orderObj.pushKV("ownerAddress",ScriptToString(makeoffer.ownerAddress));
+    orderObj.pushKV("ownerAddress", ScriptToString(makeoffer.ownerAddress));
     if (order->orderType == CICXOrder::TYPE_EXTERNAL)
         orderObj.pushKV("receivePubkey", HexStr(makeoffer.receivePubkey));
     orderObj.pushKV("takerFee", ValueFromAmount(makeoffer.takerFee));
@@ -76,7 +79,7 @@ UniValue icxMakeOfferToJSON(CICXMakeOfferImplemetation const& makeoffer, uint8_t
     return (ret);
 }
 
-UniValue icxSubmitDFCHTLCToJSON(CICXSubmitDFCHTLCImplemetation const& dfchtlc, uint8_t const status) {
+UniValue icxSubmitDFCHTLCToJSON(CICXSubmitDFCHTLCImplemetation const &dfchtlc, uint8_t const status) {
     auto offer = pcustomcsview->GetICXMakeOfferByCreationTx(dfchtlc.offerTx);
     if (!offer)
         return (UniValue::VNULL);
@@ -86,27 +89,29 @@ UniValue icxSubmitDFCHTLCToJSON(CICXSubmitDFCHTLCImplemetation const& dfchtlc, u
 
     UniValue orderObj(UniValue::VOBJ);
     orderObj.pushKV("type", "DFC");
-    switch (status)
-    {
-        case 0: orderObj.pushKV("status", "OPEN");
-                break;
-        case 1: orderObj.pushKV("status", "CLAIMED");
-                break;
-        case 2: orderObj.pushKV("status", "REFUNDED");
-                break;
-        case 3: orderObj.pushKV("status", "EXPIRED");
-                break;
+    switch (status) {
+        case 0:
+            orderObj.pushKV("status", "OPEN");
+            break;
+        case 1:
+            orderObj.pushKV("status", "CLAIMED");
+            break;
+        case 2:
+            orderObj.pushKV("status", "REFUNDED");
+            break;
+        case 3:
+            orderObj.pushKV("status", "EXPIRED");
+            break;
     }
     orderObj.pushKV("offerTx", dfchtlc.offerTx.GetHex());
     orderObj.pushKV("amount", ValueFromAmount(dfchtlc.amount));
-    if (order->orderType == CICXOrder::TYPE_INTERNAL)
-    {
-        CAmount calcedAmount(static_cast<CAmount>((arith_uint256(dfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+    if (order->orderType == CICXOrder::TYPE_INTERNAL) {
+        CAmount calcedAmount(static_cast<CAmount>(
+            (arith_uint256(dfchtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
         orderObj.pushKV("amountInEXTAsset", ValueFromAmount(calcedAmount));
-    }
-    else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-    {
-        CAmount calcedAmount(static_cast<CAmount>((arith_uint256(dfchtlc.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
+    } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
+        CAmount calcedAmount(static_cast<CAmount>(
+            (arith_uint256(dfchtlc.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
         orderObj.pushKV("amountInEXTAsset", ValueFromAmount(calcedAmount));
     }
     orderObj.pushKV("hash", dfchtlc.hash.GetHex());
@@ -119,7 +124,7 @@ UniValue icxSubmitDFCHTLCToJSON(CICXSubmitDFCHTLCImplemetation const& dfchtlc, u
     return (ret);
 }
 
-UniValue icxSubmitEXTHTLCToJSON(CICXSubmitEXTHTLCImplemetation const& exthtlc, uint8_t const status) {
+UniValue icxSubmitEXTHTLCToJSON(CICXSubmitEXTHTLCImplemetation const &exthtlc, uint8_t const status) {
     auto offer = pcustomcsview->GetICXMakeOfferByCreationTx(exthtlc.offerTx);
     if (!offer)
         return (UniValue::VNULL);
@@ -129,17 +134,19 @@ UniValue icxSubmitEXTHTLCToJSON(CICXSubmitEXTHTLCImplemetation const& exthtlc, u
 
     UniValue orderObj(UniValue::VOBJ);
     orderObj.pushKV("type", "EXTERNAL");
-    orderObj.pushKV("status", status == CICXSubmitEXTHTLC::STATUS_OPEN ? "OPEN" : status == CICXSubmitEXTHTLC::STATUS_CLOSED ? "CLOSED" : "EXPIRED");
+    orderObj.pushKV("status",
+                    status == CICXSubmitEXTHTLC::STATUS_OPEN     ? "OPEN"
+                    : status == CICXSubmitEXTHTLC::STATUS_CLOSED ? "CLOSED"
+                                                                 : "EXPIRED");
     orderObj.pushKV("offerTx", exthtlc.offerTx.GetHex());
     orderObj.pushKV("amount", ValueFromAmount(exthtlc.amount));
-    if (order->orderType == CICXOrder::TYPE_INTERNAL)
-    {
-        CAmount calcedAmount(static_cast<CAmount>((arith_uint256(exthtlc.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
+    if (order->orderType == CICXOrder::TYPE_INTERNAL) {
+        CAmount calcedAmount(static_cast<CAmount>(
+            (arith_uint256(exthtlc.amount) * arith_uint256(COIN) / arith_uint256(order->orderPrice)).GetLow64()));
         orderObj.pushKV("amountInDFCAsset", ValueFromAmount(calcedAmount));
-    }
-    else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-    {
-        CAmount calcedAmount(static_cast<CAmount>((arith_uint256(exthtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
+    } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
+        CAmount calcedAmount(static_cast<CAmount>(
+            (arith_uint256(exthtlc.amount) * arith_uint256(order->orderPrice) / arith_uint256(COIN)).GetLow64()));
         orderObj.pushKV("amountInDFCAsset", ValueFromAmount(calcedAmount));
     }
     orderObj.pushKV("hash", exthtlc.hash.GetHex());
@@ -153,7 +160,7 @@ UniValue icxSubmitEXTHTLCToJSON(CICXSubmitEXTHTLCImplemetation const& exthtlc, u
     return (ret);
 }
 
-UniValue icxClaimDFCHTLCToJSON(CICXClaimDFCHTLCImplemetation const& claimdfchtlc) {
+UniValue icxClaimDFCHTLCToJSON(CICXClaimDFCHTLCImplemetation const &claimdfchtlc) {
     UniValue orderObj(UniValue::VOBJ);
     orderObj.pushKV("type", "CLAIM DFC");
     orderObj.pushKV("dfchtlcTx", claimdfchtlc.dfchtlcTx.GetHex());
@@ -165,50 +172,78 @@ UniValue icxClaimDFCHTLCToJSON(CICXClaimDFCHTLCImplemetation const& claimdfchtlc
     return (ret);
 }
 
-UniValue icxcreateorder(const JSONRPCRequest& request) {
+UniValue icxcreateorder(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_createorder",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a order creation transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_createorder",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a order creation transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "order",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"order", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+                    {"tokenFrom|chainFrom",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Symbol or id of selling token/chain"},
+                    {"chainTo|tokenTo",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Symbol or id of buying chain/token"},
+                    {"ownerAddress",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Address of DFI token for fees and selling tokens in case of EXT/DFC order type"},
+                    {"receivePubkey",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Pubkey which can claim external HTLC in case of DFC/EXT order type"},
+                    {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "\"tokenFrom\" coins amount"},
+                    {"orderPrice", RPCArg::Type::NUM, RPCArg::Optional::NO, "Price per unit"},
+                    {"expiry",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Number of blocks until the order expires (Default: " + std::to_string(CICXOrder::DEFAULT_EXPIRY) +
+                         " DFI blocks)"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"tokenFrom|chainFrom", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Symbol or id of selling token/chain"},
-                            {"chainTo|tokenTo", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Symbol or id of buying chain/token"},
-                            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of DFI token for fees and selling tokens in case of EXT/DFC order type"},
-                            {"receivePubkey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Pubkey which can claim external HTLC in case of DFC/EXT order type"},
-                            {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "\"tokenFrom\" coins amount"},
-                            {"orderPrice", RPCArg::Type::NUM, RPCArg::Optional::NO, "Price per unit"},
-                            {"expiry", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Number of blocks until the order expires (Default: "
-                                + std::to_string(CICXOrder::DEFAULT_EXPIRY) + " DFI blocks)"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_createorder", "'{\"ownerAddress\":\"<tokenAddress>\","
-                                                        "\"tokenFrom\":\"GOLD#128\",\"chainTo\":\"BTC\","
-                                                        "\"amountFrom\":\"10\",\"orderPrice\":\"10\"}'")
-                        + HelpExampleCli("icx_createorder", "'{\"chainFrom\":\"BTC\",\"tokenTo\":\"SILVER#129\","
-                                                        "\"amountFrom\":\"5\",\"orderPrice\":\"0.01\","
-                                                        "\"expiry\":\"1000\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("icx_createorder",
+                                   "'{\"ownerAddress\":\"<tokenAddress>\","
+                                   "\"tokenFrom\":\"GOLD#128\",\"chainTo\":\"BTC\","
+                                   "\"amountFrom\":\"10\",\"orderPrice\":\"10\"}'") +
+                    HelpExampleCli("icx_createorder",
+                                   "'{\"chainFrom\":\"BTC\",\"tokenTo\":\"SILVER#129\","
+                                   "\"amountFrom\":\"5\",\"orderPrice\":\"0.01\","
+                                   "\"expiry\":\"1000\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create order while still in Initial Block Download");
@@ -217,12 +252,13 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
     if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 1 must be non-null and expected as object at least with "
-                           "{\"tokenFrom|chainFrom\",\"chainTo|tokenTo\",\"ownerAddress\",\"amountFrom\",\"orderPrice\"}");
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
+            "Invalid parameters, arguments 1 must be non-null and expected as object at least with "
+            "{\"tokenFrom|chainFrom\",\"chainTo|tokenTo\",\"ownerAddress\",\"amountFrom\",\"orderPrice\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXOrder order;
     std::string tokenFromSymbol, tokenToSymbol;
@@ -230,49 +266,54 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
     if (!metaObj["ownerAddress"].isNull())
         order.ownerAddress = DecodeScript(metaObj["ownerAddress"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           R"(Invalid parameters, argument "ownerAddress" must be specified)");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, R"(Invalid parameters, argument "ownerAddress" must be specified)");
 
     if (!::IsMine(*pwallet, order.ownerAddress))
         throw JSONRPCError(RPC_INVALID_PARAMETER,
                            strprintf("Address (%s) is not owned by the wallet", metaObj["ownerAddress"].getValStr()));
 
     if (metaObj["tokenFrom"].isNull() && metaObj["chainFrom"].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, either \"tokenFrom\" or \"chainFrom\" must not be both null - [tokenFrom,chainTo] or [chainFrom,tokenTo].");
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, either \"tokenFrom\" or \"chainFrom\" must not be both null - "
+                           "[tokenFrom,chainTo] or [chainFrom,tokenTo].");
 
     if (!metaObj["tokenFrom"].isNull()) {
         tokenFromSymbol = trim_ws(metaObj["tokenFrom"].getValStr());
 
         if (metaObj["chainTo"].isNull() || trim_ws(metaObj["chainTo"].getValStr()) != "BTC")
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"chainTo\" must be \"BTC\" if \"tokenFrom\" specified");
-    }
-    else if (!metaObj["chainFrom"].isNull()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Invalid parameters, argument \"chainTo\" must be \"BTC\" if \"tokenFrom\" specified");
+    } else if (!metaObj["chainFrom"].isNull()) {
         if (trim_ws(metaObj["chainFrom"].getValStr()) != "BTC")
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"chainFrom\" must be \"BTC\" if \"tokenTo\" specified");
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Invalid parameters, argument \"chainFrom\" must be \"BTC\" if \"tokenTo\" specified");
 
         if (!metaObj["tokenTo"].isNull())
             tokenToSymbol = trim_ws(metaObj["tokenTo"].getValStr());
         else
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"tokenTo\" must not be null if \"chainFrom\" specified");
-    }
-    else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"tokenFrom\" or \"chainFrom\" must be non-null");
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Invalid parameters, argument \"tokenTo\" must not be null if \"chainFrom\" specified");
+    } else
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, argument \"tokenFrom\" or \"chainFrom\" must be non-null");
 
     if (!metaObj["amountFrom"].isNull())
         order.amountToFill = order.amountFrom = AmountFromValue(metaObj["amountFrom"]);
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amountFrom\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"amountFrom\" must not be null");
 
     if (!metaObj["orderPrice"].isNull())
         order.orderPrice = AmountFromValue(metaObj["orderPrice"]);
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"orderPrice\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"orderPrice\" must not be null");
 
     if (!metaObj["expiry"].isNull())
         order.expiry = metaObj["expiry"].get_int();
 
     if (!tokenFromSymbol.empty() && !tokenToSymbol.empty())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, \"tokenFrom\" and \"tokenTo\" cannot be set in the same time. [tokenFrom,chainTo] or [chainFrom,tokenTo]");
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, \"tokenFrom\" and \"tokenTo\" cannot be set in the same time. "
+                           "[tokenFrom,chainTo] or [chainFrom,tokenTo]");
 
     if (!tokenFromSymbol.empty())
         order.orderType = CICXOrder::TYPE_INTERNAL;
@@ -284,8 +325,7 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
         LOCK(cs_main);
         DCT_ID idToken;
 
-        if (order.orderType == CICXOrder::TYPE_INTERNAL)
-        {
+        if (order.orderType == CICXOrder::TYPE_INTERNAL) {
             auto token = pcustomcsview->GetTokenGuessId(tokenFromSymbol, idToken);
             if (!token)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenFromSymbol));
@@ -294,14 +334,16 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
             if (!metaObj["receivePubkey"].isNull())
                 order.receivePubkey = PublickeyFromString(trim_ws(metaObj["receivePubkey"].getValStr()));
             else
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"receivePubkey\" must not be null");
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   "Invalid parameters, argument \"receivePubkey\" must not be null");
 
             CTokenAmount balance = pcustomcsview->GetBalance(order.ownerAddress, idToken);
             if (balance.nValue < order.amountFrom)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Not enough balance for Token %s on address %s!", token->CreateSymbolKey(order.idToken), ScriptToString(order.ownerAddress)));
-        }
-        else
-        {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   strprintf("Not enough balance for Token %s on address %s!",
+                                             token->CreateSymbolKey(order.idToken),
+                                             ScriptToString(order.ownerAddress)));
+        } else {
             auto token = pcustomcsview->GetTokenGuessId(tokenToSymbol, idToken);
             if (!token)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenToSymbol));
@@ -312,8 +354,7 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXCreateOrder)
-             << order;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXCreateOrder) << order;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -341,51 +382,75 @@ UniValue icxcreateorder(const JSONRPCRequest& request) {
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxmakeoffer(const JSONRPCRequest& request) {
+UniValue icxmakeoffer(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_makeoffer",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a makeoffer transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_makeoffer",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a makeoffer transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "offer",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
                 {
-                    {"offer", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of order tx for which is the offer"},
+                    {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount fulfilling the order"},
+                    {"ownerAddress",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Address of DFI token and for receiving tokens in case of DFC/EXT order"},
+                    {"receivePubkey",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Pubkey which can claim external HTLC in case of EXT/DFC order type"},
+                    {"expiry",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Number of blocks until the offer expires (Default: " +
+                         std::to_string(CICXMakeOffer::DEFAULT_EXPIRY) + " DFI blocks)"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of order tx for which is the offer"},
-                            {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount fulfilling the order"},
-                            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of DFI token and for receiving tokens in case of DFC/EXT order"},
-                            {"receivePubkey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Pubkey which can claim external HTLC in case of EXT/DFC order type"},
-                            {"expiry", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Number of blocks until the offer expires (Default: "
-                                + std::to_string(CICXMakeOffer::DEFAULT_EXPIRY) + " DFI blocks)"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_makeoffer", "'{\"orderTx\":\"<txid>\",\"amount\":\"10\","
-                                                        "\receiveAddress\":\"<address>\",}'")
-                        + HelpExampleCli("icx_makeoffer", "'{\"orderTx\":\"txid\",\"amount\":\"10\","
-                                                        "\"ownerAddress\":\"<address>\",\"receivePubkey\":\"<pubkey>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("icx_makeoffer",
+                                   "'{\"orderTx\":\"<txid>\",\"amount\":\"10\","
+                                   "\receiveAddress\":\"<address>\",}'") +
+                    HelpExampleCli("icx_makeoffer",
+                                   "'{\"orderTx\":\"txid\",\"amount\":\"10\","
+                                   "\"ownerAddress\":\"<address>\",\"receivePubkey\":\"<pubkey>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot make offer while still in Initial Block Download");
@@ -399,7 +464,7 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
                            "{\"orderTx\",\"amount\", \"receivePubkey|receiveAddress\"}");
     }
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXMakeOffer makeoffer;
 
@@ -430,19 +495,22 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
         LOCK(cs_main);
         auto order = pcustomcsview->GetICXOrderByCreationTx(makeoffer.orderTx);
         if (!order)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("orderTx (%s) does not exist",makeoffer.orderTx.GetHex()));
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("orderTx (%s) does not exist", makeoffer.orderTx.GetHex()));
 
-        if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-        {
+        if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
             if (!metaObj["receivePubkey"].isNull())
                 makeoffer.receivePubkey = PublickeyFromString(trim_ws(metaObj["receivePubkey"].getValStr()));
             else
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"receivePubkey\" must be non-null");
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   "Invalid parameters, argument \"receivePubkey\" must be non-null");
 
-            CTokenAmount balance = pcustomcsview->GetBalance(makeoffer.ownerAddress,order->idToken);
+            CTokenAmount balance = pcustomcsview->GetBalance(makeoffer.ownerAddress, order->idToken);
             if (balance.nValue < makeoffer.amount)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Not enough balance for Token %s on address %s!",
-                        pcustomcsview->GetToken(order->idToken)->CreateSymbolKey(order->idToken), ScriptToString(makeoffer.ownerAddress)));
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   strprintf("Not enough balance for Token %s on address %s!",
+                                             pcustomcsview->GetToken(order->idToken)->CreateSymbolKey(order->idToken),
+                                             ScriptToString(makeoffer.ownerAddress)));
         }
 
         targetHeight = ::ChainActive().Height() + 1;
@@ -454,8 +522,7 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXMakeOffer)
-             << makeoffer;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXMakeOffer) << makeoffer;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -477,56 +544,74 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
     if (IsValidDestination(dest))
         coinControl.destChange = dest;
 
-    fund(rawTx, pwallet, optAuthTx,&coinControl);
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
 
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
+UniValue icxsubmitdfchtlc(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_submitdfchtlc",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a dfc htlc transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_submitdfchtlc",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a dfc htlc transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "htlc",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
                 {
-                    {"htlc", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of offer tx for which the htlc is"},
+                    {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount in htlc"},
+                    {"hash", RPCArg::Type::STR, RPCArg::Optional::NO, "Hash of seed used for the hash lock part"},
+                    {"timeout",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Timeout (absolute in blocks) for expiration of htlc in DFI blocks"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of offer tx for which the htlc is"},
-                            {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount in htlc"},
-                            {"hash", RPCArg::Type::STR, RPCArg::Optional::NO, "Hash of seed used for the hash lock part"},
-                            {"timeout", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Timeout (absolute in blocks) for expiration of htlc in DFI blocks"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_submitdfchtlc", "'{\"offerTx\":\"<txid>\",\"amount\":\"10\","
-                                                        "\"receiveAddress\":\"<address>\",\"hash\":\"<hash>\",\"timeout\":\"50\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("icx_submitdfchtlc",
+                                   "'{\"offerTx\":\"<txid>\",\"amount\":\"10\","
+                                   "\"receiveAddress\":\"<address>\",\"hash\":\"<hash>\",\"timeout\":\"50\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot submit dfc htlc while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot submit dfc htlc while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -537,24 +622,24 @@ UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
                            "{\"offerTx\",\"amount\",\"receiverAddress\",\"hash\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXSubmitDFCHTLC submitdfchtlc;
 
     if (!metaObj["offerTx"].isNull())
         submitdfchtlc.offerTx = uint256S(metaObj["offerTx"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"offerTx\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"offerTx\" must be non-null");
 
     if (!metaObj["amount"].isNull())
         submitdfchtlc.amount = AmountFromValue(metaObj["amount"]);
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amount\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"amount\" must be non-null");
 
     if (!metaObj["hash"].isNull())
         submitdfchtlc.hash = uint256S(metaObj["hash"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"hash\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"hash\" must be non-null");
 
     if (!metaObj["timeout"].isNull())
         submitdfchtlc.timeout = metaObj["timeout"].get_int();
@@ -568,36 +653,40 @@ UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
 
         auto offer = pcustomcsview->GetICXMakeOfferByCreationTx(submitdfchtlc.offerTx);
         if (!offer)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("offerTx (%s) does not exist",submitdfchtlc.offerTx.GetHex()));
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("offerTx (%s) does not exist", submitdfchtlc.offerTx.GetHex()));
 
         auto order = pcustomcsview->GetICXOrderByCreationTx(offer->orderTx);
         if (!order)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("orderTx (%s) does not exist",offer->orderTx.GetHex()));
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("orderTx (%s) does not exist", offer->orderTx.GetHex()));
 
-        if (order->orderType == CICXOrder::TYPE_INTERNAL)
-        {
+        if (order->orderType == CICXOrder::TYPE_INTERNAL) {
             authScript = order->ownerAddress;
 
             if (!submitdfchtlc.timeout)
-                submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
-        }
-        else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-        {
+                submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight)
+                                            ? CICXSubmitDFCHTLC::MINIMUM_TIMEOUT
+                                            : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
+        } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
             authScript = offer->ownerAddress;
 
             if (!submitdfchtlc.timeout)
-            submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
+                submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight)
+                                            ? CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT
+                                            : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
 
-            CTokenAmount balance = pcustomcsview->GetBalance(offer->ownerAddress,order->idToken);
+            CTokenAmount balance = pcustomcsview->GetBalance(offer->ownerAddress, order->idToken);
             if (balance.nValue < offer->amount)
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Not enough balance for Token %s on address %s!",
-                        pcustomcsview->GetToken(order->idToken)->CreateSymbolKey(order->idToken), ScriptToString(offer->ownerAddress)));
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   strprintf("Not enough balance for Token %s on address %s!",
+                                             pcustomcsview->GetToken(order->idToken)->CreateSymbolKey(order->idToken),
+                                             ScriptToString(offer->ownerAddress)));
         }
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXSubmitDFCHTLC)
-             << submitdfchtlc;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXSubmitDFCHTLC) << submitdfchtlc;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -625,53 +714,74 @@ UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxsubmitexthtlc(const JSONRPCRequest& request) {
+UniValue icxsubmitexthtlc(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_submitexthtlc",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) ext htlc transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_submitexthtlc",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) ext htlc transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "htlc",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
                 {
-                    {"htlc", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of offer tx for which the htlc is"},
+                    {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount in htlc"},
+                    {"htlcScriptAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Script address of external htlc"},
+                    {"hash", RPCArg::Type::STR, RPCArg::Optional::NO, "Hash of seed used for the hash lock part"},
+                    {"ownerPubkey",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Pubkey of the owner to which the funds are refunded if HTLC timeouts"},
+                    {"timeout",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::NO,
+                     "Timeout (absolute in block) for expiration of external htlc in external chain blocks"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of offer tx for which the htlc is"},
-                            {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "Amount in htlc"},
-                            {"htlcScriptAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Script address of external htlc"},
-                            {"hash", RPCArg::Type::STR, RPCArg::Optional::NO, "Hash of seed used for the hash lock part"},
-                            {"ownerPubkey", RPCArg::Type::STR, RPCArg::Optional::NO, "Pubkey of the owner to which the funds are refunded if HTLC timeouts"},
-                            {"timeout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Timeout (absolute in block) for expiration of external htlc in external chain blocks"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_submitexthtlc", "'{\"offerTx\":\"<txid>\",\"amount\":\"1\""
-                                                        "\"htlcScriptAddress\":\"<script_address>\",\"hash\":\"<hash>\""
-                                                        "\"ownerPubkey\":\"<pubkey>\",\"timeout\":\"20\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("icx_submitexthtlc",
+                                   "'{\"offerTx\":\"<txid>\",\"amount\":\"1\""
+                                   "\"htlcScriptAddress\":\"<script_address>\",\"hash\":\"<hash>\""
+                                   "\"ownerPubkey\":\"<pubkey>\",\"timeout\":\"20\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot submit ext htlc while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot submit ext htlc while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -682,39 +792,40 @@ UniValue icxsubmitexthtlc(const JSONRPCRequest& request) {
                            "{\"offerTx\",\"amount\",\"htlcScriptAddress\",\"hash\",\"refundPubkey\",\"timeout\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXSubmitEXTHTLC submitexthtlc;
 
     if (!metaObj["offerTx"].isNull())
         submitexthtlc.offerTx = uint256S(metaObj["offerTx"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"offerTx\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"offerTx\" must be non-null");
 
     if (!metaObj["amount"].isNull())
         submitexthtlc.amount = AmountFromValue(metaObj["amount"]);
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amount\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"amount\" must be non-null");
 
     if (!metaObj["hash"].isNull())
         submitexthtlc.hash = uint256S(metaObj["hash"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"hash\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"hash\" must be non-null");
 
     if (!metaObj["htlcScriptAddress"].isNull())
         submitexthtlc.htlcscriptAddress = trim_ws(metaObj["htlcScriptAddress"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"htlcScriptAddress\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, argument \"htlcScriptAddress\" must be non-null");
 
     if (!metaObj["ownerPubkey"].isNull())
         submitexthtlc.ownerPubkey = PublickeyFromString(metaObj["ownerPubkey"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"ownerPubkey\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"ownerPubkey\" must be non-null");
 
     if (!metaObj["timeout"].isNull())
         submitexthtlc.timeout = metaObj["timeout"].get_int();
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"timeout\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"timeout\" must be non-null");
 
     int targetHeight;
     CScript authScript;
@@ -725,25 +836,23 @@ UniValue icxsubmitexthtlc(const JSONRPCRequest& request) {
 
         auto offer = pcustomcsview->GetICXMakeOfferByCreationTx(submitexthtlc.offerTx);
         if (!offer)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("offerTx (%s) does not exist",submitexthtlc.offerTx.GetHex()));\
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("offerTx (%s) does not exist", submitexthtlc.offerTx.GetHex()));
 
         auto order = pcustomcsview->GetICXOrderByCreationTx(offer->orderTx);
         if (!order)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("orderTx (%s) does not exist",offer->orderTx.GetHex()));
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("orderTx (%s) does not exist", offer->orderTx.GetHex()));
 
-        if (order->orderType == CICXOrder::TYPE_INTERNAL)
-        {
+        if (order->orderType == CICXOrder::TYPE_INTERNAL) {
             authScript = offer->ownerAddress;
-        }
-        else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
-        {
+        } else if (order->orderType == CICXOrder::TYPE_EXTERNAL) {
             authScript = order->ownerAddress;
         }
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXSubmitEXTHTLC)
-             << submitexthtlc;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXSubmitEXTHTLC) << submitexthtlc;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -767,53 +876,70 @@ UniValue icxsubmitexthtlc(const JSONRPCRequest& request) {
             coinControl.destChange = dest;
     }
 
-    fund(rawTx, pwallet, optAuthTx,&coinControl);
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
 
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxclaimdfchtlc(const JSONRPCRequest& request) {
+UniValue icxclaimdfchtlc(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_claimdfchtlc",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a dfc htlc transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_claimdfchtlc",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCreates (and submits to local node and network) a dfc htlc transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "htlc",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
                 {
-                    {"htlc", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                    {"dfchtlcTx",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Txid of dfc htlc tx for which the claim is"},
+                    {"seed", RPCArg::Type::STR, RPCArg::Optional::NO, "Secret seed for claiming htlc"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"dfchtlcTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of dfc htlc tx for which the claim is"},
-                            {"seed", RPCArg::Type::STR, RPCArg::Optional::NO, "Secret seed for claiming htlc"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_claimdfchtlc", "'{\"dfchtlcTx\":\"<txid>>\",\"seed\":\"<seed>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("icx_claimdfchtlc", "'{\"dfchtlcTx\":\"<txid>>\",\"seed\":\"<seed>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot claim dfc htlc while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot claim dfc htlc while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -824,19 +950,19 @@ UniValue icxclaimdfchtlc(const JSONRPCRequest& request) {
                            "{\"dfchtlcTx\",\"receiverAddress\",\"seed\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXClaimDFCHTLC claimdfchtlc;
 
     if (!metaObj["dfchtlcTx"].isNull())
         claimdfchtlc.dfchtlcTx = uint256S(metaObj["dfchtlcTx"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"dfchtlcTx\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"dfchtlcTx\" must be non-null");
 
     if (!metaObj["seed"].isNull())
         claimdfchtlc.seed = ParseHex(metaObj["seed"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"seed\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"seed\" must be non-null");
 
     int targetHeight;
     {
@@ -846,8 +972,7 @@ UniValue icxclaimdfchtlc(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXClaimDFCHTLC)
-             << claimdfchtlc;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXClaimDFCHTLC) << claimdfchtlc;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -875,40 +1000,49 @@ UniValue icxclaimdfchtlc(const JSONRPCRequest& request) {
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxcloseorder(const JSONRPCRequest& request) {
+UniValue icxcloseorder(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_closeorder",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCloses (and submits to local node and network) order transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_closeorder",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCloses (and submits to local node and network) order transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of order"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
                 {
-                    {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of order"},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
+            },
+        },
 
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("closeorder", "'{\"orderTx\":\"<txid>>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("closeorder", "'{\"orderTx\":\"<txid>>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot close order while still in Initial Block Download");
@@ -920,7 +1054,7 @@ UniValue icxcloseorder(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
                            "Invalid parameters, arguments 1 must be non-null and expected as \"orderTx\"}");
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXCloseOrder closeorder;
     closeorder.orderTx = uint256S(request.params[0].getValStr());
@@ -936,14 +1070,14 @@ UniValue icxcloseorder(const JSONRPCRequest& request) {
         authScript = order->ownerAddress;
 
         if (!order->closeTx.IsNull())
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"orderTx (" + closeorder.orderTx.GetHex() + " is already closed!");
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "orderTx (" + closeorder.orderTx.GetHex() + " is already closed!");
 
         targetHeight = ::ChainActive().Height() + 1;
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXCloseOrder)
-             << closeorder;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXCloseOrder) << closeorder;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -965,46 +1099,55 @@ UniValue icxcloseorder(const JSONRPCRequest& request) {
     if (IsValidDestination(dest))
         coinControl.destChange = dest;
 
-    fund(rawTx, pwallet, optAuthTx,&coinControl);
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
 
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxcloseoffer(const JSONRPCRequest& request) {
+UniValue icxcloseoffer(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"icx_closeoffer",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nCloses (and submits to local node and network) offer transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "icx_closeoffer",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nCloses (and submits to local node and network) offer transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of makeoffer"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
                 {
-                    {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of makeoffer"},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
+            },
+        },
 
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("closeOffer", "'{\"offerTx\":\"<txid>>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("closeOffer", "'{\"offerTx\":\"<txid>>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot close offer while still in Initial Block Download");
@@ -1016,7 +1159,7 @@ UniValue icxcloseoffer(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
                            "Invalid parameters, arguments 1 must be non-null and expected as \"offerTx\"}");
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CICXCloseOffer closeoffer;
     closeoffer.offerTx = uint256S(request.params[0].getValStr());
@@ -1033,14 +1176,14 @@ UniValue icxcloseoffer(const JSONRPCRequest& request) {
         authScript = offer->ownerAddress;
 
         if (!offer->closeTx.IsNull())
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"OfferTx (" + closeoffer.offerTx.GetHex() + " is already closed!");
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "OfferTx (" + closeoffer.offerTx.GetHex() + " is already closed!");
 
         targetHeight = ::ChainActive().Height() + 1;
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::ICXCloseOffer)
-             << closeoffer;
+    metadata << static_cast<unsigned char>(CustomTxType::ICXCloseOffer) << closeoffer;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -1062,32 +1205,33 @@ UniValue icxcloseoffer(const JSONRPCRequest& request) {
     if (IsValidDestination(dest))
         coinControl.destChange = dest;
 
-    fund(rawTx, pwallet, optAuthTx,&coinControl);
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
 
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
     ret.pushKV("txid", signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex());
     return ret;
 }
 
-UniValue icxgetorder(const JSONRPCRequest& request) {
-    RPCHelpMan{"icx_getorder",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nReturn information about order or fillorder.\n",
-                {
-                    {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of createorder or fulfillorder tx"},
-                },
-                RPCResult
-                {
-                    "{...}     (object) Json object with order information\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("icx_getorder", "'{\"orderTx\":\"<txid>>\"}'")
-                    + "\EXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                },
-     }.Check(request);
+UniValue icxgetorder(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "icx_getorder",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nReturn information about order or fillorder.\n",
+        {
+            {"orderTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Txid of createorder or fulfillorder tx"},
+        },
+        RPCResult{"{...}     (object) Json object with order information\n"},
+        RPCExamples{HelpExampleCli("icx_getorder", "'{\"orderTx\":\"<txid>>\"}'") +
+                    "\EXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR}, false);
     if (request.params[0].isNull())
@@ -1095,23 +1239,23 @@ UniValue icxgetorder(const JSONRPCRequest& request) {
                            "Invalid parameters, arguments 1 must be non-null and expected as \"orderTx\"}");
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("EXPERIMENTAL warning:", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "EXPERIMENTAL warning:",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
 
     LOCK(cs_main);
 
-    uint256 orderTxid= uint256S(request.params[0].getValStr());
+    uint256 orderTxid = uint256S(request.params[0].getValStr());
     auto order = pcustomcsview->GetICXOrderByCreationTx(orderTxid);
-    if (order)
-    {
-        auto status = pcustomcsview->GetICXOrderStatus({order->idToken,order->creationTx});
+    if (order) {
+        auto status = pcustomcsview->GetICXOrderStatus({order->idToken, order->creationTx});
         ret.pushKVs(icxOrderToJSON(*order, status));
         return ret;
     }
 
     auto fillorder = pcustomcsview->GetICXMakeOfferByCreationTx(orderTxid);
-    if (fillorder)
-    {
-        auto status = pcustomcsview->GetICXMakeOfferStatus({fillorder->orderTx,fillorder->creationTx});
+    if (fillorder) {
+        auto status = pcustomcsview->GetICXMakeOfferStatus({fillorder->orderTx, fillorder->creationTx});
         ret.pushKVs(icxMakeOfferToJSON(*fillorder, status));
         return ret;
     }
@@ -1119,32 +1263,40 @@ UniValue icxgetorder(const JSONRPCRequest& request) {
     throw JSONRPCError(RPC_INVALID_PARAMETER, "orderTx (" + orderTxid.GetHex() + ") does not exist");
 }
 
-UniValue icxlistorders(const JSONRPCRequest& request) {
-    RPCHelpMan{"icx_listorders",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nReturn information about orders.\n",
+UniValue icxlistorders(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "icx_listorders",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nReturn information about orders.\n",
+        {
+            {
+                "by",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
                 {
-                        {"by", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                            {
-                                {"token",  RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Token asset"},
-                                {"chain",  RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Chain asset"},
-                                {"orderTx",RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Order txid to list all offers for this order"},
-                                {"limit",  RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum number of orders to return (default: 50)"},
-                                {"closed", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display closed orders (default: false)"},
-                            },
-                        },
+                    {"token", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Token asset"},
+                    {"chain", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Chain asset"},
+                    {"orderTx",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Order txid to list all offers for this order"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of orders to return (default: 50)"},
+                    {"closed", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display closed orders (default: false)"},
                 },
-                RPCResult
-                {
-                        "{{...},...}     (array) Json object with orders information\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_listorders", "'{\"limit\":\"10\"}'")
-                        + HelpExampleCli("icx_listorders", "'{\"token\":\"GOLD#128\",\"chain\":\"BTC\"}'")
-                        + HelpExampleCli("icx_listorders", "'{\"chain\":\"BTC\",\"token\":\"SILVER#129\",\"closed\":true}'")
-                        + HelpExampleCli("icx_listorders", "'{\"orderTx\":\"<txid>>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
-                }
-     }.Check(request);
+            },
+        },
+        RPCResult{"{{...},...}     (array) Json object with orders information\n"},
+        RPCExamples{HelpExampleCli("icx_listorders", "'{\"limit\":\"10\"}'") +
+                    HelpExampleCli("icx_listorders", "'{\"token\":\"GOLD#128\",\"chain\":\"BTC\"}'") +
+                    HelpExampleCli("icx_listorders", "'{\"chain\":\"BTC\",\"token\":\"SILVER#129\",\"closed\":true}'") +
+                    HelpExampleCli("icx_listorders", "'{\"orderTx\":\"<txid>>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"}}
+        .Check(request);
 
     size_t limit = 50;
     std::string tokenSymbol, chain;
@@ -1152,44 +1304,45 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
     bool closed = false, offers = false;
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
-    if (request.params.size() > 0)
-    {
+    if (request.params.size() > 0) {
         UniValue byObj = request.params[0].get_obj();
-        if (!byObj["token"].isNull()) tokenSymbol = trim_ws(byObj["token"].getValStr());
-        if (!byObj["chain"].isNull()) chain = trim_ws(byObj["chain"].getValStr());
-        if (!byObj["orderTx"].isNull())
-        {
+        if (!byObj["token"].isNull())
+            tokenSymbol = trim_ws(byObj["token"].getValStr());
+        if (!byObj["chain"].isNull())
+            chain = trim_ws(byObj["chain"].getValStr());
+        if (!byObj["orderTx"].isNull()) {
             orderTxid = uint256S(byObj["orderTx"].getValStr());
             offers = true;
         }
-        if (!byObj["limit"].isNull()) limit = (size_t) byObj["limit"].get_int64();
-        if (!byObj["closed"].isNull()) closed = byObj["closed"].get_bool();
+        if (!byObj["limit"].isNull())
+            limit = (size_t)byObj["limit"].get_int64();
+        if (!byObj["closed"].isNull())
+            closed = byObj["closed"].get_bool();
     }
 
     DCT_ID idToken = {std::numeric_limits<uint32_t>::max()};
-    if (!tokenSymbol.empty() && !chain.empty())
-    {
+    if (!tokenSymbol.empty() && !chain.empty()) {
         auto token1 = pcustomcsview->GetTokenGuessId(tokenSymbol, idToken);
         if (!token1)
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenSymbol));
     }
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
 
     LOCK(cs_main);
 
-    if (idToken.v != std::numeric_limits<uint32_t>::max())
-    {
+    if (idToken.v != std::numeric_limits<uint32_t>::max()) {
         DCT_ID prefix;
         prefix = idToken;
 
-        auto orderkeylambda = [&](CICXOrderView::OrderKey const & key, uint8_t status) {
+        auto orderkeylambda = [&](CICXOrderView::OrderKey const &key, uint8_t status) {
             if (key.first != prefix || !limit)
                 return (false);
             auto order = pcustomcsview->GetICXOrderByCreationTx(key.second);
-            if (order)
-            {
+            if (order) {
                 ret.pushKVs(icxOrderToJSON(*order, status));
                 limit--;
             }
@@ -1202,15 +1355,12 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
             pcustomcsview->ForEachICXOrderOpen(orderkeylambda, prefix);
 
         return ret;
-    }
-    else if (offers)
-    {
-        auto offerkeylambda = [&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
+    } else if (offers) {
+        auto offerkeylambda = [&](CICXOrderView::TxidPairKey const &key, uint8_t status) {
             if (key.first != orderTxid || !limit)
                 return (false);
             auto offer = pcustomcsview->GetICXMakeOfferByCreationTx(key.second);
-            if (offer)
-            {
+            if (offer) {
                 ret.pushKVs(icxMakeOfferToJSON(*offer, status));
                 limit--;
             }
@@ -1224,12 +1374,11 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
         return ret;
     }
 
-    auto orderlambda = [&](CICXOrderView::OrderKey const & key, uint8_t status) {
+    auto orderlambda = [&](CICXOrderView::OrderKey const &key, uint8_t status) {
         if (!limit)
             return false;
         auto order = pcustomcsview->GetICXOrderByCreationTx(key.second);
-        if (order)
-        {
+        if (order) {
             ret.pushKVs(icxOrderToJSON(*order, status));
             limit--;
         }
@@ -1244,29 +1393,38 @@ UniValue icxlistorders(const JSONRPCRequest& request) {
     return ret;
 }
 
-UniValue icxlisthtlcs(const JSONRPCRequest& request) {
-    RPCHelpMan{"icx_listhtlcs",
-                "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n\nReturn information about orders.\n",
+UniValue icxlisthtlcs(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "icx_listhtlcs",
+        "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. "
+        "USE IT AT YOUR OWN RISK.\n\nReturn information about orders.\n",
+        {
+            {
+                "by",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                        {"by", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
-                            {
-                                {"offerTx",RPCArg::Type::STR, RPCArg::Optional::NO, "Offer txid  for which to list all HTLCS"},
-                                {"limit",  RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum number of orders to return (default: 20)"},
-                                {"closed",  RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Display also claimed, expired and refunded HTLCs (default: false)"},
+                    {"offerTx", RPCArg::Type::STR, RPCArg::Optional::NO, "Offer txid  for which to list all HTLCS"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of orders to return (default: 20)"},
+                    {"closed",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Display also claimed, expired and refunded HTLCs (default: false)"},
 
-                            },
-                        },
                 },
-                RPCResult
-                {
-                        "{{...},...}     (array) Json object with orders information\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("icx_listorders", "'{\"offerTx\":\"<txid>\"}'")
-                        + "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.\n"
+            },
+        },
+        RPCResult{"{{...},...}     (array) Json object with orders information\n"},
+        RPCExamples{HelpExampleCli("icx_listorders", "'{\"offerTx\":\"<txid>\"}'") +
+                    "\nEXPERIMENTAL warning: ICX and Atomic Swap are experimental features. You might end up losing "
+                    "your funds. USE IT AT YOUR OWN RISK.\n"
 
-                }
-     }.Check(request);
+        }}
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VOBJ}, false);
     if (request.params[0].isNull())
@@ -1282,52 +1440,53 @@ UniValue icxlisthtlcs(const JSONRPCRequest& request) {
     if (!byObj["offerTx"].isNull())
         offerTxid = uint256S(byObj["offerTx"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"offerTx\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"offerTx\" must be non-null");
 
     if (!byObj["closed"].isNull())
         closed = byObj["closed"].get_bool();
     if (!byObj["limit"].isNull())
-        limit = (size_t) byObj["limit"].get_int64();
+        limit = (size_t)byObj["limit"].get_int64();
 
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("WARNING", "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
+    ret.pushKV(
+        "WARNING",
+        "ICX and Atomic Swap are experimental features. You might end up losing your funds. USE IT AT YOUR OWN RISK.");
 
     LOCK(cs_main);
 
-    auto dfchtlclambda = [&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
+    auto dfchtlclambda = [&](CICXOrderView::TxidPairKey const &key, uint8_t status) {
         if (key.first != offerTxid || !limit)
             return false;
         auto dfchtlc = pcustomcsview->GetICXSubmitDFCHTLCByCreationTx(key.second);
-        if (dfchtlc)
-        {
-            ret.pushKVs(icxSubmitDFCHTLCToJSON(*dfchtlc,status));
+        if (dfchtlc) {
+            ret.pushKVs(icxSubmitDFCHTLCToJSON(*dfchtlc, status));
             limit--;
         }
         return true;
     };
-    auto exthtlclambda = [&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
+    auto exthtlclambda = [&](CICXOrderView::TxidPairKey const &key, uint8_t status) {
         if (key.first != offerTxid || !limit)
             return false;
         auto exthtlc = pcustomcsview->GetICXSubmitEXTHTLCByCreationTx(key.second);
-        if (exthtlc)
-        {
+        if (exthtlc) {
             ret.pushKVs(icxSubmitEXTHTLCToJSON(*exthtlc, status));
             limit--;
         }
         return true;
     };
 
-    pcustomcsview->ForEachICXClaimDFCHTLC([&](CICXOrderView::TxidPairKey const & key, uint8_t status) {
-        if (key.first != offerTxid || !limit)
-            return false;
-        auto claimdfchtlc = pcustomcsview->GetICXClaimDFCHTLCByCreationTx(key.second);
-        if (claimdfchtlc)
-        {
-            ret.pushKVs(icxClaimDFCHTLCToJSON(*claimdfchtlc));
-            limit--;
-        }
-        return true;
-    }, offerTxid);
+    pcustomcsview->ForEachICXClaimDFCHTLC(
+        [&](CICXOrderView::TxidPairKey const &key, uint8_t status) {
+            if (key.first != offerTxid || !limit)
+                return false;
+            auto claimdfchtlc = pcustomcsview->GetICXClaimDFCHTLCByCreationTx(key.second);
+            if (claimdfchtlc) {
+                ret.pushKVs(icxClaimDFCHTLCToJSON(*claimdfchtlc));
+                limit--;
+            }
+            return true;
+        },
+        offerTxid);
 
     if (closed)
         pcustomcsview->ForEachICXSubmitDFCHTLCClose(dfchtlclambda, offerTxid);
@@ -1340,24 +1499,23 @@ UniValue icxlisthtlcs(const JSONRPCRequest& request) {
     return ret;
 }
 
-static const CRPCCommand commands[] =
-{
-//  category        name                         actor (function)        params
-//  --------------- ----------------------       ---------------------   ----------
-    {"icxorderbook",   "icx_createorder",        &icxcreateorder,        {"order", "inputs"}},
-    {"icxorderbook",   "icx_makeoffer",          &icxmakeoffer,          {"offer", "inputs"}},
-    {"icxorderbook",   "icx_closeoffer",         &icxcloseoffer,         {"offerTx", "inputs"}},
-    {"icxorderbook",   "icx_submitdfchtlc",      &icxsubmitdfchtlc,      {"dfchtlc", "inputs"}},
-    {"icxorderbook",   "icx_submitexthtlc",      &icxsubmitexthtlc,      {"exthtlc", "inputs"}},
-    {"icxorderbook",   "icx_claimdfchtlc",       &icxclaimdfchtlc,       {"claim", "inputs"}},
-    {"icxorderbook",   "icx_closeorder",         &icxcloseorder,         {"orderTx", "inputs"}},
-    {"icxorderbook",   "icx_getorder",           &icxgetorder,           {"orderTx"}},
-    {"icxorderbook",   "icx_listorders",         &icxlistorders,         {"by"}},
-    {"icxorderbook",   "icx_listhtlcs",          &icxlisthtlcs,          {"by"}},
+static const CRPCCommand commands[] = {
+    //  category        name                         actor (function)        params
+    //  --------------- ----------------------       ---------------------   ----------
+    {"icxorderbook", "icx_createorder", &icxcreateorder, {"order", "inputs"}},
+    {"icxorderbook", "icx_makeoffer", &icxmakeoffer, {"offer", "inputs"}},
+    {"icxorderbook", "icx_closeoffer", &icxcloseoffer, {"offerTx", "inputs"}},
+    {"icxorderbook", "icx_submitdfchtlc", &icxsubmitdfchtlc, {"dfchtlc", "inputs"}},
+    {"icxorderbook", "icx_submitexthtlc", &icxsubmitexthtlc, {"exthtlc", "inputs"}},
+    {"icxorderbook", "icx_claimdfchtlc", &icxclaimdfchtlc, {"claim", "inputs"}},
+    {"icxorderbook", "icx_closeorder", &icxcloseorder, {"orderTx", "inputs"}},
+    {"icxorderbook", "icx_getorder", &icxgetorder, {"orderTx"}},
+    {"icxorderbook", "icx_listorders", &icxlistorders, {"by"}},
+    {"icxorderbook", "icx_listhtlcs", &icxlisthtlcs, {"by"}},
 
 };
 
-void RegisterICXOrderbookRPCCommands(CRPCTable& tableRPC) {
+void RegisterICXOrderbookRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -1674,10 +1674,8 @@ static const CRPCCommand commands[] = {
     {"loan", "listloantokens", &listloantokens, {}},
     {"loan", "getloantoken", &getloantoken, {"by"}},
     {"loan", "createloanscheme", &createloanscheme, {"mincolratio", "interestrate", "id", "inputs"}},
-    {"loan",
-     "updateloanscheme",
-     &updateloanscheme,
-     {"mincolratio", "interestrate", "id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
+    // clang-format off
+    {"loan", "updateloanscheme", &updateloanscheme, {"mincolratio", "interestrate", "id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
     {"loan", "setdefaultloanscheme", &setdefaultloanscheme, {"id", "inputs"}},
     {"loan", "destroyloanscheme", &destroyloanscheme, {"id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
     {"loan", "listloanschemes", &listloanschemes, {}},

--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -1,12 +1,11 @@
-#include <masternodes/mn_rpc.h>
 #include <masternodes/govvariables/attributes.h>
+#include <masternodes/mn_rpc.h>
 #include <boost/asio.hpp>
 
-extern UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose);
+extern UniValue tokenToJSON(CCustomCSView &view, DCT_ID const &id, CTokenImplementation const &token, bool verbose);
 extern std::pair<int, int> GetFixedIntervalPriceBlocks(int currentHeight, const CCustomCSView &mnview);
 
-UniValue setCollateralTokenToJSON(CCustomCSView& view, CLoanSetCollateralTokenImplementation const& collToken)
-{
+UniValue setCollateralTokenToJSON(CCustomCSView &view, CLoanSetCollateralTokenImplementation const &collToken) {
     UniValue collTokenObj(UniValue::VOBJ);
 
     auto token = view.GetToken(collToken.idToken);
@@ -15,15 +14,15 @@ UniValue setCollateralTokenToJSON(CCustomCSView& view, CLoanSetCollateralTokenIm
     collTokenObj.pushKV("token", token->CreateSymbolKey(collToken.idToken));
     collTokenObj.pushKV("tokenId", collToken.creationTx.GetHex());
     collTokenObj.pushKV("factor", ValueFromAmount(collToken.factor));
-    collTokenObj.pushKV("fixedIntervalPriceId", collToken.fixedIntervalPriceId.first + "/" + collToken.fixedIntervalPriceId.second);
+    collTokenObj.pushKV("fixedIntervalPriceId",
+                        collToken.fixedIntervalPriceId.first + "/" + collToken.fixedIntervalPriceId.second);
     if (collToken.activateAfterBlock)
         collTokenObj.pushKV("activateAfterBlock", static_cast<int>(collToken.activateAfterBlock));
 
     return (collTokenObj);
 }
 
-UniValue setLoanTokenToJSON(CCustomCSView& view, CLoanSetLoanTokenImplementation const& loanToken, DCT_ID tokenId)
-{
+UniValue setLoanTokenToJSON(CCustomCSView &view, CLoanSetLoanTokenImplementation const &loanToken, DCT_ID tokenId) {
     UniValue loanTokenObj(UniValue::VOBJ);
 
     auto token = view.GetToken(tokenId);
@@ -31,14 +30,15 @@ UniValue setLoanTokenToJSON(CCustomCSView& view, CLoanSetLoanTokenImplementation
         return (UniValue::VNULL);
 
     loanTokenObj.pushKV("token", tokenToJSON(view, tokenId, *token, true));
-    loanTokenObj.pushKV("fixedIntervalPriceId", loanToken.fixedIntervalPriceId.first + "/" + loanToken.fixedIntervalPriceId.second);
+    loanTokenObj.pushKV("fixedIntervalPriceId",
+                        loanToken.fixedIntervalPriceId.first + "/" + loanToken.fixedIntervalPriceId.second);
     loanTokenObj.pushKV("interest", ValueFromAmount(loanToken.interest));
     loanTokenObj.pushKV("mintable", loanToken.mintable);
 
     return (loanTokenObj);
 }
 
-CTokenCurrencyPair DecodePriceFeedString(const std::string& value){
+CTokenCurrencyPair DecodePriceFeedString(const std::string &value) {
     auto delim = value.find('/');
     if (delim == value.npos || value.find('/', delim + 1) != value.npos)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "price feed not in valid format - token/currency!");
@@ -52,53 +52,70 @@ CTokenCurrencyPair DecodePriceFeedString(const std::string& value){
     return std::make_pair(token, currency);
 }
 
-CTokenCurrencyPair DecodePriceFeedUni(const UniValue& value)
-{
+CTokenCurrencyPair DecodePriceFeedUni(const UniValue &value) {
     auto tokenCurrency = value["fixedIntervalPriceId"].getValStr();
 
     if (tokenCurrency.empty())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"fixedIntervalPriceId\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, argument \"fixedIntervalPriceId\" must be non-null");
 
     return DecodePriceFeedString(tokenCurrency);
 }
 
-UniValue setcollateraltoken(const JSONRPCRequest& request) {
+UniValue setcollateraltoken(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"setcollateraltoken",
-                "Creates (and submits to local node and network) a set colleteral token transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "setcollateraltoken",
+        "Creates (and submits to local node and network) a set colleteral token transaction.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+                    {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "Symbol or id of collateral token"},
+                    {"factor", RPCArg::Type::NUM, RPCArg::Optional::NO, "Collateralization factor"},
+                    {"fixedIntervalPriceId",
+                     RPCArg::Type::STR_HEX,
+                     RPCArg::Optional::NO,
+                     "token/currency pair to use for price of token"},
+                    {"activateAfterBlock",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "changes will be active after the block height (Optional)"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "Symbol or id of collateral token"},
-                            {"factor", RPCArg::Type::NUM, RPCArg::Optional::NO, "Collateralization factor"},
-                            {"fixedIntervalPriceId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "token/currency pair to use for price of token"},
-                            {"activateAfterBlock", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "changes will be active after the block height (Optional)"},
-                        },
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("setcollateraltoken", R"('{"token":"TSLA","factor":"150","fixedIntervalPriceId":"TSLA/USD"}')")
-                        },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("setcollateraltoken",
+                                   R"('{"token":"TSLA","factor":"150","fixedIntervalPriceId":"TSLA/USD"}')")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot setcollateraltoken while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot setcollateraltoken while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -109,7 +126,7 @@ UniValue setcollateraltoken(const JSONRPCRequest& request) {
                            "{\"token\",\"factor\",\"fixedIntervalPriceId\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     std::string tokenSymbol;
     CLoanSetCollateralToken collToken;
@@ -117,12 +134,12 @@ UniValue setcollateraltoken(const JSONRPCRequest& request) {
     if (!metaObj["token"].isNull())
         tokenSymbol = trim_ws(metaObj["token"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"token\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"token\" must not be null");
 
     if (!metaObj["factor"].isNull())
         collToken.factor = AmountFromValue(metaObj["factor"]);
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"factor\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"factor\" must not be null");
 
     collToken.fixedIntervalPriceId = DecodePriceFeedUni(metaObj);
 
@@ -144,8 +161,7 @@ UniValue setcollateraltoken(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::SetLoanCollateralToken)
-             << collToken;
+    metadata << static_cast<unsigned char>(CustomTxType::SetLoanCollateralToken) << collToken;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -175,27 +191,26 @@ UniValue setcollateraltoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue getcollateraltoken(const JSONRPCRequest& request) {
-    RPCHelpMan{"getcollateraltoken",
-                "Return collateral token information.\n",
-                {
-                    {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "Symbol or id of collateral token"},
-                },
-                RPCResult
-                {
-                    "{...}     (object) Json object with collateral token information\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("getcollateraltoken", "DFI")
-                },
-     }.Check(request);
+UniValue getcollateraltoken(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getcollateraltoken",
+        "Return collateral token information.\n",
+        {
+            {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "Symbol or id of collateral token"},
+        },
+        RPCResult{"{...}     (object) Json object with collateral token information\n"},
+        RPCExamples{HelpExampleCli("getcollateraltoken", "DFI")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR}, false);
     if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 1 must be non-null and expected as string for token symbol or id");
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
+            "Invalid parameters, arguments 1 must be non-null and expected as string for token symbol or id");
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     UniValue ret(UniValue::VOBJ);
     std::string tokenSymbol = request.params[0].get_str();
@@ -212,33 +227,30 @@ UniValue getcollateraltoken(const JSONRPCRequest& request) {
     CollateralTokenKey start{idToken, height};
 
     auto collToken = pcustomcsview->HasLoanCollateralToken(start);
-    if (collToken && collToken->factor)
-    {
+    if (collToken && collToken->factor) {
         ret.pushKVs(setCollateralTokenToJSON(*pcustomcsview, *collToken));
     }
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-
-UniValue listcollateraltokens(const JSONRPCRequest& request) {
-    RPCHelpMan{"listcollateraltokens",
-                "Return list of all created collateral tokens. If no parameters passed it will return all current valid setcollateraltoken transactions.\n",
-                {},
-                RPCResult
-                {
-                    "{...}     (object) Json object with collateral token information\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("listcollateraltokens", "")
-                },
-     }.Check(request);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+UniValue listcollateraltokens(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listcollateraltokens",
+        "Return list of all created collateral tokens. If no parameters passed it will return all current valid "
+        "setcollateraltoken transactions.\n",
+        {},
+        RPCResult{"{...}     (object) Json object with collateral token information\n"},
+        RPCExamples{HelpExampleCli("listcollateraltokens", "")},
+    }
+        .Check(request);
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     UniValue ret(UniValue::VARR);
     CCustomCSView view(*pcustomcsview);
 
-    view.ForEachLoanCollateralToken([&](CollateralTokenKey const & key, uint256 const & collTokenTx) {
+    view.ForEachLoanCollateralToken([&](CollateralTokenKey const &key, uint256 const &collTokenTx) {
         auto collToken = view.GetLoanCollateralToken(collTokenTx);
         if (collToken)
             ret.push_back(setCollateralTokenToJSON(view, *collToken));
@@ -255,56 +267,81 @@ UniValue listcollateraltokens(const JSONRPCRequest& request) {
         return ret;
     }
 
-    attributes->ForEach([&](const CDataStructureV0& attr, const CAttributeValue&) {
-        if (attr.type != AttributeTypes::Token) {
-            return false;
-        }
-        if (attr.key == TokenKeys::LoanCollateralEnabled) {
-            if (auto collToken = view.GetCollateralTokenFromAttributes({attr.typeId})) {
-                ret.push_back(setCollateralTokenToJSON(view, *collToken));
+    attributes->ForEach(
+        [&](const CDataStructureV0 &attr, const CAttributeValue &) {
+            if (attr.type != AttributeTypes::Token) {
+                return false;
             }
-        }
-        return true;
-    }, CDataStructureV0{AttributeTypes::Token});
+            if (attr.key == TokenKeys::LoanCollateralEnabled) {
+                if (auto collToken = view.GetCollateralTokenFromAttributes({attr.typeId})) {
+                    ret.push_back(setCollateralTokenToJSON(view, *collToken));
+                }
+            }
+            return true;
+        },
+        CDataStructureV0{AttributeTypes::Token});
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue setloantoken(const JSONRPCRequest& request) {
+UniValue setloantoken(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"setloantoken",
-                "Creates (and submits to local node and network) a token for a price feed set in collateral token.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "setloantoken",
+        "Creates (and submits to local node and network) a token for a price feed set in collateral token.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+                    {"symbol",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Token's symbol (unique), not longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Token's name (optional), not longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
+                    {"fixedIntervalPriceId",
+                     RPCArg::Type::STR_HEX,
+                     RPCArg::Optional::NO,
+                     "token/currency pair to use for price of token"},
+                    {"mintable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Mintable' property (bool, optional), default is 'True'"},
+                    {"interest", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Interest rate (default: 0)"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"symbol", RPCArg::Type::STR, RPCArg::Optional::NO, "Token's symbol (unique), not longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
-                            {"name", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Token's name (optional), not longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
-                            {"fixedIntervalPriceId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "token/currency pair to use for price of token"},
-                            {"mintable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Token's 'Mintable' property (bool, optional), default is 'True'"},
-                            {"interest", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Interest rate (default: 0)"},
-                        },
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("setloantoken", R"('{"symbol":"TSLA","name":"TSLA stock token","fixedIntervalPriceId":"TSLA/USD","interest":"3"}')")
-                        },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli(
+            "setloantoken",
+            R"('{"symbol":"TSLA","name":"TSLA stock token","fixedIntervalPriceId":"TSLA/USD","interest":"3"}')")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot setloantoken while still in Initial Block Download");
@@ -318,14 +355,14 @@ UniValue setloantoken(const JSONRPCRequest& request) {
                            "{\"token\",\"factor\",\"fixedIntervalPriceId\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CLoanSetLoanToken loanToken;
 
     if (!metaObj["symbol"].isNull())
         loanToken.symbol = trim_ws(metaObj["symbol"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"symbol\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"symbol\" must not be null");
 
     if (!metaObj["name"].isNull())
         loanToken.name = trim_ws(metaObj["name"].getValStr());
@@ -349,8 +386,7 @@ UniValue setloantoken(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::SetLoanToken)
-             << loanToken;
+    metadata << static_cast<unsigned char>(CustomTxType::SetLoanToken) << loanToken;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -380,46 +416,73 @@ UniValue setloantoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue updateloantoken(const JSONRPCRequest& request) {
+UniValue updateloantoken(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"updateloantoken",
-                "Creates (and submits to local node and network) a transaction to update loan token metadata.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "updateloantoken",
+        "Creates (and submits to local node and network) a transaction to update loan token metadata.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "The tokens's symbol, id or creation tx"},
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "The tokens's symbol, id or creation tx"},
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+                    {"symbol",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "New token's symbol (unique), not longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Newoken's name (optional), not longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
+                    {"fixedIntervalPriceId",
+                     RPCArg::Type::STR_HEX,
+                     RPCArg::Optional::OMITTED,
+                     "token/currency pair to use for price of token"},
+                    {"mintable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Mintable' property (bool, optional), default is 'True'"},
+                    {"interest", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Interest rate (optional)."},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"symbol", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "New token's symbol (unique), not longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
-                            {"name", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Newoken's name (optional), not longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
-                            {"fixedIntervalPriceId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "token/currency pair to use for price of token"},
-                            {"mintable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Token's 'Mintable' property (bool, optional), default is 'True'"},
-                            {"interest", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Interest rate (optional)."},
-                        },
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("updateloantoken", R"("TSLAAA", {"symbol":"TSLA","fixedIntervalPriceId":"TSLA/USD", "mintable": true, "interest": 0.03}')") +
-                        HelpExampleRpc("updateloantoken", R"("TSLAAA", {"symbol":"TSLA","fixedIntervalPriceId":"TSLA/USD", "mintable": true, "interest": 0.03})")
-                        },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli(
+                "updateloantoken",
+                R"("TSLAAA", {"symbol":"TSLA","fixedIntervalPriceId":"TSLA/USD", "mintable": true, "interest": 0.03}')") +
+            HelpExampleRpc(
+                "updateloantoken",
+                R"("TSLAAA", {"symbol":"TSLA","fixedIntervalPriceId":"TSLA/USD", "mintable": true, "interest": 0.03})")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot updateloantoken while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot updateloantoken while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -427,7 +490,7 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
 
     std::string const tokenStr = trim_ws(request.params[0].getValStr());
     UniValue metaObj = request.params[1].get_obj();
-    UniValue const & txInputs = request.params[2];
+    UniValue const &txInputs = request.params[2];
 
     std::optional<CLoanSetLoanTokenImplementation> loanToken;
     std::optional<CTokenImplementation> token;
@@ -442,7 +505,9 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenStr));
         }
         if (!token->IsLoanToken())
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s is not a loan token! Can't alter other tokens with this tx!", tokenStr));
+            throw JSONRPCError(
+                RPC_INVALID_PARAMETER,
+                strprintf("Token %s is not a loan token! Can't alter other tokens with this tx!", tokenStr));
         if (id == DCT_ID{0}) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't alter DFI token!"));
         }
@@ -470,8 +535,8 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
         loanToken->interest = AmountFromValue(metaObj["interest"]);
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::UpdateLoanToken)
-             << static_cast<CLoanSetLoanToken>(*loanToken) << token->creationTx;
+    metadata << static_cast<unsigned char>(CustomTxType::UpdateLoanToken) << static_cast<CLoanSetLoanToken>(*loanToken)
+             << token->creationTx;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -501,25 +566,23 @@ UniValue updateloantoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue listloantokens(const JSONRPCRequest& request) {
-    RPCHelpMan{"listloantokens",
-                "Return list of all created loan tokens.\n",
-                {},
-                RPCResult
-                {
-                    "{...}     (object) Json object with loan token information\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("listloantokens", "")
-                },
-     }.Check(request);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+UniValue listloantokens(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listloantokens",
+        "Return list of all created loan tokens.\n",
+        {},
+        RPCResult{"{...}     (object) Json object with loan token information\n"},
+        RPCExamples{HelpExampleCli("listloantokens", "")},
+    }
+        .Check(request);
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     UniValue ret(UniValue::VARR);
 
     CCustomCSView view(*pcustomcsview);
 
-    view.ForEachLoanToken([&](DCT_ID const & key, CLoanView::CLoanSetLoanTokenImpl loanToken) {
+    view.ForEachLoanToken([&](DCT_ID const &key, CLoanView::CLoanSetLoanTokenImpl loanToken) {
         ret.push_back(setLoanTokenToJSON(view, loanToken, key));
         return true;
     });
@@ -533,41 +596,42 @@ UniValue listloantokens(const JSONRPCRequest& request) {
         return ret;
     }
 
-    attributes->ForEach([&](const CDataStructureV0& attr, const CAttributeValue&) {
-        if (attr.type != AttributeTypes::Token) {
-            return false;
-        }
-        if (attr.key == TokenKeys::LoanMintingEnabled) {
-            auto tokenId = DCT_ID{attr.typeId};
-            if (auto loanToken = view.GetLoanTokenFromAttributes(tokenId)) {
-                ret.push_back(setLoanTokenToJSON(view, *loanToken, tokenId));
+    attributes->ForEach(
+        [&](const CDataStructureV0 &attr, const CAttributeValue &) {
+            if (attr.type != AttributeTypes::Token) {
+                return false;
             }
-        }
-        return true;
-    }, CDataStructureV0{AttributeTypes::Token});
+            if (attr.key == TokenKeys::LoanMintingEnabled) {
+                auto tokenId = DCT_ID{attr.typeId};
+                if (auto loanToken = view.GetLoanTokenFromAttributes(tokenId)) {
+                    ret.push_back(setLoanTokenToJSON(view, *loanToken, tokenId));
+                }
+            }
+            return true;
+        },
+        CDataStructureV0{AttributeTypes::Token});
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue getloantoken(const JSONRPCRequest& request)
-{
+UniValue getloantoken(const JSONRPCRequest &request) {
     RPCHelpMan{
         "getloantoken",
         "Return loan token information.\n",
         {
             {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "Symbol or id of loan token"},
         },
-        RPCResult{
-            "{...}     (object) Json object with loan token information\n"},
-        RPCExamples{
-            HelpExampleCli("getloantoken", "DFI")},
+        RPCResult{"{...}     (object) Json object with loan token information\n"},
+        RPCExamples{HelpExampleCli("getloantoken", "DFI")},
     }
         .Check(request);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     RPCTypeCheck(request.params, {UniValue::VSTR}, false);
     if (request.params[0].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
             "Invalid parameters, arguments 1 must be non-null and expected as string for token symbol or id");
 
     std::string tokenSymbol = request.params[0].get_str();
@@ -586,42 +650,46 @@ UniValue getloantoken(const JSONRPCRequest& request)
 
     auto res = setLoanTokenToJSON(*pcustomcsview, *loanToken, idToken);
     return GetRPCResultCache().Set(request, res);
-
 }
 
-UniValue createloanscheme(const JSONRPCRequest& request) {
+UniValue createloanscheme(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"createloanscheme",
-                "Creates a loan scheme transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "createloanscheme",
+        "Creates a loan scheme transaction.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"mincolratio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Minimum collateralization ratio (integer)."},
+            {"interestrate", RPCArg::Type::NUM, RPCArg::Optional::NO, "Interest rate (integer or float)."},
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
                 {
-                    {"mincolratio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Minimum collateralization ratio (integer)."},
-                    {"interestrate", RPCArg::Type::NUM, RPCArg::Optional::NO, "Interest rate (integer or float)."},
-                    {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                            {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                     {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                   "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                   HelpExampleCli("createloanscheme", "150 5 LOAN0001") +
-                   HelpExampleRpc("createloanscheme", "150, 5, LOAN0001")
-                },
-    }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("createloanscheme", "150 5 LOAN0001") +
+                    HelpExampleRpc("createloanscheme", "150, 5, LOAN0001")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot createloanscheme while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot createloanscheme while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -637,8 +705,7 @@ UniValue createloanscheme(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::LoanScheme)
-             << loanScheme;
+    metadata << static_cast<unsigned char>(CustomTxType::LoanScheme) << loanScheme;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -669,40 +736,48 @@ UniValue createloanscheme(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue updateloanscheme(const JSONRPCRequest& request) {
+UniValue updateloanscheme(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"updateloanscheme",
-               "Updates an existing loan scheme.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                       {"mincolratio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Minimum collateralization ratio (integer)."},
-                       {"interestrate", RPCArg::Type::NUM, RPCArg::Optional::NO, "Interest rate (integer or float)."},
-                       {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-                       {"ACTIVATE_AFTER_BLOCK", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Block height at which new changes take effect."},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
+    RPCHelpMan{
+        "updateloanscheme",
+        "Updates an existing loan scheme.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"mincolratio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Minimum collateralization ratio (integer)."},
+            {"interestrate", RPCArg::Type::NUM, RPCArg::Optional::NO, "Interest rate (integer or float)."},
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+            {"ACTIVATE_AFTER_BLOCK",
+             RPCArg::Type::NUM,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "Block height at which new changes take effect."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
-                                },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("updateloanscheme", "150 5 LOAN0001") +
-                       HelpExampleRpc("updateloanscheme", "150, 5, LOAN0001")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("updateloanscheme", "150 5 LOAN0001") +
+                    HelpExampleRpc("updateloanscheme", "150, 5, LOAN0001")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot updateloanscheme while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot updateloanscheme while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -724,8 +799,7 @@ UniValue updateloanscheme(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::LoanScheme)
-             << loanScheme;
+    metadata << static_cast<unsigned char>(CustomTxType::LoanScheme) << loanScheme;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -756,37 +830,42 @@ UniValue updateloanscheme(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue setdefaultloanscheme(const JSONRPCRequest& request) {
+UniValue setdefaultloanscheme(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"setdefaultloanscheme",
-               "Sets the default loan scheme.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                       {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
+    RPCHelpMan{
+        "setdefaultloanscheme",
+        "Sets the default loan scheme.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
-                                },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("setdefaultloanscheme", "LOAN0001") +
-                       HelpExampleRpc("setdefaultloanscheme", "LOAN0001")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("setdefaultloanscheme", "LOAN0001") +
+                    HelpExampleRpc("setdefaultloanscheme", "LOAN0001")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot setdefaultloanschem while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot setdefaultloanschem while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -800,8 +879,7 @@ UniValue setdefaultloanscheme(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::DefaultLoanScheme)
-             << defaultScheme;
+    metadata << static_cast<unsigned char>(CustomTxType::DefaultLoanScheme) << defaultScheme;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -831,38 +909,45 @@ UniValue setdefaultloanscheme(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue destroyloanscheme(const JSONRPCRequest& request) {
+UniValue destroyloanscheme(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"destroyloanscheme",
-               "Destroys a loan scheme.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                       {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-                       {"ACTIVATE_AFTER_BLOCK", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Block height at which new changes take effect."},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
+    RPCHelpMan{
+        "destroyloanscheme",
+        "Destroys a loan scheme.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+            {"ACTIVATE_AFTER_BLOCK",
+             RPCArg::Type::NUM,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "Block height at which new changes take effect."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
-                                },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("destroyloanscheme", "LOAN0001") +
-                       HelpExampleRpc("destroyloanscheme", "LOAN0001")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("destroyloanscheme", "LOAN0001") + HelpExampleRpc("destroyloanscheme", "LOAN0001")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot destroyloanscheme while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot destroyloanscheme while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -879,8 +964,7 @@ UniValue destroyloanscheme(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::DestroyLoanScheme)
-             << destroyScheme;
+    metadata << static_cast<unsigned char>(CustomTxType::DestroyLoanScheme) << destroyScheme;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -910,36 +994,33 @@ UniValue destroyloanscheme(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue listloanschemes(const JSONRPCRequest& request) {
+UniValue listloanschemes(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listloanschemes",
+        "List all available loan schemes.\n",
+        {},
+        RPCResult{"[                         (json array of objects)\n"
+                  "  {\n"
+                  "    \"id\" : n                   (string)\n"
+                  "    \"mincolratio\" : n          (numeric)\n"
+                  "    \"interestrate\" : n         (numeric)\n"
+                  "  },\n"
+                  "  ...\n"
+                  "]\n"},
+        RPCExamples{HelpExampleCli("listloanschemes", "") + HelpExampleRpc("listloanschemes", "")},
+    }
+        .Check(request);
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
-    RPCHelpMan{"listloanschemes",
-               "List all available loan schemes.\n",
-               {},
-               RPCResult{
-                       "[                         (json array of objects)\n"
-                       "  {\n"
-                       "    \"id\" : n                   (string)\n"
-                       "    \"mincolratio\" : n          (numeric)\n"
-                       "    \"interestrate\" : n         (numeric)\n"
-                       "  },\n"
-                       "  ...\n"
-                       "]\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listloanschemes", "") +
-                       HelpExampleRpc("listloanschemes", "")
-               },
-    }.Check(request);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
-
-    auto cmp = [](const CLoanScheme& a, const CLoanScheme& b) {
+    auto cmp = [](const CLoanScheme &a, const CLoanScheme &b) {
         return a.ratio == b.ratio ? a.rate < b.rate : a.ratio < b.ratio;
     };
     std::set<CLoanScheme, decltype(cmp)> loans(cmp);
 
     LOCK(cs_main);
 
-    pcustomcsview->ForEachLoanScheme([&loans](const std::string& identifier, const CLoanSchemeData& data){
+    pcustomcsview->ForEachLoanScheme([&loans](const std::string &identifier, const CLoanSchemeData &data) {
         CLoanScheme loanScheme;
         loanScheme.rate = data.rate;
         loanScheme.ratio = data.ratio;
@@ -951,7 +1032,7 @@ UniValue listloanschemes(const JSONRPCRequest& request) {
     auto defaultLoan = pcustomcsview->GetDefaultLoanScheme();
 
     UniValue ret(UniValue::VARR);
-    for (const auto& item : loans) {
+    for (const auto &item : loans) {
         UniValue arr(UniValue::VOBJ);
         arr.pushKV("id", item.identifier);
         arr.pushKV("mincolratio", static_cast<uint64_t>(item.ratio));
@@ -967,29 +1048,26 @@ UniValue listloanschemes(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue getloanscheme(const JSONRPCRequest& request) {
+UniValue getloanscheme(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getloanscheme",
+        "Returns information about loan scheme.\n",
+        {
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+        },
+        RPCResult{"  {\n"
+                  "    \"id\" : n                   (string)\n"
+                  "    \"mincolratio\" : n          (numeric)\n"
+                  "    \"interestrate\" : n         (numeric)\n"
+                  "  },\n"},
+        RPCExamples{HelpExampleCli("getloanscheme", "LOAN0001") + HelpExampleRpc("getloanscheme", "LOAN0001")},
+    }
+        .Check(request);
 
-    RPCHelpMan{"getloanscheme",
-               "Returns information about loan scheme.\n",
-               {
-                    {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-               },
-               RPCResult{
-                       "  {\n"
-                       "    \"id\" : n                   (string)\n"
-                       "    \"mincolratio\" : n          (numeric)\n"
-                       "    \"interestrate\" : n         (numeric)\n"
-                       "  },\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("getloanscheme", "LOAN0001") +
-                       HelpExampleRpc("getloanscheme", "LOAN0001")
-               },
-    }.Check(request);
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
-
-    if(request.params[0].isNull())
+    if (request.params[0].isNull())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter id, argument must be non-null");
 
     auto loanSchemeId = request.params[0].getValStr();
@@ -1017,39 +1095,51 @@ UniValue getloanscheme(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, result);
 }
 
-UniValue takeloan(const JSONRPCRequest& request) {
+UniValue takeloan(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"takeloan",
-                "Creates (and submits to local node and network) a tx to mint loan token in desired amount based on defined loan.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "takeloan",
+        "Creates (and submits to local node and network) a tx to mint loan token in desired amount based on defined "
+        "loan.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Id of vault used for loan"},
+                    {"to", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address to transfer tokens (optional)"},
+                    {"amounts", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount in amount@token format."},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Id of vault used for loan"},
-                            {"to", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address to transfer tokens (optional)"},
-                            {"amounts", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount in amount@token format."},
-                        },
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("takeloan", R"('{"vaultId":84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2,"amounts":"10@TSLA"}')")
-                        },
-     }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli(
+            "takeloan",
+            R"('{"vaultId":84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2,"amounts":"10@TSLA"}')")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot takeloan while still in Initial Block Download");
@@ -1063,14 +1153,14 @@ UniValue takeloan(const JSONRPCRequest& request) {
                            "{\"vaultId\",\"amounts\"}");
 
     UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CLoanTakeLoanMessage takeLoan;
 
     if (!metaObj["vaultId"].isNull())
         takeLoan.vaultId = uint256S(metaObj["vaultId"].getValStr());
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"vaultId\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"vaultId\" must be non-null");
 
     if (!metaObj["to"].isNull())
         takeLoan.to = DecodeScript(metaObj["to"].getValStr());
@@ -1078,7 +1168,7 @@ UniValue takeloan(const JSONRPCRequest& request) {
     if (!metaObj["amounts"].isNull())
         takeLoan.amounts = DecodeAmounts(pwallet->chain(), metaObj["amounts"], "");
     else
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amounts\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"amounts\" must not be null");
 
     int targetHeight;
     CScript ownerAddress;
@@ -1092,8 +1182,7 @@ UniValue takeloan(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::TakeLoan)
-             << takeLoan;
+    metadata << static_cast<unsigned char>(CustomTxType::TakeLoan) << takeLoan;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -1123,49 +1212,78 @@ UniValue takeloan(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue paybackloan(const JSONRPCRequest& request) {
+UniValue paybackloan(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"paybackloan",
-                "Creates (and submits to local node and network) a tx to return the loan in desired amount.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "paybackloan",
+        "Creates (and submits to local node and network) a tx to return the loan in desired amount.\n" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
                 {
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
-                        {
-                            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Id of vault used for loan"},
-                            {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address containing repayment tokens. If \"from\" value is: \"*\" (star), it's means auto-selection accounts from wallet."},
-                            {"amounts", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Amount in amount@token format."},
-                            {"loans", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                                {
-                                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                        {
-                                            {"dToken", RPCArg::Type::STR, RPCArg::Optional::NO, "The dTokens's symbol, id or creation tx"},
-                                            {"amounts", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount in amount@token format."},
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
+                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Id of vault used for loan"},
+                    {"from",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Address containing repayment tokens. If \"from\" value is: \"*\" (star), it's means "
+                     "auto-selection accounts from wallet."},
+                    {"amounts", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Amount in amount@token format."},
+                    {
+                        "loans",
+                        RPCArg::Type::ARR,
+                        RPCArg::Optional::OMITTED_NAMED_ARG,
                         "A json array of json objects",
                         {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                            {
+                                "",
+                                RPCArg::Type::OBJ,
+                                RPCArg::Optional::OMITTED,
+                                "",
                                 {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                                    {"dToken",
+                                     RPCArg::Type::STR,
+                                     RPCArg::Optional::NO,
+                                     "The dTokens's symbol, id or creation tx"},
+                                    {"amounts",
+                                     RPCArg::Type::STR,
+                                     RPCArg::Optional::NO,
+                                     "Amount in amount@token format."},
                                 },
                             },
                         },
                     },
                 },
-                RPCResult{
-                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                        HelpExampleCli("paybackloan", R"('{"vaultId":84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2,"from":"<address>", "amounts":"10@TSLA"}')")
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli(
+            "paybackloan",
+            R"('{"vaultId":84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2,"from":"<address>", "amounts":"10@TSLA"}')")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot paybackloan while still in Initial Block Download");
@@ -1180,11 +1298,11 @@ UniValue paybackloan(const JSONRPCRequest& request) {
     UniValue metaObj = request.params[0].get_obj();
 
     if (metaObj["vaultId"].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"vaultId\" must be non-null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"vaultId\" must be non-null");
     auto vaultId = uint256S(metaObj["vaultId"].getValStr());
 
     if (metaObj["from"].isNull())
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"from\" must not be null");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"from\" must not be null");
     auto fromStr = metaObj["from"].getValStr();
 
     // Check amounts or/and loans
@@ -1197,23 +1315,24 @@ UniValue paybackloan(const JSONRPCRequest& request) {
     }
     bool isFCR = targetHeight >= Params().GetConsensus().FortCanningRoadHeight;
     CBalances amounts;
-    if (hasAmounts){
-        if(hasLoans)
-            throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amounts\" and \"loans\" cannot be set at the same time");
+    if (hasAmounts) {
+        if (hasLoans)
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Invalid parameters, argument \"amounts\" and \"loans\" cannot be set at the same time");
         else
             amounts = DecodeAmounts(pwallet->chain(), metaObj["amounts"], "");
-    }
-    else if(!isFCR)
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amounts\" must not be null");
-    else if(!hasLoans)
-        throw JSONRPCError(RPC_INVALID_PARAMETER,"Invalid parameters, argument \"amounts\" and \"loans\" cannot be empty at the same time");
+    } else if (!isFCR)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameters, argument \"amounts\" must not be null");
+    else if (!hasLoans)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, argument \"amounts\" and \"loans\" cannot be empty at the same time");
 
     std::map<DCT_ID, CBalances> loans;
-    UniValue array {UniValue::VARR};
-    if(hasLoans) {
+    UniValue array{UniValue::VARR};
+    if (hasLoans) {
         try {
             array = metaObj["loans"].get_array();
-            for (unsigned int i=0; i<array.size(); i++){
+            for (unsigned int i = 0; i < array.size(); i++) {
                 auto obj = array[i].get_obj();
                 auto tokenStr = trim_ws(obj["dToken"].getValStr());
 
@@ -1230,7 +1349,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't find %s loan token!", tokenStr));
                 loans[id] = DecodeAmounts(pwallet->chain(), obj["amounts"], "");
             }
-        }catch(std::runtime_error& e) {
+        } catch (std::runtime_error &e) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, e.what());
         }
     }
@@ -1238,7 +1357,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
     CScript from;
     if (fromStr == "*") {
         CBalances balances;
-        for (const auto& amounts : loans)
+        for (const auto &amounts : loans)
             balances.AddBalances(amounts.second.balances);
 
         if (loans.empty())
@@ -1246,7 +1365,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
 
         auto selectedAccounts = SelectAccountsByTargetBalances(GetAllMineAccounts(pwallet), balances, SelectionPie);
 
-        for (auto& account : selectedAccounts) {
+        for (auto &account : selectedAccounts) {
             auto it = amounts.balances.begin();
             while (it != amounts.balances.end()) {
                 if (account.second.balances[it->first] < it->second)
@@ -1261,13 +1380,13 @@ UniValue paybackloan(const JSONRPCRequest& request) {
 
         if (from.empty())
             throw JSONRPCError(RPC_INVALID_REQUEST,
-                    "Not enough tokens on account, call sendtokenstoaddress to increase it.\n");
+                               "Not enough tokens on account, call sendtokenstoaddress to increase it.\n");
     } else
         from = DecodeScript(metaObj["from"].getValStr());
 
     if (!::IsMine(*pwallet, from))
         throw JSONRPCError(RPC_INVALID_PARAMETER,
-                strprintf("Address (%s) is not owned by the wallet", metaObj["from"].getValStr()));
+                           strprintf("Address (%s) is not owned by the wallet", metaObj["from"].getValStr()));
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
 
@@ -1286,7 +1405,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths{from};
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false, optAuthTx, txInputs);
 
     rawTx.vout.emplace_back(0, scriptMeta);
@@ -1307,20 +1426,18 @@ UniValue paybackloan(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue getloaninfo(const JSONRPCRequest& request) {
-    RPCHelpMan{"getloaninfo",
-                "Returns the loan stats.\n",
-                {},
-                RPCResult
-                {
-                    "{...}     (object) Json object with loan information\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("getloaninfo", "")
-                },
-    }.Check(request);
+UniValue getloaninfo(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getloaninfo",
+        "Returns the loan stats.\n",
+        {},
+        RPCResult{"{...}     (object) Json object with loan information\n"},
+        RPCExamples{HelpExampleCli("getloaninfo", "")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
     UniValue ret{UniValue::VOBJ};
 
     LOCK(cs_main);
@@ -1331,8 +1448,7 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     bool useNextPrice = false, requireLivePrice = true;
     auto lastBlockTime = ::ChainActive().Tip()->GetBlockTime();
 
-    uint64_t totalCollateralValue = 0, totalLoanValue = 0,
-             totalVaults = 0, totalAuctions = 0, totalLoanSchemes = 0,
+    uint64_t totalCollateralValue = 0, totalLoanValue = 0, totalVaults = 0, totalAuctions = 0, totalLoanSchemes = 0,
              totalCollateralTokens = 0, totalLoanTokens = 0;
 
     auto fixedIntervalBlock = view.GetIntervalBlock();
@@ -1341,7 +1457,7 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     auto priceBlocks = GetFixedIntervalPriceBlocks(::ChainActive().Height(), view);
 
     // TODO: Later optimize this into a general dynamic worker pool, so we don't
-    // need to recreate these threads on each call. 
+    // need to recreate these threads on each call.
     boost::asio::thread_pool workerPool{[]() {
         const size_t workersMax = GetNumCores() - 1;
         // More than 8 is likely not very fruitful for ~10k vaults.
@@ -1349,19 +1465,19 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     }()};
 
     boost::asio::post(workerPool, [&] {
-        view.ForEachLoanScheme([&](const std::string& identifier, const CLoanSchemeData& data) {
+        view.ForEachLoanScheme([&](const std::string &identifier, const CLoanSchemeData &data) {
             totalLoanSchemes++;
             return true;
         });
 
         // First assume it's on the DB. For later, might be worth thinking if it's better to incorporate
         // attributes right into the for each loop, so the interface remains consistent.
-        view.ForEachLoanCollateralToken([&](CollateralTokenKey const& key, uint256 const& collTokenTx) {
+        view.ForEachLoanCollateralToken([&](CollateralTokenKey const &key, uint256 const &collTokenTx) {
             totalCollateralTokens++;
             return true;
         });
 
-        view.ForEachLoanToken([&](DCT_ID const& key, CLoanView::CLoanSetLoanTokenImpl loanToken) {
+        view.ForEachLoanToken([&](DCT_ID const &key, CLoanView::CLoanSetLoanTokenImpl loanToken) {
             totalLoanTokens++;
             return true;
         });
@@ -1372,47 +1488,56 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "attributes access failure");
         }
 
-        attributes->ForEach([&](const CDataStructureV0& attr, const CAttributeValue&) {
-            if (attr.type != AttributeTypes::Token)
-                return false;
-            if (attr.key == TokenKeys::LoanCollateralEnabled)
-                totalCollateralTokens++;
-            else if (attr.key == TokenKeys::LoanMintingEnabled)
-                totalLoanTokens++;
-            return true;
-        }, CDataStructureV0{AttributeTypes::Token});
+        attributes->ForEach(
+            [&](const CDataStructureV0 &attr, const CAttributeValue &) {
+                if (attr.type != AttributeTypes::Token)
+                    return false;
+                if (attr.key == TokenKeys::LoanCollateralEnabled)
+                    totalCollateralTokens++;
+                else if (attr.key == TokenKeys::LoanMintingEnabled)
+                    totalLoanTokens++;
+                return true;
+            },
+            CDataStructureV0{AttributeTypes::Token});
 
-        view.ForEachVaultAuction([&](const CVaultId& vaultId, const CAuctionData& data) {
-            totalAuctions += data.batchCount;
-            return true;
-        }, height);
+        view.ForEachVaultAuction(
+            [&](const CVaultId &vaultId, const CAuctionData &data) {
+                totalAuctions += data.batchCount;
+                return true;
+            },
+            height);
     });
 
     std::atomic<uint64_t> vaultsTotal{0};
     std::atomic<uint64_t> colsValTotal{0};
     std::atomic<uint64_t> loansValTotal{0};
 
-    view.ForEachVault([&](const CVaultId& vaultId, const CVaultData& data) {
-        boost::asio::post(workerPool, [&, &colsValTotal=colsValTotal, 
-            &loansValTotal=loansValTotal, &vaultsTotal=vaultsTotal,
-            vaultId=vaultId, height=height, useNextPrice=useNextPrice, 
-            requireLivePrice=requireLivePrice] {
-            auto collaterals = view.GetVaultCollaterals(vaultId);
-            if (!collaterals)
-                collaterals = CBalances{};
-            auto rate = view.GetLoanCollaterals(vaultId, *collaterals, height, lastBlockTime, useNextPrice, requireLivePrice);
-            if (rate)
-            {
-                colsValTotal.fetch_add(rate.val->totalCollaterals, std::memory_order_relaxed);
-                loansValTotal.fetch_add(rate.val->totalLoans, std::memory_order_relaxed);
-            }
-            vaultsTotal.fetch_add(1, std::memory_order_relaxed);
-        });
+    view.ForEachVault([&](const CVaultId &vaultId, const CVaultData &data) {
+        boost::asio::post(workerPool,
+                          [&,
+                           &colsValTotal = colsValTotal,
+                           &loansValTotal = loansValTotal,
+                           &vaultsTotal = vaultsTotal,
+                           vaultId = vaultId,
+                           height = height,
+                           useNextPrice = useNextPrice,
+                           requireLivePrice = requireLivePrice] {
+                              auto collaterals = view.GetVaultCollaterals(vaultId);
+                              if (!collaterals)
+                                  collaterals = CBalances{};
+                              auto rate = view.GetLoanCollaterals(
+                                  vaultId, *collaterals, height, lastBlockTime, useNextPrice, requireLivePrice);
+                              if (rate) {
+                                  colsValTotal.fetch_add(rate.val->totalCollaterals, std::memory_order_relaxed);
+                                  loansValTotal.fetch_add(rate.val->totalLoans, std::memory_order_relaxed);
+                              }
+                              vaultsTotal.fetch_add(1, std::memory_order_relaxed);
+                          });
         return true;
     });
 
     workerPool.join();
-    // We use relaxed ordering to increment. Thread joins should in theory, 
+    // We use relaxed ordering to increment. Thread joins should in theory,
     // resolve have resulted in full barriers, but we ensure
     // to throw in a full barrier anyway. x86 arch might appear to work without
     // but let's be extra cautious about RISC optimizers.
@@ -1430,7 +1555,7 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     totalsObj.pushKV("openVaults", totalVaults);
     totalsObj.pushKV("openAuctions", totalAuctions);
     UniValue defaultsObj{UniValue::VOBJ};
-    if(!defaultScheme)
+    if (!defaultScheme)
         defaultsObj.pushKV("scheme", "");
     else
         defaultsObj.pushKV("scheme", *defaultScheme);
@@ -1446,30 +1571,28 @@ UniValue getloaninfo(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue getinterest(const JSONRPCRequest& request) {
-    RPCHelpMan{"getinterest",
-                "Returns the global and per block interest by loan scheme.\n",
-                {
-                    {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
-                    {"token", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The tokens's symbol, id or creation tx"},
-                },
-                RPCResult
-                {
-                    "{...}     (object) Json object with interest information\n"
-                    "            - `interestPerBlock`: Interest per block is always ceiled\n"
-                    "               to the min. unit of fi (8 decimals), however interest\n"
-                    "               less than this will continue to accrue until actual utilization\n"
-                    "               (eg. - payback of the loan), or until sub-fi maturity."
-                    "             - `realizedInterestPerBlock`: The actual realized interest\n"
-                    "               per block. This is continues to accumulate until\n"
-                    "               the min. unit of the blockchain (fi) can be realized. \n"
-                },
-                RPCExamples{
-                    HelpExampleCli("getinterest", "LOAN0001 TSLA")
-                },
-     }.Check(request);
+UniValue getinterest(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getinterest",
+        "Returns the global and per block interest by loan scheme.\n",
+        {
+            {"id", RPCArg::Type::STR, RPCArg::Optional::NO, "Unique identifier of the loan scheme (8 chars max)."},
+            {"token", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The tokens's symbol, id or creation tx"},
+        },
+        RPCResult{"{...}     (object) Json object with interest information\n"
+                  "            - `interestPerBlock`: Interest per block is always ceiled\n"
+                  "               to the min. unit of fi (8 decimals), however interest\n"
+                  "               less than this will continue to accrue until actual utilization\n"
+                  "               (eg. - payback of the loan), or until sub-fi maturity."
+                  "             - `realizedInterestPerBlock`: The actual realized interest\n"
+                  "               per block. This is continues to accumulate until\n"
+                  "               the min. unit of the blockchain (fi) can be realized. \n"},
+        RPCExamples{HelpExampleCli("getinterest", "LOAN0001 TSLA")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValueType()}, false);
 
@@ -1492,11 +1615,10 @@ UniValue getinterest(const JSONRPCRequest& request) {
     UniValue ret(UniValue::VARR);
     const auto height = ::ChainActive().Height() + 1;
 
-    std::map<DCT_ID, std::pair<base_uint<128>, base_uint<128>> > interest;
+    std::map<DCT_ID, std::pair<base_uint<128>, base_uint<128>>> interest;
 
-    LogPrint(BCLog::LOAN,"%s():\n", __func__);
-    auto vaultInterest = [&](const CVaultId& vaultId, DCT_ID tokenId, CInterestRateV2 rate)
-    {
+    LogPrint(BCLog::LOAN, "%s():\n", __func__);
+    auto vaultInterest = [&](const CVaultId &vaultId, DCT_ID tokenId, CInterestRateV2 rate) {
         auto vault = pcustomcsview->GetVault(vaultId);
         if (!vault || vault->schemeId != loanSchemeId)
             return true;
@@ -1507,7 +1629,7 @@ UniValue getinterest(const JSONRPCRequest& request) {
         if (!token)
             return true;
 
-        LogPrint(BCLog::LOAN,"\t\tVault(%s)->", vaultId.GetHex()); /* Continued */
+        LogPrint(BCLog::LOAN, "\t\tVault(%s)->", vaultId.GetHex()); /* Continued */
         interest[tokenId].first += TotalInterestCalculation(rate, height);
         interest[tokenId].second += rate.interestPerBlock;
 
@@ -1517,14 +1639,13 @@ UniValue getinterest(const JSONRPCRequest& request) {
     if (height >= Params().GetConsensus().FortCanningHillHeight) {
         pcustomcsview->ForEachVaultInterestV2(vaultInterest);
     } else {
-        pcustomcsview->ForEachVaultInterest([&](const CVaultId& vaultId, DCT_ID tokenId, CInterestRate rate) {
+        pcustomcsview->ForEachVaultInterest([&](const CVaultId &vaultId, DCT_ID tokenId, CInterestRate rate) {
             return vaultInterest(vaultId, tokenId, ConvertInterestRateToV2(rate));
         });
     }
 
     UniValue obj(UniValue::VOBJ);
-    for (auto it=interest.begin(); it != interest.end(); ++it)
-    {
+    for (auto it = interest.begin(); it != interest.end(); ++it) {
         auto tokenId = it->first;
         auto totalInterest = it->second.first;
         auto interestPerBlock = it->second.second;
@@ -1533,40 +1654,41 @@ UniValue getinterest(const JSONRPCRequest& request) {
         obj.pushKV("token", token->CreateSymbolKey(tokenId));
         obj.pushKV("totalInterest", ValueFromAmount(CeilInterest(totalInterest, height)));
         obj.pushKV("interestPerBlock", ValueFromAmount(CeilInterest(interestPerBlock, height)));
-        if (height >= Params().GetConsensus().FortCanningHillHeight)
-        {
-            obj.pushKV("realizedInterestPerBlock", UniValue(UniValue::VNUM, GetInterestPerBlockHighPrecisionString(interestPerBlock)));
+        if (height >= Params().GetConsensus().FortCanningHillHeight) {
+            obj.pushKV("realizedInterestPerBlock",
+                       UniValue(UniValue::VNUM, GetInterestPerBlockHighPrecisionString(interestPerBlock)));
         }
         ret.push_back(obj);
     }
     return GetRPCResultCache().Set(request, ret);
 }
 
-
-static const CRPCCommand commands[] =
-{
-//  category        name                         actor (function)        params
-//  --------------- ----------------------       ---------------------   ----------
-    {"loan",        "setcollateraltoken",        &setcollateraltoken,    {"metadata", "inputs"}},
-    {"loan",        "getcollateraltoken",        &getcollateraltoken,    {"by"}},
-    {"loan",        "listcollateraltokens",      &listcollateraltokens,  {"by"}},
-    {"loan",        "setloantoken",              &setloantoken,          {"metadata", "inputs"}},
-    {"loan",        "updateloantoken",           &updateloantoken,       {"token", "metadata", "inputs"}},
-    {"loan",        "listloantokens",            &listloantokens,        {}},
-    {"loan",        "getloantoken",              &getloantoken,          {"by"}},
-    {"loan",        "createloanscheme",          &createloanscheme,      {"mincolratio", "interestrate", "id", "inputs"}},
-    {"loan",        "updateloanscheme",          &updateloanscheme,      {"mincolratio", "interestrate", "id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
-    {"loan",        "setdefaultloanscheme",      &setdefaultloanscheme,  {"id", "inputs"}},
-    {"loan",        "destroyloanscheme",         &destroyloanscheme,     {"id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
-    {"loan",        "listloanschemes",           &listloanschemes,       {}},
-    {"loan",        "getloanscheme",             &getloanscheme,         {"id"}},
-    {"loan",        "takeloan",                  &takeloan,              {"metadata", "inputs"}},
-    {"loan",        "paybackloan",               &paybackloan,           {"metadata", "inputs"}},
-    {"loan",        "getloaninfo",               &getloaninfo,           {}},
-    {"loan",        "getinterest",               &getinterest,           {"id", "token"}},
+static const CRPCCommand commands[] = {
+    //  category        name                         actor (function)        params
+    //  --------------- ----------------------       ---------------------   ----------
+    {"loan", "setcollateraltoken", &setcollateraltoken, {"metadata", "inputs"}},
+    {"loan", "getcollateraltoken", &getcollateraltoken, {"by"}},
+    {"loan", "listcollateraltokens", &listcollateraltokens, {"by"}},
+    {"loan", "setloantoken", &setloantoken, {"metadata", "inputs"}},
+    {"loan", "updateloantoken", &updateloantoken, {"token", "metadata", "inputs"}},
+    {"loan", "listloantokens", &listloantokens, {}},
+    {"loan", "getloantoken", &getloantoken, {"by"}},
+    {"loan", "createloanscheme", &createloanscheme, {"mincolratio", "interestrate", "id", "inputs"}},
+    {"loan",
+     "updateloanscheme",
+     &updateloanscheme,
+     {"mincolratio", "interestrate", "id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
+    {"loan", "setdefaultloanscheme", &setdefaultloanscheme, {"id", "inputs"}},
+    {"loan", "destroyloanscheme", &destroyloanscheme, {"id", "ACTIVATE_AFTER_BLOCK", "inputs"}},
+    {"loan", "listloanschemes", &listloanschemes, {}},
+    {"loan", "getloanscheme", &getloanscheme, {"id"}},
+    {"loan", "takeloan", &takeloan, {"metadata", "inputs"}},
+    {"loan", "paybackloan", &paybackloan, {"metadata", "inputs"}},
+    {"loan", "getloaninfo", &getloaninfo, {}},
+    {"loan", "getinterest", &getinterest, {"id", "token"}},
 };
 
-void RegisterLoanRPCCommands(CRPCTable& tableRPC) {
+void RegisterLoanRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -2,7 +2,11 @@
 
 #include <masternodes/govvariables/attributes.h>
 
-UniValue poolToJSON(const CCustomCSView view, DCT_ID const& id, CPoolPair const& pool, CToken const& token, bool verbose) {
+UniValue poolToJSON(const CCustomCSView view,
+                    DCT_ID const &id,
+                    CPoolPair const &pool,
+                    CToken const &token,
+                    bool verbose) {
     UniValue poolObj(UniValue::VOBJ);
     poolObj.pushKV("symbol", token.symbol);
     poolObj.pushKV("name", token.name);
@@ -50,15 +54,20 @@ UniValue poolToJSON(const CCustomCSView view, DCT_ID const& id, CPoolPair const&
         if (pool.reserveB == 0) {
             poolObj.pushKV("reserveA/reserveB", "0");
         } else {
-            poolObj.pushKV("reserveA/reserveB", ValueFromAmount((arith_uint256(pool.reserveA) * arith_uint256(COIN) / pool.reserveB).GetLow64()));
+            poolObj.pushKV(
+                "reserveA/reserveB",
+                ValueFromAmount((arith_uint256(pool.reserveA) * arith_uint256(COIN) / pool.reserveB).GetLow64()));
         }
 
         if (pool.reserveA == 0) {
             poolObj.pushKV("reserveB/reserveA", "0");
         } else {
-            poolObj.pushKV("reserveB/reserveA", ValueFromAmount((arith_uint256(pool.reserveB) * arith_uint256(COIN) / pool.reserveA).GetLow64()));
+            poolObj.pushKV(
+                "reserveB/reserveA",
+                ValueFromAmount((arith_uint256(pool.reserveB) * arith_uint256(COIN) / pool.reserveA).GetLow64()));
         }
-        poolObj.pushKV("tradeEnabled", pool.reserveA >= CPoolPair::SLOPE_SWAP_RATE && pool.reserveB >= CPoolPair::SLOPE_SWAP_RATE);
+        poolObj.pushKV("tradeEnabled",
+                       pool.reserveA >= CPoolPair::SLOPE_SWAP_RATE && pool.reserveB >= CPoolPair::SLOPE_SWAP_RATE);
 
         poolObj.pushKV("ownerAddress", ScriptToString(pool.ownerAddress));
 
@@ -85,7 +94,7 @@ UniValue poolToJSON(const CCustomCSView view, DCT_ID const& id, CPoolPair const&
             if (!rewards.balances.empty()) {
                 UniValue rewardArr(UniValue::VARR);
 
-                for (const auto& reward : rewards.balances) {
+                for (const auto &reward : rewards.balances) {
                     rewardArr.push_back(CTokenAmount{reward.first, reward.second}.ToString());
                 }
 
@@ -94,7 +103,7 @@ UniValue poolToJSON(const CCustomCSView view, DCT_ID const& id, CPoolPair const&
         }
 
         poolObj.pushKV("creationTx", pool.creationTx.GetHex());
-        poolObj.pushKV("creationHeight", (uint64_t) pool.creationHeight);
+        poolObj.pushKV("creationHeight", (uint64_t)pool.creationHeight);
     }
 
     UniValue ret(UniValue::VOBJ);
@@ -102,11 +111,16 @@ UniValue poolToJSON(const CCustomCSView view, DCT_ID const& id, CPoolPair const&
     return ret;
 }
 
-UniValue poolShareToJSON(DCT_ID const & poolId, CScript const & provider, CAmount const& amount, CPoolPair const& poolPair, bool verbose) {
+UniValue poolShareToJSON(DCT_ID const &poolId,
+                         CScript const &provider,
+                         CAmount const &amount,
+                         CPoolPair const &poolPair,
+                         bool verbose) {
     UniValue poolObj(UniValue::VOBJ);
     poolObj.pushKV("poolID", poolId.ToString());
     poolObj.pushKV("owner", ScriptToString(provider));
-    CAmount percentage = (arith_uint256(amount * 100) * arith_uint256(COIN) / arith_uint256(poolPair.totalLiquidity)).GetLow64();
+    CAmount percentage =
+        (arith_uint256(amount * 100) * arith_uint256(COIN) / arith_uint256(poolPair.totalLiquidity)).GetLow64();
     poolObj.pushKV("%", ValueFromAmount(percentage));
 
     if (verbose) {
@@ -119,19 +133,18 @@ UniValue poolShareToJSON(DCT_ID const & poolId, CScript const & provider, CAmoun
     return ret;
 }
 
-
-UniValue poolPathsToJSON(std::vector<std::vector<DCT_ID>> & poolPaths) {
+UniValue poolPathsToJSON(std::vector<std::vector<DCT_ID>> &poolPaths) {
     UniValue paths(UniValue::VARR);
     for (auto poolIds : poolPaths) {
         UniValue pathObj(UniValue::VARR);
-        for (auto poolId : poolIds){
+        for (auto poolId : poolIds) {
             pathObj.push_back(poolId.ToString());
         }
         paths.push_back(pathObj);
     }
     return paths;
 }
-void CheckAndFillPoolSwapMessage(const JSONRPCRequest& request, CPoolSwapMessage &poolSwapMsg) {
+void CheckAndFillPoolSwapMessage(const JSONRPCRequest &request, CPoolSwapMessage &poolSwapMsg) {
     std::string tokenFrom, tokenTo;
     UniValue metadataObj = request.params[0].get_obj();
     if (!metadataObj["from"].isNull()) {
@@ -171,34 +184,45 @@ void CheckAndFillPoolSwapMessage(const JSONRPCRequest& request, CPoolSwapMessage
     }
 }
 
-UniValue listpoolpairs(const JSONRPCRequest& request) {
-    RPCHelpMan{"listpoolpairs",
-               "\nReturns information about pools.\n",
-               {
-                        {"pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                            {
-                                 {"start", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Optional first key to iterate from, in lexicographical order."
-                                  "Typically it's set to last ID from previous request."},
-                                 {"including_start", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                  "If true, then iterate including starting position. False by default"},
-                                 {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Maximum number of pools to return, 100 by default"},
-                            },
-                        },
-                        {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                    "Flag for verbose list (default = true), otherwise only ids, symbols and names are listed"},
-               },
-               RPCResult{
-                       "{id:{...},...}     (array) Json object with pools information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listpoolpairs", "'{\"start\":128}' false")
-                       + HelpExampleRpc("listpoolpairs", "'{\"start\":128}' false")
-               },
-    }.Check(request);
+UniValue listpoolpairs(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listpoolpairs",
+        "\nReturns information about pools.\n",
+        {
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"start",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Optional first key to iterate from, in lexicographical order."
+                     "Typically it's set to last ID from previous request."},
+                    {"including_start",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "If true, then iterate including starting position. False by default"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of pools to return, 100 by default"},
+                },
+            },
+            {"verbose",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Flag for verbose list (default = true), otherwise only ids, symbols and names are listed"},
+        },
+        RPCResult{"{id:{...},...}     (array) Json object with pools information\n"},
+        RPCExamples{HelpExampleCli("listpoolpairs", "'{\"start\":128}' false") +
+                    HelpExampleRpc("listpoolpairs", "'{\"start\":128}' false")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     bool verbose = true;
     if (request.params.size() > 1) {
@@ -213,11 +237,11 @@ UniValue listpoolpairs(const JSONRPCRequest& request) {
         if (request.params.size() > 0) {
             UniValue paginationObj = request.params[0].get_obj();
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
             if (!paginationObj["start"].isNull()) {
                 including_start = false;
-                start.v = (uint32_t) paginationObj["start"].get_int();
+                start.v = (uint32_t)paginationObj["start"].get_int();
             }
             if (!paginationObj["including_start"].isNull()) {
                 including_start = paginationObj["including_start"].getBool();
@@ -234,38 +258,39 @@ UniValue listpoolpairs(const JSONRPCRequest& request) {
     LOCK(cs_main);
 
     UniValue ret(UniValue::VOBJ);
-    pcustomcsview->ForEachPoolPair([&](DCT_ID const & id, CPoolPair pool) {
-        const auto token = pcustomcsview->GetToken(id);
-        if (token) {
-            ret.pushKVs(poolToJSON(*pcustomcsview, id, pool, *token, verbose));
-            limit--;
-        }
+    pcustomcsview->ForEachPoolPair(
+        [&](DCT_ID const &id, CPoolPair pool) {
+            const auto token = pcustomcsview->GetToken(id);
+            if (token) {
+                ret.pushKVs(poolToJSON(*pcustomcsview, id, pool, *token, verbose));
+                limit--;
+            }
 
-        return limit != 0;
-    }, start);
+            return limit != 0;
+        },
+        start);
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue getpoolpair(const JSONRPCRequest& request) {
-    RPCHelpMan{"getpoolpair",
-               "\nReturns information about pool.\n",
-               {
-                       {"key", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "One of the keys may be specified (id/symbol/creationTx)"},
-                       {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                        "Flag for verbose list (default = true), otherwise limited objects are listed"},
-               },
-               RPCResult{
-                       "{id:{...}}     (array) Json object with pool information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("getpoolpair", "GOLD")
-                       + HelpExampleRpc("getpoolpair", "GOLD")
-               },
-    }.Check(request);
+UniValue getpoolpair(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getpoolpair",
+        "\nReturns information about pool.\n",
+        {
+            {"key", RPCArg::Type::STR, RPCArg::Optional::NO, "One of the keys may be specified (id/symbol/creationTx)"},
+            {"verbose",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Flag for verbose list (default = true), otherwise limited objects are listed"},
+        },
+        RPCResult{"{id:{...}}     (array) Json object with pool information\n"},
+        RPCExamples{HelpExampleCli("getpoolpair", "GOLD") + HelpExampleRpc("getpoolpair", "GOLD")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     bool verbose = true;
     if (request.params.size() > 1) {
@@ -287,62 +312,78 @@ UniValue getpoolpair(const JSONRPCRequest& request) {
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pool not found");
 }
 
-UniValue addpoolliquidity(const JSONRPCRequest& request) {
+UniValue addpoolliquidity(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"addpoolliquidity",
-               "\nCreates (and submits to local node and network) a add pool liquidity transaction.\n"
-               "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                       {"from", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
+    RPCHelpMan{
+        "addpoolliquidity",
+        "\nCreates (and submits to local node and network) a add pool liquidity transaction.\n"
+        "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "from",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
+                {
+                    {"address",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "The defi address(es) is the key(s), the value(s) is amount in amount@token format. "
+                     "You should provide exectly two types of tokens for pool's 'token A' and 'token B' in any "
+                     "combinations."
+                     "If multiple tokens from one address are to be transferred, specify an array [\"amount1@t1\", "
+                     "\"amount2@t2\"]"
+                     "If \"from\" obj contain only one amount entry with address-key: \"*\" (star), it's means "
+                     "auto-selection accounts from wallet."},
+                },
+            },
+            {"shareAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address for crediting tokens."},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                                {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address(es) is the key(s), the value(s) is amount in amount@token format. "
-                                                                                     "You should provide exectly two types of tokens for pool's 'token A' and 'token B' in any combinations."
-                                                                                     "If multiple tokens from one address are to be transferred, specify an array [\"amount1@t1\", \"amount2@t2\"]"
-                                                                                     "If \"from\" obj contain only one amount entry with address-key: \"*\" (star), it's means auto-selection accounts from wallet."},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                       },
-                       {"shareAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address for crediting tokens."},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                 {
-                                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                 },
-                                },
-                        },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("addpoolliquidity",
-                                      "'{\"address1\":\"1.0@DFI\",\"address2\":\"1.0@DFI\"}' "
-                                      "share_address '[]'")
-                       + HelpExampleCli("addpoolliquidity",
-                                      "'{\"*\": [\"2.0@BTC\", \"3.0@ETH\"]}' "
-                                      "share_address '[]'")
-                       + HelpExampleRpc("addpoolliquidity",
-                                      "'{\"address1\":\"1.0@DFI\",\"address2\":\"1.0@DFI\"}' "
-                                      "share_address '[]'")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("addpoolliquidity",
+                                   "'{\"address1\":\"1.0@DFI\",\"address2\":\"1.0@DFI\"}' "
+                                   "share_address '[]'") +
+                    HelpExampleCli("addpoolliquidity",
+                                   "'{\"*\": [\"2.0@BTC\", \"3.0@ETH\"]}' "
+                                   "share_address '[]'") +
+                    HelpExampleRpc("addpoolliquidity",
+                                   "'{\"address1\":\"1.0@DFI\",\"address2\":\"1.0@DFI\"}' "
+                                   "share_address '[]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    RPCTypeCheck(request.params, { UniValue::VOBJ, UniValue::VSTR, UniValue::VARR }, true);
+    RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VSTR, UniValue::VARR}, true);
 
     // decode
     CLiquidityMessage msg{};
     if (request.params[0].get_obj().getKeys().size() == 1 &&
-        request.params[0].get_obj().getKeys()[0] == "*") { // auto-selection accounts from wallet
+        request.params[0].get_obj().getKeys()[0] == "*") {  // auto-selection accounts from wallet
 
         CAccounts foundMineAccounts = GetAllMineAccounts(pwallet);
 
@@ -352,18 +393,16 @@ UniValue addpoolliquidity(const JSONRPCRequest& request) {
 
         if (msg.from.empty()) {
             throw JSONRPCError(RPC_INVALID_REQUEST,
-                                   "Not enough balance on wallet accounts, call utxostoaccount to increase it.\n");
+                               "Not enough balance on wallet accounts, call utxostoaccount to increase it.\n");
         }
-    }
-    else {
+    } else {
         msg.from = DecodeRecipients(pwallet->chain(), request.params[0].get_obj());
     }
     msg.shareAddress = DecodeScript(request.params[1].get_str());
 
     // encode
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::AddPoolLiquidity)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::AddPoolLiquidity) << msg;
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
 
@@ -375,10 +414,10 @@ UniValue addpoolliquidity(const JSONRPCRequest& request) {
 
     // auth
     std::set<CScript> auths;
-    for (const auto& kv : msg.from) {
+    for (const auto &kv : msg.from) {
         auths.emplace(kv.first);
     }
-    UniValue const & txInputs = request.params[2];
+    UniValue const &txInputs = request.params[2];
     CTransactionRef optAuthTx;
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, txInputs);
 
@@ -402,47 +441,53 @@ UniValue addpoolliquidity(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue removepoolliquidity(const JSONRPCRequest& request) {
+UniValue removepoolliquidity(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"removepoolliquidity",
-               "\nCreates (and submits to local node and network) a remove pool liquidity transaction.\n"
-               "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                       {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address which has tokens"},
-                       {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Liquidity amount@Liquidity pool symbol"},
-                       {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                            "A json array of json objects",
-                            {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                    {
-                                        {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                        {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                    },
-                                },
-                            },
-                       },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("removepoolliquidity", "from_address 1.0@LpSymbol")
-                       + HelpExampleRpc("removepoolliquidity", "from_address 1.0@LpSymbol")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "removepoolliquidity",
+        "\nCreates (and submits to local node and network) a remove pool liquidity transaction.\n"
+        "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "The defi address which has tokens"},
+            {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Liquidity amount@Liquidity pool symbol"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                        },
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("removepoolliquidity", "from_address 1.0@LpSymbol") +
+                    HelpExampleRpc("removepoolliquidity", "from_address 1.0@LpSymbol")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    RPCTypeCheck(request.params, { UniValue::VSTR, UniValue::VSTR, UniValue::VARR }, true);
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VARR}, true);
 
     std::string from = request.params[0].get_str();
     std::string amount = request.params[1].get_str();
-    UniValue const & txInputs = request.params[2];
+    UniValue const &txInputs = request.params[2];
 
     // decode
     CRemoveLiquidityMessage msg{};
@@ -451,8 +496,7 @@ UniValue removepoolliquidity(const JSONRPCRequest& request) {
 
     // encode
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::RemovePoolLiquidity)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::RemovePoolLiquidity) << msg;
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
 
@@ -468,7 +512,7 @@ UniValue removepoolliquidity(const JSONRPCRequest& request) {
 
     CCoinControl coinControl;
 
-     // Set change to from address
+    // Set change to from address
     CTxDestination dest;
     ExtractDestination(msg.from, dest);
     if (IsValidDestination(dest)) {
@@ -484,77 +528,91 @@ UniValue removepoolliquidity(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue createpoolpair(const JSONRPCRequest& request) {
+UniValue createpoolpair(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"createpoolpair",
-               "\nCreates (and submits to local node and network) a poolpair transaction with given metadata.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                   {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                       {
-                            {"tokenA", RPCArg::Type::STR, RPCArg::Optional::NO,
-                            "One of the keys may be specified (id/symbol)"},
-                            {"tokenB", RPCArg::Type::STR, RPCArg::Optional::NO,
-                            "One of the keys may be specified (id/symbol)"},
-                            {"commission", RPCArg::Type::NUM, RPCArg::Optional::NO,
-                            "Pool commission, up to 10^-8"},
-                            {"status", RPCArg::Type::BOOL, RPCArg::Optional::NO,
-                            "Pool Status: True is Active, False is Restricted"},
-                            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
-                            "Address of the pool owner."},
-                            {"customRewards", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                            "Token reward to be paid on each block, multiple can be specified."},
-                            {"pairSymbol", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                             "Pair symbol (unique), no longer than " +
-                             std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
-                       },
-                   },
-                   {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                       {
-                           {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                               {
-                                   {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                   {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                               },
-                           },
-                       },
-                   },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("createpoolpair",   "'{\"tokenA\":\"MyToken1\","
-                                                          "\"tokenB\":\"MyToken2\","
-                                                          "\"commission\":\"0.001\","
-                                                          "\"status\":\"True\","
-                                                          "\"ownerAddress\":\"Address\","
-                                                          "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
-                                                          "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-                       + HelpExampleRpc("createpoolpair", "'{\"tokenA\":\"MyToken1\","
-                                                          "\"tokenB\":\"MyToken2\","
-                                                          "\"commission\":\"0.001\","
-                                                          "\"status\":\"True\","
-                                                          "\"ownerAddress\":\"Address\","
-                                                          "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
-                                                          "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "createpoolpair",
+        "\nCreates (and submits to local node and network) a poolpair transaction with given metadata.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"tokenA", RPCArg::Type::STR, RPCArg::Optional::NO, "One of the keys may be specified (id/symbol)"},
+                    {"tokenB", RPCArg::Type::STR, RPCArg::Optional::NO, "One of the keys may be specified (id/symbol)"},
+                    {"commission", RPCArg::Type::NUM, RPCArg::Optional::NO, "Pool commission, up to 10^-8"},
+                    {"status",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::NO,
+                     "Pool Status: True is Active, False is Restricted"},
+                    {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the pool owner."},
+                    {"customRewards",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Token reward to be paid on each block, multiple can be specified."},
+                    {"pairSymbol",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Pair symbol (unique), no longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                        },
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("createpoolpair",
+                                   "'{\"tokenA\":\"MyToken1\","
+                                   "\"tokenB\":\"MyToken2\","
+                                   "\"commission\":\"0.001\","
+                                   "\"status\":\"True\","
+                                   "\"ownerAddress\":\"Address\","
+                                   "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("createpoolpair",
+                                   "'{\"tokenA\":\"MyToken1\","
+                                   "\"tokenB\":\"MyToken2\","
+                                   "\"commission\":\"0.001\","
+                                   "\"status\":\"True\","
+                                   "\"ownerAddress\":\"Address\","
+                                   "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, true);
 
     std::string tokenA, tokenB, pairSymbol;
-    CAmount commission = 0; // !!!
+    CAmount commission = 0;  // !!!
     CScript ownerAddress;
     CBalances rewards;
-    bool status = true; // default Active
+    bool status = true;  // default Active
     UniValue metadataObj = request.params[0].get_obj();
     if (!metadataObj["tokenA"].isNull()) {
         tokenA = metadataObj["tokenA"].getValStr();
@@ -602,8 +660,7 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     poolPairMsg.ownerAddress = ownerAddress;
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::CreatePoolPair)
-             << poolPairMsg << pairSymbol;
+    metadata << static_cast<unsigned char>(CustomTxType::CreatePoolPair) << poolPairMsg << pairSymbol;
 
     if (targetHeight >= Params().GetConsensus().ClarkeQuayHeight) {
         metadata << rewards;
@@ -616,7 +673,7 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
@@ -639,49 +696,65 @@ UniValue createpoolpair(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue updatepoolpair(const JSONRPCRequest& request) {
+UniValue updatepoolpair(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"updatepoolpair",
-               "\nCreates (and submits to local node and network) a pool status update transaction.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must belong to the pool's owner (collateral) address" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                   {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                       {
-                           {"pool", RPCArg::Type::STR, RPCArg::Optional::NO, "The pool's symbol, id or creation tx"},
-                           {"status", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Pool Status new property (bool)"},
-                           {"commission", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Pool commission, up to 10^-8"},
-                           {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address of the pool owner."},
-                           {"customRewards", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Token reward to be paid on each block, multiple can be specified."},
-                       },
-                   },
-                   {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
+    RPCHelpMan{
+        "updatepoolpair",
+        "\nCreates (and submits to local node and network) a pool status update transaction.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must "
+        "belong to the pool's owner (collateral) address" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"pool", RPCArg::Type::STR, RPCArg::Optional::NO, "The pool's symbol, id or creation tx"},
+                    {"status", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Pool Status new property (bool)"},
+                    {"commission", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Pool commission, up to 10^-8"},
+                    {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address of the pool owner."},
+                    {"customRewards",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Token reward to be paid on each block, multiple can be specified."},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                   },
+                    },
+                },
+            },
 
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("updatepoolpair", "'{\"pool\":\"POOL\",\"status\":true,"
-                                                     "\"commission\":0.01,\"ownerAddress\":\"Address\","
-                                                     "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
-                                                     "'[{\"txid\":\"id\",\"vout\":0}]'")
-                       + HelpExampleRpc("updatepoolpair", "'{\"pool\":\"POOL\",\"status\":true,"
-                                                       "\"commission\":0.01,\"ownerAddress\":\"Address\","
-                                                       "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
-                                                       "'[{\"txid\":\"id\",\"vout\":0}]'")
-               },
-    }.Check(request);
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("updatepoolpair",
+                                   "'{\"pool\":\"POOL\",\"status\":true,"
+                                   "\"commission\":0.01,\"ownerAddress\":\"Address\","
+                                   "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("updatepoolpair",
+                                   "'{\"pool\":\"POOL\",\"status\":true,"
+                                   "\"commission\":0.01,\"ownerAddress\":\"Address\","
+                                   "\"customRewards\":\"[\\\"1@tokena\\\",\\\"10@tokenb\\\"]\"}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
@@ -695,8 +768,8 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     CAmount commission = -1;
     CScript ownerAddress;
     CBalances rewards;
-    UniValue const & metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &metaObj = request.params[0].get_obj();
+    UniValue const &txInputs = request.params[1];
 
     std::string const poolStr = trim_ws(metaObj["pool"].getValStr());
     DCT_ID poolId;
@@ -730,7 +803,8 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
 
         if (rewards.balances.empty()) {
             // Add special case to wipe rewards
-            rewards.balances.insert(std::pair<DCT_ID, CAmount>(DCT_ID{std::numeric_limits<uint32_t>::max()}, std::numeric_limits<CAmount>::max()));
+            rewards.balances.insert(std::pair<DCT_ID, CAmount>(DCT_ID{std::numeric_limits<uint32_t>::max()},
+                                                               std::numeric_limits<CAmount>::max()));
         }
     }
 
@@ -772,64 +846,77 @@ UniValue updatepoolpair(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue poolswap(const JSONRPCRequest& request) {
+UniValue poolswap(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"poolswap",
-               "\nCreates (and submits to local node and network) a poolswap transaction with given metadata.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                   {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
-                       {
-                           {"from", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenA."},
-                           {"tokenFrom", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO,
-                                       "tokenFrom coins amount"},
-                           {"to", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenB."},
-                           {"tokenTo", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                       "Maximum acceptable price"},
-                       },
-                   },
-                   {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                       {
-                           {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                               {
-                                   {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                   {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                               },
-                           },
-                       },
-                   },
-               },
-                      RPCResult{
-                          "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                      },
-                             RPCExamples{
-                                 HelpExampleCli("poolswap",   "'{\"from\":\"MyAddress\","
-                                                                    "\"tokenFrom\":\"MyToken1\","
-                                                                    "\"amountFrom\":\"0.001\","
-                                                                    "\"to\":\"Address\","
-                                                                    "\"tokenTo\":\"Token2\","
-                                                                    "\"maxPrice\":\"0.01\""
-                                                                    "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-                                         + HelpExampleRpc("poolswap", "'{\"from\":\"MyAddress\","
-                                                                            "\"tokenFrom\":\"MyToken1\","
-                                                                            "\"amountFrom\":\"0.001\","
-                                                                            "\"to\":\"Address\","
-                                                                            "\"tokenTo\":\"Token2\","
-                                                                            "\"maxPrice\":\"0.01\""
-                                                                            "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-                             },
-              }.Check(request);
+    RPCHelpMan{
+        "poolswap",
+        "\nCreates (and submits to local node and network) a poolswap transaction with given metadata.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
+                {
+                    {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenA."},
+                    {"tokenFrom",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "tokenFrom coins amount"},
+                    {"to", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenB."},
+                    {"tokenTo",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum acceptable price"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                        },
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("poolswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("poolswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -850,7 +937,7 @@ UniValue poolswap(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.emplace_back(0, scriptMeta);
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
     CTransactionRef optAuthTx;
     std::set<CScript> auths{poolSwapMsg.from};
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, txInputs);
@@ -873,64 +960,78 @@ UniValue poolswap(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue compositeswap(const JSONRPCRequest& request) {
+UniValue compositeswap(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"compositeswap",
-               "\nCreates (and submits to local node and network) a composite swap (swap between multiple poolpairs) transaction with given metadata.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                   {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
-                       {
-                           {"from", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenA."},
-                           {"tokenFrom", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO,
-                                       "tokenFrom coins amount"},
-                           {"to", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenB."},
-                           {"tokenTo", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                       "Maximum acceptable price"},
-                       },
-                   },
-                   {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                       {
-                           {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                               {
-                                   {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                   {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                               },
-                           },
-                       },
-                   },
-               },
-                      RPCResult{
-                          "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                      },
-                             RPCExamples{
-                                 HelpExampleCli("compositeswap",   "'{\"from\":\"MyAddress\","
-                                                                    "\"tokenFrom\":\"MyToken1\","
-                                                                    "\"amountFrom\":\"0.001\","
-                                                                    "\"to\":\"Address\","
-                                                                    "\"tokenTo\":\"Token2\","
-                                                                    "\"maxPrice\":\"0.01\""
-                                                                    "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-                                         + HelpExampleRpc("compositeswap", "'{\"from\":\"MyAddress\","
-                                                                            "\"tokenFrom\":\"MyToken1\","
-                                                                            "\"amountFrom\":\"0.001\","
-                                                                            "\"to\":\"Address\","
-                                                                            "\"tokenTo\":\"Token2\","
-                                                                            "\"maxPrice\":\"0.01\""
-                                                                            "}' '[{\"txid\":\"id\",\"vout\":0}]'")
-                             },
-              }.Check(request);
+    RPCHelpMan{
+        "compositeswap",
+        "\nCreates (and submits to local node and network) a composite swap (swap between multiple poolpairs) "
+        "transaction with given metadata.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
+                {
+                    {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenA."},
+                    {"tokenFrom",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "tokenFrom coins amount"},
+                    {"to", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenB."},
+                    {"tokenTo",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum acceptable price"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                        },
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("compositeswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("compositeswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}' '[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create transactions while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot create transactions while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -942,14 +1043,13 @@ UniValue compositeswap(const JSONRPCRequest& request) {
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VARR}, true);
 
     CPoolSwapMessageV2 poolSwapMsgV2{};
-    CPoolSwapMessage& poolSwapMsg = poolSwapMsgV2.swapInfo;
+    CPoolSwapMessage &poolSwapMsg = poolSwapMsgV2.swapInfo;
     CheckAndFillPoolSwapMessage(request, poolSwapMsg);
 
     {
         LOCK(cs_main);
         // If no direct swap found search for composite swap
         if (!pcustomcsview->GetPoolPair(poolSwapMsg.idTokenFrom, poolSwapMsg.idTokenTo)) {
-
             auto compositeSwap = CPoolSwap(poolSwapMsg, targetHeight);
             poolSwapMsgV2.poolIDs = compositeSwap.CalculateSwaps(*pcustomcsview);
 
@@ -960,7 +1060,8 @@ UniValue compositeswap(const JSONRPCRequest& request) {
                 if (!compositeSwap.errors.empty()) {
                     errorMsg += " Details: (";
                     for (size_t i{0}; i < compositeSwap.errors.size(); ++i) {
-                        errorMsg += '"' + compositeSwap.errors[i].first + "\":\"" +  compositeSwap.errors[i].second + '"' + (i + 1 < compositeSwap.errors.size() ? "," : "");
+                        errorMsg += '"' + compositeSwap.errors[i].first + "\":\"" + compositeSwap.errors[i].second +
+                                    '"' + (i + 1 < compositeSwap.errors.size() ? "," : "");
                     }
                     errorMsg += ')';
                 }
@@ -980,7 +1081,7 @@ UniValue compositeswap(const JSONRPCRequest& request) {
     CMutableTransaction rawTx(txVersion);
     rawTx.vout.emplace_back(0, scriptMeta);
 
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
     CTransactionRef optAuthTx;
     std::set<CScript> auths{poolSwapMsg.from};
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, txInputs);
@@ -1003,60 +1104,64 @@ UniValue compositeswap(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue testpoolswap(const JSONRPCRequest& request) {
-
-    RPCHelpMan{"testpoolswap",
-               "\nTests a poolswap transaction with given metadata and returns poolswap result.\n",
-               {
-                   {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                       {
-                           {"from", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenA."},
-                           {"tokenFrom", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO,
-                                       "tokenFrom coins amount"},
-                           {"to", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "Address of the owner of tokenB."},
-                           {"tokenTo", RPCArg::Type::STR, RPCArg::Optional::NO,
-                                       "One of the keys may be specified (id/symbol)"},
-                           {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                       "Maximum acceptable price"},
-                       },
-                   },
-                   {
-                       "path", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                       "One of auto/direct (default = direct)\n"
-                       "auto - automatically use composite swap or direct swap as needed.\n"
-                       "direct - uses direct path only or fails.\n"
-                       "composite - uses composite path only or fails.\n"
-                       "Note: The default will be switched to auto in the upcoming versions."
-                   },
-                   {
-                       "verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                       "Returns estimated composite path when true (default = false)"
-                   },
-               },
-               RPCResult{
-                          "\"amount@tokenId\"    (string) The string with amount result of poolswap in format AMOUNT@TOKENID.\n"
-               },
-               RPCExamples{
-                    HelpExampleCli("testpoolswap",   "'{\"from\":\"MyAddress\","
-                                                    "\"tokenFrom\":\"MyToken1\","
-                                                    "\"amountFrom\":\"0.001\","
-                                                    "\"to\":\"Address\","
-                                                    "\"tokenTo\":\"Token2\","
-                                                    "\"maxPrice\":\"0.01\""
-                                                    "}'")
-                    + HelpExampleRpc("testpoolswap", "'{\"from\":\"MyAddress\","
-                                                    "\"tokenFrom\":\"MyToken1\","
-                                                    "\"amountFrom\":\"0.001\","
-                                                    "\"to\":\"Address\","
-                                                    "\"tokenTo\":\"Token2\","
-                                                    "\"maxPrice\":\"0.01\""
-                                                    "}'")
-               },
-    }.Check(request);
+UniValue testpoolswap(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "testpoolswap",
+        "\nTests a poolswap transaction with given metadata and returns poolswap result.\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenA."},
+                    {"tokenFrom",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"amountFrom", RPCArg::Type::NUM, RPCArg::Optional::NO, "tokenFrom coins amount"},
+                    {"to", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the owner of tokenB."},
+                    {"tokenTo",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "One of the keys may be specified (id/symbol)"},
+                    {"maxPrice", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Maximum acceptable price"},
+                },
+            },
+            {"path",
+             RPCArg::Type::STR,
+             RPCArg::Optional::OMITTED,
+             "One of auto/direct (default = direct)\n"
+             "auto - automatically use composite swap or direct swap as needed.\n"
+             "direct - uses direct path only or fails.\n"
+             "composite - uses composite path only or fails.\n"
+             "Note: The default will be switched to auto in the upcoming versions."},
+            {"verbose",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Returns estimated composite path when true (default = false)"},
+        },
+        RPCResult{
+            "\"amount@tokenId\"    (string) The string with amount result of poolswap in format AMOUNT@TOKENID.\n"},
+        RPCExamples{HelpExampleCli("testpoolswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}'") +
+                    HelpExampleRpc("testpoolswap",
+                                   "'{\"from\":\"MyAddress\","
+                                   "\"tokenFrom\":\"MyToken1\","
+                                   "\"amountFrom\":\"0.001\","
+                                   "\"to\":\"Address\","
+                                   "\"tokenTo\":\"Token2\","
+                                   "\"maxPrice\":\"0.01\""
+                                   "}'")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValueType(), UniValue::VBOOL}, true);
 
@@ -1079,17 +1184,19 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
     Res res = Res::Ok();
     {
         LOCK(cs_main);
-        CCustomCSView mnview_dummy(*pcustomcsview); // create dummy cache for test state writing
+        CCustomCSView mnview_dummy(*pcustomcsview);  // create dummy cache for test state writing
 
         int targetHeight = ::ChainActive().Height() + 1;
 
         auto poolPair = mnview_dummy.GetPoolPair(poolSwapMsg.idTokenFrom, poolSwapMsg.idTokenTo);
-        if (poolPair && path == "auto") path = "direct";
+        if (poolPair && path == "auto")
+            path = "direct";
 
         // If no direct swap found search for composite swap
         if (path == "direct") {
             if (!poolPair)
-                throw JSONRPCError(RPC_INVALID_REQUEST, std::string{"Direct pool pair not found. Use 'auto' mode to use composite swap."});
+                throw JSONRPCError(RPC_INVALID_REQUEST,
+                                   std::string{"Direct pool pair not found. Use 'auto' mode to use composite swap."});
 
             if (poolSwapMsg.amountFrom <= 0)
                 throw JSONRPCError(RPC_INVALID_REQUEST, "Input amount should be positive");
@@ -1111,21 +1218,27 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
             const auto dirB = attributes->GetValue(dirBKey, CFeeDir{FeeDirValues::Both});
             const auto asymmetricFee = std::make_pair(dirA, dirB);
 
-            res = pp.Swap({poolSwapMsg.idTokenFrom, poolSwapMsg.amountFrom}, dexfeeInPct, poolSwapMsg.maxPrice, asymmetricFee, [&] (const CTokenAmount &, const CTokenAmount &tokenAmount) {
-                auto resPP = mnview_dummy.SetPoolPair(poolPair->first, targetHeight, pp);
-                if (!resPP) {
-                    return resPP;
-                }
+            res = pp.Swap(
+                {poolSwapMsg.idTokenFrom, poolSwapMsg.amountFrom},
+                dexfeeInPct,
+                poolSwapMsg.maxPrice,
+                asymmetricFee,
+                [&](const CTokenAmount &, const CTokenAmount &tokenAmount) {
+                    auto resPP = mnview_dummy.SetPoolPair(poolPair->first, targetHeight, pp);
+                    if (!resPP) {
+                        return resPP;
+                    }
 
-                auto resultAmount = tokenAmount;
-                auto dexfeeOutPct = mnview_dummy.GetDexFeeOutPct(poolPair->first, tokenAmount.nTokenId);
-                if (dexfeeOutPct > 0) {
-                    auto dexfeeOutAmount = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
-                    resultAmount.nValue -= dexfeeOutAmount;
-                }
+                    auto resultAmount = tokenAmount;
+                    auto dexfeeOutPct = mnview_dummy.GetDexFeeOutPct(poolPair->first, tokenAmount.nTokenId);
+                    if (dexfeeOutPct > 0) {
+                        auto dexfeeOutAmount = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
+                        resultAmount.nValue -= dexfeeOutAmount;
+                    }
 
-                return Res::Ok(resultAmount.ToString());
-            }, targetHeight);
+                    return Res::Ok(resultAmount.ToString());
+                },
+                targetHeight);
 
             if (!res)
                 throw JSONRPCError(RPC_VERIFY_ERROR, res.msg);
@@ -1147,7 +1260,7 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
                     poolArray.read(request.params[1].getValStr().c_str());
                 }
 
-                for (const auto& id : poolArray.getValues()) {
+                for (const auto &id : poolArray.getValues()) {
                     poolIds.push_back(DCT_ID::FromString(id.getValStr()));
                 }
 
@@ -1163,13 +1276,14 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
                 if (!compositeSwap.errors.empty()) {
                     errorMsg += " Details: (";
                     for (size_t i{0}; i < compositeSwap.errors.size(); ++i) {
-                        errorMsg += '"' + compositeSwap.errors[i].first + "\":\"" +  compositeSwap.errors[i].second + '"' + (i + 1 < compositeSwap.errors.size() ? "," : "");
+                        errorMsg += '"' + compositeSwap.errors[i].first + "\":\"" + compositeSwap.errors[i].second +
+                                    '"' + (i + 1 < compositeSwap.errors.size() ? "," : "");
                     }
                     errorMsg += ')';
                 }
                 throw JSONRPCError(RPC_INVALID_REQUEST, errorMsg);
             }
-            for (const auto& id : poolIds) {
+            for (const auto &id : poolIds) {
                 pools.push_back(id.ToString());
             }
             res.msg = compositeSwap.GetResult().ToString();
@@ -1186,35 +1300,48 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
     return res.msg;
 }
 
-UniValue listpoolshares(const JSONRPCRequest& request) {
-    RPCHelpMan{"listpoolshares",
-               "\nReturns information about pool shares.\n",
-               {
-                        {"pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                            {
-                                 {"start", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Optional first key to iterate from, in lexicographical order."},
-                                 {"including_start", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                  "If true, then iterate including starting position. False by default"},
-                                 {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Maximum number of pools to return, 100 by default"},
-                            },
-                        },
-                        {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                    "Flag for verbose list (default = true), otherwise only % are shown."},
-                        {"is_mine_only", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                    "Get shares for all accounts belonging to the wallet (default = false)"},
-               },
-               RPCResult{
-                       "{id:{...},...}     (array) Json object with pools information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listpoolshares", "'{\"start\":128}' false false")
-                       + HelpExampleRpc("listpoolshares", "'{\"start\":128}' false false")
-               },
-    }.Check(request);
+UniValue listpoolshares(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listpoolshares",
+        "\nReturns information about pool shares.\n",
+        {
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"start",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Optional first key to iterate from, in lexicographical order."},
+                    {"including_start",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "If true, then iterate including starting position. False by default"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of pools to return, 100 by default"},
+                },
+            },
+            {"verbose",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Flag for verbose list (default = true), otherwise only % are shown."},
+            {"is_mine_only",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Get shares for all accounts belonging to the wallet (default = false)"},
+        },
+        RPCResult{"{id:{...},...}     (array) Json object with pools information\n"},
+        RPCExamples{HelpExampleCli("listpoolshares", "'{\"start\":128}' false false") +
+                    HelpExampleRpc("listpoolshares", "'{\"start\":128}' false false")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     bool verbose = true;
     if (request.params.size() > 1) {
@@ -1236,11 +1363,11 @@ UniValue listpoolshares(const JSONRPCRequest& request) {
         if (request.params.size() > 0) {
             UniValue paginationObj = request.params[0].get_obj();
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
             if (!paginationObj["start"].isNull()) {
                 including_start = false;
-                start.v = (uint32_t) paginationObj["start"].get_int();
+                start.v = (uint32_t)paginationObj["start"].get_int();
             }
             if (!paginationObj["including_start"].isNull()) {
                 including_start = paginationObj["including_start"].getBool();
@@ -1256,51 +1383,52 @@ UniValue listpoolshares(const JSONRPCRequest& request) {
 
     LOCK(cs_main);
 
-    PoolShareKey startKey{ start, CScript{} };
-//    startKey.poolID = start;
-//    startKey.owner = CScript(0);
+    PoolShareKey startKey{start, CScript{}};
+    //    startKey.poolID = start;
+    //    startKey.owner = CScript(0);
 
     UniValue ret(UniValue::VOBJ);
-    pcustomcsview->ForEachPoolShare([&](DCT_ID const & poolId, CScript const & provider, uint32_t) {
-        const CTokenAmount tokenAmount = pcustomcsview->GetBalance(provider, poolId);
-        if(tokenAmount.nValue) {
-            const auto poolPair = pcustomcsview->GetPoolPair(poolId);
-            if(poolPair) {
-                if (isMineOnly) {
-                    if (IsMineCached(*pwallet, provider) == ISMINE_SPENDABLE) {
+    pcustomcsview->ForEachPoolShare(
+        [&](DCT_ID const &poolId, CScript const &provider, uint32_t) {
+            const CTokenAmount tokenAmount = pcustomcsview->GetBalance(provider, poolId);
+            if (tokenAmount.nValue) {
+                const auto poolPair = pcustomcsview->GetPoolPair(poolId);
+                if (poolPair) {
+                    if (isMineOnly) {
+                        if (IsMineCached(*pwallet, provider) == ISMINE_SPENDABLE) {
+                            ret.pushKVs(poolShareToJSON(poolId, provider, tokenAmount.nValue, *poolPair, verbose));
+                            limit--;
+                        }
+                    } else {
                         ret.pushKVs(poolShareToJSON(poolId, provider, tokenAmount.nValue, *poolPair, verbose));
                         limit--;
                     }
-                } else {
-                    ret.pushKVs(poolShareToJSON(poolId, provider, tokenAmount.nValue, *poolPair, verbose));
-                    limit--;
                 }
             }
-        }
 
-        return limit != 0;
-    }, startKey);
+            return limit != 0;
+        },
+        startKey);
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-static const CRPCCommand commands[] =
-{
-//  category        name                        actor (function)            params
-//  -------------   -----------------------     ---------------------       ----------
-    {"poolpair",    "listpoolpairs",            &listpoolpairs,             {"pagination", "verbose"}},
-    {"poolpair",    "getpoolpair",              &getpoolpair,               {"key", "verbose" }},
-    {"poolpair",    "addpoolliquidity",         &addpoolliquidity,          {"from", "shareAddress", "inputs"}},
-    {"poolpair",    "removepoolliquidity",      &removepoolliquidity,       {"from", "amount", "inputs"}},
-    {"poolpair",    "createpoolpair",           &createpoolpair,            {"metadata", "inputs"}},
-    {"poolpair",    "updatepoolpair",           &updatepoolpair,            {"metadata", "inputs"}},
-    {"poolpair",    "poolswap",                 &poolswap,                  {"metadata", "inputs"}},
-    {"poolpair",    "compositeswap",            &compositeswap,             {"metadata", "inputs"}},
-    {"poolpair",    "listpoolshares",           &listpoolshares,            {"pagination", "verbose", "is_mine_only"}},
-    {"poolpair",    "testpoolswap",             &testpoolswap,              {"metadata", "path", "verbose"}},
+static const CRPCCommand commands[] = {
+    //  category        name                        actor (function)            params
+    //  -------------   -----------------------     ---------------------       ----------
+    {"poolpair", "listpoolpairs", &listpoolpairs, {"pagination", "verbose"}},
+    {"poolpair", "getpoolpair", &getpoolpair, {"key", "verbose"}},
+    {"poolpair", "addpoolliquidity", &addpoolliquidity, {"from", "shareAddress", "inputs"}},
+    {"poolpair", "removepoolliquidity", &removepoolliquidity, {"from", "amount", "inputs"}},
+    {"poolpair", "createpoolpair", &createpoolpair, {"metadata", "inputs"}},
+    {"poolpair", "updatepoolpair", &updatepoolpair, {"metadata", "inputs"}},
+    {"poolpair", "poolswap", &poolswap, {"metadata", "inputs"}},
+    {"poolpair", "compositeswap", &compositeswap, {"metadata", "inputs"}},
+    {"poolpair", "listpoolshares", &listpoolshares, {"pagination", "verbose", "is_mine_only"}},
+    {"poolpair", "testpoolswap", &testpoolswap, {"metadata", "path", "verbose"}},
 };
 
-void RegisterPoolpairRPCCommands(CRPCTable& tableRPC) {
+void RegisterPoolpairRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -4,62 +4,88 @@
 
 #include <index/txindex.h>
 
-UniValue createtoken(const JSONRPCRequest& request) {
+UniValue createtoken(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"createtoken",
-               "\nCreates (and submits to local node and network) a token creation transaction with given metadata.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+    RPCHelpMan{
+        "createtoken",
+        "\nCreates (and submits to local node and network) a token creation transaction with given metadata.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"symbol",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Token's symbol (unique), no longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Token's name (optional), no longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
+                    {"isDAT",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'isDAT' property (bool, optional), default is 'False'"},
+                    {"decimal",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Token's decimal places (optional, fixed to 8 for now, unchecked)"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Token's total supply limit (optional, zero for now, unchecked)"},
+                    {"mintable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Mintable' property (bool, optional), default is 'True'"},
+                    {"tradeable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Tradeable' property (bool, optional), default is 'True'"},
+                    {"collateralAddress",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::NO,
+                     "Any valid destination for keeping collateral amount - used as token's owner auth"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"symbol", RPCArg::Type::STR, RPCArg::Optional::NO,
-                             "Token's symbol (unique), no longer than " +
-                             std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
-                            {"name", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                             "Token's name (optional), no longer than " +
-                             std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
-                            {"isDAT", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                             "Token's 'isDAT' property (bool, optional), default is 'False'"},
-                            {"decimal", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                             "Token's decimal places (optional, fixed to 8 for now, unchecked)"},
-                            {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                             "Token's total supply limit (optional, zero for now, unchecked)"},
-                            {"mintable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                             "Token's 'Mintable' property (bool, optional), default is 'True'"},
-                            {"tradeable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                             "Token's 'Tradeable' property (bool, optional), default is 'True'"},
-                            {"collateralAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
-                             "Any valid destination for keeping collateral amount - used as token's owner auth"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("createtoken", "'{\"symbol\":\"MyToken\","
-                                                     "\"collateralAddress\":\"address\"}'")
-                       + HelpExampleCli("createtoken", "'{\"symbol\":\"MyToken\","
-                                                     "\"collateralAddress\":\"address\"}' "
-                                                     "'[{\"txid\":\"id\",\"vout\":0}]'")
-                       + HelpExampleRpc("createtoken", "'{\"symbol\":\"MyToken\","
-                                                       "\"collateralAddress\":\"address\"}' "
-                                                       "'[{\"txid\":\"id\",\"vout\":0}]'")
-               },
-    }.Check(request);
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("createtoken",
+                                   "'{\"symbol\":\"MyToken\","
+                                   "\"collateralAddress\":\"address\"}'") +
+                    HelpExampleCli("createtoken",
+                                   "'{\"symbol\":\"MyToken\","
+                                   "\"collateralAddress\":\"address\"}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("createtoken",
+                                   "'{\"symbol\":\"MyToken\","
+                                   "\"collateralAddress\":\"address\"}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot create token while still in Initial Block Download");
@@ -74,33 +100,32 @@ UniValue createtoken(const JSONRPCRequest& request) {
     }
 
     const UniValue metaObj = request.params[0].get_obj();
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     std::string collateralAddress = metaObj["collateralAddress"].getValStr();
     CTxDestination collateralDest = DecodeDestination(collateralAddress);
     if (collateralDest.index() == 0) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "collateralAddress (" + collateralAddress + ") does not refer to any valid address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "collateralAddress (" + collateralAddress + ") does not refer to any valid address");
     }
 
     CToken token;
     token.symbol = trim_ws(metaObj["symbol"].getValStr()).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
     token.name = trim_ws(metaObj["name"].getValStr()).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
-    token.flags = metaObj["isDAT"].getBool() ? token.flags | (uint8_t)CToken::TokenFlags::DAT : token.flags; // setting isDAT
+    token.flags =
+        metaObj["isDAT"].getBool() ? token.flags | (uint8_t)CToken::TokenFlags::DAT : token.flags;  // setting isDAT
 
     if (!metaObj["tradeable"].isNull()) {
-        token.flags = metaObj["tradeable"].getBool() ?
-            token.flags | uint8_t(CToken::TokenFlags::Tradeable) :
-            token.flags & ~uint8_t(CToken::TokenFlags::Tradeable);
+        token.flags = metaObj["tradeable"].getBool() ? token.flags | uint8_t(CToken::TokenFlags::Tradeable)
+                                                     : token.flags & ~uint8_t(CToken::TokenFlags::Tradeable);
     }
     if (!metaObj["mintable"].isNull()) {
-        token.flags = metaObj["mintable"].getBool() ?
-            token.flags | uint8_t(CToken::TokenFlags::Mintable) :
-            token.flags & ~uint8_t(CToken::TokenFlags::Mintable);
+        token.flags = metaObj["mintable"].getBool() ? token.flags | uint8_t(CToken::TokenFlags::Mintable)
+                                                    : token.flags & ~uint8_t(CToken::TokenFlags::Mintable);
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::CreateToken)
-             << token;
+    metadata << static_cast<unsigned char>(CustomTxType::CreateToken) << token;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -112,7 +137,8 @@ UniValue createtoken(const JSONRPCRequest& request) {
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
-    rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, metaObj["isDAT"].getBool() /*needFoundersAuth*/, optAuthTx, txInputs);
+    rawTx.vin = GetAuthInputsSmart(
+        pwallet, rawTx.nVersion, auths, metaObj["isDAT"].getBool() /*needFoundersAuth*/, optAuthTx, txInputs);
 
     rawTx.vout.push_back(CTxOut(GetTokenCreationFee(targetHeight), scriptMeta));
     rawTx.vout.push_back(CTxOut(GetTokenCollateralAmount(), GetScriptForDestination(collateralDest)));
@@ -136,77 +162,100 @@ UniValue createtoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue updatetoken(const JSONRPCRequest& request) {
+UniValue updatetoken(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"updatetoken",
-               "\nCreates (and submits to local node and network) a transaction of token promotion to isDAT or demotion from isDAT. Collateral will be unlocked.\n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must belong to the token's owner (collateral) address" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "The tokens's symbol, id or creation tx"},
-                    {"metadata", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+    RPCHelpMan{
+        "updatetoken",
+        "\nCreates (and submits to local node and network) a transaction of token promotion to isDAT or demotion from "
+        "isDAT. Collateral will be unlocked.\n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must "
+        "belong to the token's owner (collateral) address" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"token", RPCArg::Type::STR, RPCArg::Optional::NO, "The tokens's symbol, id or creation tx"},
+            {
+                "metadata",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"symbol",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "New token's symbol, no longer than " + std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
+                    {"name",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "New token's name (optional), no longer than " + std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
+                    {"isDAT",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'isDAT' property (bool, optional), default is 'False'"},
+                    {"mintable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Mintable' property (bool, optional)"},
+                    {"tradeable",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Token's 'Tradeable' property (bool, optional)"},
+                    {"finalize",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "Lock token properties forever (bool, optional)"},
+                    // it is possible to transfer token's owner. but later
+                    //                           {"collateralAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
+                    //                            "Any valid destination for keeping collateral amount - used as token's
+                    //                            owner auth"},
+                    // omitted for now, need to research/discuss
+                    //                           {"decimal", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                    //                            "Token's decimal places (optional, fixed to 8 for now, unchecked)"},
+                    //                           {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                    //                            "Token's total supply limit (optional, zero for now, unchecked)"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects. Provide it if you want to spent specific UTXOs",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                           {"symbol", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                            "New token's symbol, no longer than " +
-                            std::to_string(CToken::MAX_TOKEN_SYMBOL_LENGTH)},
-                           {"name", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                            "New token's name (optional), no longer than " +
-                            std::to_string(CToken::MAX_TOKEN_NAME_LENGTH)},
-                           {"isDAT", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                            "Token's 'isDAT' property (bool, optional), default is 'False'"},
-                           {"mintable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                            "Token's 'Mintable' property (bool, optional)"},
-                           {"tradeable", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                            "Token's 'Tradeable' property (bool, optional)"},
-                           {"finalize", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                            "Lock token properties forever (bool, optional)"},
-                           // it is possible to transfer token's owner. but later
-//                           {"collateralAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
-//                            "Any valid destination for keeping collateral amount - used as token's owner auth"},
-                           // omitted for now, need to research/discuss
-//                           {"decimal", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-//                            "Token's decimal places (optional, fixed to 8 for now, unchecked)"},
-//                           {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-//                            "Token's total supply limit (optional, zero for now, unchecked)"},
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects. Provide it if you want to spent specific UTXOs",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("updatetoken", "token '{\"isDAT\":true}' "
-                                                     "'[{\"txid\":\"id\",\"vout\":0}]'")
-                       + HelpExampleRpc("updatetoken", "token '{\"isDAT\":true}' "
-                                                       "'[{\"txid\":\"id\",\"vout\":0}]'")
-               },
-    }.Check(request);
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("updatetoken",
+                                   "token '{\"isDAT\":true}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("updatetoken",
+                                   "token '{\"isDAT\":true}' "
+                                   "'[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                           "Cannot update token while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot update token while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
-    RPCTypeCheck(request.params, {UniValueType(), UniValue::VOBJ, UniValue::VARR}, true); // first means "any"
+    RPCTypeCheck(request.params, {UniValueType(), UniValue::VOBJ, UniValue::VARR}, true);  // first means "any"
 
     /// @todo RPCTypeCheckObj or smth to help with option's names and old/new tx type
 
     std::string const tokenStr = trim_ws(request.params[0].getValStr());
     UniValue metaObj = request.params[1].get_obj();
-    UniValue const & txInputs = request.params[2];
+    UniValue const &txInputs = request.params[2];
 
     CTokenImplementation tokenImpl;
     CTxDestination ownerDest;
@@ -222,12 +271,14 @@ UniValue updatetoken(const JSONRPCRequest& request) {
         if (!token) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenStr));
         }
-        tokenImpl = static_cast<CTokenImplementation const& >(*token);
+        tokenImpl = static_cast<CTokenImplementation const &>(*token);
         if (tokenImpl.IsPoolShare()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s is the LPS token! Can't alter pool share's tokens!", tokenStr));
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               strprintf("Token %s is the LPS token! Can't alter pool share's tokens!", tokenStr));
         }
 
-        const Coin& authCoin = ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(tokenImpl.creationTx, 1)); // always n=1 output
+        const Coin &authCoin =
+            ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(tokenImpl.creationTx, 1));  // always n=1 output
         if (!ExtractDestination(authCoin.out.scriptPubKey, ownerDest)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,
                                strprintf("Can't extract destination for token's %s collateral", tokenImpl.symbol));
@@ -243,24 +294,20 @@ UniValue updatetoken(const JSONRPCRequest& request) {
         tokenImpl.name = trim_ws(metaObj["name"].getValStr()).substr(0, CToken::MAX_TOKEN_NAME_LENGTH);
     }
     if (!metaObj["isDAT"].isNull()) {
-        tokenImpl.flags = metaObj["isDAT"].getBool() ?
-                              tokenImpl.flags | (uint8_t)CToken::TokenFlags::DAT :
-                              tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::DAT;
+        tokenImpl.flags = metaObj["isDAT"].getBool() ? tokenImpl.flags | (uint8_t)CToken::TokenFlags::DAT
+                                                     : tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::DAT;
     }
     if (!metaObj["tradeable"].isNull()) {
-        tokenImpl.flags = metaObj["tradeable"].getBool() ?
-                              tokenImpl.flags | (uint8_t)CToken::TokenFlags::Tradeable :
-                              tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::Tradeable;
+        tokenImpl.flags = metaObj["tradeable"].getBool() ? tokenImpl.flags | (uint8_t)CToken::TokenFlags::Tradeable
+                                                         : tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::Tradeable;
     }
     if (!metaObj["mintable"].isNull()) {
-        tokenImpl.flags = metaObj["mintable"].getBool() ?
-                              tokenImpl.flags | (uint8_t)CToken::TokenFlags::Mintable :
-                              tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::Mintable;
+        tokenImpl.flags = metaObj["mintable"].getBool() ? tokenImpl.flags | (uint8_t)CToken::TokenFlags::Mintable
+                                                        : tokenImpl.flags & ~(uint8_t)CToken::TokenFlags::Mintable;
     }
     if (!metaObj["finalize"].isNull()) {
-        tokenImpl.flags = metaObj["finalize"].getBool() ?
-                              tokenImpl.flags | (uint8_t)CToken::TokenFlags::Finalized :
-                              tokenImpl.flags;
+        tokenImpl.flags =
+            metaObj["finalize"].getBool() ? tokenImpl.flags | (uint8_t)CToken::TokenFlags::Finalized : tokenImpl.flags;
     }
 
     const auto txVersion = GetTransactionVersion(targetHeight);
@@ -270,21 +317,24 @@ UniValue updatetoken(const JSONRPCRequest& request) {
 
     if (targetHeight < Params().GetConsensus().BayfrontHeight) {
         if (metaObj.size() > 1 || !metaObj.exists("isDAT")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Only 'isDAT' flag modification allowed before Bayfront fork (<" + std::to_string(Params().GetConsensus().BayfrontHeight) + ")");
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Only 'isDAT' flag modification allowed before Bayfront fork (<" +
+                                   std::to_string(Params().GetConsensus().BayfrontHeight) + ")");
         }
 
         // before BayfrontHeight it needs only founders auth
-        rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths /*auths*/, true /*needFoundersAuth*/, optAuthTx, txInputs);
-    }
-    else
-    { // post-bayfront auth
-        bool isFoundersToken = Params().GetConsensus().foundationMembers.find(owner) != Params().GetConsensus().foundationMembers.end();
-        if (isFoundersToken) { // need any founder's auth
-            rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths /*auths*/, true /*needFoundersAuth*/, optAuthTx, txInputs);
-        }
-        else {// "common" auth
+        rawTx.vin = GetAuthInputsSmart(
+            pwallet, rawTx.nVersion, auths /*auths*/, true /*needFoundersAuth*/, optAuthTx, txInputs);
+    } else {  // post-bayfront auth
+        bool isFoundersToken =
+            Params().GetConsensus().foundationMembers.find(owner) != Params().GetConsensus().foundationMembers.end();
+        if (isFoundersToken) {  // need any founder's auth
+            rawTx.vin = GetAuthInputsSmart(
+                pwallet, rawTx.nVersion, auths /*auths*/, true /*needFoundersAuth*/, optAuthTx, txInputs);
+        } else {  // "common" auth
             auths.insert(owner);
-            rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, txInputs);
+            rawTx.vin =
+                GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, txInputs);
         }
     }
 
@@ -292,12 +342,11 @@ UniValue updatetoken(const JSONRPCRequest& request) {
 
     // tx type and serialized data differ:
     if (targetHeight < Params().GetConsensus().BayfrontHeight) {
-        metadata << static_cast<unsigned char>(CustomTxType::UpdateToken)
-                 << tokenImpl.creationTx <<  metaObj["isDAT"].getBool();
-    }
-    else {
-        metadata << static_cast<unsigned char>(CustomTxType::UpdateTokenAny)
-                 << tokenImpl.creationTx << static_cast<CToken>(tokenImpl); // casting to base token's data
+        metadata << static_cast<unsigned char>(CustomTxType::UpdateToken) << tokenImpl.creationTx
+                 << metaObj["isDAT"].getBool();
+    } else {
+        metadata << static_cast<unsigned char>(CustomTxType::UpdateTokenAny) << tokenImpl.creationTx
+                 << static_cast<CToken>(tokenImpl);  // casting to base token's data
     }
 
     CScript scriptMeta;
@@ -322,7 +371,7 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation const& token, bool verbose) {
+UniValue tokenToJSON(CCustomCSView &view, DCT_ID const &id, CTokenImplementation const &token, bool verbose) {
     UniValue tokenObj(UniValue::VOBJ);
     tokenObj.pushKV("symbol", token.symbol);
     tokenObj.pushKV("symbolKey", token.CreateSymbolKey(id));
@@ -352,7 +401,8 @@ UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation
         tokenObj.pushKV("destructionTx", token.destructionTx.ToString());
         tokenObj.pushKV("destructionHeight", token.destructionHeight);
         if (!token.IsPoolShare()) {
-            const Coin& authCoin = ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(token.creationTx, 1)); // always n=1 output
+            const Coin &authCoin =
+                ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(token.creationTx, 1));  // always n=1 output
             tokenObj.pushKV("collateralAddress", ScriptToString(authCoin.out.scriptPubKey));
         } else {
             tokenObj.pushKV("collateralAddress", "undefined");
@@ -363,34 +413,45 @@ UniValue tokenToJSON(CCustomCSView& view, DCT_ID const& id, CTokenImplementation
     return ret;
 }
 
-UniValue listtokens(const JSONRPCRequest& request) {
-    RPCHelpMan{"listtokens",
-               "\nReturns information about tokens.\n",
-               {
-                        {"pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                            {
-                                 {"start", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Optional first key to iterate from, in lexicographical order."
-                                  "Typically it's set to last ID from previous request."},
-                                 {"including_start", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                  "If true, then iterate including starting position. False by default"},
-                                 {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                  "Maximum number of tokens to return, 100 by default"},
-                            },
-                        },
-                        {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                    "Flag for verbose list (default = true), otherwise only ids, symbols and names are listed"},
-               },
-               RPCResult{
-                       "{id:{...},...}     (array) Json object with tokens information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listtokens", "'{\"start\":128}' false")
-                       + HelpExampleRpc("listtokens", "'{\"start\":128}' false")
-               },
-    }.Check(request);
+UniValue listtokens(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listtokens",
+        "\nReturns information about tokens.\n",
+        {
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"start",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Optional first key to iterate from, in lexicographical order."
+                     "Typically it's set to last ID from previous request."},
+                    {"including_start",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "If true, then iterate including starting position. False by default"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of tokens to return, 100 by default"},
+                },
+            },
+            {"verbose",
+             RPCArg::Type::BOOL,
+             RPCArg::Optional::OMITTED,
+             "Flag for verbose list (default = true), otherwise only ids, symbols and names are listed"},
+        },
+        RPCResult{"{id:{...},...}     (array) Json object with tokens information\n"},
+        RPCExamples{HelpExampleCli("listtokens", "'{\"start\":128}' false") +
+                    HelpExampleRpc("listtokens", "'{\"start\":128}' false")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     bool verbose = true;
     if (request.params.size() > 1) {
@@ -405,11 +466,11 @@ UniValue listtokens(const JSONRPCRequest& request) {
         if (request.params.size() > 0) {
             UniValue paginationObj = request.params[0].get_obj();
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
             if (!paginationObj["start"].isNull()) {
                 including_start = false;
-                start.v = (uint32_t) paginationObj["start"].get_int();
+                start.v = (uint32_t)paginationObj["start"].get_int();
             }
             if (!paginationObj["including_start"].isNull()) {
                 including_start = paginationObj["including_start"].getBool();
@@ -426,33 +487,32 @@ UniValue listtokens(const JSONRPCRequest& request) {
     LOCK(cs_main);
 
     UniValue ret(UniValue::VOBJ);
-    pcustomcsview->ForEachToken([&](DCT_ID const& id, CTokenImplementation token) {
-        ret.pushKVs(tokenToJSON(*pcustomcsview, id, token, verbose));
+    pcustomcsview->ForEachToken(
+        [&](DCT_ID const &id, CTokenImplementation token) {
+            ret.pushKVs(tokenToJSON(*pcustomcsview, id, token, verbose));
 
-        limit--;
-        return limit != 0;
-    }, start);
+            limit--;
+            return limit != 0;
+        },
+        start);
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue gettoken(const JSONRPCRequest& request) {
-    RPCHelpMan{"gettoken",
-               "\nReturns information about token.\n",
-               {
-                       {"key", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "One of the keys may be specified (id/symbol/creationTx)"},
-               },
-               RPCResult{
-                       "{id:{...}}     (array) Json object with token information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("gettoken", "GOLD")
-                       + HelpExampleRpc("gettoken", "GOLD")
-               },
-    }.Check(request);
+UniValue gettoken(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "gettoken",
+        "\nReturns information about token.\n",
+        {
+            {"key", RPCArg::Type::STR, RPCArg::Optional::NO, "One of the keys may be specified (id/symbol/creationTx)"},
+        },
+        RPCResult{"{id:{...}}     (array) Json object with token information\n"},
+        RPCExamples{HelpExampleCli("gettoken", "GOLD") + HelpExampleRpc("gettoken", "GOLD")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     LOCK(cs_main);
 
@@ -465,34 +525,37 @@ UniValue gettoken(const JSONRPCRequest& request) {
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Token not found");
 }
 
-UniValue getcustomtx(const JSONRPCRequest& request)
-{
+UniValue getcustomtx(const JSONRPCRequest &request) {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    CWallet* const pwallet = wallet.get();
+    CWallet *const pwallet = wallet.get();
 
-    RPCHelpMan{"getcustomtx",
-        "\nGet detailed information about a DeFiChain custom transaction. Will search wallet transactions and mempool transaction,\n"
-        "if a blockhash is provided and that block is available then details for that transaction can be returned. -txindex\n"
+    RPCHelpMan{
+        "getcustomtx",
+        "\nGet detailed information about a DeFiChain custom transaction. Will search wallet transactions and mempool "
+        "transaction,\n"
+        "if a blockhash is provided and that block is available then details for that transaction can be returned. "
+        "-txindex\n"
         "can be enabled to return details for any transaction.",
         {
             {"txid", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction id"},
-            {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED_NAMED_ARG, "The block in which to look for the transaction"},
+            {"blockhash",
+             RPCArg::Type::STR_HEX,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "The block in which to look for the transaction"},
         },
-        RPCResult{
-            "{\n"
-            "  \"type\":               (string) The transaction type.\n"
-            "  \"valid\"               (bool) Whether the transaction was valid.\n"
-            "  \"results\"             (json object) Set of results related to the transaction type\n"
-            "  \"block height\"        (string) The block height containing the transaction.\n"
-            "  \"blockhash\"           (string) The block hash containing the transaction.\n"
-            "  \"confirmations\": n,   (numeric) The number of confirmations for the transaction."
-            "}\n"
-        },
+        RPCResult{"{\n"
+                  "  \"type\":               (string) The transaction type.\n"
+                  "  \"valid\"               (bool) Whether the transaction was valid.\n"
+                  "  \"results\"             (json object) Set of results related to the transaction type\n"
+                  "  \"block height\"        (string) The block height containing the transaction.\n"
+                  "  \"blockhash\"           (string) The block hash containing the transaction.\n"
+                  "  \"confirmations\": n,   (numeric) The number of confirmations for the transaction."
+                  "}\n"},
         RPCExamples{
-            HelpExampleCli("getcustomtx", "\"66ea2ac081e2917f075e2cca7c1c0baa12fb85c469f34561185fa64d7d2f9305\"")
-                    + HelpExampleRpc("getcustomtx", "\"66ea2ac081e2917f075e2cca7c1c0baa12fb85c469f34561185fa64d7d2f9305\"")
-        },
-    }.Check(request);
+            HelpExampleCli("getcustomtx", "\"66ea2ac081e2917f075e2cca7c1c0baa12fb85c469f34561185fa64d7d2f9305\"") +
+            HelpExampleRpc("getcustomtx", "\"66ea2ac081e2917f075e2cca7c1c0baa12fb85c469f34561185fa64d7d2f9305\"")},
+    }
+        .Check(request);
 
     const uint256 hash(ParseHashV(request.params[0], "txid"));
 
@@ -502,18 +565,16 @@ UniValue getcustomtx(const JSONRPCRequest& request)
     // Search wallet if available
     if (pwallet) {
         LOCK(pwallet->cs_wallet);
-        if (auto wtx = pwallet->GetWalletTx(hash))
-        {
+        if (auto wtx = pwallet->GetWalletTx(hash)) {
             tx = wtx->tx;
             hashBlock = wtx->hashBlock;
         }
     }
 
-    CBlockIndex* blockindex{nullptr};
+    CBlockIndex *blockindex{nullptr};
 
     // No wallet or not a wallet TX, try mempool, txindex and a block if hash provided
-    if (!pwallet || !tx)
-    {
+    if (!pwallet || !tx) {
         if (!request.params[1].isNull()) {
             LOCK(cs_main);
 
@@ -539,7 +600,8 @@ UniValue getcustomtx(const JSONRPCRequest& request)
             } else if (!g_txindex) {
                 errmsg = "No such mempool or wallet transaction. Use -txindex or provide a block hash.";
             } else if (!f_txindex_ready) {
-                errmsg = "No such mempool or wallet transaction. Transactions are still in the process of being indexed.";
+                errmsg =
+                    "No such mempool or wallet transaction. Transactions are still in the process of being indexed.";
             } else {
                 errmsg = "No such mempool, wallet or blockchain transaction.";
             }
@@ -553,8 +615,7 @@ UniValue getcustomtx(const JSONRPCRequest& request)
     UniValue txResults(UniValue::VOBJ);
     Res res{};
 
-    if (tx)
-    {
+    if (tx) {
         LOCK(cs_main);
 
         // Found a block hash but no block index yet
@@ -590,7 +651,6 @@ UniValue getcustomtx(const JSONRPCRequest& request)
 
     result.pushKV("type", ToString(guess));
     if (!actualHeight) {
-
         LOCK(cs_main);
         CCustomCSView mnview(*pcustomcsview);
         CCoinsViewCache view(&::ChainstateActive().CoinsTip());
@@ -627,48 +687,54 @@ UniValue getcustomtx(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue minttokens(const JSONRPCRequest& request) {
+UniValue minttokens(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"minttokens",
-               "\nCreates (and submits to local node and network) a transaction minting your token (for accounts and/or UTXOs). \n"
-               "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must belong to the token's owner (collateral) address" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"amounts", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "Amount as json string, or array. Example: '[ \"amount@token\" ]'"
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects. Provide it if you want to spent specific UTXOs",
+    RPCHelpMan{
+        "minttokens",
+        "\nCreates (and submits to local node and network) a transaction minting your token (for accounts and/or "
+        "UTXOs). \n"
+        "The second optional argument (may be empty array) is an array of specific UTXOs to spend. One of UTXO's must "
+        "belong to the token's owner (collateral) address" +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"amounts",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Amount as json string, or array. Example: '[ \"amount@token\" ]'"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects. Provide it if you want to spent specific UTXOs",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
                         {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("minttokens", "10@symbol")
-                       + HelpExampleCli("minttokens",
-                                      "10@symbol '[{\"txid\":\"id\",\"vout\":0}]'")
-                       + HelpExampleRpc("minttokens", "10@symbol '[{\"txid\":\"id\",\"vout\":0}]'")
-               },
-    }.Check(request);
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("minttokens", "10@symbol") +
+                    HelpExampleCli("minttokens", "10@symbol '[{\"txid\":\"id\",\"vout\":0}]'") +
+                    HelpExampleRpc("minttokens", "10@symbol '[{\"txid\":\"id\",\"vout\":0}]'")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                           "Cannot mint tokens while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot mint tokens while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
     const CBalances minted = DecodeAmounts(pwallet->chain(), request.params[0], "");
-    UniValue const & txInputs = request.params[1];
+    UniValue const &txInputs = request.params[1];
 
     int targetHeight = chainHeight(*pwallet->chain().lock()) + 1;
 
@@ -681,7 +747,7 @@ UniValue minttokens(const JSONRPCRequest& request) {
     bool needFoundersAuth = false;
     if (txInputs.isNull() || txInputs.empty()) {
         LOCK(cs_main);
-        for (auto const & kv : minted.balances) {
+        for (auto const &kv : minted.balances) {
             auto token = pcustomcsview->GetToken(kv.first);
             if (!token) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", kv.first.ToString()));
@@ -690,7 +756,8 @@ UniValue minttokens(const JSONRPCRequest& request) {
                 needFoundersAuth = true;
             }
             // Get token owner auth if present
-            const Coin& authCoin = ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(token->creationTx, 1)); // always n=1 output
+            const Coin &authCoin =
+                ::ChainstateActive().CoinsTip().AccessCoin(COutPoint(token->creationTx, 1));  // always n=1 output
             auths.insert(authCoin.out.scriptPubKey);
         }
     }
@@ -698,7 +765,7 @@ UniValue minttokens(const JSONRPCRequest& request) {
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
     metadata << static_cast<unsigned char>(CustomTxType::MintToken)
-             << minted; /// @note here, that whole CBalances serialized!, not a 'minted.balances'!
+             << minted;  /// @note here, that whole CBalances serialized!, not a 'minted.balances'!
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -725,33 +792,32 @@ UniValue minttokens(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue decodecustomtx(const JSONRPCRequest& request)
-{
-    RPCHelpMan{"decodecustomtx",
+UniValue decodecustomtx(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "decodecustomtx",
         "\nGet detailed information about a DeFiChain custom transaction.\n",
         {
             {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction hex string"},
-            {"iswitness", RPCArg::Type::BOOL, /* default */ "depends on heuristic tests", "Whether the transaction hex is a serialized witness transaction.\n"
-                "If iswitness is not present, heuristic tests will be used in decoding.\n"
-                "If true, only witness deserialization will be tried.\n"
-                "If false, only non-witness deserialization will be tried.\n"
-                "This boolean should reflect whether the transaction has inputs\n"
-                "(e.g. fully valid, or on-chain transactions), if known by the caller."
-            },
+            {"iswitness",
+             RPCArg::Type::BOOL,
+             /* default */ "depends on heuristic tests",
+             "Whether the transaction hex is a serialized witness transaction.\n"
+             "If iswitness is not present, heuristic tests will be used in decoding.\n"
+             "If true, only witness deserialization will be tried.\n"
+             "If false, only non-witness deserialization will be tried.\n"
+             "This boolean should reflect whether the transaction has inputs\n"
+             "(e.g. fully valid, or on-chain transactions), if known by the caller."},
         },
-        RPCResult{
-            "{\n"
-            "  \"txid\":               (string) The transaction id.\n"
-            "  \"type\":               (string) The transaction type.\n"
-            "  \"valid\"               (bool) Whether the transaction was valid.\n"
-            "  \"results\"             (json object) Set of results related to the transaction type\n"
-            "}\n"
-        },
-        RPCExamples{
-            HelpExampleCli("decodecustomtx", "\"hexstring\"")
-            + HelpExampleRpc("decodecustomtx", "\"hexstring\"")
-        },
-    }.Check(request);
+        RPCResult{"{\n"
+                  "  \"txid\":               (string) The transaction id.\n"
+                  "  \"type\":               (string) The transaction type.\n"
+                  "  \"valid\"               (bool) Whether the transaction was valid.\n"
+                  "  \"results\"             (json object) Set of results related to the transaction type\n"
+                  "}\n"},
+        RPCExamples{HelpExampleCli("decodecustomtx", "\"hexstring\"") +
+                    HelpExampleRpc("decodecustomtx", "\"hexstring\"")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
 
@@ -770,8 +836,7 @@ UniValue decodecustomtx(const JSONRPCRequest& request)
     CTransactionRef tx = MakeTransactionRef(std::move(mtx));
     std::string warnings;
 
-    if (tx)
-    {
+    if (tx) {
         LOCK(cs_main);
         // Default to INT_MAX
         nHeight = std::numeric_limits<int>::max();
@@ -780,8 +845,8 @@ UniValue decodecustomtx(const JSONRPCRequest& request)
         if ((tx->IsCoinBase() && nHeight > 0)) {
             return "Coinbase transaction. Not a custom transaction.";
         }
-        //get custom tx info. We pass nHeight INT_MAX,
-        //just to get over hardfork validations. txResults are based on transaction metadata.
+        // get custom tx info. We pass nHeight INT_MAX,
+        // just to get over hardfork validations. txResults are based on transaction metadata.
         res = RpcInfo(*tx, nHeight, guess, txResults);
         if (guess == CustomTxType::None) {
             return "Not a custom transaction";
@@ -805,20 +870,19 @@ UniValue decodecustomtx(const JSONRPCRequest& request)
     }
 }
 
-static const CRPCCommand commands[] =
-{
-//  category        name                     actor (function)        params
-//  -------------   ---------------------    --------------------    ----------
-    {"tokens",      "createtoken",           &createtoken,           {"metadata", "inputs"}},
-    {"tokens",      "updatetoken",           &updatetoken,           {"token", "metadata", "inputs"}},
-    {"tokens",      "listtokens",            &listtokens,            {"pagination", "verbose"}},
-    {"tokens",      "gettoken",              &gettoken,              {"key" }},
-    {"tokens",      "getcustomtx",           &getcustomtx,           {"txid", "blockhash"}},
-    {"tokens",      "minttokens",            &minttokens,            {"amounts", "inputs"}},
-    {"tokens",      "decodecustomtx",        &decodecustomtx,        {"hexstring", "iswitness"}},
+static const CRPCCommand commands[] = {
+    //  category        name                     actor (function)        params
+    //  -------------   ---------------------    --------------------    ----------
+    {"tokens", "createtoken", &createtoken, {"metadata", "inputs"}},
+    {"tokens", "updatetoken", &updatetoken, {"token", "metadata", "inputs"}},
+    {"tokens", "listtokens", &listtokens, {"pagination", "verbose"}},
+    {"tokens", "gettoken", &gettoken, {"key"}},
+    {"tokens", "getcustomtx", &getcustomtx, {"txid", "blockhash"}},
+    {"tokens", "minttokens", &minttokens, {"amounts", "inputs"}},
+    {"tokens", "decodecustomtx", &decodecustomtx, {"hexstring", "iswitness"}},
 };
 
-void RegisterTokensRPCCommands(CRPCTable& tableRPC) {
+void RegisterTokensRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -3,266 +3,279 @@
 #include <masternodes/mn_rpc.h>
 #include <masternodes/vaulthistory.h>
 
-extern UniValue AmountsToJSON(TAmounts const & diffs, AmountFormat format = AmountFormat::Symbol);
-extern std::string tokenAmountString(CTokenAmount const& amount, AmountFormat format = AmountFormat::Symbol);
+extern UniValue AmountsToJSON(TAmounts const &diffs, AmountFormat format = AmountFormat::Symbol);
+extern std::string tokenAmountString(CTokenAmount const &amount, AmountFormat format = AmountFormat::Symbol);
 
 namespace {
 
-    enum class VaultState : uint32_t {
-        Unknown = 0,
-        Active = (1 << 0),
-        InLiquidation = (1 << 1),
-        Frozen = (1 << 2),
-        MayLiquidate = (1 << 3)
-    };
+enum class VaultState : uint32_t {
+    Unknown = 0,
+    Active = (1 << 0),
+    InLiquidation = (1 << 1),
+    Frozen = (1 << 2),
+    MayLiquidate = (1 << 3)
+};
 
-    std::string VaultStateToString(const VaultState& state)
-    {
-        switch (state) {
-            case VaultState::Active:
-                return "active";
-            case VaultState::Frozen:
-                return "frozen";
-            case VaultState::InLiquidation:
-                return "inLiquidation";
-            case VaultState::MayLiquidate:
-                return "mayLiquidate";
-            default:
-                return "unknown";
-        }
-    }
-
-    VaultState StringToVaultState(const std::string& stateStr)
-    {
-        if (stateStr == "active") return VaultState::Active;
-        if (stateStr == "frozen") return VaultState::Frozen;
-        if (stateStr == "inLiquidation") return VaultState::InLiquidation;
-        if (stateStr == "mayLiquidate") return VaultState::MayLiquidate;
-        return VaultState::Unknown;
-    }
-
-    bool WillLiquidateNext(const CVaultId& vaultId, const CVaultData& vault) {
-        auto height = ::ChainActive().Height();
-        auto blockTime = ::ChainActive()[height]->GetBlockTime();
-
-        auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
-        if (!collaterals)
-            return false;
-
-        bool useNextPrice = true, requireLivePrice = false;
-        auto vaultRate = pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height, blockTime, useNextPrice, requireLivePrice);
-        if (!vaultRate)
-            return false;
-
-        auto loanScheme = pcustomcsview->GetLoanScheme(vault.schemeId);
-        return (vaultRate.val->ratio() < loanScheme->ratio);
-    }
-
-    VaultState GetVaultState(const CVaultId& vaultId, const CVaultData& vault) {
-        auto height = ::ChainActive().Height();
-        auto inLiquidation = vault.isUnderLiquidation;
-        auto priceIsValid = IsVaultPriceValid(*pcustomcsview, vaultId, height);
-        auto willLiquidateNext = WillLiquidateNext(vaultId, vault);
-
-        // Can possibly optimize with flags, but provides clarity for now.
-        if (!inLiquidation && priceIsValid && !willLiquidateNext)
-            return VaultState::Active;
-        if (!inLiquidation && priceIsValid && willLiquidateNext)
-            return VaultState::MayLiquidate;
-        if (!inLiquidation && !priceIsValid)
-            return VaultState::Frozen;
-        if (inLiquidation && priceIsValid)
-            return VaultState::InLiquidation;
-        return VaultState::Unknown;
-    }
-
-    UniValue BatchToJSON(const CVaultId& vaultId, uint32_t batchCount) {
-        UniValue batchArray{UniValue::VARR};
-        for (uint32_t i = 0; i < batchCount; i++) {
-            UniValue batchObj{UniValue::VOBJ};
-            auto batch = pcustomcsview->GetAuctionBatch({vaultId, i});
-            batchObj.pushKV("index", int(i));
-            batchObj.pushKV("collaterals", AmountsToJSON(batch->collaterals.balances));
-            batchObj.pushKV("loan", tokenAmountString(batch->loanAmount));
-            if (auto bid = pcustomcsview->GetAuctionBid({vaultId, i})) {
-                UniValue bidObj{UniValue::VOBJ};
-                bidObj.pushKV("owner", ScriptToString(bid->first));
-                bidObj.pushKV("amount", tokenAmountString(bid->second));
-                batchObj.pushKV("highestBid", bidObj);
-            }
-            batchArray.push_back(batchObj);
-        }
-        return batchArray;
-    }
-
-    UniValue AuctionToJSON(const CVaultId& vaultId, const CAuctionData& data) {
-        UniValue auctionObj{UniValue::VOBJ};
-        auto vault = pcustomcsview->GetVault(vaultId);
-        auctionObj.pushKV("vaultId", vaultId.GetHex());
-        auctionObj.pushKV("loanSchemeId", vault->schemeId);
-        auctionObj.pushKV("ownerAddress", ScriptToString(vault->ownerAddress));
-        auctionObj.pushKV("state", VaultStateToString(VaultState::InLiquidation));
-        auctionObj.pushKV("liquidationHeight", int64_t(data.liquidationHeight));
-        auctionObj.pushKV("batchCount", int64_t(data.batchCount));
-        auctionObj.pushKV("liquidationPenalty", ValueFromAmount(data.liquidationPenalty * 100));
-        auctionObj.pushKV("batches", BatchToJSON(vaultId, data.batchCount));
-        return auctionObj;
-    }
-
-    UniValue VaultToJSON(const CVaultId& vaultId, const CVaultData& vault, const bool verbose = false) {
-        UniValue result{UniValue::VOBJ};
-        auto vaultState = GetVaultState(vaultId, vault);
-        auto height = ::ChainActive().Height();
-
-        if (vaultState == VaultState::InLiquidation) {
-            if (auto data = pcustomcsview->GetAuction(vaultId, height)) {
-                result.pushKVs(AuctionToJSON(vaultId, *data));
-            } else {
-                LogPrintf("Warning: Vault in liquidation, but no auctions found\n");
-            }
-            return result;
-        }
-
-        UniValue ratioValue{0}, collValue{0}, loanValue{0}, interestValue{0}, collateralRatio{0}, nextCollateralRatio{0}, totalInterestsPerBlockValue{0};
-
-        auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
-        if (!collaterals)
-            collaterals = CBalances{};
-
-
-        auto blockTime = ::ChainActive().Tip()->GetBlockTime();
-        bool useNextPrice = false, requireLivePrice = vaultState != VaultState::Frozen;
-        LogPrint(BCLog::LOAN,"%s():\n", __func__);
-        auto rate = pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height + 1, blockTime, useNextPrice, requireLivePrice);
-
-        if (rate) {
-            collValue = ValueFromUint(rate.val->totalCollaterals);
-            loanValue = ValueFromUint(rate.val->totalLoans);
-            ratioValue = ValueFromAmount(rate.val->precisionRatio());
-            collateralRatio = int(rate.val->ratio());
-        }
-
-        bool isVaultTokenLocked {false};
-        for (const auto& collateral : collaterals->balances) {
-            if(pcustomcsview->AreTokensLocked({collateral.first.v})){
-                isVaultTokenLocked = true;
-                break;
-            }
-        }
-
-        UniValue loanBalances{UniValue::VARR};
-        UniValue interestAmounts{UniValue::VARR};
-        UniValue interestsPerBlockBalances{UniValue::VARR};
-
-        if (auto loanTokens = pcustomcsview->GetLoanTokens(vaultId)) {
-            TAmounts totalBalances{};
-            TAmounts interestBalances{};
-            CAmount totalInterests{0};
-            CAmount totalInterestsPerBlock{0};
-            TAmounts interestsPerBlock{};
-
-            for (const auto& loan : loanTokens->balances) {
-                auto token = pcustomcsview->GetLoanTokenByID(loan.first);
-                if (!token) continue;
-                auto rate = pcustomcsview->GetInterestRate(vaultId, loan.first, height);
-                if (!rate) continue;
-                LogPrint(BCLog::LOAN,"%s()->%s->", __func__, token->symbol); /* Continued */
-                auto totalInterest = TotalInterest(*rate, height + 1);
-                auto value = loan.second + totalInterest;
-                if (auto priceFeed = pcustomcsview->GetFixedIntervalPrice(token->fixedIntervalPriceId)) {
-                    auto price = priceFeed.val->priceRecord[0];
-                    totalInterests += MultiplyAmounts(price, totalInterest);
-                    if (verbose) {
-                        auto interestPerBlock = rate->interestPerBlock.GetLow64();
-                        interestsPerBlock.insert({loan.first, interestPerBlock});
-                        totalInterestsPerBlock += MultiplyAmounts(price, static_cast<CAmount>(interestPerBlock));
-                    }
-                }
-
-                totalBalances.insert({loan.first, value});
-                interestBalances.insert({loan.first, totalInterest});
-                if (pcustomcsview->AreTokensLocked({loan.first.v})){
-                    isVaultTokenLocked = true;
-                }
-            }
-            interestValue = ValueFromAmount(totalInterests);
-            loanBalances = AmountsToJSON(totalBalances);
-            interestAmounts = AmountsToJSON(interestBalances);
-            if (verbose) {
-                interestsPerBlockBalances = AmountsToJSON(interestsPerBlock);
-                totalInterestsPerBlockValue = ValueFromAmount(totalInterestsPerBlock);
-            }
-        }
-
-        result.pushKV("vaultId", vaultId.GetHex());
-        result.pushKV("loanSchemeId", vault.schemeId);
-        result.pushKV("ownerAddress", ScriptToString(vault.ownerAddress));
-        result.pushKV("state", VaultStateToString(vaultState));
-        result.pushKV("collateralAmounts", AmountsToJSON(collaterals->balances));
-        result.pushKV("loanAmounts", loanBalances);
-        result.pushKV("interestAmounts", interestAmounts);
-        if (isVaultTokenLocked){
-            collValue = -1;
-            loanValue = -1;
-            interestValue = -1;
-            ratioValue = -1;
-            collateralRatio = -1;
-            totalInterestsPerBlockValue = -1;
-        }
-        result.pushKV("collateralValue", collValue);
-        result.pushKV("loanValue", loanValue);
-        result.pushKV("interestValue", interestValue);
-        result.pushKV("informativeRatio", ratioValue);
-        result.pushKV("collateralRatio", collateralRatio);
-        if (verbose) {
-            useNextPrice = true;
-            auto rate = pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height + 1, blockTime, useNextPrice, requireLivePrice);
-            if (rate) {
-                nextCollateralRatio = int(rate.val->ratio());
-                result.pushKV("nextCollateralRatio", nextCollateralRatio);
-            }
-            result.pushKV("interestPerBlockValue", totalInterestsPerBlockValue);
-            result.pushKV("interestsPerBlock", interestsPerBlockBalances);
-        }
-        return result;
+std::string VaultStateToString(const VaultState &state) {
+    switch (state) {
+        case VaultState::Active:
+            return "active";
+        case VaultState::Frozen:
+            return "frozen";
+        case VaultState::InLiquidation:
+            return "inLiquidation";
+        case VaultState::MayLiquidate:
+            return "mayLiquidate";
+        default:
+            return "unknown";
     }
 }
 
-UniValue createvault(const JSONRPCRequest& request) {
+VaultState StringToVaultState(const std::string &stateStr) {
+    if (stateStr == "active")
+        return VaultState::Active;
+    if (stateStr == "frozen")
+        return VaultState::Frozen;
+    if (stateStr == "inLiquidation")
+        return VaultState::InLiquidation;
+    if (stateStr == "mayLiquidate")
+        return VaultState::MayLiquidate;
+    return VaultState::Unknown;
+}
+
+bool WillLiquidateNext(const CVaultId &vaultId, const CVaultData &vault) {
+    auto height = ::ChainActive().Height();
+    auto blockTime = ::ChainActive()[height]->GetBlockTime();
+
+    auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
+    if (!collaterals)
+        return false;
+
+    bool useNextPrice = true, requireLivePrice = false;
+    auto vaultRate =
+        pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height, blockTime, useNextPrice, requireLivePrice);
+    if (!vaultRate)
+        return false;
+
+    auto loanScheme = pcustomcsview->GetLoanScheme(vault.schemeId);
+    return (vaultRate.val->ratio() < loanScheme->ratio);
+}
+
+VaultState GetVaultState(const CVaultId &vaultId, const CVaultData &vault) {
+    auto height = ::ChainActive().Height();
+    auto inLiquidation = vault.isUnderLiquidation;
+    auto priceIsValid = IsVaultPriceValid(*pcustomcsview, vaultId, height);
+    auto willLiquidateNext = WillLiquidateNext(vaultId, vault);
+
+    // Can possibly optimize with flags, but provides clarity for now.
+    if (!inLiquidation && priceIsValid && !willLiquidateNext)
+        return VaultState::Active;
+    if (!inLiquidation && priceIsValid && willLiquidateNext)
+        return VaultState::MayLiquidate;
+    if (!inLiquidation && !priceIsValid)
+        return VaultState::Frozen;
+    if (inLiquidation && priceIsValid)
+        return VaultState::InLiquidation;
+    return VaultState::Unknown;
+}
+
+UniValue BatchToJSON(const CVaultId &vaultId, uint32_t batchCount) {
+    UniValue batchArray{UniValue::VARR};
+    for (uint32_t i = 0; i < batchCount; i++) {
+        UniValue batchObj{UniValue::VOBJ};
+        auto batch = pcustomcsview->GetAuctionBatch({vaultId, i});
+        batchObj.pushKV("index", int(i));
+        batchObj.pushKV("collaterals", AmountsToJSON(batch->collaterals.balances));
+        batchObj.pushKV("loan", tokenAmountString(batch->loanAmount));
+        if (auto bid = pcustomcsview->GetAuctionBid({vaultId, i})) {
+            UniValue bidObj{UniValue::VOBJ};
+            bidObj.pushKV("owner", ScriptToString(bid->first));
+            bidObj.pushKV("amount", tokenAmountString(bid->second));
+            batchObj.pushKV("highestBid", bidObj);
+        }
+        batchArray.push_back(batchObj);
+    }
+    return batchArray;
+}
+
+UniValue AuctionToJSON(const CVaultId &vaultId, const CAuctionData &data) {
+    UniValue auctionObj{UniValue::VOBJ};
+    auto vault = pcustomcsview->GetVault(vaultId);
+    auctionObj.pushKV("vaultId", vaultId.GetHex());
+    auctionObj.pushKV("loanSchemeId", vault->schemeId);
+    auctionObj.pushKV("ownerAddress", ScriptToString(vault->ownerAddress));
+    auctionObj.pushKV("state", VaultStateToString(VaultState::InLiquidation));
+    auctionObj.pushKV("liquidationHeight", int64_t(data.liquidationHeight));
+    auctionObj.pushKV("batchCount", int64_t(data.batchCount));
+    auctionObj.pushKV("liquidationPenalty", ValueFromAmount(data.liquidationPenalty * 100));
+    auctionObj.pushKV("batches", BatchToJSON(vaultId, data.batchCount));
+    return auctionObj;
+}
+
+UniValue VaultToJSON(const CVaultId &vaultId, const CVaultData &vault, const bool verbose = false) {
+    UniValue result{UniValue::VOBJ};
+    auto vaultState = GetVaultState(vaultId, vault);
+    auto height = ::ChainActive().Height();
+
+    if (vaultState == VaultState::InLiquidation) {
+        if (auto data = pcustomcsview->GetAuction(vaultId, height)) {
+            result.pushKVs(AuctionToJSON(vaultId, *data));
+        } else {
+            LogPrintf("Warning: Vault in liquidation, but no auctions found\n");
+        }
+        return result;
+    }
+
+    UniValue ratioValue{0}, collValue{0}, loanValue{0}, interestValue{0}, collateralRatio{0}, nextCollateralRatio{0},
+        totalInterestsPerBlockValue{0};
+
+    auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
+    if (!collaterals)
+        collaterals = CBalances{};
+
+    auto blockTime = ::ChainActive().Tip()->GetBlockTime();
+    bool useNextPrice = false, requireLivePrice = vaultState != VaultState::Frozen;
+    LogPrint(BCLog::LOAN, "%s():\n", __func__);
+    auto rate =
+        pcustomcsview->GetLoanCollaterals(vaultId, *collaterals, height + 1, blockTime, useNextPrice, requireLivePrice);
+
+    if (rate) {
+        collValue = ValueFromUint(rate.val->totalCollaterals);
+        loanValue = ValueFromUint(rate.val->totalLoans);
+        ratioValue = ValueFromAmount(rate.val->precisionRatio());
+        collateralRatio = int(rate.val->ratio());
+    }
+
+    bool isVaultTokenLocked{false};
+    for (const auto &collateral : collaterals->balances) {
+        if (pcustomcsview->AreTokensLocked({collateral.first.v})) {
+            isVaultTokenLocked = true;
+            break;
+        }
+    }
+
+    UniValue loanBalances{UniValue::VARR};
+    UniValue interestAmounts{UniValue::VARR};
+    UniValue interestsPerBlockBalances{UniValue::VARR};
+
+    if (auto loanTokens = pcustomcsview->GetLoanTokens(vaultId)) {
+        TAmounts totalBalances{};
+        TAmounts interestBalances{};
+        CAmount totalInterests{0};
+        CAmount totalInterestsPerBlock{0};
+        TAmounts interestsPerBlock{};
+
+        for (const auto &loan : loanTokens->balances) {
+            auto token = pcustomcsview->GetLoanTokenByID(loan.first);
+            if (!token)
+                continue;
+            auto rate = pcustomcsview->GetInterestRate(vaultId, loan.first, height);
+            if (!rate)
+                continue;
+            LogPrint(BCLog::LOAN, "%s()->%s->", __func__, token->symbol); /* Continued */
+            auto totalInterest = TotalInterest(*rate, height + 1);
+            auto value = loan.second + totalInterest;
+            if (auto priceFeed = pcustomcsview->GetFixedIntervalPrice(token->fixedIntervalPriceId)) {
+                auto price = priceFeed.val->priceRecord[0];
+                totalInterests += MultiplyAmounts(price, totalInterest);
+                if (verbose) {
+                    auto interestPerBlock = rate->interestPerBlock.GetLow64();
+                    interestsPerBlock.insert({loan.first, interestPerBlock});
+                    totalInterestsPerBlock += MultiplyAmounts(price, static_cast<CAmount>(interestPerBlock));
+                }
+            }
+
+            totalBalances.insert({loan.first, value});
+            interestBalances.insert({loan.first, totalInterest});
+            if (pcustomcsview->AreTokensLocked({loan.first.v})) {
+                isVaultTokenLocked = true;
+            }
+        }
+        interestValue = ValueFromAmount(totalInterests);
+        loanBalances = AmountsToJSON(totalBalances);
+        interestAmounts = AmountsToJSON(interestBalances);
+        if (verbose) {
+            interestsPerBlockBalances = AmountsToJSON(interestsPerBlock);
+            totalInterestsPerBlockValue = ValueFromAmount(totalInterestsPerBlock);
+        }
+    }
+
+    result.pushKV("vaultId", vaultId.GetHex());
+    result.pushKV("loanSchemeId", vault.schemeId);
+    result.pushKV("ownerAddress", ScriptToString(vault.ownerAddress));
+    result.pushKV("state", VaultStateToString(vaultState));
+    result.pushKV("collateralAmounts", AmountsToJSON(collaterals->balances));
+    result.pushKV("loanAmounts", loanBalances);
+    result.pushKV("interestAmounts", interestAmounts);
+    if (isVaultTokenLocked) {
+        collValue = -1;
+        loanValue = -1;
+        interestValue = -1;
+        ratioValue = -1;
+        collateralRatio = -1;
+        totalInterestsPerBlockValue = -1;
+    }
+    result.pushKV("collateralValue", collValue);
+    result.pushKV("loanValue", loanValue);
+    result.pushKV("interestValue", interestValue);
+    result.pushKV("informativeRatio", ratioValue);
+    result.pushKV("collateralRatio", collateralRatio);
+    if (verbose) {
+        useNextPrice = true;
+        auto rate = pcustomcsview->GetLoanCollaterals(
+            vaultId, *collaterals, height + 1, blockTime, useNextPrice, requireLivePrice);
+        if (rate) {
+            nextCollateralRatio = int(rate.val->ratio());
+            result.pushKV("nextCollateralRatio", nextCollateralRatio);
+        }
+        result.pushKV("interestPerBlockValue", totalInterestsPerBlockValue);
+        result.pushKV("interestsPerBlock", interestsPerBlockBalances);
+    }
+    return result;
+}
+}  // namespace
+
+UniValue createvault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"createvault",
-                "Creates a vault transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "createvault",
+        "Creates a vault transaction.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Any valid address"},
+            {"loanSchemeId",
+             RPCArg::Type::STR,
+             RPCArg::Optional::OMITTED,
+             "Unique identifier of the loan scheme (8 chars max). If empty, the default loan scheme will be selected "
+             "(Optional)"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
                 {
-                    {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Any valid address"},
-                    {"loanSchemeId", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                        "Unique identifier of the loan scheme (8 chars max). If empty, the default loan scheme will be selected (Optional)"
-                    },
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                            {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                     {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                   "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                   HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv") +
-                   HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv \"\"") +
-                   HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv LOAN0001") +
-                   HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv")") +
-                   HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv", "")") +
-                   HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv", "LOAN0001")")
-                },
-    }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv") +
+                    HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv \"\"") +
+                    HelpExampleCli("createvault", "2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv LOAN0001") +
+                    HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv")") +
+                    HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv", "")") +
+                    HelpExampleRpc("createvault", R"("2MzfSNCkjgCbNLen14CYrVtwGomfDA5AGYv", "LOAN0001")")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot createvault while still in Initial Block Download");
@@ -287,8 +300,7 @@ UniValue createvault(const JSONRPCRequest& request) {
     }
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::Vault)
-             << vault;
+    metadata << static_cast<unsigned char>(CustomTxType::Vault) << vault;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -321,35 +333,47 @@ UniValue createvault(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue closevault(const JSONRPCRequest& request) {
+UniValue closevault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"closevault",
-                "Close vault transaction.\n" +
-                HelpRequiringPassphrase(pwallet) + "\n",
+    RPCHelpMan{
+        "closevault",
+        "Close vault transaction.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault to be closed"},
+            {"to",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Any valid address to receive collaterals (if any) and half fee back"},
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
                 {
-                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault to be closed"},
-                    {"to", RPCArg::Type::STR, RPCArg::Optional::NO, "Any valid address to receive collaterals (if any) and half fee back"},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
-                        "A json array of json objects",
-                            {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                     {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                     {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
                     },
                 },
-                RPCResult{
-                   "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-                },
-                RPCExamples{
-                    HelpExampleCli("closevault", "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF") +
-                    HelpExampleRpc("closevault", R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF")")
-                },
-    }.Check(request);
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli(
+                "closevault",
+                "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF") +
+            HelpExampleRpc(
+                "closevault",
+                R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF")")},
+    }
+        .Check(request);
 
     if (pwallet->chain().isInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot closevault while still in Initial Block Download");
@@ -379,8 +403,7 @@ UniValue closevault(const JSONRPCRequest& request) {
     msg.to = DecodeScript(request.params[1].getValStr());
 
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    metadata << static_cast<unsigned char>(CustomTxType::CloseVault)
-             << msg;
+    metadata << static_cast<unsigned char>(CustomTxType::CloseVault) << msg;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(metadata);
@@ -411,69 +434,76 @@ UniValue closevault(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue listvaults(const JSONRPCRequest& request) {
+UniValue listvaults(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listvaults",
+        "List all available vaults.\n",
+        {
+            {
+                "options",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {{"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address of the vault owner."},
+                 {"loanSchemeId", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Vault's loan scheme id"},
+                 {"state",
+                  RPCArg::Type::STR,
+                  RPCArg::Optional::OMITTED,
+                  "Wether the vault is under a given state. (default = 'unknown')"},
+                 {"verbose",
+                  RPCArg::Type::BOOL,
+                  RPCArg::Optional::OMITTED,
+                  "Flag for verbose list (default = false), otherwise only ids, ownerAddress, loanSchemeIds and state "
+                  "are listed"}},
+            },
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"start",
+                     RPCArg::Type::STR_HEX,
+                     RPCArg::Optional::OMITTED,
+                     "Optional first key to iterate from, in lexicographical order. "
+                     "Typically it's set to last ID from previous request."},
+                    {"including_start",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "If true, then iterate including starting position. False by default"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of orders to return, 100 by default"},
+                },
+            },
+        },
+        RPCResult{"[                         (json array of objects)\n"
+                  "{...}                 (object) Json object with vault information\n"
+                  "]\n"},
+        RPCExamples{
+            HelpExampleCli("listvaults", "") + HelpExampleCli("listvaults", "'{\"loanSchemeId\": \"LOAN1502\"}'") +
+            HelpExampleCli("listvaults",
+                           "'{\"loanSchemeId\": \"LOAN1502\"}' "
+                           "'{\"start\":\"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013\", "
+                           "\"including_start\": true, "
+                           "\"limit\":100}'") +
+            HelpExampleCli("listvaults",
+                           "{} '{\"start\":\"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013\", "
+                           "\"including_start\": true, "
+                           "\"limit\":100}'") +
+            HelpExampleRpc("listvaults", "") + HelpExampleRpc("listvaults", R"({"loanSchemeId": "LOAN1502"})") +
+            HelpExampleRpc(
+                "listvaults",
+                R"({"loanSchemeId": "LOAN1502"}, {"start":"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013", "including_start": true, "limit":100})") +
+            HelpExampleRpc(
+                "listvaults",
+                R"({}, {"start":"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013", "including_start": true, "limit":100})")},
+    }
+        .Check(request);
 
-    RPCHelpMan{"listvaults",
-               "List all available vaults.\n",
-               {
-                    {
-                       "options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                        {
-                            {
-                                "ownerAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                "Address of the vault owner."
-                            },
-                            {
-                                "loanSchemeId", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                "Vault's loan scheme id"
-                            },
-                            {
-                                "state", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                "Wether the vault is under a given state. (default = 'unknown')"
-                            },
-                            {
-                                "verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                "Flag for verbose list (default = false), otherwise only ids, ownerAddress, loanSchemeIds and state are listed"
-                            }
-                        },
-                    },
-                    {
-                       "pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                        {
-                            {
-                                "start", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
-                                "Optional first key to iterate from, in lexicographical order. "
-                                "Typically it's set to last ID from previous request."
-                            },
-                            {
-                                "including_start", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                "If true, then iterate including starting position. False by default"
-                            },
-                            {
-                                "limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                "Maximum number of orders to return, 100 by default"
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                    "[                         (json array of objects)\n"
-                        "{...}                 (object) Json object with vault information\n"
-                    "]\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listvaults", "")
-                       + HelpExampleCli("listvaults", "'{\"loanSchemeId\": \"LOAN1502\"}'")
-                       + HelpExampleCli("listvaults", "'{\"loanSchemeId\": \"LOAN1502\"}' '{\"start\":\"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013\", ""\"including_start\": true, ""\"limit\":100}'")
-                       + HelpExampleCli("listvaults", "{} '{\"start\":\"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013\", ""\"including_start\": true, ""\"limit\":100}'")
-                       + HelpExampleRpc("listvaults", "")
-                       + HelpExampleRpc("listvaults", R"({"loanSchemeId": "LOAN1502"})")
-                       + HelpExampleRpc("listvaults", R"({"loanSchemeId": "LOAN1502"}, {"start":"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013", "including_start": true, "limit":100})")
-                       + HelpExampleRpc("listvaults", R"({}, {"start":"3ef9fd5bd1d0ce94751e6286710051361e8ef8fac43cca9cb22397bf0d17e013", "including_start": true, "limit":100})")
-               },
-    }.Check(request);
-
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     CScript ownerAddress = {};
     std::string loanSchemeId;
@@ -503,7 +533,7 @@ UniValue listvaults(const JSONRPCRequest& request) {
         if (request.params.size() > 1) {
             UniValue paginationObj = request.params[1].get_obj();
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
             if (!paginationObj["start"].isNull()) {
                 including_start = false;
@@ -522,56 +552,57 @@ UniValue listvaults(const JSONRPCRequest& request) {
 
     LOCK(cs_main);
 
-    pcustomcsview->ForEachVault([&](const CVaultId& vaultId, const CVaultData& data) {
-        if (!including_start)
-        {
-            including_start = true;
-            return (true);
-        }
-        if (!ownerAddress.empty() && ownerAddress != data.ownerAddress) {
-            return false;
-        }
-        auto vaultState = GetVaultState(vaultId, data);
-
-        if ((loanSchemeId.empty() || loanSchemeId == data.schemeId)
-        && (state == VaultState::Unknown || state == vaultState)) {
-            UniValue vaultObj{UniValue::VOBJ};
-            if(!verbose){
-                vaultObj.pushKV("vaultId", vaultId.GetHex());
-                vaultObj.pushKV("ownerAddress", ScriptToString(data.ownerAddress));
-                vaultObj.pushKV("loanSchemeId", data.schemeId);
-                vaultObj.pushKV("state", VaultStateToString(vaultState));
-            } else {
-                vaultObj = VaultToJSON(vaultId, data);
+    pcustomcsview->ForEachVault(
+        [&](const CVaultId &vaultId, const CVaultData &data) {
+            if (!including_start) {
+                including_start = true;
+                return (true);
             }
-            valueArr.push_back(vaultObj);
-            limit--;
-        }
-        return limit != 0;
-    }, start, ownerAddress);
+            if (!ownerAddress.empty() && ownerAddress != data.ownerAddress) {
+                return false;
+            }
+            auto vaultState = GetVaultState(vaultId, data);
+
+            if ((loanSchemeId.empty() || loanSchemeId == data.schemeId) &&
+                (state == VaultState::Unknown || state == vaultState)) {
+                UniValue vaultObj{UniValue::VOBJ};
+                if (!verbose) {
+                    vaultObj.pushKV("vaultId", vaultId.GetHex());
+                    vaultObj.pushKV("ownerAddress", ScriptToString(data.ownerAddress));
+                    vaultObj.pushKV("loanSchemeId", data.schemeId);
+                    vaultObj.pushKV("state", VaultStateToString(vaultState));
+                } else {
+                    vaultObj = VaultToJSON(vaultId, data);
+                }
+                valueArr.push_back(vaultObj);
+                limit--;
+            }
+            return limit != 0;
+        },
+        start,
+        ownerAddress);
 
     return GetRPCResultCache().Set(request, valueArr);
 }
 
-UniValue getvault(const JSONRPCRequest& request) {
-
-    RPCHelpMan{"getvault",
-               "Returns information about vault.\n",
-                {
-                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "vault hex id"},
-                    {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Verbose vault information (default = false)"},
-                },
-                RPCResult{
-                    "\"json\"                  (string) vault data in json form\n"
-                },
-               RPCExamples{
-                       HelpExampleCli("getvault", "5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf") +
-                       HelpExampleRpc("getvault", R"("5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf")")
-               },
-    }.Check(request);
+UniValue getvault(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "getvault",
+        "Returns information about vault.\n",
+        {
+            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "vault hex id"},
+            {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Verbose vault information (default = false)"},
+        },
+        RPCResult{"\"json\"                  (string) vault data in json form\n"},
+        RPCExamples{
+            HelpExampleCli("getvault", "5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf") +
+            HelpExampleRpc("getvault", R"("5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf")")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR}, false);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
     bool verbose{false};
@@ -590,53 +621,61 @@ UniValue getvault(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, res);
 }
 
-UniValue updatevault(const JSONRPCRequest& request) {
+UniValue updatevault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"updatevault",
-               "\nCreates (and submits to local node and network) an `update vault transaction`, \n"
-               "and saves vault updates to database.\n"
-               "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                        {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
-                        {"parameters", RPCArg::Type::OBJ, RPCArg::Optional::NO, "",
-                            {
-                                {"ownerAddress", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Vault's owner address"},
-                                {"loanSchemeId", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Vault's loan scheme id"},
-                            },
+    RPCHelpMan{
+        "updatevault",
+        "\nCreates (and submits to local node and network) an `update vault transaction`, \n"
+        "and saves vault updates to database.\n"
+        "The last optional argument (may be empty array) is an array of specific UTXOs to spend." +
+            HelpRequiringPassphrase(pwallet) + "\n",
+        {
+            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
+            {
+                "parameters",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::NO,
+                "",
+                {
+                    {"ownerAddress", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Vault's owner address"},
+                    {"loanSchemeId", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Vault's loan scheme id"},
+                },
+            },
+            {
+                "inputs",
+                RPCArg::Type::ARR,
+                RPCArg::Optional::OMITTED_NAMED_ARG,
+                "A json array of json objects",
+                {
+                    {
+                        "",
+                        RPCArg::Type::OBJ,
+                        RPCArg::Optional::OMITTED,
+                        "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
                         },
-                        {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                            {
-                                {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                    {
-                                        {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                        {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                    },
-                                },
-                            },
-                        },
-               },
-               RPCResult{
-                       "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli(
-                               "updatevault",
-                               R"(84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 '{"ownerAddress": "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "loanSchemeId": "LOANSCHEME001"}')")
-                       + HelpExampleRpc(
-                               "updatevault",
-                               R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", {"ownerAddress": "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "loanSchemeId": "LOANSCHEME001"})")
-               },
-    }.Check(request);
+                    },
+                },
+            },
+        },
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli(
+                "updatevault",
+                R"(84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 '{"ownerAddress": "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "loanSchemeId": "LOANSCHEME001"}')") +
+            HelpExampleRpc(
+                "updatevault",
+                R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", {"ownerAddress": "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "loanSchemeId": "LOANSCHEME001"})")},
+    }
+        .Check(request);
 
-    RPCTypeCheck(request.params,
-                 {UniValue::VSTR, UniValue::VOBJ, UniValue::VARR},
-                 false);
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ, UniValue::VARR}, false);
 
     if (pwallet->chain().isInitialBlockDownload()) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                           "Cannot update vault while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot update vault while still in Initial Block Download");
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -654,28 +693,25 @@ UniValue updatevault(const JSONRPCRequest& request) {
         if (!storedVault)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Vault <%s> not found", vaultId.GetHex()));
 
-        if(storedVault->isUnderLiquidation)
+        if (storedVault->isUnderLiquidation)
             throw JSONRPCError(RPC_TRANSACTION_REJECTED, "Vault is under liquidation.");
 
         vault = *storedVault;
     }
 
-    CUpdateVaultMessage msg{
-        vaultId,
-        vault.ownerAddress,
-        vault.schemeId
-    };
+    CUpdateVaultMessage msg{vaultId, vault.ownerAddress, vault.schemeId};
 
-    if (request.params[1].isNull()){
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-                           "Invalid parameters, arguments 2 must be non-null and expected as object at least with one of"
-                           "{\"ownerAddress\",\"loanSchemeId\"}");
+    if (request.params[1].isNull()) {
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER,
+            "Invalid parameters, arguments 2 must be non-null and expected as object at least with one of"
+            "{\"ownerAddress\",\"loanSchemeId\"}");
     }
     UniValue params = request.params[1].get_obj();
     if (params["ownerAddress"].isNull() && params["loanSchemeId"].isNull())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "At least ownerAddress OR loanSchemeId must be set");
 
-    if (!params["ownerAddress"].isNull()){
+    if (!params["ownerAddress"].isNull()) {
         auto ownerAddress = params["ownerAddress"].getValStr();
         // check address validity
         CTxDestination ownerDest = DecodeDestination(ownerAddress);
@@ -684,15 +720,14 @@ UniValue updatevault(const JSONRPCRequest& request) {
         }
         msg.ownerAddress = DecodeScript(ownerAddress);
     }
-    if(!params["loanSchemeId"].isNull()){
+    if (!params["loanSchemeId"].isNull()) {
         auto loanschemeid = params["loanSchemeId"].getValStr();
         msg.schemeId = loanschemeid;
     }
 
     // encode
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::UpdateVault)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::UpdateVault) << msg;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
@@ -725,44 +760,59 @@ UniValue updatevault(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue deposittovault(const JSONRPCRequest& request) {
+UniValue deposittovault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"deposittovault",
-               "Deposit collateral token amount to vault.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
-                    {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address containing collateral",},
-                    {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount of collateral in amount@symbol format",},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    }
-               },
-               RPCResult{
-                    "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("deposittovault",
-                        "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 1@DFI") +
-                       HelpExampleRpc("deposittovault",
-                        R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DFI")")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "deposittovault",
+        "Deposit collateral token amount to vault.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {{"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
+         {
+             "from",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Address containing collateral",
+         },
+         {
+             "amount",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Amount of collateral in amount@symbol format",
+         },
+         {
+             "inputs",
+             RPCArg::Type::ARR,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "A json array of json objects",
+             {
+                 {
+                     "",
+                     RPCArg::Type::OBJ,
+                     RPCArg::Optional::OMITTED,
+                     "",
+                     {
+                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                     },
+                 },
+             },
+         }},
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli("deposittovault",
+                           "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i "
+                           "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 1@DFI") +
+            HelpExampleRpc(
+                "deposittovault",
+                R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DFI")")},
+    }
+        .Check(request);
 
-    RPCTypeCheck(request.params,
-                 {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR, UniValue::VARR},
-                 false);
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR, UniValue::VARR}, false);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot upddeposittovaultate vault while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot upddeposittovaultate vault while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -772,12 +822,11 @@ UniValue deposittovault(const JSONRPCRequest& request) {
     // decode vaultId
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
     auto from = DecodeScript(request.params[1].get_str());
-    CTokenAmount amount = DecodeAmount(pwallet->chain(),request.params[2].get_str(), "amount");
+    CTokenAmount amount = DecodeAmount(pwallet->chain(), request.params[2].get_str(), "amount");
 
     CDepositToVaultMessage msg{vaultId, from, amount};
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::DepositToVault)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::DepositToVault) << msg;
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
 
@@ -788,7 +837,7 @@ UniValue deposittovault(const JSONRPCRequest& request) {
 
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
-    UniValue const & txInputs = request.params[3];
+    UniValue const &txInputs = request.params[3];
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths{from};
@@ -796,7 +845,7 @@ UniValue deposittovault(const JSONRPCRequest& request) {
 
     CCoinControl coinControl;
 
-     // Set change to from address
+    // Set change to from address
     CTxDestination dest;
     ExtractDestination(from, dest);
     if (IsValidDestination(dest)) {
@@ -811,44 +860,59 @@ UniValue deposittovault(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue withdrawfromvault(const JSONRPCRequest& request) {
+UniValue withdrawfromvault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"withdrawfromvault",
-               "Withdraw collateral token amount from vault.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"vaultId", RPCArg::Type::STR, RPCArg::Optional::NO, "Vault id"},
-                    {"to", RPCArg::Type::STR, RPCArg::Optional::NO, "Destination address for withdraw of collateral",},
-                    {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount of collateral in amount@symbol format",},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    }
-               },
-               RPCResult{
-                    "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("withdrawfromvault",
-                        "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 1@DFI") +
-                       HelpExampleRpc("withdrawfromvault",
-                        R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DFI")")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "withdrawfromvault",
+        "Withdraw collateral token amount from vault.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {{"vaultId", RPCArg::Type::STR, RPCArg::Optional::NO, "Vault id"},
+         {
+             "to",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Destination address for withdraw of collateral",
+         },
+         {
+             "amount",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Amount of collateral in amount@symbol format",
+         },
+         {
+             "inputs",
+             RPCArg::Type::ARR,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "A json array of json objects",
+             {
+                 {
+                     "",
+                     RPCArg::Type::OBJ,
+                     RPCArg::Optional::OMITTED,
+                     "",
+                     {
+                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                     },
+                 },
+             },
+         }},
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli("withdrawfromvault",
+                           "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i "
+                           "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 1@DFI") +
+            HelpExampleRpc(
+                "withdrawfromvault",
+                R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2i", "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DFI")")},
+    }
+        .Check(request);
 
-    RPCTypeCheck(request.params,
-                 {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR, UniValue::VARR},
-                 false);
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VSTR, UniValue::VARR}, false);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot withdrawfromvault while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot withdrawfromvault while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -858,12 +922,11 @@ UniValue withdrawfromvault(const JSONRPCRequest& request) {
     // decode vaultId
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
     auto to = DecodeScript(request.params[1].get_str());
-    CTokenAmount amount = DecodeAmount(pwallet->chain(),request.params[2].get_str(), "amount");
+    CTokenAmount amount = DecodeAmount(pwallet->chain(), request.params[2].get_str(), "amount");
 
     CWithdrawFromVaultMessage msg{vaultId, to, amount};
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::WithdrawFromVault)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::WithdrawFromVault) << msg;
 
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
@@ -886,7 +949,7 @@ UniValue withdrawfromvault(const JSONRPCRequest& request) {
 
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
 
-    UniValue const & txInputs = request.params[3];
+    UniValue const &txInputs = request.params[3];
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths{ownerAddress};
@@ -894,7 +957,7 @@ UniValue withdrawfromvault(const JSONRPCRequest& request) {
 
     CCoinControl coinControl;
 
-     // Set change to from address
+    // Set change to from address
     CTxDestination dest;
     ExtractDestination(ownerAddress, dest);
     if (IsValidDestination(dest)) {
@@ -909,45 +972,54 @@ UniValue withdrawfromvault(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue placeauctionbid(const JSONRPCRequest& request) {
+UniValue placeauctionbid(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"placeauctionbid",
-               "Bid to vault in auction.\n" +
-               HelpRequiringPassphrase(pwallet) + "\n",
-               {
-                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
-                    {"index", RPCArg::Type::NUM, RPCArg::Optional::NO, "Auction index"},
-                    {"from", RPCArg::Type::STR, RPCArg::Optional::NO, "Address to get tokens. If \"from\" value is: \"*\" (star), it's means auto-selection accounts from wallet."},
-                    {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount of amount@symbol format"},
-                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG, "A json array of json objects",
-                        {
-                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
-                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
-                                },
-                            },
-                        },
-                    }
-               },
-               RPCResult{
-                    "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("placeauctionbid",
-                        "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 0 mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 100@TSLA") +
-                       HelpExampleRpc("placeauctionbid",
-                        R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", 0, "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DTSLA")")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "placeauctionbid",
+        "Bid to vault in auction.\n" + HelpRequiringPassphrase(pwallet) + "\n",
+        {{"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault id"},
+         {"index", RPCArg::Type::NUM, RPCArg::Optional::NO, "Auction index"},
+         {"from",
+          RPCArg::Type::STR,
+          RPCArg::Optional::NO,
+          "Address to get tokens. If \"from\" value is: \"*\" (star), it's means auto-selection accounts from wallet."},
+         {"amount", RPCArg::Type::STR, RPCArg::Optional::NO, "Amount of amount@symbol format"},
+         {
+             "inputs",
+             RPCArg::Type::ARR,
+             RPCArg::Optional::OMITTED_NAMED_ARG,
+             "A json array of json objects",
+             {
+                 {
+                     "",
+                     RPCArg::Type::OBJ,
+                     RPCArg::Optional::OMITTED,
+                     "",
+                     {
+                         {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                         {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                     },
+                 },
+             },
+         }},
+        RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
+        RPCExamples{
+            HelpExampleCli("placeauctionbid",
+                           "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 0 "
+                           "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF 100@TSLA") +
+            HelpExampleRpc(
+                "placeauctionbid",
+                R"("84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2", 0, "mwSDMvn1Hoc8DsoB7AkLv7nxdrf5Ja4jsF", "1@DTSLA")")},
+    }
+        .Check(request);
 
-    RPCTypeCheck(request.params,
-                 {UniValue::VSTR, UniValue::VNUM, UniValue::VSTR, UniValue::VSTR, UniValue::VARR},
-                 false);
+    RPCTypeCheck(
+        request.params, {UniValue::VSTR, UniValue::VNUM, UniValue::VSTR, UniValue::VSTR, UniValue::VARR}, false);
 
     if (pwallet->chain().isInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot make auction bid while still in Initial Block Download");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "Cannot make auction bid while still in Initial Block Download");
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
@@ -959,9 +1031,10 @@ UniValue placeauctionbid(const JSONRPCRequest& request) {
     CScript from = {};
     auto fromStr = request.params[2].get_str();
     if (fromStr == "*") {
-        auto selectedAccounts = SelectAccountsByTargetBalances(GetAllMineAccounts(pwallet), CBalances{TAmounts{{amount.nTokenId, amount.nValue}}}, SelectionPie);
+        auto selectedAccounts = SelectAccountsByTargetBalances(
+            GetAllMineAccounts(pwallet), CBalances{TAmounts{{amount.nTokenId, amount.nValue}}}, SelectionPie);
 
-        for (auto& account : selectedAccounts) {
+        for (auto &account : selectedAccounts) {
             if (account.second.balances[amount.nTokenId] >= amount.nValue) {
                 from = account.first;
                 break;
@@ -970,7 +1043,7 @@ UniValue placeauctionbid(const JSONRPCRequest& request) {
 
         if (from.empty()) {
             throw JSONRPCError(RPC_INVALID_REQUEST,
-                      "Not enough tokens on account, call sendtokenstoaddress to increase it.\n");
+                               "Not enough tokens on account, call sendtokenstoaddress to increase it.\n");
         }
     } else {
         from = DecodeScript(fromStr);
@@ -978,8 +1051,7 @@ UniValue placeauctionbid(const JSONRPCRequest& request) {
 
     CAuctionBidMessage msg{vaultId, index, from, amount};
     CDataStream markedMetadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
-    markedMetadata << static_cast<unsigned char>(CustomTxType::AuctionBid)
-                   << msg;
+    markedMetadata << static_cast<unsigned char>(CustomTxType::AuctionBid) << msg;
     CScript scriptMeta;
     scriptMeta << OP_RETURN << ToByteVector(markedMetadata);
 
@@ -992,11 +1064,12 @@ UniValue placeauctionbid(const JSONRPCRequest& request) {
 
     CTransactionRef optAuthTx;
     std::set<CScript> auths{from};
-    rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, request.params[4]);
+    rawTx.vin =
+        GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, request.params[4]);
 
     CCoinControl coinControl;
 
-     // Set change to from address
+    // Set change to from address
     CTxDestination dest;
     ExtractDestination(from, dest);
     if (IsValidDestination(dest)) {
@@ -1011,52 +1084,53 @@ UniValue placeauctionbid(const JSONRPCRequest& request) {
     return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
 }
 
-UniValue listauctions(const JSONRPCRequest& request) {
+UniValue listauctions(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "listauctions",
+        "List all available auctions.\n",
+        {
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"start",
+                     RPCArg::Type::OBJ,
+                     RPCArg::Optional::OMITTED,
+                     "",
+                     {{"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Vault id"},
+                      {"height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Height to iterate from"}}},
+                    {"including_start",
+                     RPCArg::Type::BOOL,
+                     RPCArg::Optional::OMITTED,
+                     "If true, then iterate including starting position. False by default"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of orders to return, 100 by default"},
+                },
+            },
+        },
+        RPCResult{"[                         (json array of objects)\n"
+                  "{...}                 (object) Json object with auction information\n"
+                  "]\n"},
+        RPCExamples{
+            HelpExampleCli("listauctions", "") +
+            HelpExampleCli(
+                "listauctions",
+                "'{\"start\": {\"vaultId\":\"eeea650e5de30b77d17e3907204d200dfa4996e5c4d48b000ae8e70078fe7542\", "
+                "\"height\": 1000}, \"including_start\": true, "
+                "\"limit\":100}'") +
+            HelpExampleRpc("listauctions", "") +
+            HelpExampleRpc(
+                "listauctions",
+                R"({"start": {"vaultId":"eeea650e5de30b77d17e3907204d200dfa4996e5c4d48b000ae8e70078fe7542", "height": 1000}, "including_start": true, "limit":100})")},
+    }
+        .Check(request);
 
-    RPCHelpMan{"listauctions",
-               "List all available auctions.\n",
-               {
-                   {
-                       "pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                        {
-                            {
-                                "start", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                                {
-                                    {
-                                        "vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
-                                        "Vault id"
-                                    },
-                                    {
-                                        "height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                        "Height to iterate from"
-                                    }
-                                }
-                            },
-                            {
-                                "including_start", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                                "If true, then iterate including starting position. False by default"
-                            },
-                            {
-                                "limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                "Maximum number of orders to return, 100 by default"
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                    "[                         (json array of objects)\n"
-                        "{...}                 (object) Json object with auction information\n"
-                    "]\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listauctions",  "") +
-                       HelpExampleCli("listauctions", "'{\"start\": {\"vaultId\":\"eeea650e5de30b77d17e3907204d200dfa4996e5c4d48b000ae8e70078fe7542\", \"height\": 1000}, \"including_start\": true, ""\"limit\":100}'") +
-                       HelpExampleRpc("listauctions",  "") +
-                       HelpExampleRpc("listauctions", R"({"start": {"vaultId":"eeea650e5de30b77d17e3907204d200dfa4996e5c4d48b000ae8e70078fe7542", "height": 1000}, "including_start": true, "limit":100})")
-               },
-    }.Check(request);
-
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     // parse pagination
     CVaultId vaultId;
@@ -1067,7 +1141,7 @@ UniValue listauctions(const JSONRPCRequest& request) {
         if (request.params.size() > 0) {
             UniValue paginationObj = request.params[0].get_obj();
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
             if (!paginationObj["start"].isNull()) {
                 UniValue startObj = paginationObj["start"].get_obj();
@@ -1091,78 +1165,80 @@ UniValue listauctions(const JSONRPCRequest& request) {
     UniValue valueArr{UniValue::VARR};
 
     LOCK(cs_main);
-    pcustomcsview->ForEachVaultAuction([&](const CVaultId& vaultId, const CAuctionData& data) {
-        if (!including_start)
-        {
-            including_start = true;
-            return (true);
-        }
-        valueArr.push_back(AuctionToJSON(vaultId, data));
-        return --limit != 0;
-    }, height, vaultId);
+    pcustomcsview->ForEachVaultAuction(
+        [&](const CVaultId &vaultId, const CAuctionData &data) {
+            if (!including_start) {
+                including_start = true;
+                return (true);
+            }
+            valueArr.push_back(AuctionToJSON(vaultId, data));
+            return --limit != 0;
+        },
+        height,
+        vaultId);
 
     return GetRPCResultCache().Set(request, valueArr);
 }
 
-UniValue auctionhistoryToJSON(AuctionHistoryKey const & key, AuctionHistoryValue const & value) {
+UniValue auctionhistoryToJSON(AuctionHistoryKey const &key, AuctionHistoryValue const &value) {
     UniValue obj(UniValue::VOBJ);
 
     obj.pushKV("winner", ScriptToString(key.owner));
-    obj.pushKV("blockHeight", (uint64_t) key.blockHeight);
+    obj.pushKV("blockHeight", (uint64_t)key.blockHeight);
     if (auto block = ::ChainActive()[key.blockHeight]) {
         obj.pushKV("blockHash", block->GetBlockHash().GetHex());
         obj.pushKV("blockTime", block->GetBlockTime());
     }
     obj.pushKV("vaultId", key.vaultId.GetHex());
-    obj.pushKV("batchIndex", (uint64_t) key.index);
+    obj.pushKV("batchIndex", (uint64_t)key.index);
     obj.pushKV("auctionBid", tokenAmountString(value.bidAmount));
     obj.pushKV("auctionWon", AmountsToJSON(value.collaterals));
     return obj;
 }
 
-UniValue listauctionhistory(const JSONRPCRequest& request) {
+UniValue listauctionhistory(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"listauctionhistory",
-               "\nReturns information about auction history.\n",
-               {
-                    {"owner|vaultId", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                "Single account ID (CScript or address) or vaultId or reserved words: \"mine\" - to list history for all owned accounts or \"all\" to list whole DB (default = \"mine\")."},
-                    {"pagination", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                        {
-                            {
-                                "maxBlockHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                "Optional height to iterate from (downto genesis block)"
-                            },
-                            {
-                                "vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
-                                "Vault id"
-                            },
-                            {
-                                "index", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                "Batch index"
-                            },
-                            {
-                                "limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                "Maximum number of orders to return, 100 by default"
-                            },
-                        },
-                    },
-               },
-               RPCResult{
-                       "[{},{}...]     (array) Objects with auction history information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listauctionhistory", "all '{\"height\":160}'")
-                       + HelpExampleRpc("listauctionhistory", "")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "listauctionhistory",
+        "\nReturns information about auction history.\n",
+        {
+            {"owner|vaultId",
+             RPCArg::Type::STR,
+             RPCArg::Optional::OMITTED,
+             "Single account ID (CScript or address) or vaultId or reserved words: \"mine\" - to list history for all "
+             "owned accounts or \"all\" to list whole DB (default = \"mine\")."},
+            {
+                "pagination",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"maxBlockHeight",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Optional height to iterate from (downto genesis block)"},
+                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Vault id"},
+                    {"index", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Batch index"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of orders to return, 100 by default"},
+                },
+            },
+        },
+        RPCResult{"[{},{}...]     (array) Objects with auction history information\n"},
+        RPCExamples{HelpExampleCli("listauctionhistory", "all '{\"height\":160}'") +
+                    HelpExampleRpc("listauctionhistory", "")},
+    }
+        .Check(request);
 
     if (!paccountHistoryDB) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "-acindex is needed for auction history");
     }
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     // parse pagination
     size_t limit = 100;
@@ -1180,7 +1256,7 @@ UniValue listauctionhistory(const JSONRPCRequest& request) {
                 start.blockHeight = paginationObj["maxBlockHeight"].get_int64();
             }
             if (!paginationObj["limit"].isNull()) {
-                limit = (size_t) paginationObj["limit"].get_int64();
+                limit = (size_t)paginationObj["limit"].get_int64();
             }
         }
         if (limit == 0) {
@@ -1205,29 +1281,36 @@ UniValue listauctionhistory(const JSONRPCRequest& request) {
     LOCK(cs_main);
     UniValue ret(UniValue::VARR);
 
-    paccountHistoryDB->ForEachAuctionHistory([&](AuctionHistoryKey const & key, CLazySerialize<AuctionHistoryValue> valueLazy) -> bool {
-        if (filter == 0 && start.owner != key.owner) {
-            return true;
-        }
+    paccountHistoryDB->ForEachAuctionHistory(
+        [&](AuctionHistoryKey const &key, CLazySerialize<AuctionHistoryValue> valueLazy) -> bool {
+            if (filter == 0 && start.owner != key.owner) {
+                return true;
+            }
 
-        if (filter == 1 && start.vaultId != key.vaultId) {
-            return true;
-        }
+            if (filter == 1 && start.vaultId != key.vaultId) {
+                return true;
+            }
 
-        if (isMine && !(IsMineCached(*pwallet, key.owner) & ISMINE_SPENDABLE)) {
-            return true;
-        }
+            if (isMine && !(IsMineCached(*pwallet, key.owner) & ISMINE_SPENDABLE)) {
+                return true;
+            }
 
-        ret.push_back(auctionhistoryToJSON(key, valueLazy.get()));
+            ret.push_back(auctionhistoryToJSON(key, valueLazy.get()));
 
-        return --limit != 0;
-    }, start);
+            return --limit != 0;
+        },
+        start);
 
     return GetRPCResultCache().Set(request, ret);
 }
 
-UniValue vaultToJSON(const uint256& vaultID, const std::string& address, const uint64_t blockHeight, const std::string& type,
-                     const uint64_t txn, const std::string& txid, const TAmounts& amounts) {
+UniValue vaultToJSON(const uint256 &vaultID,
+                     const std::string &address,
+                     const uint64_t blockHeight,
+                     const std::string &type,
+                     const uint64_t txn,
+                     const std::string &txid,
+                     const TAmounts &amounts) {
     UniValue obj(UniValue::VOBJ);
 
     if (!address.empty()) {
@@ -1267,14 +1350,16 @@ UniValue BatchToJSON(const std::vector<CAuctionBatch> batches) {
     return batchArray;
 }
 
-UniValue stateToJSON(VaultStateKey const & key, VaultStateValue const & value) {
+UniValue stateToJSON(VaultStateKey const &key, VaultStateValue const &value) {
     auto obj = vaultToJSON(key.vaultID, "", key.blockHeight, "", 0, "", {});
 
     UniValue snapshot(UniValue::VOBJ);
     snapshot.pushKV("state", !value.auctionBatches.empty() ? "inLiquidation" : "active");
     snapshot.pushKV("collateralAmounts", AmountsToJSON(value.collaterals));
     snapshot.pushKV("collateralValue", ValueFromUint(value.collateralsValues.totalCollaterals));
-    snapshot.pushKV("collateralRatio", static_cast<int>(value.ratio != static_cast<uint32_t>(-1) ? value.ratio :value.collateralsValues.ratio()));
+    snapshot.pushKV(
+        "collateralRatio",
+        static_cast<int>(value.ratio != static_cast<uint32_t>(-1) ? value.ratio : value.collateralsValues.ratio()));
     if (!value.auctionBatches.empty()) {
         snapshot.pushKV("batches", BatchToJSON(value.auctionBatches));
     }
@@ -1284,13 +1369,19 @@ UniValue stateToJSON(VaultStateKey const & key, VaultStateValue const & value) {
     return obj;
 }
 
-UniValue historyToJSON(VaultHistoryKey const & key, VaultHistoryValue const & value) {
-    return vaultToJSON(key.vaultID, ScriptToString(key.address), key.blockHeight, ToString(CustomTxCodeToType(value.category)),
-                       key.txn, value.txid.ToString(), value.diff);
+UniValue historyToJSON(VaultHistoryKey const &key, VaultHistoryValue const &value) {
+    return vaultToJSON(key.vaultID,
+                       ScriptToString(key.address),
+                       key.blockHeight,
+                       ToString(CustomTxCodeToType(value.category)),
+                       key.txn,
+                       value.txid.ToString(),
+                       value.diff);
 }
 
-UniValue schemeToJSON(VaultSchemeKey const & key, const VaultGlobalSchemeValue& value) {
-    auto obj = vaultToJSON(key.vaultID, "", key.blockHeight, ToString(CustomTxCodeToType(value.category)), 0, value.txid.ToString(), {});
+UniValue schemeToJSON(VaultSchemeKey const &key, const VaultGlobalSchemeValue &value) {
+    auto obj = vaultToJSON(
+        key.vaultID, "", key.blockHeight, ToString(CustomTxCodeToType(value.category)), 0, value.txid.ToString(), {});
 
     UniValue scheme(UniValue::VOBJ);
     scheme.pushKV("id", value.loanScheme.identifier);
@@ -1302,42 +1393,56 @@ UniValue schemeToJSON(VaultSchemeKey const & key, const VaultGlobalSchemeValue& 
     return obj;
 }
 
-UniValue listvaulthistory(const JSONRPCRequest& request) {
+UniValue listvaulthistory(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"listvaulthistory",
-               "\nReturns the history of the specified vault.\n",
-               {
-                       {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault to get history for"},
-                       {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
-                        {
-                                {"maxBlockHeight", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                 "Optional height to iterate from (down to genesis block), (default = chaintip)."},
-                                {"depth", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                 "Maximum depth, from the genesis block is the default"},
-                                {"token", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                 "Filter by token"},
-                                {"txtype", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-                                 "Filter by transaction type, supported letter from {CustomTxType}"},
-                                {"limit", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                                 "Maximum number of records to return, 100 by default"},
-                        },
-                       },
-               },
-               RPCResult{
-                       "[{},{}...]     (array) Objects with vault history information\n"
-               },
-               RPCExamples{
-                       HelpExampleCli("listvaulthistory", "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 '{\"maxBlockHeight\":160,\"depth\":10}'")
-                       + HelpExampleRpc("listvaulthistory", "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2, '{\"maxBlockHeight\":160,\"depth\":10}'")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "listvaulthistory",
+        "\nReturns the history of the specified vault.\n",
+        {
+            {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Vault to get history for"},
+            {
+                "options",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "",
+                {
+                    {"maxBlockHeight",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Optional height to iterate from (down to genesis block), (default = chaintip)."},
+                    {"depth",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum depth, from the genesis block is the default"},
+                    {"token", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Filter by token"},
+                    {"txtype",
+                     RPCArg::Type::STR,
+                     RPCArg::Optional::OMITTED,
+                     "Filter by transaction type, supported letter from {CustomTxType}"},
+                    {"limit",
+                     RPCArg::Type::NUM,
+                     RPCArg::Optional::OMITTED,
+                     "Maximum number of records to return, 100 by default"},
+                },
+            },
+        },
+        RPCResult{"[{},{}...]     (array) Objects with vault history information\n"},
+        RPCExamples{HelpExampleCli("listvaulthistory",
+                                   "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2 "
+                                   "'{\"maxBlockHeight\":160,\"depth\":10}'") +
+                    HelpExampleRpc("listvaulthistory",
+                                   "84b22eee1964768304e624c416f29a91d78a01dc5e8e12db26bdac0670c67bb2, "
+                                   "'{\"maxBlockHeight\":160,\"depth\":10}'")},
+    }
+        .Check(request);
 
     if (!pvaultHistoryDB) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "-vaultindex required for vault history");
     }
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     uint256 vaultID = ParseHashV(request.params[0], "vaultId");
     uint32_t maxBlockHeight = std::numeric_limits<uint32_t>::max();
@@ -1351,19 +1456,21 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
         UniValue optionsObj = request.params[1].get_obj();
         RPCTypeCheckObj(optionsObj,
                         {
-                                {"maxBlockHeight", UniValueType(UniValue::VNUM)},
-                                {"depth", UniValueType(UniValue::VNUM)},
-                                {"token", UniValueType(UniValue::VSTR)},
-                                {"txtype", UniValueType(UniValue::VSTR)},
-                                {"limit", UniValueType(UniValue::VNUM)},
-                        }, true, true);
+                            {"maxBlockHeight", UniValueType(UniValue::VNUM)},
+                            {"depth", UniValueType(UniValue::VNUM)},
+                            {"token", UniValueType(UniValue::VSTR)},
+                            {"txtype", UniValueType(UniValue::VSTR)},
+                            {"limit", UniValueType(UniValue::VNUM)},
+                        },
+                        true,
+                        true);
 
         if (!optionsObj["maxBlockHeight"].isNull()) {
-            maxBlockHeight = (uint32_t) optionsObj["maxBlockHeight"].get_int64();
+            maxBlockHeight = (uint32_t)optionsObj["maxBlockHeight"].get_int64();
         }
 
         if (!optionsObj["depth"].isNull()) {
-            depth = (uint32_t) optionsObj["depth"].get_int64();
+            depth = (uint32_t)optionsObj["depth"].get_int64();
         }
 
         if (!optionsObj["token"].isNull()) {
@@ -1380,7 +1487,7 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
         }
 
         if (!optionsObj["limit"].isNull()) {
-            limit = (uint32_t) optionsObj["limit"].get_int64();
+            limit = (uint32_t)optionsObj["limit"].get_int64();
         }
 
         if (limit == 0) {
@@ -1388,17 +1495,15 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
         }
     }
 
-    std::function<bool(uint256 const &)> isMatchVault = [&vaultID](uint256 const & id) {
-        return id == vaultID;
-    };
+    std::function<bool(uint256 const &)> isMatchVault = [&vaultID](uint256 const &id) { return id == vaultID; };
 
     std::set<uint256> txs;
 
-    auto hasToken = [&tokenFilter](TAmounts const & diffs) {
-        for (auto const & diff : diffs) {
+    auto hasToken = [&tokenFilter](TAmounts const &diffs) {
+        for (auto const &diff : diffs) {
             auto token = pcustomcsview->GetToken(diff.first);
             auto const tokenIdStr = token->CreateSymbolKey(diff.first);
-            if(tokenIdStr == tokenFilter) {
+            if (tokenIdStr == tokenFilter) {
                 return true;
             }
         }
@@ -1419,8 +1524,7 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
     // Get vault TXs
     auto count = limit;
 
-    auto shouldContinue = [&](VaultHistoryKey const & key, CLazySerialize<VaultHistoryValue> valueLazy) -> bool
-    {
+    auto shouldContinue = [&](VaultHistoryKey const &key, CLazySerialize<VaultHistoryValue> valueLazy) -> bool {
         if (!isMatchVault(key.vaultID)) {
             return true;
         }
@@ -1429,17 +1533,17 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
             return true;
         }
 
-        const auto & value = valueLazy.get();
+        const auto &value = valueLazy.get();
 
         if (txTypeSearch && value.category != uint8_t(txType)) {
             return true;
         }
 
-        if(!tokenFilter.empty() && !hasToken(value.diff)) {
+        if (!tokenFilter.empty() && !hasToken(value.diff)) {
             return true;
         }
 
-        auto& array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
+        auto &array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
         array.push_back(historyToJSON(key, value));
 
         return --count != 0;
@@ -1451,8 +1555,7 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
     // Get vault state changes
     count = limit;
 
-    auto shouldContinueState = [&](VaultStateKey const & key, CLazySerialize<VaultStateValue> valueLazy) -> bool
-    {
+    auto shouldContinueState = [&](VaultStateKey const &key, CLazySerialize<VaultStateValue> valueLazy) -> bool {
         if (!isMatchVault(key.vaultID)) {
             return false;
         }
@@ -1461,9 +1564,9 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
             return true;
         }
 
-        const auto & value = valueLazy.get();
+        const auto &value = valueLazy.get();
 
-        auto& array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
+        auto &array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
         array.push_back(stateToJSON(key, value));
 
         return --count != 0;
@@ -1479,8 +1582,7 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
 
     std::map<uint32_t, uint256> schemes;
 
-    auto shouldContinueScheme = [&](VaultSchemeKey const & key, CLazySerialize<VaultSchemeValue> valueLazy) -> bool
-    {
+    auto shouldContinueScheme = [&](VaultSchemeKey const &key, CLazySerialize<VaultSchemeValue> valueLazy) -> bool {
         if (!isMatchVault(key.vaultID)) {
             return false;
         }
@@ -1489,23 +1591,25 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
             return true;
         }
 
-        const auto & value = valueLazy.get();
+        const auto &value = valueLazy.get();
 
         if (txTypeSearch && value.category != uint8_t(txType)) {
             return true;
         }
 
         CLoanScheme loanScheme;
-        pvaultHistoryDB->ForEachGlobalScheme([&](VaultGlobalSchemeKey const & schemeKey, CLazySerialize<VaultGlobalSchemeValue> lazyValue) {
-            if (lazyValue.get().loanScheme.identifier != value.schemeID) {
-                return true;
-            }
-            loanScheme = lazyValue.get().loanScheme;
-            schemes.emplace(key.blockHeight, schemeKey.schemeCreationTxid);
-            return false;
-        }, {key.blockHeight, value.txn});
+        pvaultHistoryDB->ForEachGlobalScheme(
+            [&](VaultGlobalSchemeKey const &schemeKey, CLazySerialize<VaultGlobalSchemeValue> lazyValue) {
+                if (lazyValue.get().loanScheme.identifier != value.schemeID) {
+                    return true;
+                }
+                loanScheme = lazyValue.get().loanScheme;
+                schemes.emplace(key.blockHeight, schemeKey.schemeCreationTxid);
+                return false;
+            },
+            {key.blockHeight, value.txn});
 
-        auto& array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
+        auto &array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
         array.push_back(schemeToJSON(key, {loanScheme, value.category, value.txid}));
 
         return --count != 0;
@@ -1519,7 +1623,7 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
 
     if (!schemes.empty()) {
         auto lastScheme = schemes.cbegin()->second;
-        for (auto it = ++schemes.cbegin(); it != schemes.cend(); ) {
+        for (auto it = ++schemes.cbegin(); it != schemes.cend();) {
             if (lastScheme == it->second) {
                 schemes.erase(it++);
             } else {
@@ -1531,36 +1635,38 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
         for (auto it = schemes.cbegin(); it != schemes.cend(); ++it) {
             auto nit = std::next(it);
             uint32_t endHeight = nit != schemes.cend() ? nit->first - 1 : std::numeric_limits<uint32_t>::max();
-            pvaultHistoryDB->ForEachGlobalScheme([&](VaultGlobalSchemeKey const & key, CLazySerialize<VaultGlobalSchemeValue> valueLazy){
-                if (key.blockHeight < minHeight) {
-                    return false;
-                }
+            pvaultHistoryDB->ForEachGlobalScheme(
+                [&](VaultGlobalSchemeKey const &key, CLazySerialize<VaultGlobalSchemeValue> valueLazy) {
+                    if (key.blockHeight < minHeight) {
+                        return false;
+                    }
 
-                if (it->second != key.schemeCreationTxid) {
-                    return true;
-                }
+                    if (it->second != key.schemeCreationTxid) {
+                        return true;
+                    }
 
-                if (shouldSkipBlock(key.blockHeight)) {
-                    return true;
-                }
+                    if (shouldSkipBlock(key.blockHeight)) {
+                        return true;
+                    }
 
-                const auto & value = valueLazy.get();
+                    const auto &value = valueLazy.get();
 
-                if (txTypeSearch && value.category != uint8_t(txType)) {
-                    return true;
-                }
+                    if (txTypeSearch && value.category != uint8_t(txType)) {
+                        return true;
+                    }
 
-                auto& array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
-                array.push_back(schemeToJSON({vaultID, key.blockHeight}, value));
+                    auto &array = ret.emplace(key.blockHeight, UniValue::VARR).first->second;
+                    array.push_back(schemeToJSON({vaultID, key.blockHeight}, value));
 
-                return --count != 0;
-            }, {endHeight, std::numeric_limits<uint32_t>::max(), it->second});
+                    return --count != 0;
+                },
+                {endHeight, std::numeric_limits<uint32_t>::max(), it->second});
         }
     }
 
     UniValue slice(UniValue::VARR);
     for (auto it = ret.cbegin(); limit != 0 && it != ret.cend(); ++it) {
-        const auto& array = it->second.get_array();
+        const auto &array = it->second.get_array();
         for (size_t i = 0; limit != 0 && i < array.size(); ++i) {
             slice.push_back(array[i]);
             --limit;
@@ -1570,32 +1676,45 @@ UniValue listvaulthistory(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, slice);
 }
 
-UniValue estimateloan(const JSONRPCRequest& request) {
+UniValue estimateloan(const JSONRPCRequest &request) {
+    RPCHelpMan{
+        "estimateloan",
+        "Returns amount of loan tokens a vault can take depending on a target collateral ratio.\n",
+        {{
+             "vaultId",
+             RPCArg::Type::STR_HEX,
+             RPCArg::Optional::NO,
+             "vault hex id",
+         },
+         {
+             "tokens",
+             RPCArg::Type::OBJ,
+             RPCArg::Optional::NO,
+             "Object with loans token as key and their percent split as value",
+             {
 
-    RPCHelpMan{"estimateloan",
-               "Returns amount of loan tokens a vault can take depending on a target collateral ratio.\n",
-                {
-                    {"vaultId", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "vault hex id",},
-                    {"tokens", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Object with loans token as key and their percent split as value",
-                        {
-
-                            {"split", RPCArg::Type::NUM, RPCArg::Optional::NO, "The percent split"},
-                        },
-                    },
-                    {"targetRatio", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Target collateral ratio. (defaults to vault's loan scheme ratio)"}
-                },
-                RPCResult{
-                    "\"json\"                  (Array) Array of <amount@token> strings\n"
-                },
-               RPCExamples{
-                       HelpExampleCli("estimateloan", R"(5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf '{"TSLA":0.5, "FB": 0.4, "GOOGL":0.1}' 150)") +
-                       HelpExampleRpc("estimateloan", R"("5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf", {"TSLA":0.5, "FB": 0.4, "GOOGL":0.1}, 150)")
-               },
-    }.Check(request);
+                 {"split", RPCArg::Type::NUM, RPCArg::Optional::NO, "The percent split"},
+             },
+         },
+         {"targetRatio",
+          RPCArg::Type::NUM,
+          RPCArg::Optional::OMITTED,
+          "Target collateral ratio. (defaults to vault's loan scheme ratio)"}},
+        RPCResult{"\"json\"                  (Array) Array of <amount@token> strings\n"},
+        RPCExamples{
+            HelpExampleCli(
+                "estimateloan",
+                R"(5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf '{"TSLA":0.5, "FB": 0.4, "GOOGL":0.1}' 150)") +
+            HelpExampleRpc(
+                "estimateloan",
+                R"("5474b2e9bfa96446e5ef3c9594634e1aa22d3a0722cb79084d61253acbdf87bf", {"TSLA":0.5, "FB": 0.4, "GOOGL":0.1}, 150)")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ, UniValue::VNUM}, false);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     CVaultId vaultId = ParseHashV(request.params[0], "vaultId");
 
@@ -1614,7 +1733,7 @@ UniValue estimateloan(const JSONRPCRequest& request) {
     auto scheme = pcustomcsview->GetLoanScheme(vault->schemeId);
     uint32_t ratio = scheme->ratio;
     if (request.params.size() > 2) {
-        ratio = (size_t) request.params[2].get_int64();
+        ratio = (size_t)request.params[2].get_int64();
     }
 
     auto collaterals = pcustomcsview->GetVaultCollaterals(vaultId);
@@ -1632,7 +1751,7 @@ UniValue estimateloan(const JSONRPCRequest& request) {
     CBalances loanBalances;
     CAmount totalSplit{0};
     if (request.params.size() > 1 && request.params[1].isObject()) {
-        for (const auto& tokenId : request.params[1].getKeys()) {
+        for (const auto &tokenId : request.params[1].getKeys()) {
             CAmount split = AmountFromValue(request.params[1][tokenId]);
 
             auto token = pcustomcsview->GetToken(tokenId);
@@ -1663,39 +1782,46 @@ UniValue estimateloan(const JSONRPCRequest& request) {
             totalSplit += split;
         }
         if (totalSplit != COIN)
-            throw JSONRPCError(RPC_MISC_ERROR, strprintf("total split between loan tokens = %s vs expected %s", GetDecimaleString(totalSplit), GetDecimaleString(COIN)));
+            throw JSONRPCError(RPC_MISC_ERROR,
+                               strprintf("total split between loan tokens = %s vs expected %s",
+                                         GetDecimaleString(totalSplit),
+                                         GetDecimaleString(COIN)));
     }
     auto res = AmountsToJSON(loanBalances.balances);
     return GetRPCResultCache().Set(request, res);
 }
 
-UniValue estimatecollateral(const JSONRPCRequest& request) {
+UniValue estimatecollateral(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"estimatecollateral",
-               "Returns amount of collateral tokens needed to take an amount of loan tokens for a target collateral ratio.\n",
+    RPCHelpMan{
+        "estimatecollateral",
+        "Returns amount of collateral tokens needed to take an amount of loan tokens for a target collateral ratio.\n",
+        {
+            {"loanAmounts",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Amount as json string, or array. Example: '[ \"amount@token\" ]'"},
+            {"targetRatio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Target collateral ratio."},
+            {
+                "tokens",
+                RPCArg::Type::OBJ,
+                RPCArg::Optional::OMITTED,
+                "Object with collateral token as key and their percent split as value. (defaults to { DFI: 1 }",
                 {
-                    {"loanAmounts", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "Amount as json string, or array. Example: '[ \"amount@token\" ]'"
-                    },
-                    {"targetRatio", RPCArg::Type::NUM, RPCArg::Optional::NO, "Target collateral ratio."},
-                    {"tokens", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "Object with collateral token as key and their percent split as value. (defaults to { DFI: 1 }",
-                        {
-                            {"split", RPCArg::Type::NUM, RPCArg::Optional::NO, "The percent split"},
-                        },
-                    },
+                    {"split", RPCArg::Type::NUM, RPCArg::Optional::NO, "The percent split"},
                 },
-                RPCResult{
-                    "\"json\"                  (Array) Array of <amount@token> strings\n"
-                },
-               RPCExamples{
-                       HelpExampleCli("estimatecollateral", R"(23.55311144@MSFT 150 '{"DFI": 0.8, "BTC":0.2}')") +
-                       HelpExampleRpc("estimatecollateral", R"("23.55311144@MSFT" 150 {"DFI": 0.8, "BTC":0.2})")
-               },
-    }.Check(request);
+            },
+        },
+        RPCResult{"\"json\"                  (Array) Array of <amount@token> strings\n"},
+        RPCExamples{HelpExampleCli("estimatecollateral", R"(23.55311144@MSFT 150 '{"DFI": 0.8, "BTC":0.2}')") +
+                    HelpExampleRpc("estimatecollateral", R"("23.55311144@MSFT" 150 {"DFI": 0.8, "BTC":0.2})")},
+    }
+        .Check(request);
 
     RPCTypeCheck(request.params, {UniValueType(), UniValue::VNUM, UniValue::VOBJ}, false);
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     const CBalances loanBalances = DecodeAmounts(pwallet->chain(), request.params[0], "");
     auto ratio = request.params[1].get_int();
@@ -1710,9 +1836,11 @@ UniValue estimatecollateral(const JSONRPCRequest& request) {
     LOCK(cs_main);
 
     CAmount totalLoanValue{0};
-    for (const auto& loan : loanBalances.balances) {
+    for (const auto &loan : loanBalances.balances) {
         auto loanToken = pcustomcsview->GetLoanTokenByID(loan.first);
-        if (!loanToken) throw JSONRPCError(RPC_INVALID_PARAMETER, "Token with id (" + loan.first.ToString() + ") is not a loan token!");
+        if (!loanToken)
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Token with id (" + loan.first.ToString() + ") is not a loan token!");
 
         auto amountInCurrency = pcustomcsview->GetAmountInCurrency(loan.second, loanToken->fixedIntervalPriceId);
         if (!amountInCurrency) {
@@ -1724,7 +1852,7 @@ UniValue estimatecollateral(const JSONRPCRequest& request) {
     uint32_t height = ::ChainActive().Height();
     CBalances collateralBalances;
     CAmount totalSplit{0};
-    for (const auto& collateralSplit : collateralSplits) {
+    for (const auto &collateralSplit : collateralSplits) {
         CAmount split = AmountFromValue(collateralSplit.second);
 
         auto token = pcustomcsview->GetToken(collateralSplit.first);
@@ -1756,66 +1884,75 @@ UniValue estimatecollateral(const JSONRPCRequest& request) {
         totalSplit += split;
     }
     if (totalSplit != COIN) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("total split between collateral tokens = %s vs expected %s", GetDecimaleString(totalSplit), GetDecimaleString(COIN)));
+        throw JSONRPCError(RPC_MISC_ERROR,
+                           strprintf("total split between collateral tokens = %s vs expected %s",
+                                     GetDecimaleString(totalSplit),
+                                     GetDecimaleString(COIN)));
     }
 
     auto res = AmountsToJSON(collateralBalances.balances);
     return GetRPCResultCache().Set(request, res);
 }
 
-UniValue estimatevault(const JSONRPCRequest& request) {
+UniValue estimatevault(const JSONRPCRequest &request) {
     auto pwallet = GetWallet(request);
 
-    RPCHelpMan{"estimatevault",
-               "Returns estimated vault for given collateral and loan amounts.\n",
-                {
-                    {"collateralAmounts", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "Collateral amounts as json string, or array. Example: '[ \"amount@token\" ]'"
-                    },
-                    {"loanAmounts", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "Loan amounts as json string, or array. Example: '[ \"amount@token\" ]'"
-                    },
-                },
-                RPCResult{
-                       "{\n"
-                       "  \"collateralValue\" : n.nnnnnnnn,        (amount) The total collateral value in USD\n"
-                       "  \"loanValue\" : n.nnnnnnnn,              (amount) The total loan value in USD\n"
-                       "  \"informativeRatio\" : n.nnnnnnnn,       (amount) Informative ratio with 8 digit precision\n"
-                       "  \"collateralRatio\" : n,                 (uint) Ratio as unsigned int\n"
-                       "}\n"
-                },
-               RPCExamples{
-                       HelpExampleCli("estimatevault", R"('["1000.00000000@DFI"]' '["0.65999990@GOOGL"]')") +
-                       HelpExampleRpc("estimatevault", R"(["1000.00000000@DFI"], ["0.65999990@GOOGL"])")
-               },
-    }.Check(request);
+    RPCHelpMan{
+        "estimatevault",
+        "Returns estimated vault for given collateral and loan amounts.\n",
+        {
+            {"collateralAmounts",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Collateral amounts as json string, or array. Example: '[ \"amount@token\" ]'"},
+            {"loanAmounts",
+             RPCArg::Type::STR,
+             RPCArg::Optional::NO,
+             "Loan amounts as json string, or array. Example: '[ \"amount@token\" ]'"},
+        },
+        RPCResult{"{\n"
+                  "  \"collateralValue\" : n.nnnnnnnn,        (amount) The total collateral value in USD\n"
+                  "  \"loanValue\" : n.nnnnnnnn,              (amount) The total loan value in USD\n"
+                  "  \"informativeRatio\" : n.nnnnnnnn,       (amount) Informative ratio with 8 digit precision\n"
+                  "  \"collateralRatio\" : n,                 (uint) Ratio as unsigned int\n"
+                  "}\n"},
+        RPCExamples{HelpExampleCli("estimatevault", R"('["1000.00000000@DFI"]' '["0.65999990@GOOGL"]')") +
+                    HelpExampleRpc("estimatevault", R"(["1000.00000000@DFI"], ["0.65999990@GOOGL"])")},
+    }
+        .Check(request);
 
-    if (auto res = GetRPCResultCache().TryGet(request)) return *res;
+    if (auto res = GetRPCResultCache().TryGet(request))
+        return *res;
 
     CBalances collateralBalances = DecodeAmounts(pwallet->chain(), request.params[0], "");
     CBalances loanBalances = DecodeAmounts(pwallet->chain(), request.params[1], "");
 
     LOCK(cs_main);
-    auto height = (uint32_t) ::ChainActive().Height();
+    auto height = (uint32_t)::ChainActive().Height();
 
     CCollateralLoans result{};
 
-    for (const auto& collateral : collateralBalances.balances) {
+    for (const auto &collateral : collateralBalances.balances) {
         auto collateralToken = pcustomcsview->HasLoanCollateralToken({collateral.first, height});
         if (!collateralToken || !collateralToken->factor) {
-            throw JSONRPCError(RPC_DATABASE_ERROR, strprintf("Token with id (%s) is not a valid collateral!", collateral.first.ToString()));
+            throw JSONRPCError(RPC_DATABASE_ERROR,
+                               strprintf("Token with id (%s) is not a valid collateral!", collateral.first.ToString()));
         }
 
-        auto amountInCurrency = pcustomcsview->GetAmountInCurrency(collateral.second, collateralToken->fixedIntervalPriceId);
+        auto amountInCurrency =
+            pcustomcsview->GetAmountInCurrency(collateral.second, collateralToken->fixedIntervalPriceId);
         if (!amountInCurrency) {
             throw JSONRPCError(RPC_DATABASE_ERROR, amountInCurrency.msg);
         }
-        result.totalCollaterals += MultiplyAmounts(collateralToken->factor, *amountInCurrency.val);;
+        result.totalCollaterals += MultiplyAmounts(collateralToken->factor, *amountInCurrency.val);
+        ;
     }
 
-    for (const auto& loan : loanBalances.balances) {
+    for (const auto &loan : loanBalances.balances) {
         auto loanToken = pcustomcsview->GetLoanTokenByID(loan.first);
-        if (!loanToken) throw JSONRPCError(RPC_INVALID_PARAMETER, "Token with id (" + loan.first.ToString() + ") is not a loan token!");
+        if (!loanToken)
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                               "Token with id (" + loan.first.ToString() + ") is not a loan token!");
 
         auto amountInCurrency = pcustomcsview->GetAmountInCurrency(loan.second, loanToken->fixedIntervalPriceId);
         if (!amountInCurrency) {
@@ -1832,27 +1969,26 @@ UniValue estimatevault(const JSONRPCRequest& request) {
     return GetRPCResultCache().Set(request, ret);
 }
 
-static const CRPCCommand commands[] =
-{
-//  category        name                         actor (function)        params
-//  --------------- ----------------------       ---------------------   ----------
-    {"vault",        "createvault",               &createvault,           {"ownerAddress", "schemeId", "inputs"}},
-    {"vault",        "closevault",                &closevault,            {"id", "returnAddress", "inputs"}},
-    {"vault",        "listvaults",                &listvaults,            {"options", "pagination"}},
-    {"vault",        "getvault",                  &getvault,              {"id", "verbose"}},
-    {"vault",        "listvaulthistory",          &listvaulthistory,      {"id", "options"}},
-    {"vault",        "updatevault",               &updatevault,           {"id", "parameters", "inputs"}},
-    {"vault",        "deposittovault",            &deposittovault,        {"id", "from", "amount", "inputs"}},
-    {"vault",        "withdrawfromvault",         &withdrawfromvault,     {"id", "to", "amount", "inputs"}},
-    {"vault",        "placeauctionbid",           &placeauctionbid,       {"id", "index", "from", "amount", "inputs"}},
-    {"vault",        "listauctions",              &listauctions,          {"pagination"}},
-    {"vault",        "listauctionhistory",        &listauctionhistory,    {"owner", "pagination"}},
-    {"vault",        "estimateloan",              &estimateloan,          {"vaultId", "tokens", "targetRatio"}},
-    {"vault",        "estimatecollateral",        &estimatecollateral,    {"loanAmounts", "targetRatio", "tokens"}},
-    {"vault",        "estimatevault",             &estimatevault,         {"collateralAmounts", "loanAmounts"}},
+static const CRPCCommand commands[] = {
+    //  category        name                         actor (function)        params
+    //  --------------- ----------------------       ---------------------   ----------
+    {"vault", "createvault", &createvault, {"ownerAddress", "schemeId", "inputs"}},
+    {"vault", "closevault", &closevault, {"id", "returnAddress", "inputs"}},
+    {"vault", "listvaults", &listvaults, {"options", "pagination"}},
+    {"vault", "getvault", &getvault, {"id", "verbose"}},
+    {"vault", "listvaulthistory", &listvaulthistory, {"id", "options"}},
+    {"vault", "updatevault", &updatevault, {"id", "parameters", "inputs"}},
+    {"vault", "deposittovault", &deposittovault, {"id", "from", "amount", "inputs"}},
+    {"vault", "withdrawfromvault", &withdrawfromvault, {"id", "to", "amount", "inputs"}},
+    {"vault", "placeauctionbid", &placeauctionbid, {"id", "index", "from", "amount", "inputs"}},
+    {"vault", "listauctions", &listauctions, {"pagination"}},
+    {"vault", "listauctionhistory", &listauctionhistory, {"owner", "pagination"}},
+    {"vault", "estimateloan", &estimateloan, {"vaultId", "tokens", "targetRatio"}},
+    {"vault", "estimatecollateral", &estimatecollateral, {"loanAmounts", "targetRatio", "tokens"}},
+    {"vault", "estimatevault", &estimatevault, {"collateralAmounts", "loanAmounts"}},
 };
 
-void RegisterVaultRPCCommands(CRPCTable& tableRPC) {
+void RegisterVaultRPCCommands(CRPCTable &tableRPC) {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/masternodes/skipped_txs.cpp
+++ b/src/masternodes/skipped_txs.cpp
@@ -1,12 +1,11 @@
 
-#include <algorithm>
 #include <chainparams.h>
+#include <uint256.h>
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <uint256.h>
 
-bool IsSkippedTx(const uint256& hash) {
-
+bool IsSkippedTx(const uint256 &hash) {
     static const std::vector<std::string> skipped_txs_mainnet = {
         "ffcafd71820269ffe9cbecc12619154a3c5b272f1437d4e0242ff73d2bf09e4e",
         "4218d310d9a67b5e9a93d2a9ecf17bd70bda7a3670191efbc755b05c5fb8a6a4",
@@ -369,7 +368,7 @@ bool IsSkippedTx(const uint256& hash) {
         "e30ad732c4ec80946a9aef649e3eef521bf408f29539c0ff254b67272cc908ea",
     };
 
-    static const auto& skipped_txs = Params().NetworkIDString() == "main" ? skipped_txs_mainnet : skipped_txs_testnet;
+    static const auto &skipped_txs = Params().NetworkIDString() == "main" ? skipped_txs_mainnet : skipped_txs_testnet;
 
     return std::find(skipped_txs.begin(), skipped_txs.end(), hash.GetHex()) != skipped_txs.end();
 }

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -5,7 +5,7 @@
 #include <masternodes/tokens.h>
 
 #include <amount.h>
-#include <chainparams.h> // Params()
+#include <chainparams.h>  // Params()
 #include <core_io.h>
 #include <primitives/transaction.h>
 #include <util/strencodings.h>
@@ -16,13 +16,12 @@ const DCT_ID CTokensView::DCT_ID_START = DCT_ID{128};
 
 extern const std::string CURRENCY_UNIT;
 
-std::optional<CTokensView::CTokenImpl> CTokensView::GetToken(DCT_ID id) const
-{
+std::optional<CTokensView::CTokenImpl> CTokensView::GetToken(DCT_ID id) const {
     return ReadBy<ID, CTokenImpl>(id);
 }
 
-std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> CTokensView::GetToken(const std::string & symbolKey) const
-{
+std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> CTokensView::GetToken(
+    const std::string &symbolKey) const {
     DCT_ID id;
     if (ReadBy<Symbol, std::string>(symbolKey, id)) {
         return std::make_pair(id, GetToken(id));
@@ -30,8 +29,7 @@ std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> CTokens
     return {};
 }
 
-std::optional<std::pair<DCT_ID, CTokensView::CTokenImpl> > CTokensView::GetTokenByCreationTx(const uint256 & txid) const
-{
+std::optional<std::pair<DCT_ID, CTokensView::CTokenImpl>> CTokensView::GetTokenByCreationTx(const uint256 &txid) const {
     DCT_ID id;
     if (ReadBy<CreationTx, uint256>(txid, id)) {
         if (auto tokenImpl = ReadBy<ID, CTokenImpl>(id)) {
@@ -41,13 +39,12 @@ std::optional<std::pair<DCT_ID, CTokensView::CTokenImpl> > CTokensView::GetToken
     return {};
 }
 
-void CTokensView::ForEachToken(std::function<bool (const DCT_ID &, CLazySerialize<CTokenImpl>)> callback, DCT_ID const & start)
-{
+void CTokensView::ForEachToken(std::function<bool(const DCT_ID &, CLazySerialize<CTokenImpl>)> callback,
+                               DCT_ID const &start) {
     ForEach<ID, DCT_ID, CTokenImpl>(callback, start);
 }
 
-Res CTokensView::CreateDFIToken()
-{
+Res CTokensView::CreateDFIToken() {
     CTokenImpl token;
     token.symbol = CURRENCY_UNIT;
     token.name = "Default Defi token";
@@ -65,8 +62,7 @@ Res CTokensView::CreateDFIToken()
     return Res::Ok();
 }
 
-ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl & token, bool isPreBayfront)
-{
+ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token, bool isPreBayfront) {
     // this should not happen, but for sure
     if (GetTokenByCreationTx(token.creationTx)) {
         return Res::Err("token with creation tx %s already exists!", token.creationTx.ToString());
@@ -78,20 +74,30 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl & token, b
     }
 
     DCT_ID id{0};
-    if(token.IsDAT()) {
+    if (token.IsDAT()) {
         if (GetToken(token.symbol)) {
             return Res::Err("token '%s' already exists!", token.symbol);
         }
-        ForEachToken([&](DCT_ID const& currentId, CLazySerialize<CTokenImplementation>) {
-            if(currentId < DCT_ID_START)
-                id.v = currentId.v + 1;
-            return currentId < DCT_ID_START;
-        }, id);
+        ForEachToken(
+            [&](DCT_ID const &currentId, CLazySerialize<CTokenImplementation>) {
+                if (currentId < DCT_ID_START)
+                    id.v = currentId.v + 1;
+                return currentId < DCT_ID_START;
+            },
+            id);
         if (id == DCT_ID_START) {
             if (isPreBayfront)
-                return Res::Err("Critical fault: trying to create DCT_ID same as DCT_ID_START for Foundation owner\n"); // asserted before BayfrontHeight, keep it for strict sameness
+                return Res::Err(
+                    "Critical fault: trying to create DCT_ID same as DCT_ID_START for Foundation owner\n");  // asserted
+                                                                                                             // before
+                                                                                                             // BayfrontHeight,
+                                                                                                             // keep it
+                                                                                                             // for
+                                                                                                             // strict
+                                                                                                             // sameness
             id = IncrementLastDctId();
-            LogPrintf("Warning! Range <DCT_ID_START already filled. Using \"common\" id=%s for new token\n", id.ToString().c_str());
+            LogPrintf("Warning! Range <DCT_ID_START already filled. Using \"common\" id=%s for new token\n",
+                      id.ToString().c_str());
         }
     } else {
         id = IncrementLastDctId();
@@ -105,16 +111,17 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl & token, b
     return {id, Res::Ok()};
 }
 
-Res CTokensView::UpdateToken(const CTokenImpl& newToken, bool isPreBayfront, const bool tokenSplitUpdate)
-{
+Res CTokensView::UpdateToken(const CTokenImpl &newToken, bool isPreBayfront, const bool tokenSplitUpdate) {
     auto pair = GetTokenByCreationTx(newToken.creationTx);
     if (!pair) {
         return Res::Err("token with creationTx %s does not exist!", newToken.creationTx.ToString());
     }
     DCT_ID id = pair->first;
-    CTokenImpl & oldToken = pair->second;
+    CTokenImpl &oldToken = pair->second;
 
-    if (!isPreBayfront && oldToken.IsFinalized()) { // for compatibility, in potential case when someone cheat and create finalized token with old node (and then alter dat for ex.)
+    if (!isPreBayfront &&
+        oldToken.IsFinalized()) {  // for compatibility, in potential case when someone cheat and create finalized token
+                                   // with old node (and then alter dat for ex.)
         return Res::Err("can't alter 'Finalized' tokens");
     }
 
@@ -130,7 +137,8 @@ Res CTokensView::UpdateToken(const CTokenImpl& newToken, bool isPreBayfront, con
     }
 
     // deal with DB symbol indexes before touching symbols/DATs:
-    if (oldToken.symbol != newToken.symbol || oldToken.IsDAT() != newToken.IsDAT()) { // in both cases it leads to index changes
+    if (oldToken.symbol != newToken.symbol ||
+        oldToken.IsDAT() != newToken.IsDAT()) {  // in both cases it leads to index changes
         // create keys with regard of new flag
         std::string oldSymbolKey = oldToken.CreateSymbolKey(id);
         std::string newSymbolKey = newToken.CreateSymbolKey(id);
@@ -153,7 +161,7 @@ Res CTokensView::UpdateToken(const CTokenImpl& newToken, bool isPreBayfront, con
     if (oldToken.IsTradeable() != newToken.IsTradeable())
         oldToken.flags ^= (uint8_t)CToken::TokenFlags::Tradeable;
 
-    if (!oldToken.IsFinalized() && newToken.IsFinalized()) // IsFinalized() itself was checked upthere (with Err)
+    if (!oldToken.IsFinalized() && newToken.IsFinalized())  // IsFinalized() itself was checked upthere (with Err)
         oldToken.flags |= (uint8_t)CToken::TokenFlags::Finalized;
 
     if (tokenSplitUpdate && oldToken.IsLoanToken() != newToken.IsLoanToken())
@@ -175,30 +183,30 @@ Res CTokensView::UpdateToken(const CTokenImpl& newToken, bool isPreBayfront, con
  * Removes `Finalized` and/or `LPS` flags _possibly_set_ by bytecoded (cheated) txs before bayfront fork
  * Call this EXECTLY at the 'bayfrontHeight-1' block
  */
-Res CTokensView::BayfrontFlagsCleanup()
-{
-    ForEachToken([&] (DCT_ID const & id, CTokenImpl token){
-        bool changed{false};
-        if (token.IsFinalized()) {
-            token.flags ^= (uint8_t)CToken::TokenFlags::Finalized;
-            LogPrintf("Warning! Got `Finalized` token, id=%s\n", id.ToString().c_str());
-            changed = true;
-        }
-        if (token.IsPoolShare()) {
-            token.flags ^= (uint8_t)CToken::TokenFlags::LPS;
-            LogPrintf("Warning! Got `LPS` token, id=%s\n", id.ToString().c_str());
-            changed = true;
-        }
-        if (changed) {
-            WriteBy<ID>(id, token);
-        }
-        return true;
-    }, DCT_ID{1}); // start from non-DFI
+Res CTokensView::BayfrontFlagsCleanup() {
+    ForEachToken(
+        [&](DCT_ID const &id, CTokenImpl token) {
+            bool changed{false};
+            if (token.IsFinalized()) {
+                token.flags ^= (uint8_t)CToken::TokenFlags::Finalized;
+                LogPrintf("Warning! Got `Finalized` token, id=%s\n", id.ToString().c_str());
+                changed = true;
+            }
+            if (token.IsPoolShare()) {
+                token.flags ^= (uint8_t)CToken::TokenFlags::LPS;
+                LogPrintf("Warning! Got `LPS` token, id=%s\n", id.ToString().c_str());
+                changed = true;
+            }
+            if (changed) {
+                WriteBy<ID>(id, token);
+            }
+            return true;
+        },
+        DCT_ID{1});  // start from non-DFI
     return Res::Ok();
 }
 
-Res CTokensView::AddMintedTokens(DCT_ID const &id, CAmount const & amount)
-{
+Res CTokensView::AddMintedTokens(DCT_ID const &id, CAmount const &amount) {
     auto tokenImpl = GetToken(id);
     if (!tokenImpl) {
         return Res::Err("token with id %d does not exist!", id.v);
@@ -214,8 +222,7 @@ Res CTokensView::AddMintedTokens(DCT_ID const &id, CAmount const & amount)
     return Res::Ok();
 }
 
-Res CTokensView::SubMintedTokens(DCT_ID const &id, CAmount const & amount)
-{
+Res CTokensView::SubMintedTokens(DCT_ID const &id, CAmount const &amount) {
     auto tokenImpl = GetToken(id);
     if (!tokenImpl) {
         return Res::Err("token with id %d does not exist!", id.v);
@@ -231,19 +238,17 @@ Res CTokensView::SubMintedTokens(DCT_ID const &id, CAmount const & amount)
     return Res::Ok();
 }
 
-DCT_ID CTokensView::IncrementLastDctId()
-{
+DCT_ID CTokensView::IncrementLastDctId() {
     DCT_ID result{DCT_ID_START};
     auto lastDctId = ReadLastDctId();
     if (lastDctId) {
         result = DCT_ID{std::max(lastDctId->v + 1, result.v)};
     }
-    assert (Write(LastDctId::prefix(), result));
+    assert(Write(LastDctId::prefix(), result));
     return result;
 }
 
-std::optional<DCT_ID> CTokensView::ReadLastDctId() const
-{
+std::optional<DCT_ID> CTokensView::ReadLastDctId() const {
     DCT_ID lastDctId{DCT_ID_START};
     if (Read(LastDctId::prefix(), lastDctId)) {
         return {lastDctId};
@@ -251,8 +256,7 @@ std::optional<DCT_ID> CTokensView::ReadLastDctId() const
     return {};
 }
 
-inline Res CTokenImplementation::IsValidSymbol() const
-{
+inline Res CTokenImplementation::IsValidSymbol() const {
     if (symbol.size() == 0 || IsDigit(symbol[0])) {
         return Res::Err("token symbol should be non-empty and starts with a letter");
     }

--- a/src/masternodes/tokens.h
+++ b/src/masternodes/tokens.h
@@ -16,72 +16,46 @@
 class CTransaction;
 class UniValue;
 
-class CToken
-{
-public:
+class CToken {
+   public:
     static const uint8_t MAX_TOKEN_NAME_LENGTH = 128;
     static const uint8_t MAX_TOKEN_SYMBOL_LENGTH = 8;
     static const uint8_t MAX_TOKEN_POOLPAIR_LENGTH = 16;
-    enum class TokenFlags : uint8_t
-    {
+    enum class TokenFlags : uint8_t {
         None = 0,
         Mintable = 0x01,
         Tradeable = 0x02,
         DAT = 0x04,
-        LPS = 0x08, // Liquidity Pool Share
-        Finalized = 0x10, // locked forever
-        LoanToken = 0x20, // token created for loan
+        LPS = 0x08,        // Liquidity Pool Share
+        Finalized = 0x10,  // locked forever
+        LoanToken = 0x20,  // token created for loan
         Default = TokenFlags::Mintable | TokenFlags::Tradeable
     };
 
     //! basic properties
     std::string symbol;
     std::string name;
-    uint8_t decimal;    // now fixed to 8
-    CAmount limit;      // now isn't tracked
-    uint8_t flags;      // minting support, tradeability
+    uint8_t decimal;  // now fixed to 8
+    CAmount limit;    // now isn't tracked
+    uint8_t flags;    // minting support, tradeability
 
-    CToken()
-        : symbol("")
-        , name("")
-        , decimal(8)
-        , limit(0)
-        , flags(uint8_t(TokenFlags::Default))
-    {}
+    CToken() : symbol(""), name(""), decimal(8), limit(0), flags(uint8_t(TokenFlags::Default)) {}
     virtual ~CToken() = default;
 
-    inline bool IsMintable() const
-    {
-        return flags & (uint8_t)TokenFlags::Mintable;
-    }
-    inline bool IsTradeable() const
-    {
-        return flags & (uint8_t)TokenFlags::Tradeable;
-    }
-    inline bool IsDAT() const
-    {
-        return flags & (uint8_t)TokenFlags::DAT;
-    }
-    inline bool IsPoolShare() const
-    {
-        return flags & (uint8_t)TokenFlags::LPS;
-    }
-    inline bool IsFinalized() const
-    {
-        return flags & (uint8_t)TokenFlags::Finalized;
-    }
-    inline bool IsLoanToken () const
-    {
-        return flags & (uint8_t)TokenFlags::LoanToken;
-    }
-    inline std::string CreateSymbolKey(DCT_ID const & id) const {
+    inline bool IsMintable() const { return flags & (uint8_t)TokenFlags::Mintable; }
+    inline bool IsTradeable() const { return flags & (uint8_t)TokenFlags::Tradeable; }
+    inline bool IsDAT() const { return flags & (uint8_t)TokenFlags::DAT; }
+    inline bool IsPoolShare() const { return flags & (uint8_t)TokenFlags::LPS; }
+    inline bool IsFinalized() const { return flags & (uint8_t)TokenFlags::Finalized; }
+    inline bool IsLoanToken() const { return flags & (uint8_t)TokenFlags::LoanToken; }
+    inline std::string CreateSymbolKey(DCT_ID const &id) const {
         return symbol + (IsDAT() ? "" : "#" + std::to_string(id.v));
     }
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(symbol);
         READWRITE(name);
         READWRITE(decimal);
@@ -90,30 +64,20 @@ public:
     }
 };
 
-class CTokenImplementation : public CToken
-{
-public:
+class CTokenImplementation : public CToken {
+   public:
     //! tx related properties
     CAmount minted;
     uint256 creationTx;
     uint256 destructionTx;
-    int32_t creationHeight; // @todo use unsigned integers, because serialization of signed integers isn't fulled defined
+    int32_t
+        creationHeight;  // @todo use unsigned integers, because serialization of signed integers isn't fulled defined
     int32_t destructionHeight;
 
     CTokenImplementation()
-        : CToken()
-        , minted(0)
-        , creationTx()
-        , destructionTx()
-        , creationHeight(-1)
-        , destructionHeight(-1)
-    {}
-    explicit CTokenImplementation(const CToken& token)
-            : CToken(token)
-            , minted(0)
-            , creationHeight(-1)
-            , destructionHeight(-1)
-    {}
+        : CToken(), minted(0), creationTx(), destructionTx(), creationHeight(-1), destructionHeight(-1) {}
+    explicit CTokenImplementation(const CToken &token)
+        : CToken(token), minted(0), creationHeight(-1), destructionHeight(-1) {}
     ~CTokenImplementation() override = default;
 
     [[nodiscard]] inline Res IsValidSymbol() const;
@@ -121,7 +85,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CToken, *this);
         READWRITE(minted);
         READWRITE(creationTx);
@@ -131,39 +95,47 @@ public:
     }
 };
 
-class CTokensView : public virtual CStorageView
-{
-public:
-    static const DCT_ID DCT_ID_START; // = 128;
-    static const unsigned char DB_TOKEN_LASTID; // = 'L';
+class CTokensView : public virtual CStorageView {
+   public:
+    static const DCT_ID DCT_ID_START;            // = 128;
+    static const unsigned char DB_TOKEN_LASTID;  // = 'L';
 
     using CTokenImpl = CTokenImplementation;
     std::optional<CTokenImpl> GetToken(DCT_ID id) const;
-    std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> GetToken(std::string const & symbol) const;
+    std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl>>> GetToken(std::string const &symbol) const;
     // the only possible type of token (with creationTx) is CTokenImpl
-    std::optional<std::pair<DCT_ID, CTokenImpl>> GetTokenByCreationTx(uint256 const & txid) const;
-    [[nodiscard]] virtual std::optional<CTokenImpl> GetTokenGuessId(const std::string & str, DCT_ID & id) const = 0;
+    std::optional<std::pair<DCT_ID, CTokenImpl>> GetTokenByCreationTx(uint256 const &txid) const;
+    [[nodiscard]] virtual std::optional<CTokenImpl> GetTokenGuessId(const std::string &str, DCT_ID &id) const = 0;
 
-    void ForEachToken(std::function<bool(DCT_ID const &, CLazySerialize<CTokenImpl>)> callback, DCT_ID const & start = DCT_ID{0});
+    void ForEachToken(std::function<bool(DCT_ID const &, CLazySerialize<CTokenImpl>)> callback,
+                      DCT_ID const &start = DCT_ID{0});
 
     Res CreateDFIToken();
-    ResVal<DCT_ID> CreateToken(CTokenImpl const & token, bool isPreBayfront = false);
-    Res UpdateToken(CTokenImpl const & newToken, bool isPreBayfront = false, const bool tokenSplitUpdatea = false);
+    ResVal<DCT_ID> CreateToken(CTokenImpl const &token, bool isPreBayfront = false);
+    Res UpdateToken(CTokenImpl const &newToken, bool isPreBayfront = false, const bool tokenSplitUpdatea = false);
 
     Res BayfrontFlagsCleanup();
-    Res AddMintedTokens(DCT_ID const & id, CAmount const & amount);
-    Res SubMintedTokens(DCT_ID const & id, CAmount const & amount);
+    Res AddMintedTokens(DCT_ID const &id, CAmount const &amount);
+    Res SubMintedTokens(DCT_ID const &id, CAmount const &amount);
 
     // tags
-    struct ID           { static constexpr uint8_t prefix() { return 'T'; } };
-    struct Symbol       { static constexpr uint8_t prefix() { return 'S'; } };
-    struct CreationTx   { static constexpr uint8_t prefix() { return 'c'; } };
-    struct LastDctId    { static constexpr uint8_t prefix() { return 'L'; } };
+    struct ID {
+        static constexpr uint8_t prefix() { return 'T'; }
+    };
+    struct Symbol {
+        static constexpr uint8_t prefix() { return 'S'; }
+    };
+    struct CreationTx {
+        static constexpr uint8_t prefix() { return 'c'; }
+    };
+    struct LastDctId {
+        static constexpr uint8_t prefix() { return 'L'; }
+    };
 
-private:
+   private:
     // have to incapsulate "last token id" related methods here
     DCT_ID IncrementLastDctId();
     std::optional<DCT_ID> ReadLastDctId() const;
 };
 
-#endif // DEFI_MASTERNODES_TOKENS_H
+#endif  // DEFI_MASTERNODES_TOKENS_H

--- a/src/masternodes/undo.h
+++ b/src/masternodes/undo.h
@@ -5,21 +5,20 @@
 #ifndef DEFI_MASTERNODES_UNDO_H
 #define DEFI_MASTERNODES_UNDO_H
 
-
-#include <cstdint>
-#include <uint256.h>
+#include <flushablestorage.h>
 #include <serialize.h>
 #include <serialize_optional.h>
-#include <flushablestorage.h>
+#include <uint256.h>
+#include <cstdint>
 
 struct UndoKey {
-    uint32_t height; // height is there to be able to prune older undos using lexicographic iteration
+    uint32_t height;  // height is there to be able to prune older undos using lexicographic iteration
     uint256 txid;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(WrapBigEndian(height));
         READWRITE(txid);
     }
@@ -28,10 +27,10 @@ struct UndoKey {
 struct CUndo {
     MapKV before;
 
-    static CUndo Construct(CStorageKV const & before, MapKV const & diff) {
+    static CUndo Construct(CStorageKV const &before, MapKV const &diff) {
         CUndo result;
-        for (const auto & kv : diff) {
-            const auto& beforeKey = kv.first;
+        for (const auto &kv : diff) {
+            const auto &beforeKey = kv.first;
             TBytes beforeVal;
             if (before.Read(beforeKey, beforeVal)) {
                 result.before[beforeKey] = std::move(beforeVal);
@@ -42,8 +41,8 @@ struct CUndo {
         return result;
     }
 
-    static void Revert(CStorageKV & after, CUndo const & undo) {
-        for (const auto & kv : undo.before) {
+    static void Revert(CStorageKV &after, CUndo const &undo) {
+        for (const auto &kv : undo.before) {
             if (kv.second) {
                 after.Write(kv.first, *kv.second);
             } else {
@@ -55,10 +54,9 @@ struct CUndo {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(before);
     }
 };
 
-
-#endif //DEFI_MASTERNODES_UNDO_H
+#endif  // DEFI_MASTERNODES_UNDO_H

--- a/src/masternodes/undos.cpp
+++ b/src/masternodes/undos.cpp
@@ -4,25 +4,22 @@
 
 #include <masternodes/undos.h>
 
-void CUndosView::ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback, UndoKey const & start)
-{
+void CUndosView::ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback,
+                             UndoKey const &start) {
     ForEach<ByUndoKey, UndoKey, CUndo>(callback, start);
 }
 
-Res CUndosView::SetUndo(UndoKey const & key, CUndo const & undo)
-{
+Res CUndosView::SetUndo(UndoKey const &key, CUndo const &undo) {
     WriteBy<ByUndoKey>(key, undo);
     return Res::Ok();
 }
 
-Res CUndosView::DelUndo(UndoKey const & key)
-{
+Res CUndosView::DelUndo(UndoKey const &key) {
     EraseBy<ByUndoKey>(key);
     return Res::Ok();
 }
 
-std::optional<CUndo> CUndosView::GetUndo(UndoKey const & key) const
-{
+std::optional<CUndo> CUndosView::GetUndo(UndoKey const &key) const {
     CUndo val;
     bool ok = ReadBy<ByUndoKey>(key, val);
     if (ok) {

--- a/src/masternodes/undos.h
+++ b/src/masternodes/undos.h
@@ -5,21 +5,22 @@
 #ifndef DEFI_MASTERNODES_UNDOS_H
 #define DEFI_MASTERNODES_UNDOS_H
 
-#include <masternodes/undo.h>
 #include <flushablestorage.h>
 #include <masternodes/res.h>
+#include <masternodes/undo.h>
 
 class CUndosView : public virtual CStorageView {
-public:
-    void ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback, UndoKey const & start = {});
+   public:
+    void ForEachUndo(std::function<bool(UndoKey const &, CLazySerialize<CUndo>)> callback, UndoKey const &start = {});
 
-    std::optional<CUndo> GetUndo(UndoKey const & key) const;
-    Res SetUndo(UndoKey const & key, CUndo const & undo);
-    Res DelUndo(UndoKey const & key);
+    std::optional<CUndo> GetUndo(UndoKey const &key) const;
+    Res SetUndo(UndoKey const &key, CUndo const &undo);
+    Res DelUndo(UndoKey const &key);
 
     // tags
-    struct ByUndoKey { static constexpr uint8_t prefix() { return 'u'; } };
+    struct ByUndoKey {
+        static constexpr uint8_t prefix() { return 'u'; }
+    };
 };
 
-
-#endif //DEFI_MASTERNODES_UNDOS_H
+#endif  // DEFI_MASTERNODES_UNDOS_H

--- a/src/masternodes/vault.cpp
+++ b/src/masternodes/vault.cpp
@@ -9,22 +9,19 @@ struct CAuctionKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(WrapBigEndian(height));
         READWRITE(vaultId);
     }
 };
 
-Res CVaultView::StoreVault(const CVaultId& vaultId, const CVaultData& vault)
-{
+Res CVaultView::StoreVault(const CVaultId &vaultId, const CVaultData &vault) {
     WriteBy<VaultKey>(vaultId, vault);
     WriteBy<OwnerVaultKey>(std::make_pair(vault.ownerAddress, vaultId), '\0');
     return Res::Ok();
 }
 
-Res CVaultView::EraseVault(const CVaultId& vaultId)
-{
+Res CVaultView::EraseVault(const CVaultId &vaultId) {
     auto vault = GetVault(vaultId);
     if (!vault) {
         return Res::Err("Vault <%s> not found", vaultId.GetHex());
@@ -35,13 +32,11 @@ Res CVaultView::EraseVault(const CVaultId& vaultId)
     return Res::Ok();
 }
 
-std::optional<CVaultData> CVaultView::GetVault(const CVaultId& vaultId) const
-{
+std::optional<CVaultData> CVaultView::GetVault(const CVaultId &vaultId) const {
     return ReadBy<VaultKey, CVaultData>(vaultId);
 }
 
-Res CVaultView::UpdateVault(const CVaultId& vaultId, const CVaultMessage& newVault)
-{
+Res CVaultView::UpdateVault(const CVaultId &vaultId, const CVaultMessage &newVault) {
     auto vault = GetVault(vaultId);
     if (!vault) {
         return Res::Err("Vault <%s> not found", vaultId.GetHex());
@@ -55,19 +50,21 @@ Res CVaultView::UpdateVault(const CVaultId& vaultId, const CVaultMessage& newVau
     return StoreVault(vaultId, *vault);
 }
 
-void CVaultView::ForEachVault(std::function<bool(const CVaultId&, const CVaultData&)> callback, const CVaultId& start, const CScript& ownerAddress)
-{
+void CVaultView::ForEachVault(std::function<bool(const CVaultId &, const CVaultData &)> callback,
+                              const CVaultId &start,
+                              const CScript &ownerAddress) {
     if (ownerAddress.empty()) {
         ForEach<VaultKey, CVaultId, CVaultData>(callback, start);
     } else {
-        ForEach<OwnerVaultKey, std::pair<CScript, CVaultId>, char>([&](const std::pair<CScript, CVaultId>& key, const char) {
-            return callback(key.second, *GetVault(key.second));
-        }, std::make_pair(ownerAddress, start));
+        ForEach<OwnerVaultKey, std::pair<CScript, CVaultId>, char>(
+            [&](const std::pair<CScript, CVaultId> &key, const char) {
+                return callback(key.second, *GetVault(key.second));
+            },
+            std::make_pair(ownerAddress, start));
     }
 }
 
-Res CVaultView::AddVaultCollateral(const CVaultId& vaultId, CTokenAmount amount)
-{
+Res CVaultView::AddVaultCollateral(const CVaultId &vaultId, CTokenAmount amount) {
     CBalances amounts;
     ReadBy<CollateralKey>(vaultId, amounts);
     auto res = amounts.Add(amount);
@@ -80,8 +77,7 @@ Res CVaultView::AddVaultCollateral(const CVaultId& vaultId, CTokenAmount amount)
     return Res::Ok();
 }
 
-Res CVaultView::SubVaultCollateral(const CVaultId& vaultId, CTokenAmount amount)
-{
+Res CVaultView::SubVaultCollateral(const CVaultId &vaultId, CTokenAmount amount) {
     auto amounts = GetVaultCollaterals(vaultId);
     if (!amounts || !amounts->Sub(amount)) {
         return Res::Err("Collateral for vault <%s> not found", vaultId.GetHex());
@@ -94,24 +90,20 @@ Res CVaultView::SubVaultCollateral(const CVaultId& vaultId, CTokenAmount amount)
     return Res::Ok();
 }
 
-std::optional<CBalances> CVaultView::GetVaultCollaterals(const CVaultId& vaultId)
-{
+std::optional<CBalances> CVaultView::GetVaultCollaterals(const CVaultId &vaultId) {
     return ReadBy<CollateralKey, CBalances>(vaultId);
 }
 
-void CVaultView::ForEachVaultCollateral(std::function<bool(const CVaultId&, const CBalances&)> callback)
-{
+void CVaultView::ForEachVaultCollateral(std::function<bool(const CVaultId &, const CBalances &)> callback) {
     ForEach<CollateralKey, CVaultId, CBalances>(callback);
 }
 
-Res CVaultView::StoreAuction(const CVaultId& vaultId, const CAuctionData& data)
-{
+Res CVaultView::StoreAuction(const CVaultId &vaultId, const CAuctionData &data) {
     WriteBy<AuctionHeightKey>(CAuctionKey{vaultId, data.liquidationHeight}, data);
     return Res::Ok();
 }
 
-Res CVaultView::EraseAuction(const CVaultId& vaultId, uint32_t height)
-{
+Res CVaultView::EraseAuction(const CVaultId &vaultId, uint32_t height) {
     auto it = LowerBound<AuctionHeightKey>(CAuctionKey{vaultId, height});
     for (; it.Valid(); it.Next()) {
         if (it.Key().vaultId == vaultId) {
@@ -127,8 +119,7 @@ Res CVaultView::EraseAuction(const CVaultId& vaultId, uint32_t height)
     return Res::Err("Auction for vault <%s> not found", vaultId.GetHex());
 }
 
-std::optional<CAuctionData> CVaultView::GetAuction(const CVaultId& vaultId, uint32_t height)
-{
+std::optional<CAuctionData> CVaultView::GetAuction(const CVaultId &vaultId, uint32_t height) {
     auto it = LowerBound<AuctionHeightKey>(CAuctionKey{vaultId, height});
     for (; it.Valid(); it.Next()) {
         if (it.Key().vaultId == vaultId) {
@@ -140,54 +131,50 @@ std::optional<CAuctionData> CVaultView::GetAuction(const CVaultId& vaultId, uint
     return {};
 }
 
-Res CVaultView::StoreAuctionBatch(const AuctionStoreKey& key, const CAuctionBatch& batch)
-{
+Res CVaultView::StoreAuctionBatch(const AuctionStoreKey &key, const CAuctionBatch &batch) {
     WriteBy<AuctionBatchKey>(key, batch);
     return Res::Ok();
 }
 
-Res CVaultView::EraseAuctionBatch(const AuctionStoreKey& key)
-{
+Res CVaultView::EraseAuctionBatch(const AuctionStoreKey &key) {
     EraseBy<AuctionBatchKey>(key);
     return Res::Ok();
 }
 
-std::optional<CAuctionBatch> CVaultView::GetAuctionBatch(const AuctionStoreKey& key)
-{
+std::optional<CAuctionBatch> CVaultView::GetAuctionBatch(const AuctionStoreKey &key) {
     return ReadBy<AuctionBatchKey, CAuctionBatch>(key);
 }
 
-void CVaultView::ForEachAuctionBatch(std::function<bool(const AuctionStoreKey&, const CAuctionBatch&)> callback)
-{
+void CVaultView::ForEachAuctionBatch(std::function<bool(const AuctionStoreKey &, const CAuctionBatch &)> callback) {
     ForEach<AuctionBatchKey, AuctionStoreKey, CAuctionBatch>(callback);
 }
 
-void CVaultView::ForEachVaultAuction(std::function<bool(const CVaultId&, const CAuctionData&)> callback, uint32_t height, const CVaultId& vaultId)
-{
-    ForEach<AuctionHeightKey, CAuctionKey, CAuctionData>([&](const CAuctionKey& auction, CAuctionData data) {
-        data.liquidationHeight = auction.height;
-        return callback(auction.vaultId, data);
-    }, CAuctionKey{vaultId, height});
+void CVaultView::ForEachVaultAuction(std::function<bool(const CVaultId &, const CAuctionData &)> callback,
+                                     uint32_t height,
+                                     const CVaultId &vaultId) {
+    ForEach<AuctionHeightKey, CAuctionKey, CAuctionData>(
+        [&](const CAuctionKey &auction, CAuctionData data) {
+            data.liquidationHeight = auction.height;
+            return callback(auction.vaultId, data);
+        },
+        CAuctionKey{vaultId, height});
 }
 
-Res CVaultView::StoreAuctionBid(const AuctionStoreKey& key, COwnerTokenAmount amount)
-{
+Res CVaultView::StoreAuctionBid(const AuctionStoreKey &key, COwnerTokenAmount amount) {
     WriteBy<AuctionBidKey>(key, amount);
     return Res::Ok();
 }
 
-Res CVaultView::EraseAuctionBid(const AuctionStoreKey& key)
-{
+Res CVaultView::EraseAuctionBid(const AuctionStoreKey &key) {
     EraseBy<AuctionBidKey>(key);
     return Res::Ok();
 }
 
-std::optional<CVaultView::COwnerTokenAmount> CVaultView::GetAuctionBid(const AuctionStoreKey& key)
-{
+std::optional<CVaultView::COwnerTokenAmount> CVaultView::GetAuctionBid(const AuctionStoreKey &key) {
     return ReadBy<AuctionBidKey, COwnerTokenAmount>(key);
 }
 
-void CVaultView::ForEachAuctionBid(std::function<bool(const AuctionStoreKey& key, const COwnerTokenAmount& amount)> callback)
-{
+void CVaultView::ForEachAuctionBid(
+    std::function<bool(const AuctionStoreKey &key, const COwnerTokenAmount &amount)> callback) {
     ForEach<AuctionBidKey, AuctionStoreKey, COwnerTokenAmount>(callback);
 }

--- a/src/masternodes/vault.h
+++ b/src/masternodes/vault.h
@@ -19,8 +19,7 @@ struct CVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(ownerAddress);
         READWRITE(schemeId);
     }
@@ -32,8 +31,7 @@ struct CVaultData : public CVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITEAS(CVaultMessage, *this);
         READWRITE(isUnderLiquidation);
     }
@@ -46,8 +44,7 @@ struct CCloseVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(to);
     }
@@ -61,8 +58,7 @@ struct CUpdateVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(ownerAddress);
         READWRITE(schemeId);
@@ -77,8 +73,7 @@ struct CDepositToVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(from);
         READWRITE(amount);
@@ -93,8 +88,7 @@ struct CWithdrawFromVaultMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(to);
         READWRITE(amount);
@@ -110,8 +104,7 @@ struct CAuctionBidMessage {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultId);
         READWRITE(index);
         READWRITE(from);
@@ -121,14 +114,13 @@ struct CAuctionBidMessage {
 
 struct CAuctionData {
     uint32_t batchCount;
-    uint32_t liquidationHeight; // temporary
+    uint32_t liquidationHeight;  // temporary
     CAmount liquidationPenalty;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(batchCount);
         READWRITE(liquidationPenalty);
     }
@@ -142,51 +134,65 @@ struct CAuctionBatch {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(collaterals);
         READWRITE(loanAmount);
         READWRITE(loanInterest);
     }
 };
 
-class CVaultView : public virtual CStorageView
-{
-public:
+class CVaultView : public virtual CStorageView {
+   public:
     using COwnerTokenAmount = std::pair<CScript, CTokenAmount>;
     using AuctionStoreKey = std::pair<CVaultId, uint32_t>;
 
-    Res StoreVault(const CVaultId&, const CVaultData&);
-    Res EraseVault(const CVaultId&);
-    std::optional<CVaultData> GetVault(const CVaultId&) const;
-    Res UpdateVault(const CVaultId& vaultId, const CVaultMessage& newVault);
-    void ForEachVault(std::function<bool(const CVaultId&, const CVaultData&)> callback, const CVaultId& start = {}, const CScript& ownerAddress = {});
+    Res StoreVault(const CVaultId &, const CVaultData &);
+    Res EraseVault(const CVaultId &);
+    std::optional<CVaultData> GetVault(const CVaultId &) const;
+    Res UpdateVault(const CVaultId &vaultId, const CVaultMessage &newVault);
+    void ForEachVault(std::function<bool(const CVaultId &, const CVaultData &)> callback,
+                      const CVaultId &start = {},
+                      const CScript &ownerAddress = {});
 
-    Res AddVaultCollateral(const CVaultId& vaultId, CTokenAmount amount);
-    Res SubVaultCollateral(const CVaultId& vaultId, CTokenAmount amount);
-    std::optional<CBalances> GetVaultCollaterals(const CVaultId& vaultId);
-    void ForEachVaultCollateral(std::function<bool(const CVaultId&, const CBalances&)> callback);
+    Res AddVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);
+    Res SubVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);
+    std::optional<CBalances> GetVaultCollaterals(const CVaultId &vaultId);
+    void ForEachVaultCollateral(std::function<bool(const CVaultId &, const CBalances &)> callback);
 
-    Res StoreAuction(const CVaultId& vaultId, const CAuctionData& data);
-    Res EraseAuction(const CVaultId& vaultId, uint32_t height);
-    std::optional<CAuctionData> GetAuction(const CVaultId& vaultId, uint32_t height);
-    Res StoreAuctionBatch(const AuctionStoreKey& key, const CAuctionBatch& batch);
-    Res EraseAuctionBatch(const AuctionStoreKey& key);
-    std::optional<CAuctionBatch> GetAuctionBatch(const AuctionStoreKey& vaultId);
-    void ForEachVaultAuction(std::function<bool(const CVaultId&, const CAuctionData&)> callback, uint32_t height, const CVaultId& vaultId = {});
-    void ForEachAuctionBatch(std::function<bool(const AuctionStoreKey&, const CAuctionBatch&)> callback);
+    Res StoreAuction(const CVaultId &vaultId, const CAuctionData &data);
+    Res EraseAuction(const CVaultId &vaultId, uint32_t height);
+    std::optional<CAuctionData> GetAuction(const CVaultId &vaultId, uint32_t height);
+    Res StoreAuctionBatch(const AuctionStoreKey &key, const CAuctionBatch &batch);
+    Res EraseAuctionBatch(const AuctionStoreKey &key);
+    std::optional<CAuctionBatch> GetAuctionBatch(const AuctionStoreKey &vaultId);
+    void ForEachVaultAuction(std::function<bool(const CVaultId &, const CAuctionData &)> callback,
+                             uint32_t height,
+                             const CVaultId &vaultId = {});
+    void ForEachAuctionBatch(std::function<bool(const AuctionStoreKey &, const CAuctionBatch &)> callback);
 
-    Res StoreAuctionBid(const AuctionStoreKey& key, COwnerTokenAmount amount);
-    Res EraseAuctionBid(const AuctionStoreKey& key);
-    std::optional<COwnerTokenAmount> GetAuctionBid(const AuctionStoreKey& key);
-    void ForEachAuctionBid(std::function<bool(const AuctionStoreKey& key, const COwnerTokenAmount& amount)> callback);
+    Res StoreAuctionBid(const AuctionStoreKey &key, COwnerTokenAmount amount);
+    Res EraseAuctionBid(const AuctionStoreKey &key);
+    std::optional<COwnerTokenAmount> GetAuctionBid(const AuctionStoreKey &key);
+    void ForEachAuctionBid(std::function<bool(const AuctionStoreKey &key, const COwnerTokenAmount &amount)> callback);
 
-    struct VaultKey         { static constexpr uint8_t prefix() { return 0x20; } };
-    struct OwnerVaultKey    { static constexpr uint8_t prefix() { return 0x21; } };
-    struct CollateralKey    { static constexpr uint8_t prefix() { return 0x22; } };
-    struct AuctionBatchKey  { static constexpr uint8_t prefix() { return 0x23; } };
-    struct AuctionHeightKey { static constexpr uint8_t prefix() { return 0x24; } };
-    struct AuctionBidKey    { static constexpr uint8_t prefix() { return 0x25; } };
+    struct VaultKey {
+        static constexpr uint8_t prefix() { return 0x20; }
+    };
+    struct OwnerVaultKey {
+        static constexpr uint8_t prefix() { return 0x21; }
+    };
+    struct CollateralKey {
+        static constexpr uint8_t prefix() { return 0x22; }
+    };
+    struct AuctionBatchKey {
+        static constexpr uint8_t prefix() { return 0x23; }
+    };
+    struct AuctionHeightKey {
+        static constexpr uint8_t prefix() { return 0x24; }
+    };
+    struct AuctionBidKey {
+        static constexpr uint8_t prefix() { return 0x25; }
+    };
 };
 
-#endif // DEFI_MASTERNODES_VAULT_H
+#endif  // DEFI_MASTERNODES_VAULT_H

--- a/src/masternodes/vaulthistory.cpp
+++ b/src/masternodes/vaulthistory.cpp
@@ -2,33 +2,31 @@
 
 #include <chain.h>
 
-void CVaultHistoryView::ForEachVaultHistory(std::function<bool(VaultHistoryKey const &, CLazySerialize<VaultHistoryValue>)> callback, VaultHistoryKey const & start)
-{
+void CVaultHistoryView::ForEachVaultHistory(
+    std::function<bool(VaultHistoryKey const &, CLazySerialize<VaultHistoryValue>)> callback,
+    VaultHistoryKey const &start) {
     ForEach<ByVaultHistoryKey, VaultHistoryKey, VaultHistoryValue>(callback, start);
 }
 
-void CVaultHistoryView::WriteVaultHistory(VaultHistoryKey const & key, VaultHistoryValue const & value) {
+void CVaultHistoryView::WriteVaultHistory(VaultHistoryKey const &key, VaultHistoryValue const &value) {
     WriteBy<ByVaultHistoryKey>(key, value);
 }
 
-void CVaultHistoryView::WriteVaultScheme(VaultSchemeKey const & key, const VaultSchemeValue& value)
-{
+void CVaultHistoryView::WriteVaultScheme(VaultSchemeKey const &key, const VaultSchemeValue &value) {
     WriteBy<ByVaultSchemeKey>(key, value);
 }
 
-void CVaultHistoryView::WriteGlobalScheme(VaultGlobalSchemeKey const & key, const VaultGlobalSchemeValue& value)
-{
+void CVaultHistoryView::WriteGlobalScheme(VaultGlobalSchemeKey const &key, const VaultGlobalSchemeValue &value) {
     WriteBy<ByVaultGlobalSchemeKey>(key, value);
 }
 
-void CVaultHistoryView::EraseVaultHistory(const uint32_t height)
-{
+void CVaultHistoryView::EraseVaultHistory(const uint32_t height) {
     std::vector<VaultHistoryKey> keys;
     auto historyIt = LowerBound<ByVaultHistoryKey>(VaultHistoryKey{height});
     for (; historyIt.Valid() && historyIt.Key().blockHeight == height; historyIt.Next()) {
         keys.push_back(historyIt.Key());
     }
-    for (auto& key : keys) {
+    for (auto &key : keys) {
         EraseBy<ByVaultHistoryKey>(key);
         const auto stateKey = VaultStateKey{key.vaultID, key.blockHeight};
         EraseBy<ByVaultStateKey>(stateKey);
@@ -40,28 +38,33 @@ void CVaultHistoryView::EraseVaultHistory(const uint32_t height)
     for (; schemeIt.Valid() && schemeIt.Key().blockHeight == height; schemeIt.Next()) {
         schemeKeys.push_back(schemeIt.Key());
     }
-    for (auto& key : schemeKeys) {
+    for (auto &key : schemeKeys) {
         EraseGlobalScheme(key);
     }
 }
 
-void CVaultHistoryView::ForEachVaultScheme(std::function<bool(VaultSchemeKey const &, CLazySerialize<VaultSchemeValue>)> callback, VaultSchemeKey const & start)
-{
+void CVaultHistoryView::ForEachVaultScheme(
+    std::function<bool(VaultSchemeKey const &, CLazySerialize<VaultSchemeValue>)> callback,
+    VaultSchemeKey const &start) {
     ForEach<ByVaultSchemeKey, VaultSchemeKey, VaultSchemeValue>(callback, start);
 }
 
-void CVaultHistoryView::ForEachVaultState(std::function<bool(VaultStateKey const &, CLazySerialize<VaultStateValue>)> callback, VaultStateKey const & start)
-{
+void CVaultHistoryView::ForEachVaultState(
+    std::function<bool(VaultStateKey const &, CLazySerialize<VaultStateValue>)> callback,
+    VaultStateKey const &start) {
     ForEach<ByVaultStateKey, VaultStateKey, VaultStateValue>(callback, start);
 }
 
-void CVaultHistoryView::ForEachGlobalScheme(std::function<bool(VaultGlobalSchemeKey const &, CLazySerialize<VaultGlobalSchemeValue>)> callback, VaultGlobalSchemeKey const & start)
-{
+void CVaultHistoryView::ForEachGlobalScheme(
+    std::function<bool(VaultGlobalSchemeKey const &, CLazySerialize<VaultGlobalSchemeValue>)> callback,
+    VaultGlobalSchemeKey const &start) {
     ForEach<ByVaultGlobalSchemeKey, VaultGlobalSchemeKey, VaultGlobalSchemeValue>(callback, start);
 }
 
-void CVaultHistoryView::WriteVaultState(CCustomCSView& mnview, const CBlockIndex& pindex, const uint256& vaultID, const uint32_t ratio)
-{
+void CVaultHistoryView::WriteVaultState(CCustomCSView &mnview,
+                                        const CBlockIndex &pindex,
+                                        const uint256 &vaultID,
+                                        const uint32_t ratio) {
     const auto vault = mnview.GetVault(vaultID);
     assert(vault);
 
@@ -71,7 +74,8 @@ void CVaultHistoryView::WriteVaultState(CCustomCSView& mnview, const CBlockIndex
     }
 
     bool useNextPrice = false, requireLivePrice = false;
-    auto rate = mnview.GetLoanCollaterals(vaultID, *collaterals, pindex.nHeight, pindex.nTime, useNextPrice, requireLivePrice);
+    auto rate =
+        mnview.GetLoanCollaterals(vaultID, *collaterals, pindex.nHeight, pindex.nTime, useNextPrice, requireLivePrice);
 
     CCollateralLoans collateralLoans{0, 0, {}, {}};
     if (rate) {
@@ -91,14 +95,11 @@ void CVaultHistoryView::WriteVaultState(CCustomCSView& mnview, const CBlockIndex
     WriteBy<ByVaultStateKey>(VaultStateKey{vaultID, static_cast<uint32_t>(pindex.nHeight)}, value);
 }
 
-void CVaultHistoryView::EraseGlobalScheme(const VaultGlobalSchemeKey& key)
-{
+void CVaultHistoryView::EraseGlobalScheme(const VaultGlobalSchemeKey &key) {
     EraseBy<ByVaultGlobalSchemeKey>(key);
 }
 
-CVaultHistoryStorage::CVaultHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
-        : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe))
-{
-}
+CVaultHistoryStorage::CVaultHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory, bool fWipe)
+    : CStorageView(new CStorageLevelDB(dbName, cacheSize, fMemory, fWipe)) {}
 
 std::unique_ptr<CVaultHistoryStorage> pvaultHistoryDB;

--- a/src/masternodes/vaulthistory.h
+++ b/src/masternodes/vaulthistory.h
@@ -14,18 +14,17 @@
 struct VaultHistoryKey {
     uint32_t blockHeight;
     uint256 vaultID;
-    uint32_t txn; // for order in block
+    uint32_t txn;  // for order in block
     CScript address;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(blockHeight));
             blockHeight = ~blockHeight;
-        }
-        else {
+        } else {
             uint32_t blockHeight_ = ~blockHeight;
             READWRITE(WrapBigEndian(blockHeight_));
         }
@@ -33,8 +32,7 @@ struct VaultHistoryKey {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(txn));
             txn = ~txn;
-        }
-        else {
+        } else {
             uint32_t txn_ = ~txn;
             READWRITE(WrapBigEndian(txn_));
         }
@@ -50,7 +48,7 @@ struct VaultHistoryValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(txid);
         READWRITE(category);
         READWRITE(diff);
@@ -64,14 +62,13 @@ struct VaultStateKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(vaultID);
 
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(blockHeight));
             blockHeight = ~blockHeight;
-        }
-        else {
+        } else {
             uint32_t blockHeight_ = ~blockHeight;
             READWRITE(WrapBigEndian(blockHeight_));
         }
@@ -87,7 +84,7 @@ struct VaultStateValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(collaterals);
         READWRITE(collateralsValues);
         READWRITE(auctionBatches);
@@ -101,12 +98,12 @@ struct VaultSchemeValue {
     unsigned char category;
     uint256 txid;
     std::string schemeID;
-    uint32_t txn; // For looking up global scheme from specific place in the block
+    uint32_t txn;  // For looking up global scheme from specific place in the block
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(category);
         READWRITE(txid);
         READWRITE(schemeID);
@@ -122,15 +119,13 @@ struct VaultGlobalSchemeKey {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         if (ser_action.ForRead()) {
             READWRITE(WrapBigEndian(blockHeight));
             blockHeight = ~blockHeight;
             READWRITE(WrapBigEndian(txn));
             txn = ~txn;
-        }
-        else {
+        } else {
             uint32_t blockHeight_ = ~blockHeight;
             READWRITE(WrapBigEndian(blockHeight_));
             uint32_t txn_ = ~txn;
@@ -149,46 +144,61 @@ struct VaultGlobalSchemeValue {
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(loanScheme);
         READWRITE(category);
         READWRITE(txid);
     }
 };
 
-class CVaultHistoryView : public virtual CStorageView
-{
-public:
-    void WriteVaultHistory(VaultHistoryKey const & key, VaultHistoryValue const & value);
-    void WriteVaultScheme(VaultSchemeKey const & key, const VaultSchemeValue& value);
-    void WriteVaultState(CCustomCSView& mnview, const CBlockIndex& pindex, const uint256& vaultID, const uint32_t ratio = 0);
+class CVaultHistoryView : public virtual CStorageView {
+   public:
+    void WriteVaultHistory(VaultHistoryKey const &key, VaultHistoryValue const &value);
+    void WriteVaultScheme(VaultSchemeKey const &key, const VaultSchemeValue &value);
+    void WriteVaultState(CCustomCSView &mnview,
+                         const CBlockIndex &pindex,
+                         const uint256 &vaultID,
+                         const uint32_t ratio = 0);
 
     void EraseVaultHistory(const uint32_t height);
 
-    void ForEachVaultHistory(std::function<bool(VaultHistoryKey const &, CLazySerialize<VaultHistoryValue>)> callback, VaultHistoryKey const & start = {});
-    void ForEachVaultScheme(std::function<bool(VaultSchemeKey const &, CLazySerialize<VaultSchemeValue>)> callback, VaultSchemeKey const & start = {});
-    void ForEachVaultState(std::function<bool(VaultStateKey const &, CLazySerialize<VaultStateValue>)> callback, VaultStateKey const & start = {});
+    void ForEachVaultHistory(std::function<bool(VaultHistoryKey const &, CLazySerialize<VaultHistoryValue>)> callback,
+                             VaultHistoryKey const &start = {});
+    void ForEachVaultScheme(std::function<bool(VaultSchemeKey const &, CLazySerialize<VaultSchemeValue>)> callback,
+                            VaultSchemeKey const &start = {});
+    void ForEachVaultState(std::function<bool(VaultStateKey const &, CLazySerialize<VaultStateValue>)> callback,
+                           VaultStateKey const &start = {});
 
     // Loan Scheme storage
-    void WriteGlobalScheme(VaultGlobalSchemeKey const & key, const VaultGlobalSchemeValue& value);
-    void EraseGlobalScheme(const VaultGlobalSchemeKey& key);
-    void ForEachGlobalScheme(std::function<bool(VaultGlobalSchemeKey const &, CLazySerialize<VaultGlobalSchemeValue>)> callback, VaultGlobalSchemeKey const & start = {});
+    void WriteGlobalScheme(VaultGlobalSchemeKey const &key, const VaultGlobalSchemeValue &value);
+    void EraseGlobalScheme(const VaultGlobalSchemeKey &key);
+    void ForEachGlobalScheme(
+        std::function<bool(VaultGlobalSchemeKey const &, CLazySerialize<VaultGlobalSchemeValue>)> callback,
+        VaultGlobalSchemeKey const &start = {});
 
-    struct ByVaultHistoryKey { static constexpr uint8_t prefix() { return 0x01; } };
-    struct ByVaultStateKey { static constexpr uint8_t prefix() { return 0x02; } };
-    struct ByVaultSchemeKey { static constexpr uint8_t prefix() { return 0x03; } };
-    struct ByVaultGlobalSchemeKey { static constexpr uint8_t prefix() { return 0x04; } };
+    struct ByVaultHistoryKey {
+        static constexpr uint8_t prefix() { return 0x01; }
+    };
+    struct ByVaultStateKey {
+        static constexpr uint8_t prefix() { return 0x02; }
+    };
+    struct ByVaultSchemeKey {
+        static constexpr uint8_t prefix() { return 0x03; }
+    };
+    struct ByVaultGlobalSchemeKey {
+        static constexpr uint8_t prefix() { return 0x04; }
+    };
 };
 
-class CVaultHistoryStorage : public CVaultHistoryView
-{
-public:
-    CVaultHistoryStorage(CVaultHistoryStorage& vaultHistory) : CStorageView(new CFlushableStorageKV(vaultHistory.DB())) {}
-    CVaultHistoryStorage(const fs::path& dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
+class CVaultHistoryStorage : public CVaultHistoryView {
+   public:
+    CVaultHistoryStorage(CVaultHistoryStorage &vaultHistory)
+        : CStorageView(new CFlushableStorageKV(vaultHistory.DB())) {}
+    CVaultHistoryStorage(const fs::path &dbName, std::size_t cacheSize, bool fMemory = false, bool fWipe = false);
 };
 
 extern std::unique_ptr<CVaultHistoryStorage> pvaultHistoryDB;
 
 static constexpr bool DEFAULT_VAULTINDEX = false;
 
-#endif //DEFI_MASTERNODES_VAULTHISTORY_H
+#endif  // DEFI_MASTERNODES_VAULTHISTORY_H

--- a/test/lint/lint-logs.sh
+++ b/test/lint/lint-logs.sh
@@ -13,7 +13,8 @@
 # ignored
 
 export LC_ALL=C
-UNTERMINATED_LOGS=$(git grep --extended-regexp "LogPrintf?\(" -- "*.cpp" | \
+UNTERMINATED_LOGS=$(git grep --extended-regexp "LogPrintf\(" -- "*.cpp" | \
+    git grep --extended-regexp "LogPrint\(.*, ?\"" -- "*.cpp" | \
     grep -v '\\n"' | \
     grep -v "/\* Continued \*/" | \
     grep -v "LogPrint()" | \


### PR DESCRIPTION
/kind chore

Format with clang-format with a combination of Chromium and Microsoft styles.

- Base style: Chromium. 
- PointerAlignment and indent widths from Microsoft.
  - Right pointeraligned provides unmistakable clarity on vars.
  - Indent width of 4 provides better readability. 
- Disable BinPacking on args to ensure attributes and the likes formatted more read-friendly. 

Others: 

- Makes lint-logs a bit more friendly to auto format.