### PR TITLE
Move Gov var to feature category

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -196,7 +196,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys
                 {"gov",                         DFIPKeys::GovernanceEnabled},
                 {"consortium",                  DFIPKeys::ConsortiumEnabled},
                 {"members",                     DFIPKeys::Members},
-                {"cfp_automatic_payout",        DFIPKeys::CFPPayout},
+                {"gov-payout",                  DFIPKeys::CFPPayout},
             }
         },
         {
@@ -273,7 +273,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {DFIPKeys::GovernanceEnabled,       "gov"},
                 {DFIPKeys::ConsortiumEnabled,       "consortium"},
                 {DFIPKeys::Members,                 "members"},
-                {DFIPKeys::CFPPayout,               "cfp_automatic_payout"},
+                {DFIPKeys::CFPPayout,               "gov-payout"},
             }
         },
         {

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -196,13 +196,13 @@ const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys
                 {"gov",                         DFIPKeys::GovernanceEnabled},
                 {"consortium",                  DFIPKeys::ConsortiumEnabled},
                 {"members",                     DFIPKeys::Members},
+                {"cfp_automatic_payout",        DFIPKeys::CFPPayout},
             }
         },
         {
             AttributeTypes::Governance, {
                 {"fee_redistribution",          GovernanceKeys::FeeRedistribution},
                 {"fee_burn_pct",                GovernanceKeys::FeeBurnPct},
-                {"cfp_automatic_payout",        GovernanceKeys::CFPPayout},
                 {"cfp_fee",                     GovernanceKeys::CFPFee},
                 {"cfp_required_votes",          GovernanceKeys::CFPMajority},
                 {"voc_fee",                     GovernanceKeys::VOCFee},
@@ -273,6 +273,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {DFIPKeys::GovernanceEnabled,       "gov"},
                 {DFIPKeys::ConsortiumEnabled,       "consortium"},
                 {DFIPKeys::Members,                 "members"},
+                {DFIPKeys::CFPPayout,               "cfp_automatic_payout"},
             }
         },
         {
@@ -299,7 +300,6 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
             AttributeTypes::Governance, {
                 {GovernanceKeys::FeeRedistribution,     "fee_redistribution"},
                 {GovernanceKeys::FeeBurnPct,            "fee_burn_pct"},
-                {GovernanceKeys::CFPPayout,             "cfp_automatic_payout"},
                 {GovernanceKeys::CFPFee,                "cfp_fee"},
                 {GovernanceKeys::CFPMajority,           "cfp_required_votes"},
                 {GovernanceKeys::VOCFee,                "voc_fee"},
@@ -603,6 +603,7 @@ const std::map<uint8_t, std::map<uint8_t,
                 {DFIPKeys::GovernanceEnabled,       VerifyBool},
                 {DFIPKeys::ConsortiumEnabled,       VerifyBool},
                 {DFIPKeys::Members,                 VerifyMember},
+                {DFIPKeys::CFPPayout,               VerifyBool},
             }
         },
         {
@@ -619,7 +620,6 @@ const std::map<uint8_t, std::map<uint8_t,
             AttributeTypes::Governance, {
                 {GovernanceKeys::FeeRedistribution,     VerifyBool},
                 {GovernanceKeys::FeeBurnPct,            VerifyPct},
-                {GovernanceKeys::CFPPayout,             VerifyBool},
                 {GovernanceKeys::CFPFee,                VerifyPct},
                 {GovernanceKeys::CFPMajority,           VerifyPct},
                 {GovernanceKeys::VOCFee,                VerifyPositiveFloat},
@@ -832,7 +832,8 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, std::optional<std::strin
                     typeKey != DFIPKeys::MNSetOperatorAddress &&
                     typeKey != DFIPKeys::MNSetOwnerAddress &&
                     typeKey != DFIPKeys::GovernanceEnabled &&
-                    typeKey != DFIPKeys::ConsortiumEnabled) {
+                    typeKey != DFIPKeys::ConsortiumEnabled &&
+                    typeKey != DFIPKeys::CFPPayout) {
                     return Res::Err("Unsupported type for Feature {%d}", typeKey);
                 }
             } else if (typeId == ParamIDs::Foundation)  {
@@ -845,7 +846,7 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, std::optional<std::strin
         } else if (type == AttributeTypes::Governance) {
             if (typeId == GovernanceIDs::Proposals) {
                 if (typeKey != GovernanceKeys::FeeRedistribution && typeKey != GovernanceKeys::FeeBurnPct
-                    && typeKey != GovernanceKeys::CFPPayout && typeKey != GovernanceKeys::CFPFee
+                    && typeKey != GovernanceKeys::CFPFee
                     && typeKey != GovernanceKeys::CFPMajority && typeKey != GovernanceKeys::VOCFee
                     && typeKey != GovernanceKeys::VOCMajority && typeKey != GovernanceKeys::VOCEmergencyPeriod
                     && typeKey != GovernanceKeys::VOCEmergencyFee && typeKey != GovernanceKeys::VOCEmergencyQuorum

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -83,12 +83,12 @@ enum DFIPKeys : uint8_t  {
     ConsortiumEnabled       = 'o',
     Members                 = 'p',
     GovernanceEnabled       = 'q',
+    CFPPayout               = 'r',
 };
 
 enum GovernanceKeys : uint8_t  {
     FeeRedistribution       = 'a',
     FeeBurnPct              = 'b',
-    CFPPayout               = 'c',
     CFPFee                  = 'd',
     CFPMajority             = 'e',
     VOCFee                  = 'f',

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4274,7 +4274,7 @@ void CChainState::ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView
             cache.UpdatePropCycle(propId, prop.cycle + 1);
         }
 
-        CDataStructureV0 payoutKey{AttributeTypes::Governance, GovernanceIDs::Proposals, GovernanceKeys::CFPPayout};
+        CDataStructureV0 payoutKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::CFPPayout};
 
         if (prop.type == CPropType::CommunityFundProposal && attributes->GetValue(payoutKey, false)) {
             auto res = cache.SubCommunityBalance(CommunityAccountType::CommunityDevFunds, prop.nAmount);

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -108,7 +108,7 @@ class ChainGornmentTest(DefiTestFramework):
         assert("proposal context cannot be more than 512 bytes" in errorString)
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/fee_redistribution':'true'}})
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/cfp_automatic_payout':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/cfp_automatic_payout':'true'}})
 
         # Create CFP
         tx = self.nodes[0].creategovcfp({"title": title, "context": context, "amount": 100, "cycles": 2, "payoutAddress": address})
@@ -284,7 +284,7 @@ class ChainGornmentTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listgovproposals("all", "rejected")), 1)
 
         self.nodes[0].setgov({"ATTRIBUTES":{
-            'v0/gov/proposals/cfp_automatic_payout':'false',
+            'v0/params/feature/cfp_automatic_payout':'false',
             'v0/gov/proposals/cfp_fee':'0.25',
             'v0/gov/proposals/voting_period':'100',
         }})
@@ -408,7 +408,7 @@ class ChainGornmentTest(DefiTestFramework):
         title = 'Emergency VOC'
 
         self.nodes[0].setgov({"ATTRIBUTES":{
-            'v0/gov/proposals/cfp_automatic_payout':'true',
+            'v0/params/feature/cfp_automatic_payout':'true',
             'v0/gov/proposals/voc_emergency_period': f'{emergencyPeriod}',
             'v0/gov/proposals/voc_emergency_fee':'20.00000000',
             'v0/gov/proposals/voc_required_votes':'0.4999'

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -108,7 +108,7 @@ class ChainGornmentTest(DefiTestFramework):
         assert("proposal context cannot be more than 512 bytes" in errorString)
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/fee_redistribution':'true'}})
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/cfp_automatic_payout':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/gov-payout':'true'}})
 
         # Create CFP
         tx = self.nodes[0].creategovcfp({"title": title, "context": context, "amount": 100, "cycles": 2, "payoutAddress": address})
@@ -284,7 +284,7 @@ class ChainGornmentTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listgovproposals("all", "rejected")), 1)
 
         self.nodes[0].setgov({"ATTRIBUTES":{
-            'v0/params/feature/cfp_automatic_payout':'false',
+            'v0/params/feature/gov-payout':'false',
             'v0/gov/proposals/cfp_fee':'0.25',
             'v0/gov/proposals/voting_period':'100',
         }})
@@ -408,7 +408,7 @@ class ChainGornmentTest(DefiTestFramework):
         title = 'Emergency VOC'
 
         self.nodes[0].setgov({"ATTRIBUTES":{
-            'v0/params/feature/cfp_automatic_payout':'true',
+            'v0/params/feature/gov-payout':'true',
             'v0/gov/proposals/voc_emergency_period': f'{emergencyPeriod}',
             'v0/gov/proposals/voc_emergency_fee':'20.00000000',
             'v0/gov/proposals/voc_required_votes':'0.4999'

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -63,7 +63,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.sync_blocks()
 
         # Activate payout on second cycle
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/cfp_automatic_payout':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/gov-payout':'true'}})
         self.nodes[0].generate(1)
 
         # Vote during second cycle

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -63,7 +63,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.sync_blocks()
 
         # Activate payout on second cycle
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/cfp_automatic_payout':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/cfp_automatic_payout':'true'}})
         self.nodes[0].generate(1)
 
         # Vote during second cycle


### PR DESCRIPTION
Move the Gov var to enable CFP payouts automatically to the feature category.