### PR TITLE
Allow object to be empty in listgovproposals and listgovproposalvotes

### DIFF
--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -634,10 +634,12 @@ UniValue listgovproposalvotes(const JSONRPCRequest &request) {
 
     UniValue optionsObj(UniValue::VOBJ);
 
-    if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
-        RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ, UniValue::VBOOL, UniValue::VBOOL}, true);
-    else if (request.params[0].isObject())
-        optionsObj = request.params[0].get_obj();
+    if (!request.params[0].empty()) {
+        if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
+            RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ, UniValue::VBOOL, UniValue::VBOOL}, true);
+        else if (request.params[0].isObject())
+            optionsObj = request.params[0].get_obj();
+    }
 
     CCustomCSView view(*pcustomcsview);
 
@@ -1023,10 +1025,12 @@ UniValue listgovproposals(const JSONRPCRequest &request) {
 
     UniValue optionsObj(UniValue::VOBJ);
 
-    if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
-        RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ}, true);
-    else if (request.params[0].isObject())
-        optionsObj = request.params[0].get_obj();
+    if (!request.params[0].empty()) {
+        if (!request.params[0].isObject() && !optionsObj.read(request.params[0].getValStr()))
+            RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VSTR, UniValue::VNUM, UniValue::VOBJ}, true);
+        else if (request.params[0].isObject())
+            optionsObj = request.params[0].get_obj();
+    }
 
     uint8_t type{0}, status{0};
     int cycle{0};

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -657,7 +657,6 @@ UniValue listgovproposalvotes(const JSONRPCRequest &request) {
     bool including_start = true;
 
     if (!optionsObj.empty()) {
-
         if (!optionsObj["proposalId"].isNull()) {
             propId = ParseHashV(optionsObj["proposalId"].get_str(), "proposalId");
             aggregate = false;
@@ -708,7 +707,7 @@ UniValue listgovproposalvotes(const JSONRPCRequest &request) {
             limit = std::numeric_limits<decltype(limit)>::max();
         }
     } else {
-        if (!request.params.empty()) {
+        if (!request.params.empty() && request.params[0].isStr()) {
             propId = ParseHashV(request.params[0].get_str(), "proposalId");
             aggregate = false;
             isMine = true;

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -1085,7 +1085,7 @@ UniValue listgovproposals(const JSONRPCRequest &request) {
             }
         }
     } else {
-        if (request.params.size() > 0) {
+        if (request.params.size() > 0 && request.params[0].isStr()) {
             auto str = request.params[0].get_str();
             if (str == "cfp") {
                 type = uint8_t(CProposalType::CommunityFundProposal);

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -727,6 +727,7 @@ class OnChainGovernanceTest(DefiTestFramework):
         self.test_default_cycles_fix()
         self.aggregate_all_votes()
         self.test_valid_votes()
+        self.test_empty_object()
 
     def test_aggregation(self, propId):
         """
@@ -792,7 +793,7 @@ class OnChainGovernanceTest(DefiTestFramework):
         Tests aggregation of all latest cycle votes for all proposals
         when no arguments are provided in listgovproposalvotes.
         """
-        votes = self.nodes[0].listgovproposalvotes()
+        votes = self.nodes[0].listgovproposalvotes({})
         proposalVotes = self.nodes[0].listgovproposalvotes(self.proposalId, "all", 0, {}, True)
         filteredVotes = list(filter(lambda vote: vote["proposalId"] == self.proposalId, votes))
         assert_equal(filteredVotes, proposalVotes)
@@ -806,6 +807,15 @@ class OnChainGovernanceTest(DefiTestFramework):
         for miss in missing:
             # proposals missing from entry must have 0 votes in the latest cycle
             assert_equal(len(self.nodes[0].listgovproposalvotes(miss, "all", 0)), 0)
+
+    def test_empty_object(self):
+        """
+        Tests fix for an issue where providing an empty object would
+        cause the node to incorrectly throw an error
+        """
+        votes = self.nodes[0].listgovproposalvotes()
+        votesObj = self.nodes[0].listgovproposalvotes({})
+        assert_equal(votes, votesObj)
 
     def test_valid_votes(self):
         """

--- a/test/functional/rpc_listgovproposals.py
+++ b/test/functional/rpc_listgovproposals.py
@@ -125,6 +125,8 @@ class ListGovProposalsTest(DefiTestFramework):
 
         prop_list = self.nodes[0].listgovproposals()
         assert_equal(len(prop_list), 30)
+        prop_list = self.nodes[0].listgovproposals({})
+        assert_equal(len(prop_list), 30)
         prop_list = self.nodes[0].listgovproposals("all", "all", 0)
         assert_equal(len(prop_list), 30)
         prop_list = self.nodes[0].listgovproposals("all", "all", -1)
@@ -295,4 +297,4 @@ class ListGovProposalsTest(DefiTestFramework):
         self.create_10_proposals_and_aprove_half()
 
 if __name__ == '__main__':
-    ListGovProposalsTest().main ()
+    ListGovProposalsTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import time
 
+from typing import List
 from .authproxy import JSONRPCException
 from . import coverage
 from .test_node import TestNode
@@ -93,7 +94,7 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
         self.chain = 'regtest'
         self.setup_clean_chain = False
-        self.nodes = []
+        self.nodes: List[TestNode] = []
         self.network_thread = None
         self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
         self.supports_cli = False


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind

#### What this PR does / why we need it:

When an empty object was passed to listgovproposals and listgovproposalvotes, the RPC would incorrectly error out with a JSON error. This PR allows users to pass in empty objects without throwing an error.

Fixes Jellyfish test failures.
