### PR TITLE
Fix CI full sync test

### DIFF
--- a/.github/workflows/fullsync-tests.yml
+++ b/.github/workflows/fullsync-tests.yml
@@ -122,10 +122,6 @@ jobs:
     - name: Sync and Diff
       run: ./sync_then_diff.sh
 
-    - name: Show debug.log
+    - name: Show Debug Log
       run: cat $DATADIR/debug.log
-      if: ${{ failure() ||  success() }}
-
-    - name: Show log file
-      run: cat $DATADIR/debug-tmp-$STOP_BLOCK.log
       if: ${{ failure() ||  success() }}

--- a/ci/parallel_sync/sync_then_diff.sh
+++ b/ci/parallel_sync/sync_then_diff.sh
@@ -75,9 +75,6 @@ main() {
     CUR_BLOCK=$($DEFI_CLI_CMD getblockcount || echo $BLOCK)
     if [ "$CUR_BLOCK" -eq "$BLOCK" ]; then
       ATTEMPTS=$((ATTEMPTS + 1))
-
-      # Handle odd case where node get stuck on previously invalidated block
-      $DEFI_CLI_CMD reconsiderblock $($DEFI_CLI_CMD getbestblockhash)
     else
       ATTEMPTS=0
     fi

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -658,13 +658,16 @@ static void TrackLiveBalance(CCustomCSView& mnview, const CTokenAmount& amount, 
     assert(attributes);
     CDataStructureV0 key{AttributeTypes::Live, ParamIDs::Economy, dataKey};
     auto balances = attributes->GetValue(key, CBalances{});
+    Res res{};
     if (add) {
-        balances.Add(amount);
+        res = balances.Add(amount);
     } else {
-        balances.Sub(amount);
+        res = balances.Sub(amount);
     }
-    attributes->SetValue(key, balances);
-    mnview.SetVariable(*attributes);
+    if (res) {
+        attributes->SetValue(key, balances);
+        mnview.SetVariable(*attributes);
+    }
 }
 
 void TrackNegativeInterest(CCustomCSView& mnview, const CTokenAmount& amount) {


### PR DESCRIPTION
Full sync tests fail due to subtract being called on zero value generating an error. Fix is to skip updating Governance variables when setting Add or Sub is in error.