### PR TITLE
Change first parameter of listgovproposals and listgovproposalvotes to be string and parsed as JSON in rpc

### DIFF
--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -562,10 +562,12 @@ UniValue listgovproposalvotes(const JSONRPCRequest &request) {
     }
         .Check(request);
 
-    if (request.params[0].isObject())
-        RPCTypeCheck(request.params, {UniValue::VOBJ}, true);
-    else
+    UniValue optionsObj(UniValue::VOBJ);
+
+    if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
         RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ}, true);
+    else if (request.params[0].isObject())
+        optionsObj = request.params[0].get_obj();
 
     CCustomCSView view(*pcustomcsview);
 
@@ -579,8 +581,7 @@ UniValue listgovproposalvotes(const JSONRPCRequest &request) {
     size_t start         = 0;
     bool including_start = true;
 
-    if (request.params[0].isObject()) {
-        auto optionsObj = request.params[0].get_obj();
+    if (!optionsObj.empty()) {
         propId          = ParseHashV(optionsObj["proposalId"].get_str(), "proposalId");
 
         if (!optionsObj["masternode"].isNull()) {
@@ -865,10 +866,12 @@ UniValue listgovproposals(const JSONRPCRequest &request) {
     }
         .Check(request);
 
-    if (request.params[0].isObject())
-        RPCTypeCheck(request.params, {UniValue::VOBJ}, true);
-    else
+    UniValue optionsObj(UniValue::VOBJ);
+
+    if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
         RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ}, true);
+    else if (request.params[0].isObject())
+        optionsObj = request.params[0].get_obj();
 
     uint8_t type{0}, status{0};
     int cycle{0};
@@ -876,9 +879,7 @@ UniValue listgovproposals(const JSONRPCRequest &request) {
     CProposalId start    = {};
     bool including_start = true;
 
-    if (request.params[0].isObject()) {
-        auto optionsObj = request.params[0].get_obj();
-
+    if (!optionsObj.empty()) {
         if (optionsObj.exists("type")) {
             auto str = optionsObj["type"].get_str();
             if (str == "cfp") {

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -1034,9 +1034,9 @@ static const CRPCCommand commands[] = {
     {"proposals", "creategovcfp",         &creategovcfp,         {"data", "inputs"}                                  },
     {"proposals", "creategovvoc",         &creategovvoc,         {"data", "inputs"}                                  },
     {"proposals", "votegov",              &votegov,              {"proposalId", "masternodeId", "decision", "inputs"}},
-    {"proposals", "listgovproposalvotes", &listgovproposalvotes, {"proposalId", "masternode", "cycle"}               },
+    {"proposals", "listgovproposalvotes", &listgovproposalvotes, {"proposalId", "masternode", "cycle", "pagination"} },
     {"proposals", "getgovproposal",       &getgovproposal,       {"proposalId"}                                      },
-    {"proposals", "listgovproposals",     &listgovproposals,     {"type", "status", "cycle"}                         },
+    {"proposals", "listgovproposals",     &listgovproposals,     {"type", "status", "cycle", "pagination"}           },
 };
 
 void RegisterProposalRPCCommands(CRPCTable &tableRPC) {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -356,7 +356,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "creategovvoc", 0, "data" },
     { "creategovvoc", 1, "inputs" },
     { "listgovproposalvotes", 2, "cycle" },
-    { "listgovproposals", 0, "type" },
+    { "listgovproposalvotes", 3, "pagination" },
+    { "listgovproposals", 2, "cycle" },
+    { "listgovproposals", 3, "pagination" },
 };
 // clang-format on
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:
In order for `listgovproposals` and `listgovproposalvotes` RPCs to work in both CLI and functional tests and all other systems that use RPC first param needs to be string and parsed in RPC function as JSON object.

#### Which issue(s) does this PR fixes?:

Fixes #1720 

