### PR TITLE
Throw better errors when invalid global mint limits are set

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -363,6 +363,15 @@ ResVal<CAttributeValue> VerifyPositiveFloat(const std::string& str) {
     return {amount, Res::Ok()};
 }
 
+ResVal<CAttributeValue> VerifyPositiveOrUnlimitedFloat(const std::string& str) {
+    CAmount amount = 0;
+    if (!ParseFixedPoint(str, 8, &amount) || !(amount > 0 || amount == -1 * COIN)) {
+        return Res::Err("Amount must be positive or -1");
+    }
+
+    return {amount, Res::Ok()};
+}
+
 static ResVal<CAttributeValue> VerifyPct(const std::string& str) {
     std::string val = str;
     bool isPct = (val.size() > 0 && val.back() == '%');
@@ -569,8 +578,8 @@ const std::map<uint8_t, std::map<uint8_t,
         {
             AttributeTypes::Consortium, {
                 {ConsortiumKeys::MemberValues,          VerifyConsortiumMember},
-                {ConsortiumKeys::MintLimit,        VerifyFloat},
-                {ConsortiumKeys::DailyMintLimit,   VerifyFloat},
+                {ConsortiumKeys::MintLimit,             VerifyPositiveOrUnlimitedFloat},
+                {ConsortiumKeys::DailyMintLimit,        VerifyPositiveOrUnlimitedFloat},
             }
         },
         {

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -363,7 +363,7 @@ ResVal<CAttributeValue> VerifyPositiveFloat(const std::string& str) {
     return {amount, Res::Ok()};
 }
 
-ResVal<CAttributeValue> VerifyPositiveOrUnlimitedFloat(const std::string& str) {
+ResVal<CAttributeValue> VerifyPositiveOrMinusOneFloat(const std::string& str) {
     CAmount amount = 0;
     if (!ParseFixedPoint(str, 8, &amount) || !(amount > 0 || amount == -1 * COIN)) {
         return Res::Err("Amount must be positive or -1");
@@ -578,8 +578,8 @@ const std::map<uint8_t, std::map<uint8_t,
         {
             AttributeTypes::Consortium, {
                 {ConsortiumKeys::MemberValues,          VerifyConsortiumMember},
-                {ConsortiumKeys::MintLimit,             VerifyPositiveOrUnlimitedFloat},
-                {ConsortiumKeys::DailyMintLimit,        VerifyPositiveOrUnlimitedFloat},
+                {ConsortiumKeys::MintLimit,             VerifyPositiveOrMinusOneFloat},
+                {ConsortiumKeys::DailyMintLimit,        VerifyPositiveOrMinusOneFloat},
             }
         },
         {

--- a/test/functional/feature_consortium.py
+++ b/test/functional/feature_consortium.py
@@ -509,5 +509,11 @@ class ConsortiumTest (DefiTestFramework):
                                                                                             "dailyMintLimit":1.00000000, \
                                                                                             "mintLimit":1.00000000}}'}})
 
+        # Throw error for invalid values
+        assert_raises_rpc_error(-5, "Amount must be positive or -1", self.nodes[0].setgov, {
+            "ATTRIBUTES": {'v0/consortium/' + idBTC + '/mint_limit': '-2'}})
+        assert_raises_rpc_error(-5, "Amount must be positive or -1", self.nodes[0].setgov, {
+            "ATTRIBUTES": {'v0/consortium/' + idBTC + '/mint_limit': '0'}})
+
 if __name__ == '__main__':
     ConsortiumTest().main()


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:

The current implementation throws an ambiguous `Mint limit higher than global mint limit` error when the mint limit is set to 0 or any negative value other than -1. This PR changes the error to say `Amount must be positive or -1`.