### PR TITLE
Add lock before wallet backup

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -679,6 +679,9 @@ void MaybeCompactWalletDB()
 
 void AutoBackupWallet() {
     for (const std::shared_ptr<CWallet> &pwallet: GetWallets()) {
+        auto locked_chain = pwallet->chain().lock();
+        LOCK2(pwallet->cs_wallet, locked_chain->mutex());
+
         auto env = pwallet->GetDBHandle().env;
         std::string walletName = pwallet->GetName().empty() ? "default" : pwallet->GetName();
         fs::path prevBackup = env->Directory() / strprintf("auto.backup.%s.bak1", walletName);


### PR DESCRIPTION
When scheduler backs up the wallet make sure wallet locks are held before proceeding.