### PR TITLE
Pull bdb, libevent, miniupnpc upstream updates

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -4,19 +4,22 @@ $(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).NC.tar.gz
 $(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
 $(package)_build_subdir=build_unix
+$(package)_patches=clang_cxx_11.patch
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --enable-cxx --disable-replication
+$(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
-$(package)_cflags+=-Wno-error=implicit-function-declaration
-$(package)_cxxflags=-std=c++17
+$(package)_config_opts_freebsd=--with-pic
+$(package)_config_opts_netbsd=--with-pic
+$(package)_config_opts_openbsd=--with-pic
+$(package)_config_opts_android=--with-pic
+$(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' dbinc/atomic.h && \
-  sed -i.old 's/atomic_init/atomic_init_db/' dbinc/atomic.h mp/mp_region.c mp/mp_mvcc.c mp/mp_fget.c mutex/mut_method.c mutex/mut_tas.c && \
+  patch -p1 < $($(package)_patch_dir)/clang_cxx_11.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist
 endef
 

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,17 +1,26 @@
 package=libevent
-$(package)_version=2.1.8-stable
-$(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_file_name=release-$($(package)_version).tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_version=2.1.12-stable
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
-define $(package)_preprocess_cmds
-  ./autogen.sh
-endef
-
+# When building for Windows, we set _WIN32_WINNT to target the same Windows
+# version as we do in configure. Due to quirks in libevents build system, this
+# is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_freebsd=--with-pic
+  $(package)_config_opts_netbsd=--with-pic
+  $(package)_config_opts_openbsd=--with-pic
+  $(package)_config_opts_android=--with-pic
+  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
+endef
+
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux
 endef
 
 define $(package)_config_cmds
@@ -27,5 +36,7 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm lib/*.la && \
+  rm include/ev*.h && \
+  rm include/event2/*_compat.h
 endef

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,20 +1,22 @@
 package=miniupnpc
-$(package)_version=2.0.20180203
+$(package)_version=2.2.2
 $(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=90dda8c7563ca6cd4a83e23b3c66dbbea89603a1675bfdb852897c2c9cc220b7
+$(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
+$(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch
 
+# Next time this package is updated, ensure that _WIN32_WINNT is still properly set.
+# See discussion in https://github.com/bitcoin/bitcoin/pull/25964.
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
 $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
-$(package)_build_opts_mingw32=-f Makefile.mingw
+$(package)_build_opts_mingw32=-f Makefile.mingw CFLAGS="$($(package)_cflags) -D_WIN32_WINNT=0x0601"
 $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
 endef
 
 define $(package)_preprocess_cmds
-  mkdir dll && \
-  sed -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"$($(package)_version)\"|' -e 's|OS/version|$(host)|' miniupnpcstrings.h.in > miniupnpcstrings.h && \
-  sed -i.old "s|miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings|miniupnpcstrings.h: miniupnpcstrings.h.in|" Makefile.mingw
+  patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch && \
+  patch -p1 < $($(package)_patch_dir)/respect_mingw_cflags.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/bdb/clang_cxx_11.patch
+++ b/depends/patches/bdb/clang_cxx_11.patch
@@ -1,0 +1,147 @@
+commit 3311d68f11d1697565401eee6efc85c34f022ea7
+Author: fanquake <fanquake@gmail.com>
+Date:   Mon Aug 17 20:03:56 2020 +0800
+
+    Fix C++11 compatibility
+
+diff --git a/dbinc/atomic.h b/dbinc/atomic.h
+index 0034dcc..7c11d4a 100644
+--- a/dbinc/atomic.h
++++ b/dbinc/atomic.h
+@@ -70,7 +70,7 @@ typedef struct {
+  * These have no memory barriers; the caller must include them when necessary.
+  */
+ #define	atomic_read(p)		((p)->value)
+-#define	atomic_init(p, val)	((p)->value = (val))
++#define	atomic_init_db(p, val)	((p)->value = (val))
+ 
+ #ifdef HAVE_ATOMIC_SUPPORT
+ 
+@@ -144,7 +144,7 @@ typedef LONG volatile *interlocked_val;
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@ static inline int __atomic_dec(db_atomic_t *p)
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;
+@@ -206,7 +206,7 @@ static inline int __atomic_compare_exchange(
+ #define	atomic_dec(env, p)	(--(p)->value)
+ #define	atomic_compare_exchange(env, p, oldval, newval)		\
+ 	(DB_ASSERT(env, atomic_read(p) == (oldval)),		\
+-	atomic_init(p, (newval)), 1)
++	atomic_init_db(p, (newval)), 1)
+ #else
+ #define atomic_inc(env, p)	__atomic_inc(env, p)
+ #define atomic_dec(env, p)	__atomic_dec(env, p)
+diff --git a/mp/mp_fget.c b/mp/mp_fget.c
+index 5fdee5a..0b75f57 100644
+--- a/mp/mp_fget.c
++++ b/mp/mp_fget.c
+@@ -617,7 +617,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 
+ 		/* Initialize enough so we can call __memp_bhfree. */
+ 		alloc_bhp->flags = 0;
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ #ifdef DIAGNOSTIC
+ 		if ((uintptr_t)alloc_bhp->buf & (sizeof(size_t) - 1)) {
+ 			__db_errx(env,
+@@ -911,7 +911,7 @@ alloc:		/* Allocate a new buffer header and data space. */
+ 			MVCC_MPROTECT(bhp->buf, mfp->stat.st_pagesize,
+ 			    PROT_READ);
+ 
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+ 		alloc_bhp->priority = bhp->priority;
+ 		alloc_bhp->pgno = bhp->pgno;
+diff --git a/mp/mp_mvcc.c b/mp/mp_mvcc.c
+index 34467d2..f05aa0c 100644
+--- a/mp/mp_mvcc.c
++++ b/mp/mp_mvcc.c
+@@ -276,7 +276,7 @@ __memp_bh_freeze(dbmp, infop, hp, bhp, need_frozenp)
+ #else
+ 	memcpy(frozen_bhp, bhp, SSZA(BH, buf));
+ #endif
+-	atomic_init(&frozen_bhp->ref, 0);
++	atomic_init_db(&frozen_bhp->ref, 0);
+ 	if (mutex != MUTEX_INVALID)
+ 		frozen_bhp->mtx_buf = mutex;
+ 	else if ((ret = __mutex_alloc(env, MTX_MPOOL_BH,
+@@ -428,7 +428,7 @@ __memp_bh_thaw(dbmp, infop, hp, frozen_bhp, alloc_bhp)
+ #endif
+ 		alloc_bhp->mtx_buf = mutex;
+ 		MUTEX_LOCK(env, alloc_bhp->mtx_buf);
+-		atomic_init(&alloc_bhp->ref, 1);
++		atomic_init_db(&alloc_bhp->ref, 1);
+ 		F_CLR(alloc_bhp, BH_FROZEN);
+ 	}
+ 
+diff --git a/mp/mp_region.c b/mp/mp_region.c
+index e6cece9..ddbe906 100644
+--- a/mp/mp_region.c
++++ b/mp/mp_region.c
+@@ -224,7 +224,7 @@ __memp_init(env, dbmp, reginfo_off, htab_buckets, max_nreg)
+ 			     MTX_MPOOL_FILE_BUCKET, 0, &htab[i].mtx_hash)) != 0)
+ 				return (ret);
+ 			SH_TAILQ_INIT(&htab[i].hash_bucket);
+-			atomic_init(&htab[i].hash_page_dirty, 0);
++			atomic_init_db(&htab[i].hash_page_dirty, 0);
+ 		}
+ 
+ 		/*
+@@ -269,7 +269,7 @@ __memp_init(env, dbmp, reginfo_off, htab_buckets, max_nreg)
+ 		hp->mtx_hash = (mtx_base == MUTEX_INVALID) ? MUTEX_INVALID :
+ 		    mtx_base + i;
+ 		SH_TAILQ_INIT(&hp->hash_bucket);
+-		atomic_init(&hp->hash_page_dirty, 0);
++		atomic_init_db(&hp->hash_page_dirty, 0);
+ #ifdef HAVE_STATISTICS
+ 		hp->hash_io_wait = 0;
+ 		hp->hash_frozen = hp->hash_thawed = hp->hash_frozen_freed = 0;
+diff --git a/mutex/mut_method.c b/mutex/mut_method.c
+index 2588763..5c6d516 100644
+--- a/mutex/mut_method.c
++++ b/mutex/mut_method.c
+@@ -426,7 +426,7 @@ atomic_compare_exchange(env, v, oldval, newval)
+ 	MUTEX_LOCK(env, mtx);
+ 	ret = atomic_read(v) == oldval;
+ 	if (ret)
+-		atomic_init(v, newval);
++		atomic_init_db(v, newval);
+ 	MUTEX_UNLOCK(env, mtx);
+ 
+ 	return (ret);
+diff --git a/mutex/mut_tas.c b/mutex/mut_tas.c
+index f3922e0..e40fcdf 100644
+--- a/mutex/mut_tas.c
++++ b/mutex/mut_tas.c
+@@ -46,7 +46,7 @@ __db_tas_mutex_init(env, mutex, flags)
+ 
+ #ifdef HAVE_SHARED_LATCHES
+ 	if (F_ISSET(mutexp, DB_MUTEX_SHARED))
+-		atomic_init(&mutexp->sharecount, 0);
++		atomic_init_db(&mutexp->sharecount, 0);
+ 	else
+ #endif
+ 	if (MUTEX_INIT(&mutexp->tas)) {
+@@ -486,7 +486,7 @@ __db_tas_mutex_unlock(env, mutex)
+ 			F_CLR(mutexp, DB_MUTEX_LOCKED);
+ 			/* Flush flag update before zeroing count */
+ 			MEMBAR_EXIT();
+-			atomic_init(&mutexp->sharecount, 0);
++			atomic_init_db(&mutexp->sharecount, 0);
+ 		} else {
+ 			DB_ASSERT(env, sharecount > 0);
+ 			MEMBAR_EXIT();

--- a/depends/patches/miniupnpc/dont_leak_info.patch
+++ b/depends/patches/miniupnpc/dont_leak_info.patch
@@ -1,0 +1,32 @@
+commit 8815452257437ba36607d0e2381c01142d1c7bb0
+Author: fanquake <fanquake@gmail.com>
+Date:   Thu Nov 19 10:51:19 2020 +0800
+
+    Don't leak OS and miniupnpc version info in User-Agent
+
+diff --git a//minisoap.c b/minisoap.c
+index 7860667..775580b 100644
+--- a/minisoap.c
++++ b/minisoap.c
+@@ -90,7 +90,7 @@ int soapPostSubmit(SOCKET fd,
+ 	headerssize = snprintf(headerbuf, sizeof(headerbuf),
+                        "POST %s HTTP/%s\r\n"
+ 	                   "Host: %s%s\r\n"
+-					   "User-Agent: " OS_STRING ", " UPNP_VERSION_STRING ", MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
++					   "User-Agent: " UPNP_VERSION_STRING "\r\n"
+ 	                   "Content-Length: %d\r\n"
+ 					   "Content-Type: text/xml\r\n"
+ 					   "SOAPAction: \"%s\"\r\n"
+diff --git a/miniwget.c b/miniwget.c
+index d5b7970..05aeb9c 100644
+--- a/miniwget.c
++++ b/miniwget.c
+@@ -444,7 +444,7 @@ miniwget3(const char * host,
+                  "GET %s HTTP/%s\r\n"
+ 			     "Host: %s:%d\r\n"
+ 				 "Connection: Close\r\n"
+-				 "User-Agent: " OS_STRING ", " UPNP_VERSION_STRING ", MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
++				 "User-Agent: " UPNP_VERSION_STRING "\r\n"
+ 
+ 				 "\r\n",
+ 			   path, httpversion, host, port);

--- a/depends/patches/miniupnpc/respect_mingw_cflags.patch
+++ b/depends/patches/miniupnpc/respect_mingw_cflags.patch
@@ -1,0 +1,23 @@
+commit fec515a7ac9991a0ee91068fda046b54b191155e
+Author: fanquake <fanquake@gmail.com>
+Date:   Wed Jul 27 15:52:37 2022 +0100
+
+    build: respect CFLAGS in makefile.mingw
+    
+    Similar to the other Makefile.
+
+    Cherry-pick of https://github.com/miniupnp/miniupnp/pull/619.
+
+diff --git a/Makefile.mingw b/Makefile.mingw
+index 2bff7bd..88430d2 100644
+--- a/Makefile.mingw
++++ b/Makefile.mingw
+@@ -19,7 +19,7 @@ else
+ RM = rm -f
+ endif
+ #CFLAGS = -Wall -g -DDEBUG -D_WIN32_WINNT=0X501
+-CFLAGS = -Wall -W -Wstrict-prototypes -Os -DNDEBUG -D_WIN32_WINNT=0X501
++CFLAGS ?= -Wall -W -Wstrict-prototypes -Os -DNDEBUG -D_WIN32_WINNT=0X501
+ LDLIBS = -lws2_32 -liphlpapi
+ # -lwsock32
+ # -liphlpapi is needed for GetBestRoute() and GetIpAddrTable()


### PR DESCRIPTION
/kind chore

Update dependencies and pull recent patches from BTC conservatively with PIC based optimizations for the following:

- bdb
- libevent
- miniupnpc
- libevent update is required to remove deprecated usage of autoconf in 2.70+ and make it buildable.

This is an alternative PR for https://github.com/DeFiCh/ain/pull/1532 without ZeroMQ upstream updates. Reason: ZeroMQ updates also require additional dep updates for MacOS. 