### PR TITLE
Fix compositeswap to use direct pool when available and fix testpoolswap calculation

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -4101,13 +4101,15 @@ std::vector<DCT_ID> CPoolSwap::CalculateSwaps(CCustomCSView& view, bool testOnly
 
 std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& view) {
 
-    DCT_ID directPool{0};
+    std::vector<std::vector<DCT_ID>> poolPaths;
+
     // For tokens to be traded get all pairs and pool IDs
     std::multimap<uint32_t, DCT_ID> fromPoolsID, toPoolsID;
     view.ForEachPoolPair([&](DCT_ID const & id, const CPoolPair& pool) {
         if ((obj.idTokenFrom == pool.idTokenA && obj.idTokenTo == pool.idTokenB)
         || (obj.idTokenTo == pool.idTokenA && obj.idTokenFrom == pool.idTokenB)) {
-            directPool = id;
+            // Push poolId when direct path
+            poolPaths.push_back({{id}});
         }
 
         if (pool.idTokenA == obj.idTokenFrom) {
@@ -4128,10 +4130,6 @@ std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& vi
         return {};
     }
 
-    if (directPool != DCT_ID{0}) {
-        return {{directPool}};
-    }
-
     // Find intersection on key
     std::map<uint32_t, DCT_ID> commonPairs;
     set_intersection(fromPoolsID.begin(), fromPoolsID.end(), toPoolsID.begin(), toPoolsID.end(),
@@ -4141,7 +4139,6 @@ std::vector<std::vector<DCT_ID>> CPoolSwap::CalculatePoolPaths(CCustomCSView& vi
                      });
 
     // Loop through all common pairs and record direct pool to pool swaps
-    std::vector<std::vector<DCT_ID>> poolPaths;
     for (const auto& item : commonPairs) {
         // Loop through all source/intermediate pools matching common pairs
         const auto poolFromIDs = fromPoolsID.equal_range(item.first);

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -1082,100 +1082,60 @@ UniValue testpoolswap(const JSONRPCRequest& request) {
         LOCK(cs_main);
         CCustomCSView mnview_dummy(*pcustomcsview); // create dummy cache for test state writing
 
-        int targetHeight = ::ChainActive().Height() + 1;
-
+        uint32_t targetHeight = ::ChainActive().Height() + 1;
+        auto poolSwap = CPoolSwap({poolSwapMsg, targetHeight});
+        std::vector<DCT_ID> poolIds;
         auto poolPair = mnview_dummy.GetPoolPair(poolSwapMsg.idTokenFrom, poolSwapMsg.idTokenTo);
+
         if (poolPair && poolPair->second.status && path == "auto") path = "direct";
 
         // If no direct swap found search for composite swap
         if (path == "direct") {
             if (!poolPair)
-                throw JSONRPCError(RPC_INVALID_REQUEST, std::string{"Direct pool pair not found. Use 'auto' mode to use composite swap."});
+                throw JSONRPCError(RPC_INVALID_REQUEST, "Direct pool pair not found. Use 'auto' mode to use composite swap.");
 
-            if (poolSwapMsg.amountFrom <= 0)
-                throw JSONRPCError(RPC_INVALID_REQUEST, "Input amount should be positive");
-
-            CPoolPair pp = poolPair->second;
-
-            if (mnview_dummy.AreTokensLocked({pp.idTokenA.v, pp.idTokenB.v})) {
-                throw JSONRPCError(RPC_INVALID_REQUEST, "Pool currently disabled due to locked token");
-            }
-
-            auto dexfeeInPct = mnview_dummy.GetDexFeeInPct(poolPair->first, poolSwapMsg.idTokenFrom);
-
-            const auto attributes = mnview_dummy.GetAttributes();
-            assert(attributes);
-
-            CDataStructureV0 dirAKey{AttributeTypes::Poolpairs, poolPair->first.v, PoolKeys::TokenAFeeDir};
-            CDataStructureV0 dirBKey{AttributeTypes::Poolpairs, poolPair->first.v, PoolKeys::TokenBFeeDir};
-            const auto dirA = attributes->GetValue(dirAKey, CFeeDir{FeeDirValues::Both});
-            const auto dirB = attributes->GetValue(dirBKey, CFeeDir{FeeDirValues::Both});
-            const auto asymmetricFee = std::make_pair(dirA, dirB);
-
-            res = pp.Swap({poolSwapMsg.idTokenFrom, poolSwapMsg.amountFrom}, dexfeeInPct, poolSwapMsg.maxPrice, asymmetricFee, [&] (const CTokenAmount &, const CTokenAmount &tokenAmount) {
-                auto resPP = mnview_dummy.SetPoolPair(poolPair->first, targetHeight, pp);
-                if (!resPP) {
-                    return resPP;
-                }
-
-                auto resultAmount = tokenAmount;
-                auto dexfeeOutPct = mnview_dummy.GetDexFeeOutPct(poolPair->first, tokenAmount.nTokenId);
-                if (dexfeeOutPct > 0) {
-                    auto dexfeeOutAmount = MultiplyAmounts(tokenAmount.nValue, dexfeeOutPct);
-                    resultAmount.nValue -= dexfeeOutAmount;
-                }
-
-                return Res::Ok(resultAmount.ToString());
-            }, targetHeight);
-
-            if (!res)
-                throw JSONRPCError(RPC_VERIFY_ERROR, res.msg);
-
-            pools.push_back(poolPair->first.ToString());
+            poolIds.push_back(poolPair->first);
+        } else if (path == "auto" || path == "composite") {
+            poolIds = poolSwap.CalculateSwaps(mnview_dummy, true);
         } else {
-            auto compositeSwap = CPoolSwap(poolSwapMsg, targetHeight);
+            path = "custom";
 
-            std::vector<DCT_ID> poolIds;
-            if (path == "auto" || path == "composite") {
-                poolIds = compositeSwap.CalculateSwaps(mnview_dummy, true);
+            UniValue poolArray(UniValue::VARR);
+            if (request.params[1].isArray()) {
+                poolArray = request.params[1].get_array();
             } else {
-                path = "custom";
-
-                UniValue poolArray(UniValue::VARR);
-                if (request.params[1].isArray()) {
-                    poolArray = request.params[1].get_array();
-                } else {
-                    poolArray.read(request.params[1].getValStr().c_str());
-                }
-
-                for (const auto& id : poolArray.getValues()) {
-                    poolIds.push_back(DCT_ID::FromString(id.getValStr()));
-                }
-
-                auto availablePaths = compositeSwap.CalculatePoolPaths(mnview_dummy);
-                if (std::find(availablePaths.begin(), availablePaths.end(), poolIds) == availablePaths.end()) {
-                    throw JSONRPCError(RPC_INVALID_REQUEST, "Custom pool path is invalid.");
-                }
+                poolArray.read(request.params[1].getValStr().c_str());
             }
 
-            res = compositeSwap.ExecuteSwap(mnview_dummy, poolIds, true);
-            if (!res) {
-                std::string errorMsg{"Cannot find usable pool pair."};
-                if (!compositeSwap.errors.empty()) {
-                    errorMsg += " Details: (";
-                    for (size_t i{0}; i < compositeSwap.errors.size(); ++i) {
-                        errorMsg += '"' + compositeSwap.errors[i].first + "\":\"" +  compositeSwap.errors[i].second + '"' + (i + 1 < compositeSwap.errors.size() ? "," : "");
-                    }
-                    errorMsg += ')';
-                }
-                throw JSONRPCError(RPC_INVALID_REQUEST, errorMsg);
+            for (const auto& id : poolArray.getValues()) {
+                poolIds.push_back(DCT_ID::FromString(id.getValStr()));
             }
-            for (const auto& id : poolIds) {
-                pools.push_back(id.ToString());
+
+            auto availablePaths = poolSwap.CalculatePoolPaths(mnview_dummy);
+
+            if (std::find(availablePaths.begin(), availablePaths.end(), poolIds) == availablePaths.end()) {
+                throw JSONRPCError(RPC_INVALID_REQUEST, "Custom pool path is invalid.");
             }
-            res.msg = compositeSwap.GetResult().ToString();
         }
+
+        res = poolSwap.ExecuteSwap(mnview_dummy, poolIds, true);
+        if (!res) {
+            std::string errorMsg{"Cannot find usable pool pair."};
+            if (!poolSwap.errors.empty()) {
+                errorMsg += " Details: (";
+                for (size_t i{0}; i < poolSwap.errors.size(); ++i) {
+                    errorMsg += '"' + poolSwap.errors[i].first + "\":\"" +  poolSwap.errors[i].second + '"' + (i + 1 < poolSwap.errors.size() ? "," : "");
+                }
+                errorMsg += ')';
+            }
+            throw JSONRPCError(RPC_INVALID_REQUEST, errorMsg);
+        }
+        for (const auto& id : poolIds) {
+            pools.push_back(id.ToString());
+        }
+        res.msg = poolSwap.GetResult().ToString();
     }
+
     if (verbose) {
         UniValue swapObj{UniValue::VOBJ};
         swapObj.pushKV("path", path);

--- a/test/functional/feature_poolswap_composite.py
+++ b/test/functional/feature_poolswap_composite.py
@@ -244,115 +244,6 @@ class PoolPairCompositeTest(DefiTestFramework):
         }, collateral, [])
         self.nodes[0].generate(1)
 
-        estimateCompositePathsRes = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": ltc_to_doge_from,
-            "to": destination,
-            "tokenTo": symbolDOGE,
-        }, "auto", True)
-
-        assert_equal(estimateCompositePathsRes['path'], 'auto')
-
-        poolLTC_USDC = list(self.nodes[0].getpoolpair("LTC-USDC").keys())[0]
-        poolDOGE_USDC = list(self.nodes[0].getpoolpair("DOGE-USDC").keys())[0]
-        assert_equal(estimateCompositePathsRes['pools'], [poolLTC_USDC, poolDOGE_USDC])
-
-        testCPoolSwapRes = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": ltc_to_doge_from,
-            "to": destination,
-            "tokenTo": symbolDOGE,
-        }, "auto")
-
-        testCPoolSwapRes = str(testCPoolSwapRes).split("@", 2)
-
-        psTestAmount = testCPoolSwapRes[0]
-        psTestTokenId = testCPoolSwapRes[1]
-        assert_equal(psTestTokenId, idDOGE)
-
-        customPathPoolSwap = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": ltc_to_doge_from,
-            "to": destination,
-            "tokenTo": symbolDOGE,
-        }, [poolLTC_USDC, poolDOGE_USDC])
-
-        customPathPoolSwap = str(customPathPoolSwap).split("@", 2)
-
-        psTestAmount = customPathPoolSwap[0]
-        psTestTokenId = customPathPoolSwap[1]
-        assert_equal(psTestTokenId, idDOGE)
-
-        poolLTC_DFI = list(self.nodes[0].getpoolpair("LTC-DFI").keys())[0]
-        poolDOGE_DFI = list(self.nodes[0].getpoolpair("DOGE-DFI").keys())[0]
-        customPathPoolSwap = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": ltc_to_doge_from,
-            "to": destination,
-            "tokenTo": symbolDOGE,
-        }, [poolLTC_DFI, poolDOGE_DFI])
-
-        customPathPoolSwap = str(customPathPoolSwap).split("@", 2)
-
-        psTestTokenId = customPathPoolSwap[1]
-        assert_equal(psTestTokenId, idDOGE)
-
-        estimateCompositePathsResDirect = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": 1,
-            "to": destination,
-            "tokenTo": symbolDFI,
-        }, "direct", True)
-
-        estimateCompositePathsResAuto = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": 1,
-            "to": destination,
-            "tokenTo": symbolDFI,
-        }, "auto", True)
-
-        assert_equal(estimateCompositePathsResAuto['path'], "direct")
-        assert_equal(estimateCompositePathsResDirect, estimateCompositePathsResAuto)
-
-        estimateCompositePathsResComposite = self.nodes[0].testpoolswap({
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": 1,
-            "to": destination,
-            "tokenTo": symbolDFI,
-        }, "composite", True)
-
-        assert_equal(estimateCompositePathsResComposite['path'], "composite")
-
-        poolLTC_USDC = list(self.nodes[0].getpoolpair("LTC-USDC").keys())[0]
-        poolDOGE_USDC = list(self.nodes[0].getpoolpair("DOGE-USDC").keys())[0]
-        poolDOGE_DFI = list(self.nodes[0].getpoolpair("DOGE-DFI").keys())[0]
-        assert_equal(estimateCompositePathsResComposite['pools'], [poolLTC_USDC, poolDOGE_USDC, poolDOGE_DFI])
-
-        assert_raises_rpc_error(-32600, "Cannot find usable pool pair.", self.nodes[0].testpoolswap,
-        {
-            "from": source,
-            "tokenFrom": symbolDUSD,
-            "amountFrom": 100,
-            "to": destination,
-            "tokenTo": symbolDFI,
-        }, "composite")
-
-        assert_raises_rpc_error(-32600, "Custom pool path is invalid.", self.nodes[0].testpoolswap,
-        {
-            "from": source,
-            "tokenFrom": symbolLTC,
-            "amountFrom": ltc_to_doge_from,
-            "to": destination,
-            "tokenTo": symbolDOGE,
-        }, [poolLTC_DFI, "100"])
-
         self.nodes[0].compositeswap({
             "from": source,
             "tokenFrom": symbolLTC,
@@ -372,8 +263,6 @@ class PoolPairCompositeTest(DefiTestFramework):
         dest_balance = self.nodes[0].getaccount(destination, {}, True)
         assert_equal(dest_balance[idDOGE], doge_received * 2)
         assert_equal(len(dest_balance), 1)
-        # Check test swap correctness
-        assert_equal(Decimal(psTestAmount), dest_balance[idDOGE])
 
         # Set up addresses for swapping
         source = self.nodes[0].getnewaddress("", "legacy")

--- a/test/functional/feature_poolswap_composite.py
+++ b/test/functional/feature_poolswap_composite.py
@@ -68,7 +68,6 @@ class PoolPairCompositeTest(DefiTestFramework):
         self.setup_tokens(tokens)
         disconnect_nodes(self.nodes[0], 1)
 
-        symbolDFI = "DFI"
         symbolDOGE = "DOGE#" + self.get_id_token("DOGE")
         symbolTSLA = "TSLA#" + self.get_id_token("TSLA")
         symbolDUSD = "DUSD#" + self.get_id_token("DUSD")

--- a/test/functional/feature_testpoolswap.py
+++ b/test/functional/feature_testpoolswap.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test poolpair - testpoolswap."""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+import calendar
+import time
+
+class PoolPairTestPoolSwapTest (DefiTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [[
+            '-txnotokens=0',
+            '-amkheight=1',
+            '-bayfrontheight=1',
+            '-eunosheight=1',
+            '-fortcanningheight=1',
+            '-fortcanninghillheight=1',
+            '-fortcanningspringheight=1',
+            '-jellyfish_regtest=1',
+            '-simulatemainnet=1'
+            ]]
+
+    def createOracles(self):
+        self.oracle_address1 = self.nodes[0].getnewaddress("", "legacy")
+        price_feeds = [{"currency": "USD", "token": "DFI"},
+                        {"currency": "USD", "token": "DUSD"},
+                        {"currency": "USD", "token": "TSLA"},
+                        {"currency": "USD", "token": "BTC"}]
+        self.oracle_id1 = self.nodes[0].appointoracle(self.oracle_address1, price_feeds, 10)
+        self.nodes[0].generate(1)
+
+        # feed oracle
+        oracle_prices = [{"currency": "USD", "tokenAmount": "1@TSLA"},
+                        {"currency": "USD", "tokenAmount": "1@DUSD"},
+                        {"currency": "USD", "tokenAmount": "1@BTC"},
+                        {"currency": "USD", "tokenAmount": "10@DFI"}]
+
+        timestamp = calendar.timegm(time.gmtime())
+        self.nodes[0].setoracledata(self.oracle_id1, timestamp, oracle_prices)
+
+        self.oracle_address2 = self.nodes[0].getnewaddress("", "legacy")
+        self.oracle_id2 = self.nodes[0].appointoracle(self.oracle_address2, price_feeds, 10)
+        self.nodes[0].generate(1)
+
+        # feed oracle
+        timestamp = calendar.timegm(time.gmtime())
+        self.nodes[0].setoracledata(self.oracle_id2, timestamp, oracle_prices)
+        self.nodes[0].generate(120)
+
+    def setup(self):
+        self.nodes[0].generate(120)
+
+        self.createOracles()
+
+        self.mn_address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+        self.account0 = self.nodes[0].getnewaddress()
+
+        self.swapAmount = 1000
+
+        self.symbolDFI = "DFI"
+        self.symbolTSLA = "TSLA"
+        self.symbolDUSD = "DUSD"
+        self.symbolBTC = "BTC"
+
+        self.nodes[0].setloantoken({
+            'symbol': "DUSD",
+            'name': "DUSD",
+            'fixedIntervalPriceId': "DUSD/USD",
+            'mintable': True,
+            'interest': 0
+        })
+
+        self.nodes[0].setloantoken({
+            'symbol': "TSLA",
+            'name': "TSLA",
+            'fixedIntervalPriceId': "TSLA/USD",
+            'mintable': True,
+            'interest': 0
+        })
+
+        self.nodes[0].setloantoken({
+            'symbol': "BTC",
+            'name': "BTC",
+            'fixedIntervalPriceId': "BTC/USD",
+            'mintable': True,
+            'interest': 0
+        })
+        self.nodes[0].generate(120)
+
+        # Mint DUSD
+        self.nodes[0].minttokens("100000@DUSD")
+        self.nodes[0].minttokens("100000@TSLA")
+        self.nodes[0].minttokens("100000@BTC")
+        self.nodes[0].generate(1)
+
+        # Create DFI tokens
+        self.nodes[0].utxostoaccount({self.mn_address: "100000@" + self.symbolDFI})
+        self.nodes[0].generate(1)
+
+        # Create pool pair
+        self.nodes[0].createpoolpair({
+            "tokenA": self.symbolDUSD,
+            "tokenB": self.symbolDFI,
+            "commission": 0,
+            "status": True,
+            "ownerAddress": self.mn_address
+        })
+
+        self.nodes[0].createpoolpair({
+            "tokenA": self.symbolDFI,
+            "tokenB": self.symbolTSLA,
+            "commission": 0,
+            "status": True,
+            "ownerAddress": self.mn_address
+        })
+
+        self.nodes[0].createpoolpair({
+            "tokenA": self.symbolBTC,
+            "tokenB": self.symbolTSLA,
+            "commission": 0,
+            "status": True,
+            "ownerAddress": self.mn_address
+        })
+        self.nodes[0].generate(1)
+
+        self.DUSD_DFIPoolID = list(self.nodes[0].getpoolpair("DUSD-DFI"))[0]
+        self.DFI_TSLAPoolID = list(self.nodes[0].getpoolpair("DFI-TSLA"))[0]
+        self.BTC_TSLAPoolID = list(self.nodes[0].getpoolpair("BTC-TSLA"))[0]
+
+        # Add pool liquidity
+        self.nodes[0].addpoolliquidity({
+            self.mn_address: [
+                '10000@' + self.symbolDFI,
+                '10000@' + self.symbolDUSD]
+            }, self.mn_address)
+        self.nodes[0].addpoolliquidity({
+            self.mn_address: [
+                '10000@' + self.symbolTSLA,
+                '10000@' + self.symbolDFI]
+            }, self.mn_address)
+        self.nodes[0].addpoolliquidity({
+            self.mn_address: [
+                '10000@' + self.symbolTSLA,
+                '10000@' + self.symbolBTC]
+            }, self.mn_address)
+        self.nodes[0].generate(1)
+
+        self.nodes[0].accounttoaccount(self.mn_address, {self.account0: str(self.swapAmount * 2) + "@" + self.symbolDFI})
+        self.nodes[0].accounttoaccount(self.mn_address, {self.account0: str(self.swapAmount * 2) + "@" + self.symbolTSLA})
+        self.nodes[0].accounttoaccount(self.mn_address, {self.account0: str(self.swapAmount * 2) + "@" + self.symbolBTC})
+        self.nodes[0].generate(1)
+
+    def assert_testpoolswap_amount(self, swap_fn, tokenFrom, path):
+        params = {
+            "from": self.account0,
+            "tokenFrom": tokenFrom,
+            "amountFrom": self.swapAmount,
+            "to": self.account0,
+            "tokenTo": self.symbolDUSD,
+        }
+        [amountSwapped, _] = self.nodes[0].testpoolswap(params, path).split("@")
+
+        swap_fn(params)
+        self.nodes[0].generate(1)
+
+        account = self.nodes[0].getaccount(self.account0)
+        assert_equal(account[2], f'{amountSwapped}@{self.symbolDUSD}')
+
+    def test_testpoolswap_no_fee(self, swap_fn, tokenFrom, path):
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_in(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'in'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_b_fee_in(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'in'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_out(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'out'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_b_fee_out(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'out'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_in_token_b_fee_in(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'in',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'in'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_in_token_b_fee_out(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'in',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'out'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_out_token_b_fee_in(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'out',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'in'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_token_a_fee_out_token_b_fee_out(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'out',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_b_fee_direction': 'out'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def test_testpoolswap_with_multi_pool_fee(self, swap_fn, tokenFrom, path):
+        self.nodes[0].setgov({"ATTRIBUTES":{
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DUSD_DFIPoolID}/token_a_fee_direction': 'in',
+            f'v0/poolpairs/{self.DFI_TSLAPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.DFI_TSLAPoolID}/token_a_fee_direction': 'out',
+            f'v0/poolpairs/{self.BTC_TSLAPoolID}/token_a_fee_pct': '0.10',
+            f'v0/poolpairs/{self.BTC_TSLAPoolID}/token_a_fee_direction': 'out'
+        }})
+        self.nodes[0].generate(1)
+        self.assert_testpoolswap_amount(swap_fn, tokenFrom, path)
+
+    def run_test(self):
+        self.setup()
+
+        # List of (swap, tokenFrom, path) tuples
+        # swap should be one of poolswap or compositeswap RPC call
+        # path should be one of ["direct", "auto", "composite"] or a list of pool ids
+        combinations = [
+            # poolswap DFI -> DUSD through DFI-DUSD pool
+            (self.nodes[0].poolswap, self.symbolDFI, "direct"),
+            (self.nodes[0].poolswap, self.symbolDFI, "auto"),
+            (self.nodes[0].poolswap, self.symbolDFI, "composite"),
+            (self.nodes[0].poolswap, self.symbolDFI, [str(self.DUSD_DFIPoolID)]),
+
+            # compositeswap DFI -> DUSD through DFI-DUSD pool
+            (self.nodes[0].compositeswap, self.symbolDFI, "direct"),
+            (self.nodes[0].compositeswap, self.symbolDFI, "auto"),
+            (self.nodes[0].compositeswap, self.symbolDFI, "composite"),
+            (self.nodes[0].compositeswap, self.symbolDFI, [str(self.DUSD_DFIPoolID)]),
+
+            # comspositeswap TSLA -> DUSD swap through TSLA-DFI -> DFI-DUSD pools
+            (self.nodes[0].compositeswap, self.symbolTSLA, "auto"),
+            (self.nodes[0].compositeswap, self.symbolTSLA, "composite"),
+            (self.nodes[0].compositeswap, self.symbolTSLA, [str(self.DFI_TSLAPoolID), str(self.DUSD_DFIPoolID)]),
+
+            # comspositeswap BTC -> DUSD swap through BTC-TSLA -> TSLA-DFI -> DFI-DUSD pools
+            (self.nodes[0].compositeswap, self.symbolBTC, "auto"),
+            (self.nodes[0].compositeswap, self.symbolBTC, "composite"),
+            (self.nodes[0].compositeswap, self.symbolBTC, [str(self.BTC_TSLAPoolID), str(self.DFI_TSLAPoolID), str(self.DUSD_DFIPoolID)]),
+        ]
+
+        testCases = [
+            self.test_testpoolswap_no_fee,
+            self.test_testpoolswap_with_token_a_fee_in,
+            self.test_testpoolswap_with_token_b_fee_in,
+            self.test_testpoolswap_with_token_a_fee_out,
+            self.test_testpoolswap_with_token_b_fee_out,
+            self.test_testpoolswap_with_token_a_fee_in_token_b_fee_in,
+            self.test_testpoolswap_with_token_a_fee_out_token_b_fee_in,
+            self.test_testpoolswap_with_token_a_fee_in_token_b_fee_out,
+            self.test_testpoolswap_with_token_a_fee_out_token_b_fee_out,
+            self.test_testpoolswap_with_multi_pool_fee
+        ]
+
+        height = self.nodes[0].getblockcount()
+
+        for (swap_fn, tokenFrom, path) in combinations:
+            for test in testCases:
+                test(swap_fn, tokenFrom, path)
+                self.rollback_to(height)
+
+if __name__ == '__main__':
+    PoolPairTestPoolSwapTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -298,6 +298,7 @@ BASE_SCRIPTS = [
     'feature_burn_address.py',
     'feature_eunos_balances.py',
     'feature_sendutxosfrom.py',
+    'feature_testpoolswap.py',
     'feature_update_mn.py',
     'feature_block_reward.py',
     'feature_negative_interest.py',


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

- Fixes `testpoolswap` amount by using same `ExecuteSwap` method as used by `poolswap` and `compositeswap`
- Fixes `compositeswap` not using direct path when available

#### Which issue(s) does this PR fixes?:

Fixes #1397 