### PR TITLE
Fix BurnTokenMessage token accounting

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1442,10 +1442,6 @@ public:
             if (!HasAuth(obj.from))
                 return Res::Err("tx must have at least one input from account owner");
 
-            auto subMinted = mnview.SubMintedTokens(tokenId, amount);
-            if (!subMinted)
-                return subMinted;
-
             if (obj.burnType != CBurnTokensMessage::BurnType::TokenBurn)
                 return Res::Err("Currently only burn type 0 - TokenBurn is supported!");
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Removes the call of SubMintedTokens when tokens are sent to burn address as it is wrong to reduce the account of minted tokens.
