### PR TITLE
Revert "Update Bitcoin DNS seeds (#1545)"

### DIFF
--- a/src/spv/bitcoin/BRChainParams.cpp
+++ b/src/spv/bitcoin/BRChainParams.cpp
@@ -27,15 +27,14 @@
 
 #include "BRChainParams.h"
 
-static const char* BRMainNetDNSSeeds[] = {
-    "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.", "seed.bitcoinstats.com.",
-    "seed.bitcoin.jonasschnelli.ch.", "seed.btc.petertodd.org.", "seed.bitcoin.sprovoost.nl.",
-    "dnsseed.emzy.de.", "seed.bitcoin.wiz.biz.", NULL
+static const char *BRMainNetDNSSeeds[] = {
+    "seed.breadwallet.com.", "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.",
+    "seed.bitcoinstats.com.", "bitseed.xf2.org.", "seed.bitcoin.jonasschnelli.ch.", NULL
 };
 
-static const char* BRTestNetDNSSeeds[] = {
-    "testnet-seed.bitcoin.jonasschnelli.ch.", "seed.tbtc.petertodd.org.", "seed.testnet.bitcoin.sprovoost.nl.",
-    "testnet-seed.bluematt.me.", NULL
+static const char *BRTestNetDNSSeeds[] = {
+    "testnet-seed.breadwallet.com.", "testnet-seed.bitcoin.petertodd.org.", "testnet-seed.bluematt.me.",
+    "testnet-seed.bitcoin.schildbach.de.", NULL
 };
 
 // blockchain checkpoints - these are also used as starting points for partial chain downloads, so they must be at


### PR DESCRIPTION
Reverts a change to the DNS seeds which results in heavy resolver usage. The seeds restored in this PR are the sames ones used in BreadWallet-Core today.

https://github.com/breadwallet/breadwallet-core/blob/73566cb79f753954eccbf07d5ab25ca54741198e/bitcoin/BRChainParams.c#L28-L36

The changes reverted by this PR resulted in ~37% of CPU time trying to resolve the new DNS seed entries. When testing the new entries one failed to resolve with a DNS query, presumably it is this entry that caused the issue with some aggressive DNS resolution loop.