### PR TITLE
Save quorum and majorityThreshold in proposal. 

### DIFF
--- a/src/masternodes/proposals.cpp
+++ b/src/masternodes/proposals.cpp
@@ -53,10 +53,12 @@ Res CPropsView::CreateProp(const CPropId &propId, uint32_t height, const CCreate
     bool emergency = prop.options & CPropOption::Emergency;
     auto type      = static_cast<CPropType>(prop.type);
 
-    prop.creationHeight = height;
-    prop.votingPeriod   = (emergency ? GetEmergencyPeriodFromAttributes(type) : GetVotingPeriodFromAttributes());
-    prop.fee            = fee;
-    prop.feeBurnAmount  = MultiplyAmounts(fee, GetFeeBurnPctFromAttributes());
+    prop.creationHeight     = height;
+    prop.votingPeriod       = (emergency ? GetEmergencyPeriodFromAttributes(type) : GetVotingPeriodFromAttributes());
+    prop.approvalThreshold  = GetApprovalThresholdFromAttributes(type);
+    prop.quorum             = GetQuorumFromAttributes(type, emergency);
+    prop.fee                = fee;
+    prop.feeBurnAmount      = MultiplyAmounts(fee, GetFeeBurnPctFromAttributes());
 
     auto key = std::make_pair(uint8_t(CPropStatusType::Voting), propId);
     WriteBy<ByStatus>(key, static_cast<uint8_t>(1));
@@ -99,7 +101,7 @@ std::optional<CPropObject> CPropsView::GetProp(const CPropId &propId) {
 }
 
 Res CPropsView::UpdatePropCycle(const CPropId &propId, uint8_t cycle) {
-    if (cycle < 1 || cycle > 3)
+    if (cycle < 1 || cycle > MAX_CYCLES)
         return Res::Err("Cycle out of range");
 
     auto key    = std::make_pair(uint8_t(CPropStatusType::Voting), propId);
@@ -111,6 +113,17 @@ Res CPropsView::UpdatePropCycle(const CPropId &propId, uint8_t cycle) {
         return Res::Err("New cycle should be greater than old one");
 
     WriteBy<ByStatus>(key, cycle);
+
+    // Update values from attributes on each cycle
+    auto prop = GetProp(propId);
+    assert(prop);
+    bool emergency = prop->options & CPropOption::Emergency;
+    auto type      = static_cast<CPropType>(prop->type);
+
+    prop->approvalThreshold  = GetApprovalThresholdFromAttributes(type);
+    prop->quorum             = GetQuorumFromAttributes(type, emergency);
+    WriteBy<ByType>(propId, *prop);
+
     return Res::Ok();
 }
 

--- a/src/masternodes/proposals.h
+++ b/src/masternodes/proposals.h
@@ -93,6 +93,8 @@ struct CPropObject : public CCreatePropMessage {
     uint32_t proposalEndHeight{};
 
     uint32_t votingPeriod;
+    CAmount approvalThreshold;
+    CAmount quorum;
     CAmount fee;
     CAmount feeBurnAmount;
 
@@ -109,6 +111,8 @@ struct CPropObject : public CCreatePropMessage {
         READWRITE(creationHeight);
         READWRITE(proposalEndHeight);
         READWRITE(votingPeriod);
+        READWRITE(approvalThreshold);
+        READWRITE(quorum);
         READWRITE(fee);
         READWRITE(feeBurnAmount);
     }

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -7,8 +7,6 @@ UniValue propToJSON(CPropId const& propId, CPropObject const& prop, CCustomCSVie
 {
     auto type = static_cast<CPropType>(prop.type);
     bool emergency = prop.options & CPropOption::Emergency;
-    auto approvalThreshold = view.GetApprovalThresholdFromAttributes(type);
-    auto quorum = view.GetQuorumFromAttributes(type, emergency);
 
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("proposalId", propId.GetHex());
@@ -26,8 +24,8 @@ UniValue propToJSON(CPropId const& propId, CPropObject const& prop, CCustomCSVie
     ret.pushKV("proposalEndHeight", static_cast<int32_t>(prop.proposalEndHeight));
     ret.pushKV("payoutAddress", ScriptToString(prop.address));
     ret.pushKV("votingPeriod", static_cast<int32_t>(prop.votingPeriod));
-    ret.pushKV("approvalThreshold", strprintf("%d.%02d%%", approvalThreshold / 100, approvalThreshold % 100));
-    ret.pushKV("quorum", strprintf("%d.%02d%%", quorum / 100, quorum % 100));
+    ret.pushKV("approvalThreshold", strprintf("%d.%02d%%", prop.approvalThreshold / 100, prop.approvalThreshold % 100));
+    ret.pushKV("quorum", strprintf("%d.%02d%%", prop.quorum / 100, prop.quorum % 100));
     ret.pushKV("fee", ValueFromAmount(prop.fee));
     ret.pushKV("feeBurnAmount", ValueFromAmount(prop.feeBurnAmount));
     if (prop.options)
@@ -566,10 +564,8 @@ UniValue getgovproposal(const JSONRPCRequest& request)
     uint32_t votes = 0;
     auto type = static_cast<CPropType>(prop->type);
     bool emergency = prop->options & CPropOption::Emergency;
-    auto approvalThreshold = view.GetApprovalThresholdFromAttributes(type);
-    auto quorum = view.GetQuorumFromAttributes(type, emergency);
     auto allVotes = lround(voters * 10000.f / activeMasternodes.size());
-    auto valid = allVotes > quorum;
+    auto valid = allVotes > prop->quorum;
 
     if (valid) {
         votes = lround(voteYes * 10000.f / voters);
@@ -582,7 +578,7 @@ UniValue getgovproposal(const JSONRPCRequest& request)
     ret.pushKV("context", prop->context);
     ret.pushKV("contextHash", prop->contextHash);
     ret.pushKV("type", CPropTypeToString(type));
-    if (valid && votes >= approvalThreshold) {
+    if (valid && votes >= prop->approvalThreshold) {
         ret.pushKV("status", "Completed");
     } else {
         ret.pushKV("status", "Rejected");
@@ -593,8 +589,8 @@ UniValue getgovproposal(const JSONRPCRequest& request)
     ret.pushKV("proposalEndHeight", static_cast<int32_t>(prop->proposalEndHeight));
     ret.pushKV("payoutAddress", ScriptToString(prop->address));
     ret.pushKV("votingPeriod", static_cast<int32_t>(prop->votingPeriod));
-    ret.pushKV("approvalThreshold", strprintf("%d.%02d%%", approvalThreshold / 100, approvalThreshold % 100));
-    ret.pushKV("quorum", strprintf("%d.%02d%%", quorum / 100, quorum % 100));
+    ret.pushKV("approvalThreshold", strprintf("%d.%02d%%", prop->approvalThreshold / 100, prop->approvalThreshold % 100));
+    ret.pushKV("quorum", strprintf("%d.%02d%%", prop->quorum / 100, prop->quorum % 100));
     ret.pushKV("fee", ValueFromAmount(prop->fee));
     ret.pushKV("feeBurnAmount", ValueFromAmount(prop->feeBurnAmount));
 
@@ -610,9 +606,8 @@ UniValue getgovproposal(const JSONRPCRequest& request)
         ret.pushKV("options", array);
     }
 
-    ret.pushKV("votes", strprintf("%d.%02d of %d.%02d%%", votes / 100, votes % 100, approvalThreshold / 100, approvalThreshold % 100));
-    ret.pushKV("votingPercent", strprintf("%d.%02d of %d.%02d%%", allVotes / 100, allVotes % 100, quorum / 100, quorum % 100));
-
+    ret.pushKV("votes", strprintf("%d.%02d of %d.%02d%%", votes / 100, votes % 100, prop->approvalThreshold / 100, prop->approvalThreshold % 100));
+    ret.pushKV("votingPercent", strprintf("%d.%02d of %d.%02d%%", allVotes / 100, allVotes % 100, prop->quorum / 100, prop->quorum % 100));
 
     return ret;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4273,16 +4273,12 @@ void CChainState::ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView
         auto type = static_cast<CPropType>(prop.type);
         bool emergency = prop.options & CPropOption::Emergency;
 
-        auto quorum = cache.GetQuorumFromAttributes(type, emergency);
-
-        if (lround(voters.size() * 10000.f / activeMasternodes.size()) <= quorum) {
+        if (lround(voters.size() * 10000.f / activeMasternodes.size()) <= prop.quorum) {
             cache.UpdatePropStatus(propId, pindex->nHeight, CPropStatusType::Rejected);
             return true;
         }
 
-        auto approvalThreshold = cache.GetApprovalThresholdFromAttributes(type) / 10000;
-
-        if (lround(voteYes * 10000.f / voters.size()) <= approvalThreshold) {
+        if (lround(voteYes * 10000.f / voters.size()) <= prop.approvalThreshold) {
             cache.UpdatePropStatus(propId, pindex->nHeight, CPropStatusType::Rejected);
             return true;
         }

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -511,10 +511,10 @@ class CFPFeeDistributionTest(DefiTestFramework):
 
         # Vote and move to next cycle
         self.nodes[3].votegov(propId, self.mn3, "no")
-        self.nodes[3].generate(VOTING_PERIOD * 2)
+        self.nodes[3].generate(VOTING_PERIOD)
         self.sync_blocks(timeout=120)
 
-        # First cycle should be approved
+        # First cycle should be completed
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -480,6 +480,55 @@ class CFPFeeDistributionTest(DefiTestFramework):
 
         self.rollback_to(height, nodes=[0, 1, 2, 3])
 
+    def test_cfp_state_after_update(self):
+        height = self.nodes[0].getblockcount()
+
+        # Create address for CFP
+        address = self.nodes[0].getnewaddress()
+        context = "<Git issue url>"
+        title = "Create test community fund request proposal without automatic payout"
+        amount = 100
+        # Create CFP
+        propId = self.nodes[0].creategovcfp({"title": title, "context": context, "amount": amount, "cycles": 1, "payoutAddress": address})
+
+        # Fund addresses
+        self.nodes[0].sendtoaddress(self.address1, Decimal("1.0"))
+        self.nodes[0].sendtoaddress(self.address2, Decimal("1.0"))
+        self.nodes[0].sendtoaddress(self.address3, Decimal("1.0"))
+        self.nodes[0].generate(1)
+        self.sync_blocks(timeout=120)
+
+        # Vote during first cycle
+        self.nodes[0].votegov(propId, self.mn0, "yes")
+        self.nodes[0].generate(1)
+        self.sync_blocks(timeout=120)
+        self.nodes[1].votegov(propId, self.mn1, "yes")
+        self.nodes[1].generate(1)
+        self.sync_blocks(timeout=120)
+        self.nodes[2].votegov(propId, self.mn2, "yes")
+        self.nodes[2].generate(1)
+        self.sync_blocks(timeout=120)
+
+        # Vote and move to next cycle
+        self.nodes[3].votegov(propId, self.mn3, "no")
+        self.nodes[3].generate(VOTING_PERIOD * 2)
+        self.sync_blocks(timeout=120)
+
+        # First cycle should be approved
+        proposal = self.nodes[0].getgovproposal(propId)
+        assert_equal(proposal['status'], 'Completed')
+
+        # Update quorum after end of proposal.
+        # 80% of masternodes should vote
+        self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/cfp_required_votes':'80%'}})
+        self.nodes[0].generate(1)
+
+        # Attributes change should not impact state of resolved proposals
+        proposal = self.nodes[0].getgovproposal(propId)
+        assert_equal(proposal['status'], 'Completed')
+
+        self.rollback_to(height, nodes=[0, 1, 2, 3])
+
     def setup(self):
         # Get MN addresses
         self.address1 = self.nodes[1].get_genesis_keys().ownerAuthAddress
@@ -542,6 +591,8 @@ class CFPFeeDistributionTest(DefiTestFramework):
 
         self.test_cfp_update_voc_emergency_period()
         self.test_cfp_update_voc_emergency_fee()
+
+        self.test_cfp_state_after_update()
 
 if __name__ == '__main__':
     CFPFeeDistributionTest().main ()


### PR DESCRIPTION


#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

- Saves quorum and majorityThreshold on proposal creation
- Updates quorum and majorityThreshold from attributes on each new cycle

#### Which issue(s) does this PR fixes?:

- Prevents quorum and majorityThreshold values being invalid for previous proposal after an attribute update