### PR TITLE
Run generate-matrix job on ci/sync tag

### DIFF
--- a/.github/workflows/fullsync-tests.yml
+++ b/.github/workflows/fullsync-tests.yml
@@ -43,6 +43,7 @@ jobs:
           ci/parallel_sync/sync_then_diff.sh
 
   generate-matrix:
+      if: contains(github.event.pull_request.labels.*.name, 'ci/sync')
       runs-on: [self-hosted, linux, x64]
 
       # Add "id-token" with the intended permissions.
@@ -89,11 +90,6 @@ jobs:
       DEFI_CLI_BIN: ./defi-cli
       REF_LOG_DIR: ${{github.base_ref}}-datadir/log
     timeout-minutes: 4320
-
-    # Add "id-token" with the intended permissions.
-    permissions:
-      contents: 'read'
-      id-token: 'write'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

- Only run generate-matrix job when other jobs are running
- Cleanup auth remnant 
