### PR TITLE
chore(osx_docs): install instructions for rust toolchain + protobuf compiler

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -103,6 +103,29 @@ You can monitor the download process by looking at the debug.log file:
 tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 ```
 
+## Installing the rust toolchain (MacOS M1)
+```shell
+# default installation
+curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
+# custom installation
+curl https://sh.rustup.rs -sSf | bash 
+
+PATH=~/.cargo/bin/cargo:$PATH
+rustup target add x86_64-apple-darwin
+```
+
+## Installing the protobuf compiler
+```shell
+PROTOC_ZIP=protoc-3.20.0-osx-x86_64.zip
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/$PROTOC_ZIP
+sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+rm -f $PROTOC_ZIP
+
+# ensure installation was successful by running 
+protoc --version
+```
+
 ## Other commands:
 ```shell
 ./src/defid -daemon      # Starts the defi daemon.
@@ -112,7 +135,7 @@ tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 
 ## Notes
 * Tested on OS X 10.10 Yosemite through macOS 10.14 Mojave on 64-bit Intel
-processors only.
+  processors only.
 
 ## Deterministic macOS DMG Notes
 Working macOS DMGs are created in Linux by combining a recent `clang`, the Apple

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -116,11 +116,7 @@ rustup target add aarch64-apple-darwin
 
 ## Installing the protobuf compiler
 ```shell
-PROTOC_ZIP=protoc-3.20.0-osx-x86_64.zip
-curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.20.0/$PROTOC_ZIP
-sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
-sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
-rm -f $PROTOC_ZIP
+brew install protobuf@3.20
 
 # ensure installation was successful by running 
 protoc --version

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -111,7 +111,7 @@ curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain stable -y
 curl https://sh.rustup.rs -sSf | bash 
 
 PATH=~/.cargo/bin/cargo:$PATH
-rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
 ```
 
 ## Installing the protobuf compiler


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:
adding install instruction for rust toolchain and protobuf compiler.
<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1618 

#### Additional comments?:
