### PR TITLE
After GC make foundation reward as token when on-chain governance is disabled

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -867,7 +867,7 @@ inline bool IsBlockPruned(const CBlockIndex* pblockindex)
 }
 
 Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int height, CAmount nFees, const Consensus::Params& consensus);
-void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height);
+void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensus::Params& consensus);
 
 inline CAmount CalculateCoinbaseReward(const CAmount blockReward, const uint32_t percentage)
 {

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -58,13 +58,8 @@ class ChainGornmentTest(DefiTestFramework):
         # grand central
         assert_equal(self.nodes[0].getblockcount(), 101)
 
-        # Check community dev fund present
-        result = self.nodes[0].listcommunitybalances()
-        assert_equal(result['CommunityDevelopmentFunds'], Decimal('19.88746400'))
-        result = self.nodes[0].getblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
-        assert_equal(result['nonutxo'][0]['CommunityDevelopmentFunds'], Decimal('19.88746400'))
-
         # Check foundation output no longer in coinbase TX
+        result = self.nodes[0].getblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
         raw_tx = self.nodes[0].getrawtransaction(result['tx'][0], 1)
         assert_equal(len(raw_tx['vout']), 2)
         assert_equal(raw_tx['vout'][0]['value'], Decimal('134.99983200'))
@@ -81,6 +76,12 @@ class ChainGornmentTest(DefiTestFramework):
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/governance/global/enabled':'true'}})
         self.nodes[0].generate(1)
         self.sync_blocks()
+
+        # Check community dev fund present
+        result = self.nodes[0].listcommunitybalances()
+        assert_equal(result['CommunityDevelopmentFunds'], 2 * Decimal('19.88746400'))
+        result = self.nodes[0].getblock(self.nodes[0].getblockhash(self.nodes[0].getblockcount()))
+        assert_equal(result['nonutxo'][0]['CommunityDevelopmentFunds'], Decimal('19.88746400'))
 
         # Check errors
         assert_raises_rpc_error(-32600, "proposal cycles can be between 1 and 3", self.nodes[0].creategovcfp, {"title": "test", "context": context, "amount": 100, "cycles": 4, "payoutAddress": address})


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:
If on-chain governance is disabled send community dev rewards still to foundation share address but in the form of DFI token. When on-chain governance is enabled whole balance of foundation share address will be transferred to community dev balance. When it is disabled, fund from community dev balance will be returned to foundation address. 
