### PR TITLE
Convert devnet into mirror testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -587,26 +587,26 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
-        consensus.AMKHeight = 0;
-        consensus.BayfrontHeight = 0;
-        consensus.BayfrontMarinaHeight = 0;
-        consensus.BayfrontGardensHeight = 0;
-        consensus.ClarkeQuayHeight = 0;
-        consensus.DakotaHeight = 10;
-        consensus.DakotaCrescentHeight = 10;
-        consensus.EunosHeight = 150;
+        consensus.AMKHeight = 150;
+        consensus.BayfrontHeight = 3000;
+        consensus.BayfrontMarinaHeight = 90470;
+        consensus.BayfrontGardensHeight = 101342;
+        consensus.ClarkeQuayHeight = 155000;
+        consensus.DakotaHeight = 220680;
+        consensus.DakotaCrescentHeight = 287700;
+        consensus.EunosHeight = 354950;
         consensus.EunosKampungHeight = consensus.EunosHeight;
-        consensus.EunosPayaHeight = 300;
-        consensus.FortCanningHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningMuseumHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningParkHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningHillHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningRoadHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningCrunchHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningSpringHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningGreatWorldHeight = std::numeric_limits<int>::max();
-        consensus.FortCanningEpilogueHeight = std::numeric_limits<int>::max();
-        consensus.GrandCentralHeight = std::numeric_limits<int>::max();
+        consensus.EunosPayaHeight = 463300;
+        consensus.FortCanningHeight = 686200;
+        consensus.FortCanningMuseumHeight = 724000;
+        consensus.FortCanningParkHeight = 828800;
+        consensus.FortCanningHillHeight = 828900;
+        consensus.FortCanningRoadHeight = 893700;
+        consensus.FortCanningCrunchHeight = 1011600;
+        consensus.FortCanningSpringHeight = 1086000;
+        consensus.FortCanningGreatWorldHeight = 1223000;
+        consensus.FortCanningEpilogueHeight = 1244000;
+        consensus.GrandCentralHeight = 1366000;
         consensus.GrandCentralNextHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -663,13 +663,13 @@ public:
 
         consensus.props.cfp.fee = COIN / 100; // 1%
         consensus.props.cfp.minimumFee = 10 * COIN; // 10 DFI
-        consensus.props.cfp.approvalThreshold = COIN / 2; // vote pass with over 50% majority
-        consensus.props.voc.fee = 5 * COIN;
+        consensus.props.cfp.approvalThreshold = COIN / 2; // vote pass with over 50%
+        consensus.props.voc.fee = 50 * COIN;
         consensus.props.voc.emergencyFee = 10000 * COIN;
-        consensus.props.voc.approvalThreshold = 66670000; // vote pass with over 66.67% majority
+        consensus.props.voc.approvalThreshold = 66670000; // vote pass with over 66.67%
         consensus.props.quorum = COIN / 100; // 1% of the masternodes must vote
-        consensus.props.votingPeriod = 100; // tally votes every 1K blocks
-        consensus.props.emergencyPeriod = 50;
+        consensus.props.votingPeriod = 70000; // tally votes every 70K blocks
+        consensus.props.emergencyPeriod = 8640;
         consensus.props.feeBurnPct = COIN / 2;
 
         consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
@@ -691,10 +691,11 @@ public:
         consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
         consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
-        pchMessageStartPostAMK[0] = pchMessageStart[0] = 0x0b;
-        pchMessageStartPostAMK[1] = pchMessageStart[1] = 0x11;
-        pchMessageStartPostAMK[2] = pchMessageStart[2] = 0x09;
-        pchMessageStartPostAMK[3] = pchMessageStart[3] = 0x07;
+        pchMessageStartPostAMK[0] = pchMessageStart[0] = 0x0c;
+        pchMessageStartPostAMK[1] = pchMessageStart[1] = 0x10;
+        pchMessageStartPostAMK[2] = pchMessageStart[2] = 0x10;
+        pchMessageStartPostAMK[3] = pchMessageStart[3] = 0x08;
+
         nDefaultPort = 20555; /// @note devnet matter
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 30;
@@ -713,9 +714,12 @@ public:
         consensus.foundationShare = 10; // old style - just percents
         consensus.foundationShareDFIP1 = 199 * COIN / 10 / 200; // 19.9 DFI @ 200 per block (rate normalized to (COIN == 100%)
 
-        // now it is for devnet and regtest only, 2 first of genesis MNs acts as foundation members
-        consensus.foundationMembers.emplace(GetScriptForDestination(DecodeDestination("7M3g9CSERjLdXisE5pv2qryDbURUj9Vpi1", *this)));
-        consensus.foundationMembers.emplace(GetScriptForDestination(DecodeDestination("7L29itepC13pgho1X2y7mcuf4WjkBi7x2w", *this)));
+        consensus.foundationMembers.clear();
+        consensus.foundationMembers.insert(consensus.foundationShareScript);
+
+        consensus.accountDestruction.clear();
+        consensus.accountDestruction.insert(GetScriptForDestination(DecodeDestination("trnZD2qPU1c3WryBi8sWX16mEaq9WkGHeg", *this))); // cVUZfDj1B1o7eVhxuZr8FQLh626KceiGQhZ8G6YCUdeW3CAV49ti
+        consensus.accountDestruction.insert(GetScriptForDestination(DecodeDestination("75jrurn8tkDLhZ3YPyzhk6D9kc1a4hBrmM", *this))); // cSmsVpoR6dSW5hPNKeGwC561gXHXcksdQb2yAFQdjbSp5MUyzZqr
 
         consensus.smartContracts.clear();
         consensus.smartContracts[SMART_CONTRACT_DFIP_2201] = GetScriptForDestination(CTxDestination(WitnessV0KeyHash(std::vector<unsigned char>{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0})));
@@ -723,16 +727,15 @@ public:
         consensus.smartContracts[SMART_CONTRACT_DFIP2206F] = GetScriptForDestination(CTxDestination(WitnessV0KeyHash(std::vector<unsigned char>{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2})));
 
         // owner base58, operator base58
-        vMasternodes.push_back({"7M3g9CSERjLdXisE5pv2qryDbURUj9Vpi1", "7Grgx69MZJ4wDKRx1bBxLqTnU9T3quKW7n"});
-        vMasternodes.push_back({"7L29itepC13pgho1X2y7mcuf4WjkBi7x2w", "773MiaEtQK2HAwWj55gyuRiU8tSwowRTTW"});
-        vMasternodes.push_back({"75Wramp2iARchHedXcn1qRkQtMpSt9Mi3V", "7Ku81yvqbPkxpWjZpZWZZnWydXyzJozZfN"});
-        vMasternodes.push_back({"7LfqHbyh9dBQDjWB6MxcWvH2PBC5iY4wPa", "75q6ftr3QGfBT3DBu15fVfetP6duAgfhNH"});
+        vMasternodes.push_back({"7LMorkhKTDjbES6DfRxX2RiNMbeemUkxmp", "7KEu9JMKCx6aJ9wyg138W3p42rjg19DR5D"});
+        vMasternodes.push_back({"7E8Cjn9cqEwnrc3E4zN6c5xKxDSGAyiVUM", "78MWNEcAAJxihddCw1UnZD8T7fMWmUuBro"});
+        vMasternodes.push_back({"7GxxMCh7sJsvRK4GXLX5Eyh9B9EteXzuum", "7MYdTGv3bv3z65ai6y5J1NFiARg8PYu4hK"});
+        vMasternodes.push_back({"7BQZ67KKYWSmVRukgv57m4HorjbGh7NWrQ", "7GULFtS6LuJfJEikByKKg8psscg84jnfHs"});
 
         std::vector<CTxOut> initdist;
-        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("7M3g9CSERjLdXisE5pv2qryDbURUj9Vpi1", *this))));
-        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("7L29itepC13pgho1X2y7mcuf4WjkBi7x2w", *this))));
-        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("75Wramp2iARchHedXcn1qRkQtMpSt9Mi3V", *this))));
-        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("7LfqHbyh9dBQDjWB6MxcWvH2PBC5iY4wPa", *this))));
+        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("te7wgg1X9HDJvMbrP2S51uz2Gxm2LPW4Gr", *this))));
+        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("tmYVkwmcv73Hth7hhHz15mx5K8mzC1hSef", *this))));
+        initdist.push_back(CTxOut(100000000 * COIN, GetScriptForDestination(DecodeDestination("tahuMwb9eX83eJhf2vXL6NPzABy3Ca8DHi", *this))));
 
         consensus.burnAddress = GetScriptForDestination(DecodeDestination("7DefichainBurnAddressXXXXXXXdMUE5n", *this));
         consensus.retiredBurnAddress = GetScriptForDestination(DecodeDestination("7DefichainDSTBurnAddressXXXXXzS4Hi", *this));
@@ -740,11 +743,11 @@ public:
         // Destination for unused emission
         consensus.unusedEmission = GetScriptForDestination(DecodeDestination("7HYC4WVAjJ5BGVobwbGTEzWJU8tzY3Kcjq", *this));
 
-        genesis = CreateGenesisBlock(1585132338, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1296688602
+        genesis = CreateGenesisBlock(1586099762, 0x1d00ffff, 1, initdist, CreateGenesisMasternodes()); // old=1296688602
         consensus.hashGenesisBlock = genesis.GetHash();
 
-        assert(consensus.hashGenesisBlock == uint256S("0x0000099a168f636895a019eacfc1798ec54c593c015cfc5aac1f12817f7ddff7"));
-        assert(genesis.hashMerkleRoot == uint256S("0x3f327ba2475176bcf8226b10d871f0f992e17ba9e040ff3dbd11d17c1e5914cb"));
+        assert(consensus.hashGenesisBlock == uint256S("0x034ac8c88a1a9b846750768c1ad6f295bc4d0dc4b9b418aee5c0ebd609be8f90"));
+        assert(genesis.hashMerkleRoot == uint256S("0xb71cfd828e692ca1b27e9df3a859740851047a5b5a68f659a908e8815aa35f38"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -758,9 +761,12 @@ public:
 
 
         checkpointData = {
-            {
-//                {546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
-            }
+                {
+                        { 50000, uint256S("74a468206b59bfc2667aba1522471ca2f0a4b7cd807520c47355b040c7735ccc")},
+                        {100000, uint256S("9896ac2c34c20771742bccda4f00f458229819947e02204022c8ff26093ac81f")},
+                        {150000, uint256S("af9307f438f5c378d1a49cfd3872173a07ed4362d56155e457daffd1061742d4")},
+                        {300000, uint256S("205b522772ce34206a08a635c800f99d2fc4e9696ab8c470dad7f5fa51dfea1a")},
+                }
         };
 
         chainTxData = ChainTxData{
@@ -768,7 +774,11 @@ public:
             /* nTxCount */ 0,
             /* dTxRate  */ 0
         };
+
+        UpdateActivationParametersFromArgs();
     }
+
+    void UpdateActivationParametersFromArgs();
 };
 
 /**
@@ -1091,6 +1101,18 @@ void CMainParams::UpdateActivationParametersFromArgs() {
 
         // Do this at the end, to ensure simualte mainnet overrides are in place.
         SetupCommonArgActivationParams(consensus);
+    }
+}
+
+
+void CDevNetParams::UpdateActivationParametersFromArgs() {
+    if (gArgs.IsArgSet("-devnet-bootstrap")) {
+        nDefaultPort = 18555;
+        vSeeds.emplace_back("testnet-seed.defichain.io");
+        pchMessageStartPostAMK[0] = 0x0b;
+        pchMessageStartPostAMK[1] = 0x11;
+        pchMessageStartPostAMK[2] = 0x09;
+        pchMessageStartPostAMK[3] = 0x07;
     }
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -22,6 +22,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-testnet", "Use the test chain", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-devnet", "Use the dev chain", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-devnet-bootstrap", "Use the dev chain and sync from testnet", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
 }
 
@@ -35,16 +36,21 @@ const CBaseChainParams& BaseParams()
 
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
-    if (chain == CBaseChainParams::MAIN)
+    if (chain == CBaseChainParams::MAIN) {
         return std::make_unique<CBaseChainParams>("", 8554);
-    else if (chain == CBaseChainParams::TESTNET)
+    } else if (chain == CBaseChainParams::TESTNET) {
         return std::make_unique<CBaseChainParams>("testnet3", 18554);
-    else if (chain == CBaseChainParams::DEVNET)
-        return std::make_unique<CBaseChainParams>("devnet", 20554);
-    else if (chain == CBaseChainParams::REGTEST)
+    } else if (chain == CBaseChainParams::DEVNET) {
+        if (gArgs.IsArgSet("-devnet-bootstrap")) {
+            return std::make_unique<CBaseChainParams>("devnet", 18554);
+        } else {
+            return std::make_unique<CBaseChainParams>("devnet", 20554);
+        }
+    } else if (chain == CBaseChainParams::REGTEST) {
         return std::make_unique<CBaseChainParams>("regtest", 19554);
-    else
+    } else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    }
 }
 
 void SelectBaseParams(const std::string& chain)

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -31,8 +31,9 @@ std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 
 int GetMnActivationDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight || (Params().NetworkIDString() == CBaseChainParams::TESTNET &&
-                                                         height >= Params().GetConsensus().FortCanningHeight)) {
+    if (height < Params().GetConsensus().EunosHeight ||
+       ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) &&
+       height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.activationDelay;
     }
 
@@ -41,8 +42,9 @@ int GetMnActivationDelay(int height) {
 
 int GetMnResignDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight || (Params().NetworkIDString() == CBaseChainParams::TESTNET &&
-                                                         height >= Params().GetConsensus().FortCanningHeight)) {
+    if (height < Params().GetConsensus().EunosHeight ||
+       ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) &&
+       height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.resignDelay;
     }
 

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 int GetMnActivationDelay(int height) {
     // Restore previous activation delay on testnet after FC
     if (height < Params().GetConsensus().EunosHeight ||
-       ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) &&
+       (IsTestNetwork() &&
        height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.activationDelay;
     }
@@ -43,7 +43,7 @@ int GetMnActivationDelay(int height) {
 int GetMnResignDelay(int height) {
     // Restore previous activation delay on testnet after FC
     if (height < Params().GetConsensus().EunosHeight ||
-       ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) &&
+       (IsTestNetwork() &&
        height >= Params().GetConsensus().FortCanningHeight)) {
         return Params().GetConsensus().mn.resignDelay;
     }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -2329,7 +2329,7 @@ public:
         // maker bonus only on fair dBTC/BTC (1:1) trades for now
         DCT_ID BTC = FindTokenByPartialSymbolName(CICXOrder::TOKEN_BTC);
         if (order->idToken == BTC && order->orderPrice == COIN) {
-            if ((Params().NetworkIDString() == CBaseChainParams::TESTNET && height >= 1250000) ||
+            if (((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && height >= 1250000) ||
                 Params().NetworkIDString() == CBaseChainParams::REGTEST) {
                 Require(TransferTokenBalance(DCT_ID{0}, offer->takerFee * 50 / 100, CScript(), order->ownerAddress));
             } else {
@@ -3776,7 +3776,7 @@ bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params &c
 
     // disable ICX orders for all networks other than testnet
     if (Params().NetworkIDString() == CBaseChainParams::REGTEST ||
-        (Params().NetworkIDString() == CBaseChainParams::TESTNET && static_cast<int>(height) >= 1250000)) {
+        ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && static_cast<int>(height) >= 1250000)) {
         return false;
     }
 

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -2329,7 +2329,7 @@ public:
         // maker bonus only on fair dBTC/BTC (1:1) trades for now
         DCT_ID BTC = FindTokenByPartialSymbolName(CICXOrder::TOKEN_BTC);
         if (order->idToken == BTC && order->orderPrice == COIN) {
-            if (((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && height >= 1250000) ||
+            if ((IsTestNetwork() && height >= 1250000) ||
                 Params().NetworkIDString() == CBaseChainParams::REGTEST) {
                 Require(TransferTokenBalance(DCT_ID{0}, offer->takerFee * 50 / 100, CScript(), order->ownerAddress));
             } else {
@@ -3776,7 +3776,7 @@ bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params &c
 
     // disable ICX orders for all networks other than testnet
     if (Params().NetworkIDString() == CBaseChainParams::REGTEST ||
-        ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && static_cast<int>(height) >= 1250000)) {
+        (IsTestNetwork() && static_cast<int>(height) >= 1250000)) {
         return false;
     }
 
@@ -4707,4 +4707,8 @@ Res storeGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view) {
 
     // Store GovVariable set by height
     return view.SetStoredVariables(storedGovVars, obj.startHeight);
+}
+
+bool IsTestNetwork() {
+    return Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET;
 }

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -497,6 +497,7 @@ Res SwapToDFIorDUSD(CCustomCSView &mnview,
                     uint32_t height,
                     bool forceLoanSwap = false);
 Res storeGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view);
+bool IsTestNetwork();
 
 inline bool OraclePriceFeed(CCustomCSView &view, const CTokenCurrencyPair &priceFeed) {
     // Allow hard coded DUSD/USD

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -147,7 +147,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, int64_t blockTim
     bool newDifficultyAdjust{nHeight > params.EunosHeight};
 
     // Restore previous difficulty adjust on testnet after FC
-    if (Params().NetworkIDString() == CBaseChainParams::TESTNET && nHeight >= params.FortCanningHeight) {
+    if ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && nHeight >= params.FortCanningHeight) {
         newDifficultyAdjust = false;
     }
 

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -7,6 +7,7 @@
 #include <key.h>
 #include <logging.h>
 #include <masternodes/masternodes.h>
+#include <masternodes/mn_checks.h>
 #include <sync.h>
 #include <validation.h>
 
@@ -147,7 +148,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, int64_t blockTim
     bool newDifficultyAdjust{nHeight > params.EunosHeight};
 
     // Restore previous difficulty adjust on testnet after FC
-    if ((Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::DEVNET) && nHeight >= params.FortCanningHeight) {
+    if (IsTestNetwork() && nHeight >= params.FortCanningHeight) {
         newDifficultyAdjust = false;
     }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -957,7 +957,7 @@ std::string ArgsManager::GetChainName() const
     LOCK(cs_args);
     int fRegTest = ArgsManagerHelper::GetNetBoolArg(*this, "-regtest") ? 1 : 0;
     int fTestNet = ArgsManagerHelper::GetNetBoolArg(*this, "-testnet") ? 1 : 0;
-    int fDevNet  = ArgsManagerHelper::GetNetBoolArg(*this, "-devnet") ? 1 : 0;
+    int fDevNet  = ArgsManagerHelper::GetNetBoolArg(*this, "-devnet") || ArgsManagerHelper::GetNetBoolArg(*this, "-devnet-bootstrap") ? 1 : 0;
 
     if (fTestNet + fDevNet + fRegTest > 1)
         throw std::runtime_error("Invalid combination of -regtest and -testnet."); // do not modify this message, it brakes unittests


### PR DESCRIPTION
Turn devnet into a mirror of testnet allowing us to test forks on the testnet blockchain in isolation from the actual testnet network. To facilitate this a start-up flag will be added to allow devnet to connect directly to testnet to bootstrap itself without having to manually swap data directories over. Once synced devnet can then run whatever changes are being proposed.

Start up flag `-devnet-bootstrap`, this is required for defid and defi-cli as below.

```
defid -daemon -devnet-bootstrap
defi-cli -devnet-bootstrap getconnectioncount
```

To prevent the testnet and devnet talking to each other accidentally a different magic number (pchMessageStart) is used for network communication, when `devnet-bootstrap` is set then the magic number is set to the same as testnet.