### PR TITLE
Remove codowners to manually add reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Define individuals that are responsible for code in a repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                                   @Bushstar @Mixa84 @wafflespeanut @hidiego @prasannavl @mambisi @Jouzo @fuxingloh
+#/.github/                                                   @Bushstar @Mixa84 @wafflespeanut @hidiego @prasannavl @Jouzo @fuxingloh
 
-/src/                                                       @Bushstar @Mixa84 @wafflespeanut @hidiego @prasannavl @mambisi @Jouzo
+#/src/                                                       @Bushstar @Mixa84 @wafflespeanut @hidiego @prasannavl @mambisi @Jouzo


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:
Remove code owners so that reviewers are added manually.
