### PR TITLE
add empty string check for tokenTo and tokenFrom

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -2249,7 +2249,8 @@ public:
         // maker bonus only on fair dBTC/BTC (1:1) trades for now
         DCT_ID BTC = FindTokenByPartialSymbolName(CICXOrder::TOKEN_BTC);
         if (order->idToken == BTC && order->orderPrice == COIN) {
-            if (Params().NetworkIDString() == CBaseChainParams::TESTNET && height >= 1248000) {
+            if ((Params().NetworkIDString() == CBaseChainParams::TESTNET && height >= 1250000) ||
+                 Params().NetworkIDString() == CBaseChainParams::REGTEST) {
                 res = TransferTokenBalance(DCT_ID{0}, offer->takerFee * 50 / 100, CScript(), order->ownerAddress);
             } else {
                 res = TransferTokenBalance(BTC, offer->takerFee * 50 / 100, CScript(), order->ownerAddress);
@@ -3743,7 +3744,10 @@ bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params& c
     // ICXCloseOffer       = '7',
 
     // disable ICX orders for all networks other than testnet
-    if (Params().NetworkIDString() == CBaseChainParams::TESTNET && static_cast<int>(height) >= 1250000) return false;
+    if (Params().NetworkIDString() == CBaseChainParams::REGTEST ||
+        (Params().NetworkIDString() == CBaseChainParams::TESTNET && static_cast<int>(height) >= 1250000)) {
+        return false;
+    }
 
     // Leaving close orders, as withdrawal of existing should be ok
     switch (type) {

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -134,6 +134,13 @@ UniValue poolPathsToJSON(std::vector<std::vector<DCT_ID>> & poolPaths) {
 void CheckAndFillPoolSwapMessage(const JSONRPCRequest& request, CPoolSwapMessage &poolSwapMsg) {
     std::string tokenFrom, tokenTo;
     UniValue metadataObj = request.params[0].get_obj();
+
+    if (metadataObj["tokenFrom"].getValStr() == "") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "tokenFrom is empty");
+    }
+    if (metadataObj["tokenTo"].getValStr() == "") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "tokenTo is empty");
+    }
     if (!metadataObj["from"].isNull()) {
         poolSwapMsg.from = DecodeScript(metadataObj["from"].getValStr());
     }

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -135,10 +135,10 @@ void CheckAndFillPoolSwapMessage(const JSONRPCRequest& request, CPoolSwapMessage
     std::string tokenFrom, tokenTo;
     UniValue metadataObj = request.params[0].get_obj();
 
-    if (metadataObj["tokenFrom"].getValStr() == "") {
+    if (metadataObj["tokenFrom"].getValStr().empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "tokenFrom is empty");
     }
-    if (metadataObj["tokenTo"].getValStr() == "") {
+    if (metadataObj["tokenTo"].getValStr().empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "tokenTo is empty");
     }
     if (!metadataObj["from"].isNull()) {

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -528,6 +528,14 @@ class PoolPairTest (DefiTestFramework):
         assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_b'%(self.idBL)], round(dexinfee, 8))
         assert_equal(attributes['v0/live/economy/dex/%s/fee_burn_a'%(self.idBL)], Decimal(str(round(dexoutfee, 8))))
 
+    def test_testpoolswap_errors(self):
+        assert_raises_rpc_error(-8, "tokenFrom is empty", self.nodes[0].testpoolswap, {
+                                "amountFrom": 0.1, "tokenFrom": "", "tokenTo": self.symbolBTC, "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
+        assert_raises_rpc_error(-8, "tokenTo is empty", self.nodes[0].testpoolswap, {
+                                "amountFrom": 0.1, "tokenFrom": self.symbolBTC, "tokenTo": "", "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
+        assert_raises_rpc_error(-32600, "Input amount should be positive", self.nodes[0].testpoolswap, {
+                                "amountFrom": 0, "tokenFrom": self.symbolLTC, "tokenTo": self.symbolBTC, "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
+
     def revert_to_initial_state(self):
         self.rollback_to(block=0, nodes=[0, 1, 2])
         assert_equal(len(self.nodes[0].listpoolpairs()), 0)
@@ -555,6 +563,7 @@ class PoolPairTest (DefiTestFramework):
         self.test_listaccounthistory_and_burninfo()
         self.update_comission_and_fee_to_1pct_pool1()
         self.update_comission_and_fee_to_1pct_pool2()
+        self.test_testpoolswap_errors()
         self.revert_to_initial_state()
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:
Checks for an empty `tokenTo` and `tokenFrom` in `testpoolswap`. Previously the empty string evaluated as DFI on both fields, and the RPC incorrectly returned the DFI-DFI composite swap output.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1341 