### PR TITLE
Add alias "special" for emergency VOC.

### DIFF
--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -290,6 +290,7 @@ UniValue creategovvoc(const JSONRPCRequest &request) {
                      RPCArg::Optional::OMITTED,
                      "The hash of the content which context field point to of vote of confidence request"},
                     {"emergency", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Is this emergency VOC"},
+                    {"special", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Preferred alias for emergency VOC"},
                 },
             }, {
                 "inputs",
@@ -333,7 +334,8 @@ UniValue creategovvoc(const JSONRPCRequest &request) {
                         {"title",       UniValue::VSTR },
                         {"context",     UniValue::VSTR },
                         {"contextHash", UniValue::VSTR },
-                        {"emergency",   UniValue::VBOOL}
+                        {"emergency",   UniValue::VBOOL},
+                        {"special",     UniValue::VBOOL}
     },
                     true,
                     true);
@@ -355,6 +357,8 @@ UniValue creategovvoc(const JSONRPCRequest &request) {
 
     if (!data["emergency"].isNull()) {
         emergency = data["emergency"].get_bool();
+    } else if (!data["special"].isNull()) {
+        emergency = data["special"].get_bool();
     }
 
     CCreatePropMessage pm;

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -554,7 +554,7 @@ class OnChainGovernanceTest(DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
-        tx = self.nodes[0].creategovvoc({"title": "Create vote of confidence custom fee custom majority", "context": "test context", "emergency": True})
+        tx = self.nodes[0].creategovvoc({"title": "Create vote of confidence custom fee custom majority", "context": "test context", "special": True})
         self.nodes[0].generate(1)
         self.sync_blocks()
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:
Add an ability to pass `special` argument of RPC instead of `emergency` for same effect.
