### PR TITLE
Fix getcustomtx crash on mempool transaction

### DIFF
--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -514,16 +514,9 @@ public:
         rpcInfo.pushKV("context", obj.context);
         rpcInfo.pushKV("amount", ValueFromAmount(obj.nAmount));
         rpcInfo.pushKV("cycles", int(obj.nCycles));
-        auto proposalEndHeight = height;
+        auto proposalEndHeight = -1;
         if (auto prop = mnview.GetProposal(propId)) {
             proposalEndHeight = prop->proposalEndHeight;
-        } else {
-            if (auto votingPeriod = prop->votingPeriod) {
-                proposalEndHeight = height + (votingPeriod - height % votingPeriod);
-                for (uint8_t i = 1; i <= obj.nCycles; ++i) {
-                    proposalEndHeight += votingPeriod;
-                }
-            }
         }
         rpcInfo.pushKV("proposalEndHeight", int64_t(proposalEndHeight));
         rpcInfo.pushKV("payoutAddress", ScriptToString(obj.address));

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -514,11 +514,21 @@ public:
         rpcInfo.pushKV("context", obj.context);
         rpcInfo.pushKV("amount", ValueFromAmount(obj.nAmount));
         rpcInfo.pushKV("cycles", int(obj.nCycles));
-        auto proposalEndHeight = -1;
+        int64_t proposalEndHeight{};
         if (auto prop = mnview.GetProposal(propId)) {
             proposalEndHeight = prop->proposalEndHeight;
+        } else {
+            // TX still in mempool. For the most accurate guesstimate use
+            // votingPeriod as it would be set when TX is added to the chain.
+            const auto votingPeriod = obj.options & CProposalOption::Emergency ?
+                                mnview.GetEmergencyPeriodFromAttributes(type) :
+                                mnview.GetVotingPeriodFromAttributes();
+            proposalEndHeight = height + (votingPeriod - height % votingPeriod);
+            for (uint8_t i = 1; i <= obj.nCycles; ++i) {
+                proposalEndHeight += votingPeriod;
+            }
         }
-        rpcInfo.pushKV("proposalEndHeight", int64_t(proposalEndHeight));
+        rpcInfo.pushKV("proposalEndHeight", proposalEndHeight);
         rpcInfo.pushKV("payoutAddress", ScriptToString(obj.address));
         if (obj.options) {
             UniValue opt = UniValue(UniValue::VARR);

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -518,10 +518,11 @@ public:
         if (auto prop = mnview.GetProposal(propId)) {
             proposalEndHeight = prop->proposalEndHeight;
         } else {
-            auto votingPeriod = prop->votingPeriod;
-            proposalEndHeight = height + (votingPeriod - height % votingPeriod);
-            for (uint8_t i = 1; i <= obj.nCycles; ++i) {
-                proposalEndHeight += votingPeriod;
+            if (auto votingPeriod = prop->votingPeriod) {
+                proposalEndHeight = height + (votingPeriod - height % votingPeriod);
+                for (uint8_t i = 1; i <= obj.nCycles; ++i) {
+                    proposalEndHeight += votingPeriod;
+                }
             }
         }
         rpcInfo.pushKV("proposalEndHeight", int64_t(proposalEndHeight));

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -270,10 +270,38 @@ class OnChainGovernanceTest(DefiTestFramework):
         context = "Test context"
         tx = self.nodes[0].creategovvoc({"title": title, "context": context})
         raw_tx = self.nodes[0].getrawtransaction(tx)
+
+        # Check VoC in mempool
+        result = self.nodes[0].getcustomtx(tx)
+        assert_equal(result['type'], 'CreateVoc')
+        assert_equal(result['valid'], True)
+        assert_equal(result['results']['proposalId'], tx)
+        assert_equal(result['results']['type'], 'VoteOfConfidence')
+        assert_equal(result['results']['title'], title)
+        assert_equal(result['results']['context'], context)
+        assert_equal(result['results']['amount'], Decimal('0E-8'))
+        assert_equal(result['results']['cycles'], 1)
+        assert_equal(result['results']['proposalEndHeight'], 420)
+        assert_equal(result['results']['payoutAddress'], '')
+
+        # Send transaction through a different node
         self.nodes[3].sendrawtransaction(raw_tx)
         self.nodes[3].generate(1)
         self.sync_blocks()
         creationHeight = self.nodes[0].getblockcount()
+
+        # Check VoC on-chain
+        result = self.nodes[0].getcustomtx(tx)
+        assert_equal(result['type'], 'CreateVoc')
+        assert_equal(result['valid'], True)
+        assert_equal(result['results']['proposalId'], tx)
+        assert_equal(result['results']['type'], 'VoteOfConfidence')
+        assert_equal(result['results']['title'], title)
+        assert_equal(result['results']['context'], context)
+        assert_equal(result['results']['amount'], Decimal('0E-8'))
+        assert_equal(result['results']['cycles'], 1)
+        assert_equal(result['results']['proposalEndHeight'], 420)
+        assert_equal(result['results']['payoutAddress'], '')
 
         # Check burn fee increment
         assert_equal(self.nodes[0].getburninfo()['feeburn'], Decimal('7.50000000'))


### PR DESCRIPTION
When create voc transaction is in the mempool a call to getcustomtx on that transaction can result in a crash of the client. This PR fixes that issue by checking the votingPeriod is set to a non-zero number in the serialised transaction.

Fixes: https://github.com/DeFiCh/ain/issues/1739