### PR TITLE
Disconnect nodes in rollback_to

### DIFF
--- a/test/functional/feature_loan_payback_with_collateral.py
+++ b/test/functional/feature_loan_payback_with_collateral.py
@@ -36,17 +36,6 @@ class LoanPaybackWithCollateralTest (DefiTestFramework):
             '-simulatemainnet=1'
             ]]
 
-    def rollback_to(self, block):
-        self.log.info("rollback to: %d", block)
-        node = self.nodes[0]
-        current_height = node.getblockcount()
-        if current_height == block:
-            return
-        blockhash = node.getblockhash(block + 1)
-        node.invalidateblock(blockhash)
-        node.clearmempool()
-        assert_equal(block, node.getblockcount())
-
     def createOracles(self):
         self.oracle_address1 = self.nodes[0].getnewaddress("", "legacy")
         price_feeds = [{"currency": "USD", "token": "DFI"},

--- a/test/functional/feature_negative_interest.py
+++ b/test/functional/feature_negative_interest.py
@@ -19,16 +19,6 @@ def getDecimalAmount(amount):
 
 
 class NegativeInterestTest (DefiTestFramework):
-    def rollback_to(self, block):
-        self.log.info("rollback to: %d", block)
-        current_height = self.nodes[0].getblockcount()
-        if current_height == block:
-            return
-        blockhash = self.nodes[0].getblockhash(block + 1)
-        self.nodes[0].invalidateblock(blockhash)
-        self.nodes[0].clearmempool()
-        assert_equal(block, self.nodes[0].getblockcount())
-
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -7,9 +7,7 @@
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
-    assert_equal,
-    connect_nodes_bi,
-    disconnect_nodes,
+    assert_equal
 )
 from decimal import ROUND_DOWN, Decimal
 
@@ -120,19 +118,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
             history = self.nodes[0].listaccounthistory(mn3['ownerAuthAddress'], {"txtype": "ProposalFeeRedistribution"})
             assert_equal(history, [])
 
-        # Disconnect nodes and check connection count
-        for i in range(self.num_nodes - 1):
-            disconnect_nodes(self.nodes[i], i + 1)
-            assert_equal(self.nodes[i].getconnectioncount(), 0)
-        assert_equal(self.nodes[3].getconnectioncount(), 0)
-
-        # Rollback nodes in isolation
-        for i in range(self.num_nodes):
-            self.rollback_to(height, nodes=[i])
-
-        # Connect nodes
-        for i in range(self.num_nodes - 1):
-            connect_nodes_bi(self.nodes, i, i + 1)
+        self.rollback_to(height, nodes=[0, 1, 2, 3])
 
     def setup(self):
         # Get MN addresses

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -118,7 +118,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
             history = self.nodes[0].listaccounthistory(mn3['ownerAuthAddress'], {"txtype": "ProposalFeeRedistribution"})
             assert_equal(history, [])
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height)
 
     def setup(self):
         # Get MN addresses

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -93,7 +93,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account = self.nodes[0].getaccount(address)
         assert_equal(account, ['100.00000000@DFI'])
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_quorum(self):
         height = self.nodes[0].getblockcount()
@@ -157,7 +157,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_approval_threshold(self):
         height = self.nodes[0].getblockcount()
@@ -230,7 +230,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_fee_redistribution(self):
         height = self.nodes[0].getblockcount()
@@ -297,7 +297,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_cfp_fee(self):
         height = self.nodes[0].getblockcount()
@@ -358,7 +358,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_voting_period(self):
         height = self.nodes[0].getblockcount()
@@ -408,7 +408,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_voc_emergency_period(self):
         height = self.nodes[0].getblockcount()
@@ -433,7 +433,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_update_voc_emergency_fee(self):
         height = self.nodes[0].getblockcount()
@@ -478,7 +478,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def test_cfp_state_after_update(self):
         height = self.nodes[0].getblockcount()
@@ -527,7 +527,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, nodes=[0, 1, 2, 3])
+        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
 
     def setup(self):
         # Get MN addresses

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -93,7 +93,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account = self.nodes[0].getaccount(address)
         assert_equal(account, ['100.00000000@DFI'])
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_quorum(self):
         height = self.nodes[0].getblockcount()
@@ -157,7 +157,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_approval_threshold(self):
         height = self.nodes[0].getblockcount()
@@ -230,7 +230,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_fee_redistribution(self):
         height = self.nodes[0].getblockcount()
@@ -297,7 +297,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_cfp_fee(self):
         height = self.nodes[0].getblockcount()
@@ -358,7 +358,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_voting_period(self):
         height = self.nodes[0].getblockcount()
@@ -408,7 +408,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_voc_emergency_period(self):
         height = self.nodes[0].getblockcount()
@@ -433,7 +433,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_update_voc_emergency_fee(self):
         height = self.nodes[0].getblockcount()
@@ -478,7 +478,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def test_cfp_state_after_update(self):
         height = self.nodes[0].getblockcount()
@@ -527,7 +527,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, self.nodes[0:4])
+        self.rollback_to(height)
 
     def setup(self):
         # Get MN addresses

--- a/test/functional/feature_on_chain_government_govvar_update.py
+++ b/test/functional/feature_on_chain_government_govvar_update.py
@@ -93,7 +93,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account = self.nodes[0].getaccount(address)
         assert_equal(account, ['100.00000000@DFI'])
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_quorum(self):
         height = self.nodes[0].getblockcount()
@@ -157,7 +157,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_approval_threshold(self):
         height = self.nodes[0].getblockcount()
@@ -230,7 +230,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_fee_redistribution(self):
         height = self.nodes[0].getblockcount()
@@ -297,7 +297,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_cfp_fee(self):
         height = self.nodes[0].getblockcount()
@@ -358,7 +358,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_voting_period(self):
         height = self.nodes[0].getblockcount()
@@ -408,7 +408,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_voc_emergency_period(self):
         height = self.nodes[0].getblockcount()
@@ -433,7 +433,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Rejected')
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_update_voc_emergency_fee(self):
         height = self.nodes[0].getblockcount()
@@ -478,7 +478,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
         assert_equal(account1[0], expectedAmount)
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def test_cfp_state_after_update(self):
         height = self.nodes[0].getblockcount()
@@ -527,7 +527,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
         proposal = self.nodes[0].getgovproposal(propId)
         assert_equal(proposal['status'], 'Completed')
 
-        self.rollback_to(height, {self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]})
+        self.rollback_to(height, self.nodes[0:4])
 
     def setup(self):
         # Get MN addresses

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -563,7 +563,7 @@ class PoolPairTest (DefiTestFramework):
                                 "amountFrom": 0, "tokenFrom": self.symbolLTC, "tokenTo": self.symbolBTC, "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
 
     def revert_to_initial_state(self):
-        self.rollback_to(block=0, nodes=[0, 1, 2])
+        self.rollback_to(block=0, nodes={self.nodes[0], self.nodes[1], self.nodes[2]})
         assert_equal(len(self.nodes[0].listpoolpairs()), 0)
         assert_equal(len(self.nodes[1].listpoolpairs()), 0)
         assert_equal(len(self.nodes[2].listpoolpairs()), 0)

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -563,7 +563,7 @@ class PoolPairTest (DefiTestFramework):
                                 "amountFrom": 0, "tokenFrom": self.symbolLTC, "tokenTo": self.symbolBTC, "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
 
     def revert_to_initial_state(self):
-        self.rollback_to(block=0, nodes={self.nodes[0], self.nodes[1], self.nodes[2]})
+        self.rollback_to(block=0, nodes=self.nodes[:3])
         assert_equal(len(self.nodes[0].listpoolpairs()), 0)
         assert_equal(len(self.nodes[1].listpoolpairs()), 0)
         assert_equal(len(self.nodes[2].listpoolpairs()), 0)

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -563,7 +563,7 @@ class PoolPairTest (DefiTestFramework):
                                 "amountFrom": 0, "tokenFrom": self.symbolLTC, "tokenTo": self.symbolBTC, "from": self.accountGN0, "to": self.accountSN1, "maxPrice": 0.1})
 
     def revert_to_initial_state(self):
-        self.rollback_to(block=0, nodes=self.nodes[:3])
+        self.rollback_to(block=0)
         assert_equal(len(self.nodes[0].listpoolpairs()), 0)
         assert_equal(len(self.nodes[1].listpoolpairs()), 0)
         assert_equal(len(self.nodes[2].listpoolpairs()), 0)

--- a/test/functional/feature_restore_utxo.py
+++ b/test/functional/feature_restore_utxo.py
@@ -72,7 +72,7 @@ class TestRestoreUTXOs(DefiTestFramework):
                 self.nodes[1].generate(1)
                 self.nodes[1].accounttoaccount(node1_source, {node1_source: "1@BTC"})
                 self.nodes[1].generate(1)
-            self.rollback_to(block, self.nodes[:1])
+            self.rollback_to(block)
             assert_equal(len(self.nodes[1].listunspent()), node1_utxos)
 
 if __name__ == '__main__':

--- a/test/functional/feature_restore_utxo.py
+++ b/test/functional/feature_restore_utxo.py
@@ -72,7 +72,7 @@ class TestRestoreUTXOs(DefiTestFramework):
                 self.nodes[1].generate(1)
                 self.nodes[1].accounttoaccount(node1_source, {node1_source: "1@BTC"})
                 self.nodes[1].generate(1)
-            self.rollback_to(block, {self.nodes[1]})
+            self.rollback_to(block, self.nodes[:1])
             assert_equal(len(self.nodes[1].listunspent()), node1_utxos)
 
 if __name__ == '__main__':

--- a/test/functional/feature_restore_utxo.py
+++ b/test/functional/feature_restore_utxo.py
@@ -72,7 +72,7 @@ class TestRestoreUTXOs(DefiTestFramework):
                 self.nodes[1].generate(1)
                 self.nodes[1].accounttoaccount(node1_source, {node1_source: "1@BTC"})
                 self.nodes[1].generate(1)
-            self.rollback_to(block, nodes=[1])
+            self.rollback_to(block, {self.nodes[1]})
             assert_equal(len(self.nodes[1].listunspent()), node1_utxos)
 
 if __name__ == '__main__':

--- a/test/functional/rpc_getstoredinterest.py
+++ b/test/functional/rpc_getstoredinterest.py
@@ -43,16 +43,6 @@ class GetStoredInterestTest(DefiTestFramework):
             '-jellyfish_regtest=1', '-txindex=1', '-simulatemainnet=1']
         ]
 
-    # Utils
-    def rollback_to(self, block):
-        node = self.nodes[0]
-        current_height = node.getblockcount()
-        if current_height == block:
-            return
-        blockhash = node.getblockhash(block + 1)
-        node.invalidateblock(blockhash)
-        node.clearmempool()
-        assert_equal(block, node.getblockcount())
 
     def new_vault(self, loan_scheme, deposit=10):
         vaultId = self.nodes[0].createvault(self.account0, loan_scheme)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -408,8 +408,7 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
             n.importprivkey(privkey=n.get_genesis_keys().operatorPrivKey, label='coinbase', rescan=True)
 
     # rollback one node (Default = node 0)
-    def _rollback_to(self, block, node=0):
-        node = self.nodes[node]
+    def _rollback_to(self, block, node):
         current_height = node.getblockcount()
         if current_height == block:
             return
@@ -421,28 +420,25 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
     # nodes param is a list of node numbers to roll back ([0, 1, 2, 3...] (Default -> None -> node 0)
     def rollback_to(self, block, nodes=None):
         nodes = nodes or self.nodes
-        if nodes is None:
-            self._rollback_to(block)
-        else:
-            connections = {}
-            for node in nodes:
-                nodes_connections = []
-                for x in self.nodes[node].getpeerinfo():
-                    if not x['inbound']:
-                        node_number = re.findall(r'\d+', x['subver'])[-1]
-                        nodes_connections.append(int(node_number))
+        connections = {}
+        for node in nodes:
+            nodes_connections = []
+            for x in node.getpeerinfo():
+                if not x['inbound']:
+                    node_number = re.findall(r'\d+', x['subver'])[-1]
+                    nodes_connections.append(int(node_number))
                 connections[node] = nodes_connections
 
-            for node in nodes:
-                for x in connections[node]:
-                    disconnect_nodes(self.nodes[node], x)
+        for node in nodes:
+            for x in connections[node]:
+                disconnect_nodes(node, x)
 
-            for node in nodes:
-                self._rollback_to(block, node)
+        for node in nodes:
+            self._rollback_to(block, node)
 
-            for node in nodes:
-                for x in connections[node]:
-                    connect_nodes(self.nodes[node], x)
+        for node in nodes:
+            for x in connections[node]:
+                connect_nodes(node, x)
 
     def run_test(self):
         """Tests must override this method to define test logic"""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -33,7 +33,6 @@ from .util import (
     initialize_datadir,
     sync_blocks,
     sync_mempools,
-    wait_until,
 )
 
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -443,9 +443,6 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
                     disconnect_nodes(self.nodes[node], x)
 
             for node in nodes:
-                wait_until(lambda: self.nodes[node].getconnectioncount() == 0)
-
-            for node in nodes:
                 self._rollback_to(block, node)
 
             for node in nodes:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -420,6 +420,7 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
     # rollback to block
     # nodes param is a list of node numbers to roll back ([0, 1, 2, 3...] (Default -> None -> node 0)
     def rollback_to(self, block, nodes=None):
+        nodes = nodes or self.nodes
         if nodes is None:
             self._rollback_to(block)
         else:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -429,9 +429,13 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
                 nodes_connections_inbound = []
                 for x in self.nodes[node].getpeerinfo():
                     if x['inbound']:
-                        nodes_connections_inbound.append(int(x['addrbind'].split(':')[1]) - PORT_MIN)
+                        node_number = int(x['addrbind'].split(':')[1]) - PORT_MIN
+                        if node_number <= MAX_NODES:
+                            nodes_connections_inbound.append(node_number)
                     else:
-                        nodes_connections_outbound.append(int(x['addr'].split(':')[1]) - PORT_MIN)
+                        node_number = int(x['addr'].split(':')[1]) - PORT_MIN
+                        if node_number <= MAX_NODES:
+                            nodes_connections_outbound.append(node_number)
                 connections_outbound[node] = nodes_connections_outbound
                 connections_inbound[node] = nodes_connections_inbound
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -422,13 +422,13 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
         if nodes is None:
             self._rollback_to(block)
         else:
-            connections = []
+            connections = {}
             for node in nodes:
                 nodes_connections = []
                 for x in self.nodes[node].getpeerinfo():
                     if not x['inbound']:
                         nodes_connections.append(int(x['addr'].split(':')[1]) - PORT_MIN)
-                connections.append(nodes)
+                connections[node] = nodes_connections
 
             for node in nodes:
                 for x in connections[node]:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -427,7 +427,7 @@ class DefiTestFramework(metaclass=DefiTestMetaClass):
                 if not x['inbound']:
                     node_number = re.findall(r'\d+', x['subver'])[-1]
                     nodes_connections.append(int(node_number))
-                connections[node] = nodes_connections
+            connections[node] = nodes_connections
 
         for node in nodes:
             for x in connections[node]:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -23,7 +23,6 @@ from .test_node import TestNode
 from .mininode import NetworkThread
 from .util import (
     MAX_NODES,
-    PORT_MIN,
     PortSeed,
     assert_equal,
     check_json_precision,


### PR DESCRIPTION
In rollback_to if multiple nodes are connected disconnect them first before rolling back and the restore the connections again afterwards.