### PR TITLE
Skip jellyfish tests on master

### DIFF
--- a/.github/workflows/jellyfish-tests.yml
+++ b/.github/workflows/jellyfish-tests.yml
@@ -3,7 +3,6 @@ name: Jellyfish Tests
 on:
   push:
     branches:
-      - master
       - epic/*
   pull_request:
     branches:


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

- Skip on master to avoid upstream projects (JellyFish) from mis-indicating failures of the node. 
- But still continue to ensure, JellyFish tests are run on PRs to evaluate breakages.
