### PR TITLE
Revert "Adds argument `-leveldbchecksum`"

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -105,7 +105,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
         v++;
         return v;
     };
-
+    
     leveldb::Options options;
     options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
     options.write_buffer_size = ceil_power_of_two(std::min(static_cast<size_t>(64)
@@ -126,28 +126,12 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
     : m_name{path.stem().string()}
 {
     penv = nullptr;
+    readoptions.verify_checksums = true;
+    iteroptions.verify_checksums = true;
     iteroptions.fill_cache = false;
     syncoptions.sync = true;
     options = GetOptions(nCacheSize);
     options.create_if_missing = true;
-
-    auto leveldbchecksum = gArgs.GetArg("-leveldbchecksum", "auto");
-    if(leveldbchecksum == "false"){
-        // set to true by default for all versions above 1.16 of LevelDB in GetOptions()
-        options.paranoid_checks = false;
-    }
-    else if (leveldbchecksum == "true") {
-        readoptions.verify_checksums = true;
-        iteroptions.verify_checksums = true;
-    }
-    else {
-        if (leveldbchecksum != "auto")
-            LogPrint(BCLog::LEVELDB, "leveldbchecksum value not in 'true|false|value'. Falling back to default value 'auto'\n");
-        auto isMN = gArgs.IsArgSet("-masternode_operator");
-        readoptions.verify_checksums = isMN;
-        iteroptions.verify_checksums = isMN;
-    }
-
     if (fMemory) {
         penv = leveldb::NewMemEnv(leveldb::Env::Default());
         options.env = penv;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -391,16 +391,12 @@ void SetupServerArgs()
 
     // Hidden Options
     std::vector<std::string> hidden_args = {
-        "-dbcrashratio",
-        "-forcecompactdb",
-        "-leveldbchecksum=<auto|true|false>",
-        "-interrupt-block=<hash|height>",
-        "-stop-block=<hash|height>",
-        "-mocknet",
-        "-mocknet-blocktime=<secs>",
-        "-mocknet-key=<pubkey>",
-        "-checkpoints-file"
-    };
+        "-dbcrashratio", "-forcecompactdb",
+        "-interrupt-block=<hash|height>", "-stop-block=<hash|height>",
+        "-mocknet", "-mocknet-blocktime=<secs>", "-mocknet-key=<pubkey>",
+        "-checkpoints-file",
+        // GUI args. These will be overwritten by SetupUIArgs for the GUI
+        "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-splash"};
 
     gArgs.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #if HAVE_SYSTEM

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3910,7 +3910,7 @@ public:
             return Res::Err("masternode <%s> is not active", obj.masternodeId.GetHex());
 
         if (node->mintedBlocks < 1)
-            return Res::Err("masternode <%s> did not mint at least one block", obj.masternodeId.GetHex());
+            return Res::Err("masternode <%s> does not mine at least one block", obj.masternodeId.GetHex());
 
         switch (obj.vote) {
         case CPropVoteType::VoteNo:

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -138,7 +138,7 @@ class ChainGornmentTest(DefiTestFramework):
         self.sync_blocks()
 
         # Try and vote with non-staked MN
-        assert_raises_rpc_error(None, "did not mint at least one block", self.nodes[3].votegov, tx, mn3, "neutral")
+        assert_raises_rpc_error(None, "does not mine at least one block", self.nodes[3].votegov, tx, mn3, "neutral")
 
         # Calculate cycle
         cycle1 = 103 + (103 % 70) + 70

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -23,20 +23,7 @@ CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWallet
 CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set([
-    '-h',
-    '-help',
-    '-dbcrashratio',
-    '-forcecompactdb',
-    '-interrupt-block',
-    '-stop-block',
-    '-mocknet',
-    '-mocknet-key',
-    '-mocknet-blocktime',
-    '-checkpoints-file',
-    '-negativeinterest',
-    '-leveldbchecksum'
-    ])
+SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb', '-interrupt-block', '-stop-block', '-mocknet', '-mocknet-key', '-mocknet-blocktime', '-checkpoints-file', '-negativeinterest'])
 
 
 def lint_missing_argument_documentation():


### PR DESCRIPTION
Reverts DeFiCh/ain#1514

This PR is not ready.

- Paranoid checks should never be turned off
- Abstract gArgs tests out of leveldb initialisation, and do not use error messages on each init of db. 
- Also seems to skip some vars on other changes. 