### PR TITLE
Run full sync on PR labels `consensus` or `ci/sync`

### DIFF
--- a/.github/workflows/fullsync-tests.yml
+++ b/.github/workflows/fullsync-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-binaries:
-    if: ${{ github.event.label.name == 'consensus' }}
+    if: ${{ github.event.label.name == 'consensus' || github.event.label.name == 'ci/sync' }}
     runs-on: [self-hosted, linux, x64,server-2]
     steps:
     - uses: actions/checkout@v3
@@ -100,7 +100,7 @@ jobs:
            stop: 1900000
     runs-on: [self-hosted, linux, x64]
     needs: build-binaries
-    if: ${{ github.event.label.name == 'consensus' }}
+    if: ${{ github.event.label.name == 'consensus' || github.event.label.name == 'ci/sync' }}
     continue-on-error: true
     container:
       image : gcr.io/br-blockchains-dev/datadir-${{matrix.datadir.start}}

--- a/.github/workflows/fullsync-tests.yml
+++ b/.github/workflows/fullsync-tests.yml
@@ -1,13 +1,13 @@
 name: Full Sync Tests
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
+    types: [labeled]
+
 jobs:
   build-binaries:
+    if: ${{ github.event.label.name == 'consensus' }}
     runs-on: [self-hosted, linux, x64,server-2]
     steps:
     - uses: actions/checkout@v3
@@ -100,6 +100,7 @@ jobs:
            stop: 1900000
     runs-on: [self-hosted, linux, x64]
     needs: build-binaries
+    if: ${{ github.event.label.name == 'consensus' }}
     continue-on-error: true
     container:
       image : gcr.io/br-blockchains-dev/datadir-${{matrix.datadir.start}}


### PR DESCRIPTION

#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
skips `fullsync-test` workflow on PRs not labeled with `consensus`

#### Which issue(s) does this PR fixes?:
fix running full sync on PRs not related to consensus
