### PR TITLE
Disable neutral votes from RPC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -630,6 +630,7 @@ void SetupServerArgs()
     gArgs.AddArg("-consolidaterewards=<token-or-pool-symbol>", "Consolidate rewards on startup. Accepted multiple times for each token symbol", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-rpccache=<0/1/2>", "Cache rpc results - uses additional memory to hold on to the last results per block, but faster (0=none, 1=all, 2=smart)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-negativeinterest", "(experimental) Track negative interest values", ArgsManager::ALLOW_ANY, OptionsCategory::HIDDEN);
+    gArgs.AddArg("-rpc-governance-accept-neutral", "Allow voting with neutral votes for JellyFish purpose", ArgsManager::ALLOW_ANY, OptionsCategory::HIDDEN);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -453,15 +453,16 @@ UniValue votegov(const JSONRPCRequest &request) {
     auto propId = ParseHashV(request.params[0].get_str(), "proposalId");
     auto mnId   = ParseHashV(request.params[1].get_str(), "masternodeId");
     auto vote   = CProposalVoteType::VoteNeutral;
-
     auto voteStr = ToLower(request.params[2].get_str());
+    auto neutralVotesAllowed = gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL);
+
     if (voteStr == "no") {
         vote = CProposalVoteType::VoteNo;
     } else if (voteStr == "yes") {
         vote = CProposalVoteType::VoteYes;
-    } else if (gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL) && voteStr != "neutral") {
+    } else if (neutralVotesAllowed && voteStr != "neutral") {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "decision supports yes/no/neutral");
-    } else if (!gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL)) {
+    } else if (!neutralVotesAllowed) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Decision supports yes or no. Neutral is currently disabled because of issue https://github.com/DeFiCh/ain/issues/1704");
     }
 

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -457,8 +457,8 @@ UniValue votegov(const JSONRPCRequest &request) {
         vote = CProposalVoteType::VoteNo;
     } else if (voteStr == "yes") {
         vote = CProposalVoteType::VoteYes;
-    } else if (voteStr != "neutral") {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "decision supports yes/no/neutral");
+    } else {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Decision supports yes or no. Neutral is currently disabled because of issue https://github.com/DeFiCh/ain/issues/1704");
     }
 
     int targetHeight;

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -3,6 +3,8 @@
 
 #include <functional>
 
+const bool DEFAULT_RPC_GOV_NEUTRAL = false;
+
 struct VotingInfo {
     int32_t votesPossible;
     int32_t votesPresent;
@@ -457,7 +459,9 @@ UniValue votegov(const JSONRPCRequest &request) {
         vote = CProposalVoteType::VoteNo;
     } else if (voteStr == "yes") {
         vote = CProposalVoteType::VoteYes;
-    } else {
+    } else if (gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL) && voteStr != "neutral") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "decision supports yes/no/neutral");
+    } else if (!gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Decision supports yes or no. Neutral is currently disabled because of issue https://github.com/DeFiCh/ain/issues/1704");
     }
 

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -143,6 +143,8 @@ class OnChainGovernanceTest(DefiTestFramework):
         # cannot vote by non owning masternode
         assert_raises_rpc_error(-5, "Incorrect authorization", self.nodes[0].votegov, cfp1, mn1, "yes")
 
+        assert_raises_rpc_error(-8, "Decision supports yes or no. Neutral is currently disabled because of issue https://github.com/DeFiCh/ain/issues/1704", self.nodes[0].votegov, cfp1, mn0, "neutral")
+
         # Vote on proposal
         self.nodes[0].votegov(cfp1, mn0, "yes")
         self.nodes[0].generate(1)
@@ -153,7 +155,7 @@ class OnChainGovernanceTest(DefiTestFramework):
         self.sync_blocks()
 
         # Try and vote with non-staked MN
-        assert_raises_rpc_error(None, "does not mine at least one block", self.nodes[3].votegov, cfp1, mn3, "neutral")
+        assert_raises_rpc_error(None, "does not mine at least one block", self.nodes[3].votegov, cfp1, mn3, "yes")
 
         # voting period
         votingPeriod = 70

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -153,7 +153,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
-        self.test_cfp_fee_distribution(amount=1000, expectedFee=10, burnPct=30, vote="neutral",)
+        # self.test_cfp_fee_distribution(amount=1000, expectedFee=10, burnPct=30, vote="neutral",)
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/cfp_fee':'2%'}})
         self.nodes[0].generate(1)

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -17,10 +17,10 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.num_nodes = 4
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
+            ['-dummypos=0', '-txnotokens=0', '-rpc-governance-accept-neutral', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
+            ['-dummypos=0', '-txnotokens=0', '-rpc-governance-accept-neutral', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
+            ['-dummypos=0', '-txnotokens=0', '-rpc-governance-accept-neutral', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
+            ['-dummypos=0', '-txnotokens=0', '-rpc-governance-accept-neutral', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-grandcentralheight=101'],
         ]
 
     def test_cfp_fee_distribution(self, amount, expectedFee, burnPct, vote, cycles=2, changeFeeAndBurnPCT = False):
@@ -153,7 +153,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
-        # self.test_cfp_fee_distribution(amount=1000, expectedFee=10, burnPct=30, vote="neutral",)
+        self.test_cfp_fee_distribution(amount=1000, expectedFee=10, burnPct=30, vote="neutral",)
 
         self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/cfp_fee':'2%'}})
         self.nodes[0].generate(1)


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
Disable temporary neutral votes for proposals until next hardfork. Support for issue #1704.
