### PR TITLE
Fix start pagination for listgovproposals

### DIFF
--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -419,7 +419,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         title = "Create test community fund request proposal without automatic payout"
         amount = 100
         # Create CFP
-        propId = self.nodes[0].creategovvoc({"title": title, "context": context, "amount": amount, "payoutAddress": address, "emergency": True})
+        propId = self.nodes[0].creategovvoc({"title": title, "context": context, "emergency": True})
         self.nodes[0].generate(1)
         self.sync_blocks(timeout=120)
 
@@ -446,7 +446,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         title = "Create test community fund request proposal without automatic payout"
         amount = 100
         # Create CFP
-        propId = self.nodes[0].creategovvoc({"title": title, "context": context, "amount": amount, "payoutAddress": address})
+        propId = self.nodes[0].creategovvoc({"title": title, "context": context})
 
         # Fund addresses
         self.nodes[0].sendtoaddress(self.address1, Decimal("1.0"))

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -414,10 +414,8 @@ class CFPFeeDistributionTest(DefiTestFramework):
         height = self.nodes[0].getblockcount()
 
         # Create address for CFP
-        address = self.nodes[0].getnewaddress()
         context = "<Git issue url>"
         title = "Create test community fund request proposal without automatic payout"
-        amount = 100
         # Create CFP
         propId = self.nodes[0].creategovvoc({"title": title, "context": context, "emergency": True})
         self.nodes[0].generate(1)
@@ -441,10 +439,8 @@ class CFPFeeDistributionTest(DefiTestFramework):
         height = self.nodes[0].getblockcount()
 
         # Create address for CFP
-        address = self.nodes[0].getnewaddress()
         context = "<Git issue url>"
         title = "Create test community fund request proposal without automatic payout"
-        amount = 100
         # Create CFP
         propId = self.nodes[0].creategovvoc({"title": title, "context": context})
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
When using filters like `cycle` or `status` and pass `start` proposal id for pagination, it doesn't work correctly as it doesn't start from passed id. This PR solves it.
