### PR TITLE
Add lambda support to Require

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -125,7 +125,7 @@ struct CTokenAmount { // simple std::pair is less informative
 
     Res Add(CAmount amount) {
         // safety checks
-        Require(amount >= 0, "negative amount: %s", GetDecimaleString(amount));
+        Require(amount >= 0, [&]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
 
         // add
         auto sumRes = SafeAdd(nValue, amount);
@@ -137,8 +137,8 @@ struct CTokenAmount { // simple std::pair is less informative
 
     Res Sub(CAmount amount) {
         // safety checks
-        Require(amount >= 0, "negative amount: %s", GetDecimaleString(amount));
-        Require(nValue >= amount, "amount %s is less than %s", GetDecimaleString(nValue), GetDecimaleString(amount));
+        Require(amount >= 0, [&]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
+        Require(nValue >= amount, [&]{ return strprintf("amount %s is less than %s", GetDecimaleString(nValue), GetDecimaleString(amount)); });
 
         // sub
         nValue -= amount;

--- a/src/amount.h
+++ b/src/amount.h
@@ -125,7 +125,7 @@ struct CTokenAmount { // simple std::pair is less informative
 
     Res Add(CAmount amount) {
         // safety checks
-        Require(amount >= 0, [&]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
+        Require(amount >= 0, [=]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
 
         // add
         auto sumRes = SafeAdd(nValue, amount);
@@ -137,8 +137,8 @@ struct CTokenAmount { // simple std::pair is less informative
 
     Res Sub(CAmount amount) {
         // safety checks
-        Require(amount >= 0, [&]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
-        Require(nValue >= amount, [&]{ return strprintf("amount %s is less than %s", GetDecimaleString(nValue), GetDecimaleString(amount)); });
+        Require(amount >= 0, [=]{ return strprintf("negative amount: %s", GetDecimaleString(amount)); });
+        Require(nValue >= amount, [=]{ return strprintf("amount %s is less than %s", GetDecimaleString(nValue), GetDecimaleString(amount)); });
 
         // sub
         nValue -= amount;

--- a/src/masternodes/res.h
+++ b/src/masternodes/res.h
@@ -113,10 +113,11 @@ Res CheckRes(T &&res, std::tuple<Args...> &&args) {
     if constexpr (size == 0) {
         static_assert(std::is_convertible_v<T, Res>);
         return std::forward<T>(res);
-    } else if constexpr (std::
-                             is_invocable_r_v<std::string, std::tuple_element_t<0, std::tuple<Args...>>, std::string>) {
+    } else if constexpr (std::is_invocable_r_v<std::string, std::tuple_element_t<0, std::tuple<Args...>>, std::string>) {
         static_assert(std::is_convertible_v<T, Res>);
         return Res::Err(std::invoke(std::get<0>(args), res.msg));
+    } else if constexpr (size == 1 && std::is_invocable_r_v<std::string, std::tuple_element_t<0, std::tuple<Args...>>>) {
+        return Res::Err(std::invoke(std::get<0>(args)));
     } else {
         return Res::Err(args, std::make_index_sequence<size>{});
     }


### PR DESCRIPTION
Allows passing of lambdas to Require which can avoid premature string creation.