### PR TITLE
Migrate stored Gov var unlock on split

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -1376,9 +1376,9 @@ Res ATTRIBUTES::Apply(CCustomCSView & mnview, const uint32_t height)
                     CGovernanceHeightMessage lock;
                     lock.startHeight = startHeight;
                     lock.govVar = govVar;
-                    const auto res = storeGovVars(lock, mnview);
+                    auto res = storeGovVars(lock, mnview);
                     if (!res) {
-                        return Res::Err("Cannot be set at or below current height");
+                        return res;
                     }
                 } else {
                     // Less than a day's worth of blocks, apply instant lock

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1803,8 +1803,7 @@ public:
         }
 
         // Validate GovVariables before storing
-        // TODO remove GW check after fork height. No conflict expected as attrs should not been set by height before.
-        if (height >= uint32_t(consensus.FortCanningCrunchHeight) && obj.govVar->GetName() == "ATTRIBUTES") {
+        if (obj.govVar->GetName() == "ATTRIBUTES") {
 
             auto govVar = mnview.GetAttributes();
             if (!govVar) {
@@ -1812,7 +1811,6 @@ public:
             }
 
             auto storedGovVars = mnview.GetStoredVariablesRange(height, obj.startHeight);
-            storedGovVars.emplace_back(obj.startHeight, obj.govVar);
 
             Res res{};
             CCustomCSView govCache(mnview);
@@ -1824,6 +1822,30 @@ public:
                         return Res::Err("%s: Cumulative application of Gov vars failed: %s", obj.govVar->GetName(), res.msg);
                     }
                 }
+            }
+
+            // After GW exclude TokenSplit if split will have already been performed by startHeight
+            if (height >= static_cast<uint32_t>(Params().GetConsensus().GrandCentralHeight)) {
+                if (const auto attrVar = std::dynamic_pointer_cast<ATTRIBUTES>(govVar); attrVar) {
+                    const auto attrMap = attrVar->GetAttributesMap();
+                    std::vector<CDataStructureV0> keysToErase;
+                    for (const auto& [key, value] : attrMap) {
+                        if (const auto attrV0 = std::get_if<CDataStructureV0>(&key); attrV0) {
+                            if (attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits && attrV0->key < obj.startHeight) {
+                                keysToErase.push_back(*attrV0);
+                            }
+                        }
+                    }
+                    for (const auto& key : keysToErase) {
+                        attrVar->EraseKey(key);
+                    }
+                }
+            }
+
+            if (!(res = govVar->Import(obj.govVar->Export())) ||
+                !(res = govVar->Validate(govCache)) ||
+                !(res = govVar->Apply(govCache, obj.startHeight))) {
+                return Res::Err("%s: Cumulative application of Gov vars failed: %s", obj.govVar->GetName(), res.msg);
             }
         } else {
             auto result = obj.govVar->Validate(mnview);

--- a/test/functional/feature_split_migrate_lock.py
+++ b/test/functional/feature_split_migrate_lock.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test token split migrate lock"""
+
+from test_framework.test_framework import DefiTestFramework
+
+from test_framework.util import assert_equal
+from decimal import Decimal
+import time
+
+class TokenSplitMigrateLockTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ['-vaultindex=1', '-txnotokens=0', '-amkheight=1', '-bayfrontheight=1', '-eunosheight=1', '-fortcanningheight=1', '-fortcanningmuseumheight=1', '-fortcanninghillheight=1', '-fortcanningroadheight=1', f'-fortcanningcrunchheight=200', f'-greatworldheight=200', '-subsidytest=1']]
+
+    def run_test(self):
+        self.setup_test_tokens()
+        self.test_unlock_migration()
+
+    def setup_test_tokens(self):
+        self.nodes[0].generate(101)
+
+        # Symbols
+        self.symbolDFI = 'DFI'
+        self.symbolGOOGL = 'GOOGL'
+
+        # Store address
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+
+        # Price feeds
+        price_feed = [
+            {"currency": "USD", "token": self.symbolGOOGL},
+        ]
+
+        # Appoint oracle
+        oracle_address = self.nodes[0].getnewaddress("", "legacy")
+        oracle = self.nodes[0].appointoracle(oracle_address, price_feed, 10)
+        self.nodes[0].generate(1)
+
+        # Set Oracle prices
+        oracle_prices = [
+            {"currency": "USD", "tokenAmount": f"1@{self.symbolGOOGL}"},
+        ]
+        self.nodes[0].setoracledata(oracle, int(time.time()), oracle_prices)
+        self.nodes[0].generate(10)
+
+        # Set loan tokens
+        self.nodes[0].setloantoken({
+            'symbol': self.symbolGOOGL,
+            'name': self.symbolGOOGL,
+            'fixedIntervalPriceId': f"{self.symbolGOOGL}/USD",
+            "isDAT": True,
+            'interest': 0
+        })
+        self.nodes[0].generate(1)
+
+        # Store token IDs
+        self.idGOOGL = list(self.nodes[0].gettoken(self.symbolGOOGL).keys())[0]
+
+        # Mint some loan tokens
+        self.nodes[0].minttokens([
+            f'1000000@{self.symbolGOOGL}',
+        ])
+        self.nodes[0].generate(1)
+
+    def test_unlock_migration(self):
+
+        # Move to FCC / GW
+        self.nodes[0].generate(200 - self.nodes[0].getblockcount())
+
+        # Define split height
+        split_height = self.nodes[0].getblockcount() + 11
+
+        # Lock token
+        self.nodes[0].setgovheight({"ATTRIBUTES":{f'v0/locks/token/{self.idGOOGL}':'true'}}, split_height - 2)
+        self.nodes[0].generate(1)
+
+        # Token split
+        self.nodes[0].setgovheight({"ATTRIBUTES":{f'v0/oracles/splits/{split_height}':f'{self.idGOOGL}/2'}}, split_height - 1)
+        self.nodes[0].generate(1)
+
+        # Token unlock
+        self.nodes[0].setgovheight({"ATTRIBUTES":{f'v0/locks/token/{self.idGOOGL}':'false'}}, split_height + 10)
+        self.nodes[0].generate(1)
+
+        # Move to split height
+        self.nodes[0].generate(split_height - self.nodes[0].getblockcount())
+
+        # Udpate token ID
+        self.idGOOGL = list(self.nodes[0].gettoken(self.symbolGOOGL).keys())[0]
+
+        # Check split successful
+        result = self.nodes[0].gettoken(self.symbolGOOGL)[f'{self.idGOOGL}']
+        assert_equal(result['minted'], Decimal('2000000.00000000'))
+
+        # Check stored token unlock has migrated
+        result = self.nodes[0].listgovs()[8][1]
+        assert_equal(result[f'{split_height + 10}'], {f'v0/locks/token/{self.idGOOGL}': 'false'})
+
+if __name__ == '__main__':
+    TokenSplitMigrateLockTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -183,6 +183,7 @@ BASE_SCRIPTS = [
     'feature_any_accounts_to_accounts.py',
     'feature_sendtokenstoaddress.py',
     'feature_poolswap.py',
+    'feature_split_migrate_lock.py',
     'feature_poolswap_composite.py',
     'feature_poolswap_mechanism.py',
     'feature_poolswap_mainnet.py',


### PR DESCRIPTION
* On split migrate any stored unlocks in Gov vars.
* Fixes issue with cumulative checks of Gov vars by removing token split entries if they will have already been removed by that height.