### PR TITLE
Add missing ownerAddress to getcustomtx

### DIFF
--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -84,16 +84,21 @@ public:
 
     void operator()(const CUpdateMasterNodeMessage& obj) const {
         rpcInfo.pushKV("id", obj.mnId.GetHex());
-        for (const auto& item : obj.updates) {
-            if (item.first == static_cast<uint8_t>(UpdateMasternodeType::OperatorAddress)) {
-                rpcInfo.pushKV("operatorAddress", EncodeDestination(item.second.first == PKHashType ?
-                                                                    CTxDestination(PKHash(item.second.second)) :
-                                                                    CTxDestination(WitnessV0KeyHash(item.second.second))));
-            } else if (item.first == static_cast<uint8_t>(UpdateMasternodeType::SetRewardAddress)) {
-                rpcInfo.pushKV("rewardAddress", EncodeDestination(item.second.first == PKHashType ?
-                                                                  CTxDestination(PKHash(item.second.second)) :
-                                                                  CTxDestination(WitnessV0KeyHash(item.second.second))));
-            } else if (item.first == static_cast<uint8_t>(UpdateMasternodeType::RemRewardAddress)) {
+        for (const auto& [updateType, addressPair] : obj.updates) {
+            const auto& [addressType, rawAddress] = addressPair;
+            if (updateType == static_cast<uint8_t>(UpdateMasternodeType::OperatorAddress)) {
+                rpcInfo.pushKV("operatorAddress", EncodeDestination(addressType == PKHashType ?
+                                                                    CTxDestination(PKHash(rawAddress)) :
+                                                                    CTxDestination(WitnessV0KeyHash(rawAddress))));
+            } else if (updateType == static_cast<uint8_t>(UpdateMasternodeType::OwnerAddress)) {
+                rpcInfo.pushKV("ownerAddress", EncodeDestination(addressType == PKHashType ?
+                                                                    CTxDestination(PKHash(rawAddress)) :
+                                                                    CTxDestination(WitnessV0KeyHash(rawAddress))));
+            } if (updateType == static_cast<uint8_t>(UpdateMasternodeType::SetRewardAddress)) {
+                rpcInfo.pushKV("rewardAddress", EncodeDestination(addressType == PKHashType ?
+                                                                  CTxDestination(PKHash(rawAddress)) :
+                                                                  CTxDestination(WitnessV0KeyHash(rawAddress))));
+            } else if (updateType == static_cast<uint8_t>(UpdateMasternodeType::RemRewardAddress)) {
                 rpcInfo.pushKV("rewardAddress", "");
             }
         }


### PR DESCRIPTION
The ability to change owner was added after the initial work, but updating getcustomtx to include the owner address was overlooked. This PR adds the missing ownerAddress.