### PR TITLE
Fix -stop-block and -interrupt-block crashing when used on empty -datadir

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -138,9 +138,9 @@ bool fCheckBlockIndex = false;
 
 bool fStopOrInterrupt = false;
 std::string fInterruptBlockHash = "";
-int fInterruptBlockHeight = 0;
+int fInterruptBlockHeight = -1;
 std::string fStopBlockHash = "";
-int fStopBlockHeight = 0;
+int fStopBlockHeight = -1;
 
 size_t nCoinCacheUsage = 5000 * 300;
 size_t nCustomMemUsage = nDefaultDbCache << 10;


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Fix -stop-block and -interrupt-block crashing when used on empty -datadir
