### PR TITLE
Send unused emission to address

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,7 +291,7 @@ public:
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("8defichainDSTBurnAddressXXXXaCAuTq", *this));
 
         // Destination for unused emission
-        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("8Hw9iMi5u4qhfdb4ziod8gf7hHeMaexz8T", *this));
+        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("df1qlwvtdrh4a4zln3k56rqnx8chu8t0sqx36syaea", *this));
 
         genesis = CreateGenesisBlock(1587883831, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1231006505
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -290,6 +290,9 @@ public:
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("8defichainBurnAddressXXXXXXXdRQkSm", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("8defichainDSTBurnAddressXXXXaCAuTq", *this));
 
+        // Destination for unused emission
+        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("8Hw9iMi5u4qhfdb4ziod8gf7hHeMaexz8T", *this));
+
         genesis = CreateGenesisBlock(1587883831, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1231006505
         consensus.hashGenesisBlock = genesis.GetHash();
 
@@ -517,6 +520,9 @@ public:
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("7DefichainBurnAddressXXXXXXXdMUE5n", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("7DefichainDSTBurnAddressXXXXXzS4Hi", *this));
 
+        // Destination for unused emission
+        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("7HYC4WVAjJ5BGVobwbGTEzWJU8tzY3Kcjq", *this));
+
         genesis = CreateGenesisBlock(1586099762, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1296688602
         consensus.hashGenesisBlock = genesis.GetHash();
 
@@ -714,6 +720,9 @@ public:
 
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("7DefichainBurnAddressXXXXXXXdMUE5n", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("7DefichainDSTBurnAddressXXXXXzS4Hi", *this));
+
+        // Destination for unused emission
+        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("7HYC4WVAjJ5BGVobwbGTEzWJU8tzY3Kcjq", *this));
 
         genesis = CreateGenesisBlock(1585132338, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1296688602
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -916,6 +925,9 @@ public:
         // For testing send after Eunos: 93ViFmLeJVgKSPxWGQHmSdT5RbeGDtGW4bsiwQM2qnQyucChMqQ
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("mfdefichainDSTBurnAddressXXXZcE1vs", *this));
+
+        // Destination for unused emission
+        consensus.unusedEmission = GetScriptForDestination(DecodeDestination("mkzZWPwBVgdnwLSmXKW5SuUFMpm6C5ZPcJ", *this)); // cUUj4d9tkgJGwGBF7VwFvCpcFMuEpC8tYbduaCDexKMx8A8ntL7C
 
         if (isJellyfish) {
             std::vector<CTxOut> initdist;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -107,6 +107,8 @@ struct Params {
     CScript burnAddress;
     /** Previous burn address to transfer tokens from */
     CScript retiredBurnAddress;
+    /** Address to hold unused emission */
+    CScript unusedEmission;
 
     /** Struct to hold percentages for coinbase distribution.
      *  Percentages are calculated out of 10000 */

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -197,6 +197,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys
                 {"consortium",                  DFIPKeys::ConsortiumEnabled},
                 {"members",                     DFIPKeys::Members},
                 {"gov-payout",                  DFIPKeys::CFPPayout},
+                {"gov-unusedemission",          DFIPKeys::UnusedEmission},
             }
         },
         {
@@ -274,6 +275,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {DFIPKeys::ConsortiumEnabled,       "consortium"},
                 {DFIPKeys::Members,                 "members"},
                 {DFIPKeys::CFPPayout,               "gov-payout"},
+                {DFIPKeys::UnusedEmission,          "gov-unusedemission"},
             }
         },
         {
@@ -597,6 +599,7 @@ const std::map<uint8_t, std::map<uint8_t,
                 {DFIPKeys::GovernanceEnabled,       VerifyBool},
                 {DFIPKeys::ConsortiumEnabled,       VerifyBool},
                 {DFIPKeys::CFPPayout,               VerifyBool},
+                {DFIPKeys::UnusedEmission,          VerifyBool},
             }
         },
         {
@@ -822,7 +825,8 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::optional<UniV
                     typeKey != DFIPKeys::MNSetOwnerAddress &&
                     typeKey != DFIPKeys::GovernanceEnabled &&
                     typeKey != DFIPKeys::ConsortiumEnabled &&
-                    typeKey != DFIPKeys::CFPPayout) {
+                    typeKey != DFIPKeys::CFPPayout &&
+                    typeKey != DFIPKeys::UnusedEmission) {
                     return Res::Err("Unsupported type for Feature {%d}", typeKey);
                 }
             } else if (typeId == ParamIDs::Foundation)  {

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -197,7 +197,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>>& ATTRIBUTES::allowedKeys
                 {"consortium",                  DFIPKeys::ConsortiumEnabled},
                 {"members",                     DFIPKeys::Members},
                 {"gov-payout",                  DFIPKeys::CFPPayout},
-                {"gov-unusedemission",          DFIPKeys::UnusedEmission},
+                {"emission-unused-fund",        DFIPKeys::EmissionUnusedFund},
             }
         },
         {
@@ -275,7 +275,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>>& ATTRIBUTES::displayKeys
                 {DFIPKeys::ConsortiumEnabled,       "consortium"},
                 {DFIPKeys::Members,                 "members"},
                 {DFIPKeys::CFPPayout,               "gov-payout"},
-                {DFIPKeys::UnusedEmission,          "gov-unusedemission"},
+                {DFIPKeys::EmissionUnusedFund,      "emission-unused-fund"},
             }
         },
         {
@@ -599,7 +599,7 @@ const std::map<uint8_t, std::map<uint8_t,
                 {DFIPKeys::GovernanceEnabled,       VerifyBool},
                 {DFIPKeys::ConsortiumEnabled,       VerifyBool},
                 {DFIPKeys::CFPPayout,               VerifyBool},
-                {DFIPKeys::UnusedEmission,          VerifyBool},
+                {DFIPKeys::EmissionUnusedFund,      VerifyBool},
             }
         },
         {
@@ -826,7 +826,7 @@ Res ATTRIBUTES::ProcessVariable(const std::string& key, const std::optional<UniV
                     typeKey != DFIPKeys::GovernanceEnabled &&
                     typeKey != DFIPKeys::ConsortiumEnabled &&
                     typeKey != DFIPKeys::CFPPayout &&
-                    typeKey != DFIPKeys::UnusedEmission) {
+                    typeKey != DFIPKeys::EmissionUnusedFund) {
                     return Res::Err("Unsupported type for Feature {%d}", typeKey);
                 }
             } else if (typeId == ParamIDs::Foundation)  {

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -84,7 +84,7 @@ enum DFIPKeys : uint8_t  {
     Members                 = 'p',
     GovernanceEnabled       = 'q',
     CFPPayout               = 'r',
-    UnusedEmission          = 's',
+    EmissionUnusedFund          = 's',
 };
 
 enum GovernanceKeys : uint8_t  {

--- a/src/masternodes/govvariables/attributes.h
+++ b/src/masternodes/govvariables/attributes.h
@@ -84,6 +84,7 @@ enum DFIPKeys : uint8_t  {
     Members                 = 'p',
     GovernanceEnabled       = 'q',
     CFPPayout               = 'r',
+    UnusedEmission          = 's',
 };
 
 enum GovernanceKeys : uint8_t  {

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -480,6 +480,8 @@ UniValue listmasternodes(const JSONRPCRequest& request)
                },
     }.Check(request);
 
+    SyncWithValidationInterfaceQueue();
+
     if (auto res = GetRPCResultCache().TryGet(request)) return *res;
 
     bool verbose = true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2161,6 +2161,8 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                                     LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: txid=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
                             }
 
+                            nonUtxoTotal += subsidy;
+
                             continue;
                         }
                     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2145,7 +2145,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                                 continue;
                             }
                         } else if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::Options) {
-                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::UnusedEmission};
+                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
 
                             if (attributes->GetValue(enabledKey, false)) {
                                 res = mnview.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});

--- a/test/functional/feature_community_development_funds.py
+++ b/test/functional/feature_community_development_funds.py
@@ -40,7 +40,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
 
         self.sync_mempools()
         node0.generate(1)
-        self.sync_all()
+        self.sync_blocks()
         self.stop_node(2)
 
         assert_equal(node1.getbalances()['mine']['trusted'], Decimal("19.887464"))
@@ -48,7 +48,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
 
         # GrandCnetral hardfork height
         node0.generate(1)
-        self.sync_all(self.nodes[:2])
+        self.sync_blocks(self.nodes[:2])
 
         assert_equal(node1.getbalances()['mine']['trusted'], 2 * Decimal("19.887464"))
         assert_equal(node1.getbalances()['mine']['immature'], foundation['mine']['immature'] - Decimal("19.887464"))
@@ -60,7 +60,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
         # activate on-chain governance
         node0.setgov({"ATTRIBUTES":{'v0/params/feature/gov':'true'}})
         node0.generate(1)
-        self.sync_all(self.nodes[:2])
+        self.sync_blocks(self.nodes[:2])
 
         # check that funds are not trasfered yet before governance is activated
         assert_equal(node1.getaccount('2NCWAKfEehP3qibkLKYQjXaWMK23k4EDMVS'), [])
@@ -76,7 +76,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
         # activate on-chain governance
         node0.setgov({"ATTRIBUTES":{'v0/params/feature/gov':'false'}})
         node0.generate(1)
-        self.sync_all(self.nodes[:2])
+        self.sync_blocks(self.nodes[:2])
 
         # check that funds are not trasfered yet before governance is activated
         assert_equal(Decimal(node1.getaccount('2NCWAKfEehP3qibkLKYQjXaWMK23k4EDMVS')[0].split('@')[0]), balanceLessFee + 3*Decimal("19.887464"))
@@ -84,7 +84,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
 
         # foundation coins are locked
         node0.generate(2)
-        self.sync_all(self.nodes[:2])
+        self.sync_blocks(self.nodes[:2])
 
         print ("Reverting...")
         self.start_node(2)
@@ -121,6 +121,17 @@ class CommunityDevelopmentFunds(DefiTestFramework):
 
         foundation = node1.getbalances()
         assert_equal(foundation['mine']['trusted'], Decimal('2008.633864000'))
+
+        # Check unused emission address
+        assert_equal(node0.getaccount('mkzZWPwBVgdnwLSmXKW5SuUFMpm6C5ZPcJ'), [])
+
+        # Enable unused emission to address
+        node0.setgov({"ATTRIBUTES":{'v0/params/feature/gov-unusedemission':'true'}})
+        node0.generate(1)
+        self.sync_blocks(self.nodes[:2])
+
+        # Check unused balance now going to emission address
+        assert_equal(node0.getaccount('mkzZWPwBVgdnwLSmXKW5SuUFMpm6C5ZPcJ'), ['46.24546710@DFI'])
 
 if __name__ == '__main__':
     CommunityDevelopmentFunds().main ()

--- a/test/functional/feature_community_development_funds.py
+++ b/test/functional/feature_community_development_funds.py
@@ -126,7 +126,7 @@ class CommunityDevelopmentFunds(DefiTestFramework):
         assert_equal(node0.getaccount('mkzZWPwBVgdnwLSmXKW5SuUFMpm6C5ZPcJ'), [])
 
         # Enable unused emission to address
-        node0.setgov({"ATTRIBUTES":{'v0/params/feature/gov-unusedemission':'true'}})
+        node0.setgov({"ATTRIBUTES":{'v0/params/feature/emission-unused-fund':'true'}})
         node0.generate(1)
         self.sync_blocks(self.nodes[:2])
 


### PR DESCRIPTION
Quick implementation for DFIP-2211-B, sends unused emission to an address which can then be manually swapped for DUSD and burnt.