### PR TITLE
Fix `start` behaviour in `listgovproposals`

### DIFF
--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -801,10 +801,10 @@ void iterateProps(const T& list, UniValue& ret, const CPropId& start, bool inclu
         if (type && type != prop.second.type) {
             continue;
         }
-        if (start != CPropId{} && prop.first != start && !pastStart) {
+        if (prop.first == start)
             pastStart = true;
+        if (start != CPropId{} && prop.first != start && !pastStart)
             continue;
-        }
         if (!including_start) {
             including_start = true;
             continue;

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -793,15 +793,19 @@ UniValue getgovproposal(const JSONRPCRequest &request) {
 template <typename T>
 void iterateProps(const T& list, UniValue& ret, const CPropId& start, bool including_start, size_t limit, const uint8_t type, const uint8_t status)
 {
+    bool pastStart = false;
     for (const auto &prop : list) {
+        LogPrintf("%s\n", including_start);
         if (status && status != prop.second.status) {
             continue;
         }
         if (type && type != prop.second.type) {
             continue;
         }
-        if (start != CPropId{} && prop.first != start)
+        if (start != CPropId{} && prop.first != start && !pastStart) {
+            pastStart = true;
             continue;
+        }
         if (!including_start) {
             including_start = true;
             continue;

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -795,7 +795,6 @@ void iterateProps(const T& list, UniValue& ret, const CPropId& start, bool inclu
 {
     bool pastStart = false;
     for (const auto &prop : list) {
-        LogPrintf("%s\n", including_start);
         if (status && status != prop.second.status) {
             continue;
         }

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -619,6 +619,11 @@ class OnChainGovernanceTest(DefiTestFramework):
             len(self.nodes[1].listgovproposalvotes({"proposalId": tx,  "masternode": "all", "cycle": -1, "pagination": {"start": 0, "including_start": True, "limit": 0}})),
             3)
 
+        # should return all entries if limit is 0
+        assert_equal(
+            len(self.nodes[1].listgovproposalvotes({"proposalId": tx,  "masternode": "all", "cycle": -1, "pagination": {"start": 0, "including_start": False, "limit": 0}})),
+            2)
+
         # should respect filters
         assert_equal(len(self.nodes[1].listgovproposalvotes({"proposalId": tx,  "masternode": mn1, "cycle": -1, "pagination": {"start": 0}})), 0)
 
@@ -661,6 +666,7 @@ class OnChainGovernanceTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listgovproposals({"status": "voting"})), 3)
         assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": True, "limit": 1}})[0]["proposalId"], tx1)
         assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx3, "including_start": True, "limit": 1}})[0]["proposalId"], tx3)
+        assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": False, "limit": 1}})[0]["proposalId"], tx2)
 
 if __name__ == '__main__':
     OnChainGovernanceTest().main ()

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -666,7 +666,19 @@ class OnChainGovernanceTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listgovproposals({"status": "voting"})), 3)
         assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": True, "limit": 1}})[0]["proposalId"], tx1)
         assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx3, "including_start": True, "limit": 1}})[0]["proposalId"], tx3)
-        assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": False, "limit": 1}})[0]["proposalId"], tx2)
+
+        allProposals = self.nodes[0].listgovproposals({"status": "voting"})
+        nextProposal = []
+        for i in range(len(allProposals)):
+            if allProposals[i]["proposalId"] == tx1:
+                if i < len(allProposals) - 1:
+                    nextProposal = [allProposals[i + 1]]
+                else:
+                    # when tx1 is the last listed proposal
+                    nextProposal = []
+                break
+
+        assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": False, "limit": 1}}), nextProposal)
 
 if __name__ == '__main__':
-    OnChainGovernanceTest().main ()
+    OnChainGovernanceTest().main()

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -673,9 +673,7 @@ class OnChainGovernanceTest(DefiTestFramework):
             if allProposals[i]["proposalId"] == tx1:
                 if i < len(allProposals) - 1:
                     nextProposal = [allProposals[i + 1]]
-                else:
-                    # when tx1 is the last listed proposal
-                    nextProposal = []
+                # otherwise tx1 is the last proposal
                 break
 
         assert_equal(self.nodes[0].listgovproposals({"status": "voting", "pagination": {"start": tx1, "including_start": False, "limit": 1}}), nextProposal)


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:

When start is set, only start is added to ret (subsequent entries do not pass through). This PR fixes the behavior to return all values after `start`.
