### PR TITLE
Clone bitcoin-core/qa-assets only when running fuzz tests

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -10,7 +10,7 @@ mkdir -p "${BASE_SCRATCH_DIR}"
 #ccache echo "Creating ccache dir if it didn't already exist"
 mkdir -p "${CCACHE_DIR}"
 
-if [ ! -d ${DIR_QA_ASSETS} ]; then
+if [ ! -d ${DIR_QA_ASSETS} ] && [ "$RUN_FUZZ_TESTS" = "true" ]; then
   git clone https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
 fi
 export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Checks wether fuzz test are running before cloning https://github.com/bitcoin-core/qa-assets.
These assets are only used for fuzz testing.
This remove the cloning of 7.3G of unused data when running `./ci/test_run_all.sh` with default env.
