### PR TITLE
Resolve getcustomtx call with updatemasternode on owner transfer

### DIFF
--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -92,10 +92,10 @@ public:
                     EncodeDestination(addressType == PKHashType ? CTxDestination(PKHash(rawAddress))
                                                                 : CTxDestination(WitnessV0KeyHash(rawAddress))));
             } else if (updateType == static_cast<uint8_t>(UpdateMasternodeType::OwnerAddress)) {
-                rpcInfo.pushKV(
-                    "ownerAddress",
-                    EncodeDestination(addressType == PKHashType ? CTxDestination(PKHash(rawAddress))
-                                                                : CTxDestination(WitnessV0KeyHash(rawAddress))));
+                CTxDestination dest;
+                if (tx.vout.size() >= 2 && ExtractDestination(tx.vout[1].scriptPubKey, dest)) {
+                    rpcInfo.pushKV("ownerAddress",EncodeDestination(dest));
+                }
             }
             if (updateType == static_cast<uint8_t>(UpdateMasternodeType::SetRewardAddress)) {
                 rpcInfo.pushKV(

--- a/test/functional/rpc_updatemasternode.py
+++ b/test/functional/rpc_updatemasternode.py
@@ -443,13 +443,18 @@ class TestForcedRewardAddress(DefiTestFramework):
         assert_equal(result[mn6]['ownerAuthAddress'], new_mn6_owner)
 
         # Update MN to address not owned in wallet
-        self.nodes[0].updatemasternode(mn1, {'ownerAddress':foreign_owner})
+        tx = self.nodes[0].updatemasternode(mn1, {'ownerAddress':foreign_owner})
         self.nodes[0].generate(21)
 
         # Test new owner address
         result = self.nodes[0].listmasternodes()
         assert_equal(result[mn1]['state'], 'ENABLED')
         assert_equal(result[mn1]['ownerAuthAddress'], foreign_owner)
+
+        # Check result of getcustomtx for owner transfer
+        result = self.nodes[0].getcustomtx(tx)
+        assert_equal(result['results']['id'], mn1)
+        assert_equal(result['results']['ownerAddress'], foreign_owner)
 
 if __name__ == '__main__':
     TestForcedRewardAddress().main()


### PR DESCRIPTION
Resolves an issue that will crash the client due to a bug in getcustomtx and updatemasternode owner transfers. getcustomtx for owner transfer gets the new address from the TX message like with new reward and operator addresses, however the address should come from the TX output.