### PR TITLE
Migrate foundation addresses to Governance variables

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -1167,6 +1167,10 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
                     if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }
+                } else if (attrV0->typeId == ParamIDs::Foundation || attrV0->key == DFIPKeys::Members) {
+                    if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
+                        return Res::Err("Cannot be set before GrandCentralHeight");
+                    }
                 } else if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->key == DFIPKeys::StartBlock || attrV0->typeId == ParamIDs::DFIP2206A) {
                     if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
                         return Res::Err("Cannot be set before FortCanningSpringHeight");

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -83,6 +83,7 @@ const std::map<std::string, uint8_t>& ATTRIBUTES::allowedParamIDs() {
         // for testnet. May not be enabled on mainnet until testing is complete.
         {"dfip2206f",   ParamIDs::DFIP2206F},
         {"feature",     ParamIDs::Feature},
+        {"foundation",  ParamIDs::Foundation},
     };
     return params;
 }
@@ -105,6 +106,7 @@ const std::map<uint8_t, std::string>& ATTRIBUTES::displayParamsIDs() {
         {ParamIDs::TokenID,     "token"},
         {ParamIDs::Economy,     "economy"},
         {ParamIDs::Feature,     "feature"},
+        {ParamIDs::Foundation,  "foundation"},
     };
     return params;
 }
@@ -165,6 +167,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys
                 {"mn-setrewardaddress",         DFIPKeys::MNSetRewardAddress},
                 {"mn-setoperatoraddress",       DFIPKeys::MNSetOperatorAddress},
                 {"mn-setowneraddress",          DFIPKeys::MNSetOwnerAddress},
+                {"members",                     DFIPKeys::Members},
             }
         },
     };
@@ -216,6 +219,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {DFIPKeys::MNSetRewardAddress,      "mn-setrewardaddress"},
                 {DFIPKeys::MNSetOperatorAddress,    "mn-setoperatoraddress"},
                 {DFIPKeys::MNSetOwnerAddress,       "mn-setowneraddress"},
+                {DFIPKeys::Members,                 "members"},
             }
         },
         {
@@ -316,6 +320,50 @@ static ResVal<CAttributeValue> VerifySplit(const std::string& str) {
     return {splits, Res::Ok()};
 }
 
+static ResVal<CAttributeValue> VerifyMember(const std::string& str) {
+    // Support UniValue array
+    UniValue array(UniValue::VARR);
+    if (!array.read(str)) {
+        return Res::Err("Not a valid array of addresses");
+    }
+
+    std::set<std::string> addresses;
+    std::set<CScript> members;
+    bool removal{};
+
+    for (size_t i = 0; i < array.size(); ++i) {
+        auto member = array[i].getValStr();
+        if (member.empty()) {
+            return Res::Err("Invalid address provided");
+        }
+
+        CTxDestination dest;
+        if (member[0] == '-') {
+            removal = true;
+            dest = DecodeDestination(member.erase(0, 1));
+            addresses.insert(array[i].getValStr());
+        } else if (member[0] == '+') {
+            dest = DecodeDestination(member.erase(0, 1));
+            addresses.insert(member);
+        } else {
+            dest = DecodeDestination(member);
+            addresses.insert(member);
+        }
+
+        if (!IsValidDestination(dest)) {
+            return Res::Err("Invalid address provided");
+        }
+
+        members.insert(GetScriptForDestination(dest));
+    }
+
+    if (removal) {
+        return {addresses, Res::Ok()};
+    }
+
+    return {members, Res::Ok()};
+}
+
 static ResVal<CAttributeValue> VerifyCurrencyPair(const std::string& str) {
     const auto value = KeyBreaker(str);
     if (value.size() != 2) {
@@ -395,6 +443,7 @@ const std::map<uint8_t, std::map<uint8_t,
                 {DFIPKeys::MNSetRewardAddress,      VerifyBool},
                 {DFIPKeys::MNSetOperatorAddress,    VerifyBool},
                 {DFIPKeys::MNSetOwnerAddress,       VerifyBool},
+                {DFIPKeys::Members,                 VerifyMember},
             }
         },
         {
@@ -570,6 +619,10 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::string& value
                     typeKey != DFIPKeys::MNSetOperatorAddress &&
                     typeKey != DFIPKeys::MNSetOwnerAddress) {
                     return Res::Err("Unsupported type for Feature {%d}", typeKey);
+                }
+            } else if (typeId == ParamIDs::Foundation)  {
+                if (typeKey != DFIPKeys::Members) {
+                    return Res::Err("Unsupported type for Foundation {%d}", typeKey);
                 }
             }  else {
                 return Res::Err("Unsupported Param ID");
@@ -759,6 +812,24 @@ Res ATTRIBUTES::Import(const UniValue & val) {
 
                         SetValue(attribute, *splitValue);
                         return Res::Ok();
+                    } else if (attrV0->type == AttributeTypes::Param && attrV0->typeId == ParamIDs::Foundation && attrV0->key == DFIPKeys::Members) {
+                        const auto members = std::get_if<std::set<CScript>>(&value);
+                        if (members) {
+                            auto existingMembers = GetValue(attribute, std::set<CScript>{});
+
+                            for (const auto &member : *members) {
+                                if (existingMembers.count(member)) {
+                                    return Res::Err("Member to add already present");
+                                }
+                                existingMembers.insert(member);
+                            }
+
+                            SetValue(attribute, existingMembers);
+                        } else {
+                            SetValue(attribute, value);
+                        }
+
+                        return Res::Ok();
                     } else if (attrV0->type == AttributeTypes::Token && attrV0->key == TokenKeys::LoanMintingInterest) {
                         interestTokens.insert(attrV0->typeId);
                     }
@@ -908,6 +979,21 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                 } else if (result->feeDir == FeeDirValues::Out) {
                     ret.pushKV(key, "out");
                 }
+            } else if (const auto members = std::get_if<std::set<CScript>>(&attribute.second)) {
+                UniValue array(UniValue::VARR);
+                for (const auto &member : *members) {
+                    CTxDestination dest;
+                    if (ExtractDestination(member, dest)) {
+                        array.push_back(EncodeDestination(dest));
+                    }
+                }
+                ret.pushKV(key, array.write());
+            } else if (const auto strMembers = std::get_if<std::set<std::string>>(&attribute.second)) {
+                UniValue array(UniValue::VARR);
+                for (const auto &member : *strMembers) {
+                    array.push_back(member);
+                }
+                ret.pushKV(key, array.write());
             }
         } catch (const std::out_of_range&) {
             // Should not get here, that's mean maps are mismatched
@@ -1077,7 +1163,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView & view) const
             break;
 
             case AttributeTypes::Param:
-                if (attrV0->typeId == ParamIDs::Feature) {
+                if (attrV0->typeId == ParamIDs::Feature || attrV0->typeId == ParamIDs::Foundation || attrV0->key == DFIPKeys::Members) {
                     if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -31,6 +31,7 @@ enum ParamIDs : uint8_t  {
     DFIP2206A = 'f',
     DFIP2206F = 'g',
     Feature   = 'h',
+    Foundation = 'i',
 };
 
 enum OracleIDs : uint8_t  {
@@ -65,6 +66,7 @@ enum DFIPKeys : uint8_t  {
     MNSetRewardAddress      = 'l',
     MNSetOperatorAddress    = 'm',
     MNSetOwnerAddress       = 'n',
+    Members                 = 'o',
 };
 
 enum TokenKeys : uint8_t  {
@@ -199,7 +201,7 @@ using OracleSplits    = std::map<uint32_t, int32_t>;
 using DescendantValue = std::pair<uint32_t, int32_t>;
 using AscendantValue  = std::pair<uint32_t, std::string>;
 using CAttributeType  = std::variant<CDataStructureV0, CDataStructureV1>;
-using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CTokenCurrencyPair, OracleSplits, DescendantValue, AscendantValue, CFeeDir, CDexBalances>;
+using CAttributeValue = std::variant<bool, CAmount, CBalances, CTokenPayback, CTokenCurrencyPair, OracleSplits, DescendantValue, AscendantValue, CFeeDir, CDexBalances, std::set<CScript>, std::set<std::string>>;
 
 void TrackNegativeInterest(CCustomCSView& mnview, const CTokenAmount& amount);
 

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -650,8 +650,10 @@ public:
         auto members = consensus.foundationMembers;
         const auto attributes = mnview.GetAttributes();
         assert(attributes);
-        if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
-            members = databaseMembers;
+        if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+            if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+                members = databaseMembers;
+            }
         }
 
         for (const auto& input : tx.vin) {
@@ -1081,7 +1083,10 @@ public:
 
         const auto attributes = mnview.GetAttributes();
         assert(attributes);
-        const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        std::set<CScript> databaseMembers;
+        if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+            databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        }
         bool isFoundersToken = !databaseMembers.empty() ? databaseMembers.count(auth.out.scriptPubKey) > 0 : consensus.foundationMembers.count(auth.out.scriptPubKey) > 0;
 
         auto res = Res::Ok();

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -228,13 +228,6 @@ class CCustomMetadataParseVisitor
         return Res::Ok();
     }
 
-    Res isPostEunosPayaFork() const {
-        if(static_cast<int>(height) < consensus.EunosPayaHeight) {
-            return Res::Err("called before EunosPaya height");
-        }
-        return Res::Ok();
-    }
-
     Res isPostFortCanningFork() const {
         if(static_cast<int>(height) < consensus.FortCanningHeight) {
             return Res::Err("called before FortCanning height");
@@ -654,9 +647,16 @@ public:
     }
 
     Res HasFoundationAuth() const {
+        auto members = consensus.foundationMembers;
+        const auto attributes = mnview.GetAttributes();
+        assert(attributes);
+        if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+            members = databaseMembers;
+        }
+
         for (const auto& input : tx.vin) {
             const Coin& coin = coins.AccessCoin(input.prevout);
-            if (!coin.IsSpent() && consensus.foundationMembers.count(coin.out.scriptPubKey) > 0) {
+            if (!coin.IsSpent() && members.count(coin.out.scriptPubKey) > 0) {
                 return Res::Ok();
             }
         }
@@ -1078,7 +1078,11 @@ public:
 
         // check auth, depends from token's "origins"
         const Coin& auth = coins.AccessCoin(COutPoint(token.creationTx, 1)); // always n=1 output
-        bool isFoundersToken = consensus.foundationMembers.count(auth.out.scriptPubKey) > 0;
+
+        const auto attributes = mnview.GetAttributes();
+        assert(attributes);
+        const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        bool isFoundersToken = !databaseMembers.empty() ? databaseMembers.count(auth.out.scriptPubKey) > 0 : consensus.foundationMembers.count(auth.out.scriptPubKey) > 0;
 
         auto res = Res::Ok();
         if (isFoundersToken && !(res = HasFoundationAuth())) {
@@ -1717,11 +1721,59 @@ public:
 
                 govVar->time = time;
 
-                // Validate as complete set. Check for future conflicts between key pairs.
-                if (!(res = govVar->Import(var->Export()))
-                    ||  !(res = govVar->Validate(mnview))
-                    ||  !(res = govVar->Apply(mnview, height)))
-                    return Res::Err("%s: %s", var->GetName(), res.msg);
+                auto newVar = std::dynamic_pointer_cast<ATTRIBUTES>(var);
+                assert(newVar);
+
+                CDataStructureV0 key{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members};
+                auto memberRemoval = newVar->GetValue(key, std::set<std::string>{});
+
+                if (!memberRemoval.empty()) {
+                    auto existingMembers = govVar->GetValue(key, std::set<CScript>{});
+
+                    for (auto &member : memberRemoval) {
+                        if (member.empty()) {
+                            return Res::Err("Invalid address provided");
+                        }
+
+                        if (member[0] == '-') {
+                            auto memberCopy{member};
+                            const auto dest = DecodeDestination(memberCopy.erase(0, 1));
+                            if (!IsValidDestination(dest)) {
+                                return Res::Err("Invalid address provided");
+                            }
+                            CScript removeMember = GetScriptForDestination(dest);
+                            if (!existingMembers.count(removeMember)) {
+                                return Res::Err("Member to remove not present");
+                            }
+                            existingMembers.erase(removeMember);
+                        } else {
+                            const auto dest = DecodeDestination(member);
+                            if (!IsValidDestination(dest)) {
+                                return Res::Err("Invalid address provided");
+                            }
+                            CScript addMember = GetScriptForDestination(dest);
+                            if (existingMembers.count(addMember)) {
+                                return Res::Err("Member to add already present");
+                            }
+                            existingMembers.insert(addMember);
+                        }
+                    }
+
+                    govVar->SetValue(key, existingMembers);
+
+                    // Remove this key and apply any other changes
+                    newVar->EraseKey(key);
+                    if (!(res = govVar->Import(newVar->Export()))
+                        ||  !(res = govVar->Validate(mnview))
+                        ||  !(res = govVar->Apply(mnview, height)))
+                        return Res::Err("%s: %s", var->GetName(), res.msg);
+                } else {
+                    // Validate as complete set. Check for future conflicts between key pairs.
+                    if (!(res = govVar->Import(var->Export()))
+                        ||  !(res = govVar->Validate(mnview))
+                        ||  !(res = govVar->Apply(mnview, height)))
+                        return Res::Err("%s: %s", var->GetName(), res.msg);
+                }
 
                 var = govVar;
             } else {

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -274,7 +274,14 @@ static std::vector<CTxIn> GetInputs(UniValue const& inputs) {
 }
 
 std::optional<CScript> AmIFounder(CWallet* const pwallet) {
-    for(auto const & script : Params().GetConsensus().foundationMembers) {
+    auto members = Params().GetConsensus().foundationMembers;
+    const auto attributes = pcustomcsview->GetAttributes();
+    assert(attributes);
+    if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+        members = databaseMembers;
+    }
+
+    for (auto const & script : members) {
         if(IsMineCached(*pwallet, script) == ISMINE_SPENDABLE)
             return { script };
     }
@@ -348,7 +355,14 @@ static CTransactionRef CreateAuthTx(CWalletCoinsUnlocker& pwallet, std::set<CScr
 }
 
 static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker& pwallet) {
-    for (auto const & founderScript : Params().GetConsensus().foundationMembers) {
+    auto members = Params().GetConsensus().foundationMembers;
+    const auto attributes = pcustomcsview->GetAttributes();
+    assert(attributes);
+    if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+        members = databaseMembers;
+    }
+
+    for (auto const & founderScript : members) {
         if (IsMineCached(*pwallet, founderScript) == ISMINE_SPENDABLE) {
             CTxDestination destination;
             if (ExtractDestination(founderScript, destination)) {

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -277,8 +277,10 @@ std::optional<CScript> AmIFounder(CWallet* const pwallet) {
     auto members = Params().GetConsensus().foundationMembers;
     const auto attributes = pcustomcsview->GetAttributes();
     assert(attributes);
-    if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
-        members = databaseMembers;
+    if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+        if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+            members = databaseMembers;
+        }
     }
 
     for (auto const & script : members) {
@@ -358,8 +360,10 @@ static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker& pwal
     auto members = Params().GetConsensus().foundationMembers;
     const auto attributes = pcustomcsview->GetAttributes();
     assert(attributes);
-    if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
-        members = databaseMembers;
+    if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+        if (const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{}); !databaseMembers.empty()) {
+            members = databaseMembers;
+        }
     }
 
     for (auto const & founderScript : members) {

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -278,7 +278,13 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     }
     else
     { // post-bayfront auth
-        bool isFoundersToken = Params().GetConsensus().foundationMembers.find(owner) != Params().GetConsensus().foundationMembers.end();
+        const auto attributes = pcustomcsview->GetAttributes();
+        assert(attributes);
+        const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        bool isFoundersToken = !databaseMembers.empty() ?
+                               databaseMembers.find(owner) != databaseMembers.end() :
+                               Params().GetConsensus().foundationMembers.find(owner) != Params().GetConsensus().foundationMembers.end();
+
         if (isFoundersToken) { // need any founder's auth
             rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths /*auths*/, true /*needFoundersAuth*/, optAuthTx, txInputs);
         }

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -280,7 +280,10 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     { // post-bayfront auth
         const auto attributes = pcustomcsview->GetAttributes();
         assert(attributes);
-        const auto databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        std::set<CScript> databaseMembers;
+        if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+            databaseMembers = attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
+        }
         bool isFoundersToken = !databaseMembers.empty() ?
                                databaseMembers.find(owner) != databaseMembers.end() :
                                Params().GetConsensus().foundationMembers.find(owner) != Params().GetConsensus().foundationMembers.end();

--- a/src/validation.h
+++ b/src/validation.h
@@ -793,6 +793,8 @@ private:
     static void ProcessFuturesDUSD(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams);
 
     static void ProcessNegativeInterest(const CBlockIndex* pindex, CCustomCSView& cache);
+
+    static void ProcessGrandCentralEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams);
 };
 
 /** Mark a block as precious and reorganize.

--- a/test/functional/feature_foundation_migration.py
+++ b/test/functional/feature_foundation_migration.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test foundation member migration to database"""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+class FoundationMemberTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.grand_central = 202
+        self.extra_args = [
+            ['-txnotokens=0', '-amkheight=1', '-bayfrontheight=1', '-eunosheight=1', '-fortcanningheight=1', '-fortcanningmuseumheight=1', '-fortcanninghillheight=1', '-fortcanningroadheight=1', '-fortcanningcrunchheight=1', f'-grandcentralheight={self.grand_central}', '-subsidytest=1'],
+            ['-txnotokens=0', '-amkheight=1', '-bayfrontheight=1', '-eunosheight=1', '-fortcanningheight=1', '-fortcanningmuseumheight=1', '-fortcanninghillheight=1', '-fortcanningroadheight=1', '-fortcanningcrunchheight=1', f'-grandcentralheight={self.grand_central}', '-subsidytest=1']
+        ]
+
+    def run_test(self):
+
+        # Define node 0 foundation address
+        address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+
+        # Move to fork height
+        self.nodes[0].generate(101)
+        self.sync_blocks()
+
+        # Change address before fork
+        assert_raises_rpc_error(-32600, "Cannot be set before GrandCentralHeight", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/foundation/members':f'["{address}"]'}})
+
+        self.nodes[1].generate(self.grand_central - self.nodes[0].getblockcount())
+        self.sync_blocks()
+
+        # Check addresses now in DB
+        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']['v0/params/foundation/members'], '["bcrt1qyrfrpadwgw7p5eh3e9h3jmu4kwlz4prx73cqny","bcrt1qyeuu9rvq8a67j86pzvh5897afdmdjpyankp4mu","msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7","mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU"]')
+
+        # Add already existant address
+        assert_raises_rpc_error(-32600, "Member to add already present", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/foundation/members':f'["{address}"]'}})
+
+        # Remove an address that is not present
+        assert_raises_rpc_error(-32600, "Member to remove not present", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/foundation/members':f'["-{self.nodes[0].getnewaddress()}"]'}})
+
+        # Add nonsense address
+        assert_raises_rpc_error(-5, "Invalid address provided", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/foundation/members':f'["NOTANADDRESS"]'}})
+
+        # Remove address
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/foundation/members':f'["-{address}"]'}})
+        self.nodes[0].generate(1)
+
+        # Check address no longer present
+        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']['v0/params/foundation/members'], '["bcrt1qyrfrpadwgw7p5eh3e9h3jmu4kwlz4prx73cqny","bcrt1qyeuu9rvq8a67j86pzvh5897afdmdjpyankp4mu","msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7"]')
+
+        # Try and add self back in without foundation auth
+        assert_raises_rpc_error(-5, "Need foundation member authorization", self.nodes[0].setgov, {"ATTRIBUTES":{'v0/params/foundation/members':f'["{address}"]'}})
+
+        # Add address in from another node
+        self.sync_blocks()
+        self.nodes[1].setgov({"ATTRIBUTES":{'v0/params/foundation/members':f'["{address}"]'}})
+        self.nodes[1].generate(1)
+        self.sync_blocks()
+
+        # Check address present again
+        assert_equal(self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']['v0/params/foundation/members'], '["bcrt1qyrfrpadwgw7p5eh3e9h3jmu4kwlz4prx73cqny","bcrt1qyeuu9rvq8a67j86pzvh5897afdmdjpyankp4mu","msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7","mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU"]')
+
+        # Removing address again, add new address and set another variable
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/foundation/members':f'["-{address}","+2MwHamtynMqvstggG5XsVPVoAKroa4CgwFs"]','v0/params/dfip2201/active':'false'}})
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        # Check address no longer present
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/params/foundation/members'], '["bcrt1qyrfrpadwgw7p5eh3e9h3jmu4kwlz4prx73cqny","bcrt1qyeuu9rvq8a67j86pzvh5897afdmdjpyankp4mu","2MwHamtynMqvstggG5XsVPVoAKroa4CgwFs","msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7"]')
+        assert_equal(attributes['v0/params/dfip2201/active'], 'false')
+
+        # Set stored lock
+        activation_height = self.nodes[1].getblockcount() + 5
+        self.nodes[1].setgovheight({"ATTRIBUTES":{'v0/params/foundation/members':f'["-2MwHamtynMqvstggG5XsVPVoAKroa4CgwFs","2N3kCSytvetmJybdZbqV5wK3Zzekg9SiSe2"]','v0/params/dfip2203/active':'false'}}, activation_height)
+        self.nodes[1].generate(1)
+
+        # Check pending changes show as expected
+        attributes = self.nodes[1].listgovs()[8]
+        assert_equal(attributes[1][str(activation_height)]['v0/params/foundation/members'], '["-2MwHamtynMqvstggG5XsVPVoAKroa4CgwFs","2N3kCSytvetmJybdZbqV5wK3Zzekg9SiSe2"]')
+        assert_equal(attributes[1][str(activation_height)]['v0/params/dfip2203/active'], 'false')
+
+        # Move to fork height and check changes
+        self.nodes[1].generate(5)
+        attributes = self.nodes[0].getgov('ATTRIBUTES')['ATTRIBUTES']
+        assert_equal(attributes['v0/params/foundation/members'], '["bcrt1qyrfrpadwgw7p5eh3e9h3jmu4kwlz4prx73cqny","bcrt1qyeuu9rvq8a67j86pzvh5897afdmdjpyankp4mu","2N3kCSytvetmJybdZbqV5wK3Zzekg9SiSe2","msER9bmJjyEemRpQoS8YYVL21VyZZrSgQ7"]')
+        assert_equal(attributes['v0/params/dfip2203/active'], 'false')
+
+if __name__ == '__main__':
+    FoundationMemberTest().main()
+

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_block.py',
     'p2p_invalid_messages.py',
     'p2p_invalid_tx.py',
+    'feature_foundation_migration.py',
     'feature_assumevalid.py',
     'example_test.py',
     'feature_jellyfish_initial_funds.py',


### PR DESCRIPTION
Moves hard coded foundation addresses to Governance variable ATTRIBUTES. Allows adding and removing of foundation addresses. Will let us replace existing foundation addresses with multisig addresses.