### PR TITLE
Reduce range to previous value

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -142,7 +142,7 @@ class InvalidMessagesTest(DefiTestFramework):
         # Node is still up.
         conn = node.add_p2p_connection(P2PDataStore())
         conn.sync_with_ping()
-        assert(False)
+
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -67,8 +67,8 @@ class InvalidMessagesTest(DefiTestFramework):
 
         self.log.info("Sending a bunch of large, junk messages to test memory exhaustion. May take a bit...")
 
-        # Run a bunch of times to test for memory exhaustion.
-        for _ in range(80):
+        # Run a bunch of times to test for memory exhaustion. DeFi reduced to 40, was 80 before.
+        for _ in range(40):
             node.p2p.send_message(msg_at_size)
 
         # Check that, even though the node is being hammered by nonsense from one
@@ -142,7 +142,7 @@ class InvalidMessagesTest(DefiTestFramework):
         # Node is still up.
         conn = node.add_p2p_connection(P2PDataStore())
         conn.sync_with_ping()
-
+        assert(False)
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
 


### PR DESCRIPTION
Restore the previous DeFi specific value from a test that was updated from Bitcoin. The test updated runs successfully on Ubuntu 18 and 20 but fails on slow CI, possibly the reason this was reduced in the past.