### PR TITLE
Fix CI deprecation warnings

### DIFF
--- a/.github/workflows/dev-builds.yaml
+++ b/.github/workflows/dev-builds.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       BUILD_VERSION: latest # Computed
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       BUILD_VERSION: latest # Computed
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       BUILD_VERSION: latest # Computed
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ on:
       - epic/*
       - v*
       - "[0-9]+.[0-9]+.x"
-      
+
 jobs:
   unit_tests:
     name: Lint
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       BUILD_VERSION: latest # Computed
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
@@ -44,7 +44,7 @@ jobs:
     # used by subsequent steps.
     - name: Set Env
       run: set -o errexit; source ./ci/test/00_setup_env.sh
-    
+
     # The following scripts must be run in the same step as they reference Bash functions from
     # previous scripts, which are difficult to expose globally in Github workflows
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     env:
       BUILD_VERSION: latest # Computed
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
@@ -40,11 +40,11 @@ jobs:
     steps:
     - name: Checkout base branch and/or merge
       if: github.event_name != 'pull_request'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout pull request head commit
       if: github.event_name == 'pull_request'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION

#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

- Updates actions/checkout to v3
- Updates actions to run on Ubuntu 20.04
