### PR TITLE
Do not require input from new owner address

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1090,9 +1090,6 @@ public:
                 if (tx.vout.size() == 1) {
                     return Res::Err("Missing new collateral output");
                 }
-                if (!HasAuth(tx.vout[1].scriptPubKey)) {
-                    return Res::Err("Missing auth input for new masternode owner");
-                }
 
                 CTxDestination dest;
                 if (!ExtractDestination(tx.vout[1].scriptPubKey, dest) || (dest.index() != PKHashType && dest.index() != WitV0KeyHashType)) {

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -394,8 +394,7 @@ UniValue updatemasternode(const JSONRPCRequest& request)
     CMutableTransaction rawTx(txVersion);
 
     CTransactionRef optAuthTx;
-    const CScript ownerScript = !metaObj["ownerAddress"].isNull() ? GetScriptForDestination(newOwnerDest) : GetScriptForDestination(ownerDest);
-    std::set<CScript> auths{ownerScript};
+    std::set<CScript> auths{GetScriptForDestination(ownerDest)};
     rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false, optAuthTx, request.params[2]);
 
     // Return change to owner address
@@ -437,7 +436,7 @@ UniValue updatemasternode(const JSONRPCRequest& request)
     if (!metaObj["ownerAddress"].isNull()) {
         if (const auto node = pcustomcsview->GetMasternode(nodeId)) {
             rawTx.vin.emplace_back(node->collateralTx.IsNull() ? nodeId : node->collateralTx, 1);
-            rawTx.vout.emplace_back(GetMnCollateralAmount(targetHeight), ownerScript);
+            rawTx.vout.emplace_back(GetMnCollateralAmount(targetHeight), GetScriptForDestination(newOwnerDest));
         } else {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("masternode %s does not exists", nodeIdStr));
         }


### PR DESCRIPTION
Allow transferring of MN to an address not owned by the wallet.