### PR TITLE
Ensure flushes are protected

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4903,6 +4903,7 @@ bool CChainState::FlushStateToDisk(
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
         if (fMemoryCacheLarge && !CoinsTip().GetBestBlock().IsNull()) {
             // Flush view first to estimate size on disk later
+            LOCK(cs_main);
             if (!pcustomcsview->Flush()) {
                 return AbortNode(state, "Failed to write db batch");
             }


### PR DESCRIPTION
/kind fix

Ensure flushes are protected by cs_main, esp. since leveldb storage write batches, which require external synchronisation and the FlushToDisk is not protected inherently and have codepaths that call it without being locked  