### PR TITLE
Update devnet with latest testnet hard fork height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -607,7 +607,7 @@ public:
         consensus.FortCanningGreatWorldHeight = 1223000;
         consensus.FortCanningEpilogueHeight = 1244000;
         consensus.GrandCentralHeight = 1366000;
-        consensus.GrandCentralEpilogueHeight = std::numeric_limits<int>::max();
+        consensus.GrandCentralEpilogueHeight = 1438200;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks


### PR DESCRIPTION
When testnet has a fork height set the same height should be set on devnet.