### PR TITLE
Allow direct fetch and reorgs on mocknet

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -585,6 +585,10 @@ static bool TipMayBeStale(const Consensus::Params &consensusParams) EXCLUSIVE_LO
 
 static bool CanDirectFetch(const Consensus::Params &consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    if (gArgs.GetBoolArg("-mocknet", false)) {
+        return true;
+    }
+
     return ::ChainActive().Tip()->GetBlockTime() > GetAdjustedTime() - consensusParams.pos.nTargetSpacing * 20;
 }
 
@@ -1815,7 +1819,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             // very large reorg at a time we think we're close to caught up to
             // the main chain -- this shouldn't really happen.  Bail out on the
             // direct fetch and rely on parallel download instead.
-            if (!::ChainActive().Contains(pindexWalk)) {
+            if (!::ChainActive().Contains(pindexWalk) && !gArgs.GetBoolArg("-mocknet", false)) {
                 LogPrint(BCLog::NET, "Large reorg, won't direct fetch to %s (%d)\n",
                         pindexLast->GetBlockHash().ToString(),
                         pindexLast->nHeight);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1216,6 +1216,10 @@ bool CChainState::IsInitialBlockDownload() const
     if (m_cached_finished_ibd.load(std::memory_order_relaxed))
         return false;
 
+    if (gArgs.GetBoolArg("-mocknet", false)) {
+        return false;
+    }
+
     LOCK(cs_main);
     if (m_cached_finished_ibd.load(std::memory_order_relaxed))
         return false;


### PR DESCRIPTION
Connecting multiple from genesis on mocknet nodes does not work due to IBD being true, fetch direct being disabled and large reorgs being disallowed. This PR changes these three stopping points when mocknet is enabled.