### PR TITLE
Log "kernel found" without debug flag

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -807,7 +807,7 @@ namespace pos {
                     if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                                              subNodesBlockTime, timelock, ctxState))
                     {
-                        LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
+                        LogPrintf("MakeStake: kernel found\n");
 
                         found = true;
                         break;


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Logs "MakeStake: kernel found" without "debug=staking" set