### PR TITLE
Revert change to stake modifier

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -339,8 +339,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblock->deprecatedHeight = pindexPrev->nHeight + 1;
     pblock->nBits          = pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus);
     if (myIDs) {
-        const CKeyID key = nHeight >= consensus.GrandCentralHeight ? nodePtr->ownerAuthAddress : myIDs->first;
-        pblock->stakeModifier  = pos::ComputeStakeModifier(pindexPrev->stakeModifier, key);
+        pblock->stakeModifier  = pos::ComputeStakeModifier(pindexPrev->stakeModifier, myIDs->first);
     }
 
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[0]);

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -23,16 +23,6 @@ bool CheckStakeModifier(const CBlockIndex* pindexPrev, const CBlockHeader& block
         return error("%s: Can't extract minter key\n", __func__);
     }
 
-    if (pindexPrev->nHeight + 1 >= Params().GetConsensus().GrandCentralHeight) {
-        auto nodeId = pcustomcsview->GetMasternodeIdByOperator(key);
-        if (!nodeId) {
-            return error("%s: No master operator found with minter key\n", __func__);
-        }
-        auto nodePtr = pcustomcsview->GetMasternode(*nodeId);
-        assert(nodePtr);
-        key = nodePtr->ownerAuthAddress;
-    }
-
     return blockHeader.stakeModifier == pos::ComputeStakeModifier(pindexPrev->stakeModifier, key);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2648,9 +2648,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                                                                            __func__, nodeId->ToString(), nodePtr->mintedBlocks + 1, block.mintedBlocks), REJECT_INVALID, "bad-minted-blocks");
         }
         uint256 stakeModifierPrevBlock = pindex->pprev == nullptr ? uint256() : pindex->pprev->stakeModifier;
-        const CKeyID key = pindex->nHeight >= chainparams.GetConsensus().GrandCentralHeight ? nodePtr->ownerAuthAddress : nodePtr->operatorAuthAddress;
-        const auto stakeModifier = pos::ComputeStakeModifier(stakeModifierPrevBlock, key);
-        if (block.stakeModifier != stakeModifier) {            return state.Invalid(
+        const auto stakeModifier = pos::ComputeStakeModifier(stakeModifierPrevBlock, nodePtr->operatorAuthAddress);
+        if (block.stakeModifier != stakeModifier) {
+            return state.Invalid(
                     ValidationInvalidReason::CONSENSUS,
                     error("%s: block's stake Modifier should be %d, got %d!",
                             __func__, block.stakeModifier.ToString(), pos::ComputeStakeModifier(stakeModifierPrevBlock, nodePtr->operatorAuthAddress).ToString()),


### PR DESCRIPTION
This PR reverts the changes to the stake modifier made as part of the updatemasternode RPC call.

The original update masternode call allowed the operator address to the changed in a single block, as this was used as part of the stake modifier calculations this meant that an address could be pre-calculated that would allow the masternode to mint the next block and with another operator change the block after and so on. To combat this we changed the stake modifier to use the owner address instead.

Since that time we added the ability to change the owner address, but added a 1,008 block wait time before the change came into effect, making the stake modifier change redundant.