### PR TITLE
Full sync CI generate-matrix job remove last available snapshot

### DIFF
--- a/.github/workflows/fullsync-tests.yml
+++ b/.github/workflows/fullsync-tests.yml
@@ -70,7 +70,7 @@ jobs:
         - id: set-matrix
           run: |
             SNAPSHOTS=$(gsutil ls gs://team-drop/${{github.base_ref}}-datadir)
-            BLOCKS=$(echo "$SNAPSHOTS" | sed -e 's/.*\-\(.*\)\.tar.*/\1/' | grep -v gs | sort -n)
+            BLOCKS=$(echo "$SNAPSHOTS" | sed -e 's/.*\-\(.*\)\.tar.*/\1/' | grep -v gs | sort -n | head -n -1)
             JSON=$(jq -n -c -M --arg blocks "$BLOCKS" '{blocks: ($blocks | split("\n") | .[] |= tonumber | to_entries | map({start: .value , stop: (.value + 50000)}))}')
             echo "::set-output name=matrix::$JSON"
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

- Full sync CI should not use last available snapshot. The reference log won't be available at this point.