### PR TITLE
Replace Require strings with lambdas

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -92,7 +92,7 @@ typedef std::map<DCT_ID, CAmount> TAmounts;
 
 inline ResVal<CAmount> SafeAdd(CAmount _a, CAmount _b) {
     // check limits
-    Require(_a >= 0 && _b >= 0, "negative amount");
+    Require(_a >= 0 && _b >= 0, []{ return "negative amount"; });
 
     // convert to unsigned, because signed overflow is UB
     const uint64_t a = (uint64_t) _a;
@@ -101,7 +101,7 @@ inline ResVal<CAmount> SafeAdd(CAmount _a, CAmount _b) {
     const uint64_t sum = a + b;
     // check overflow
 
-    Require((sum - a) == b && (uint64_t)std::numeric_limits<CAmount>::max() >= sum, "overflow");
+    Require((sum - a) == b && (uint64_t)std::numeric_limits<CAmount>::max() >= sum, []{ return "overflow"; });
     return {(CAmount) sum, Res::Ok()};
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1189,7 +1189,7 @@ void ClearCheckpoints(CChainParams &params) {
 
 Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName) {
     std::ifstream file(fileName);
-    Require(file.good(), "Could not read %s. Ensure it exists and has read permissions", fileName);
+    Require(file.good(), [=]{ return strprintf("Could not read %s. Ensure it exists and has read permissions", fileName); });
 
     ClearCheckpoints(params);
 
@@ -1201,13 +1201,13 @@ Res UpdateCheckpointsFromFile(CChainParams &params, const std::string &fileName)
 
         std::istringstream iss(trimmed);
         std::string hashStr, heightStr;
-        Require((iss >> heightStr >> hashStr), "Error parsing line %s", trimmed);
+        Require((iss >> heightStr >> hashStr), [=]{ return strprintf("Error parsing line %s", trimmed); });
 
         uint256 hash;
-        Require(ParseHashStr(hashStr, hash), "Invalid hash: %s", hashStr);
+        Require(ParseHashStr(hashStr, hash), [=]{ return strprintf("Invalid hash: %s", hashStr); });
 
         int32_t height;
-        Require(ParseInt32(heightStr, &height), "Invalid height: %s", heightStr);
+        Require(ParseInt32(heightStr, &height), [=]{ return strprintf("Invalid height: %s", heightStr); });
 
         params.checkpointData.mapCheckpoints[height] = hash;
     }

--- a/src/masternodes/accounts.cpp
+++ b/src/masternodes/accounts.cpp
@@ -80,7 +80,7 @@ uint32_t CAccountsView::GetBalancesHeight(const CScript &owner) {
 }
 
 Res CAccountsView::StoreFuturesUserValues(const CFuturesUserKey &key, const CFuturesUserValue &futures) {
-    Require(WriteBy<ByFuturesSwapKey>(key, futures), "Failed to store futures");
+    Require(WriteBy<ByFuturesSwapKey>(key, futures), []{ return "Failed to store futures"; });
     return Res::Ok();
 }
 
@@ -91,12 +91,12 @@ void CAccountsView::ForEachFuturesUserValues(
 }
 
 Res CAccountsView::EraseFuturesUserValues(const CFuturesUserKey &key) {
-    Require(EraseBy<ByFuturesSwapKey>(key), "Failed to erase futures");
+    Require(EraseBy<ByFuturesSwapKey>(key), [=]{ return "Failed to erase futures"; });
     return Res::Ok();
 }
 
 Res CAccountsView::StoreFuturesDUSD(const CFuturesUserKey &key, const CAmount &amount) {
-    Require(WriteBy<ByFuturesDUSDKey>(key, amount), "Failed to store futures");
+    Require(WriteBy<ByFuturesDUSDKey>(key, amount), []{ return "Failed to store futures"; });
     return Res::Ok();
 }
 
@@ -106,6 +106,6 @@ void CAccountsView::ForEachFuturesDUSD(std::function<bool(const CFuturesUserKey 
 }
 
 Res CAccountsView::EraseFuturesDUSD(const CFuturesUserKey &key) {
-    Require(EraseBy<ByFuturesDUSDKey>(key), "Failed to erase futures");
+    Require(EraseBy<ByFuturesDUSDKey>(key), []{ return "Failed to erase futures"; });
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -309,13 +309,13 @@ const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys
 
 static ResVal<int32_t> VerifyInt32(const std::string &str) {
     int32_t int32;
-    Require(ParseInt32(str, &int32), "Value must be an integer");
+    Require(ParseInt32(str, &int32), []{ return "Value must be an integer"; });
     return {int32, Res::Ok()};
 }
 
 static ResVal<int32_t> VerifyPositiveInt32(const std::string &str) {
     int32_t int32;
-    Require(ParseInt32(str, &int32) && int32 >= 0, "Value must be a positive integer");
+    Require(ParseInt32(str, &int32) && int32 >= 0, []{ return "Value must be a positive integer"; });
     return {int32, Res::Ok()};
 }
 
@@ -329,19 +329,19 @@ static ResVal<CAttributeValue> VerifyUInt32(const std::string &str) {
 
 static ResVal<CAttributeValue> VerifyInt64(const std::string &str) {
     CAmount int64;
-    Require(ParseInt64(str, &int64) && int64 >= 0, "Value must be a positive integer");
+    Require(ParseInt64(str, &int64) && int64 >= 0, []{ return "Value must be a positive integer"; });
     return {int64, Res::Ok()};
 }
 
 static ResVal<CAttributeValue> VerifyFloat(const std::string &str) {
     CAmount amount = 0;
-    Require(ParseFixedPoint(str, 8, &amount), "Amount must be a valid number");
+    Require(ParseFixedPoint(str, 8, &amount), []{ return "Amount must be a valid number"; });
     return {amount, Res::Ok()};
 }
 
 ResVal<CAttributeValue> VerifyPositiveFloat(const std::string &str) {
     CAmount amount = 0;
-    Require(ParseFixedPoint(str, 8, &amount) && amount >= 0, "Amount must be a positive value");
+    Require(ParseFixedPoint(str, 8, &amount) && amount >= 0, []{ return "Amount must be a positive value"; });
     return {amount, Res::Ok()};
 }
 
@@ -382,13 +382,13 @@ static ResVal<CAttributeValue> VerifyBool(const std::string &str) {
 static ResVal<CAttributeValue> VerifySplit(const std::string &str) {
     OracleSplits splits;
     const auto pairs = KeyBreaker(str);
-    Require(pairs.size() == 2, "Two int values expected for split in id/mutliplier");
+    Require(pairs.size() == 2, []{ return "Two int values expected for split in id/mutliplier"; });
     const auto resId = VerifyPositiveInt32(pairs[0]);
     Require(resId);
 
     const auto resMultiplier = VerifyInt32(pairs[1]);
     Require(resMultiplier);
-    Require(*resMultiplier != 0, "Mutliplier cannot be zero");
+    Require(*resMultiplier != 0, []{ return "Mutliplier cannot be zero"; });
 
     splits[*resId] = *resMultiplier;
 
@@ -435,11 +435,11 @@ static ResVal<CAttributeValue> VerifyMember(const UniValue &array) {
 
 static ResVal<CAttributeValue> VerifyCurrencyPair(const std::string &str) {
     const auto value = KeyBreaker(str);
-    Require(value.size() == 2, "Exactly two entires expected for currency pair");
+    Require(value.size() == 2, []{ return "Exactly two entires expected for currency pair"; });
 
     auto token    = trim_all_ws(value[0]).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
     auto currency = trim_all_ws(value[1]).substr(0, CToken::MAX_TOKEN_SYMBOL_LENGTH);
-    Require(!token.empty() && !currency.empty(), "Empty token / currency");
+    Require(!token.empty() && !currency.empty(), []{ return "Empty token / currency"; });
     return {
         CTokenCurrencyPair{token, currency},
         Res::Ok()
@@ -451,7 +451,7 @@ static std::set<std::string> dirSet{"both", "in", "out"};
 static ResVal<CAttributeValue> VerifyFeeDirection(const std::string &str) {
     auto lowerStr = ToLower(str);
     const auto it = dirSet.find(lowerStr);
-    Require(it != dirSet.end(), "Fee direction value must be both, in or out");
+    Require(it != dirSet.end(), []{ return "Fee direction value must be both, in or out"; });
     return {CFeeDir{static_cast<uint8_t>(std::distance(dirSet.begin(), it))}, Res::Ok()};
 }
 
@@ -666,41 +666,41 @@ void TrackLiveBalances(CCustomCSView &mnview, const CBalances &balances, const u
 Res ATTRIBUTES::ProcessVariable(const std::string &key,
                                 const std::optional<UniValue> &value,
                                 std::function<Res(const CAttributeType &, const CAttributeValue &)> applyVariable) {
-    Require(key.size() <= 128, "Identifier exceeds maximum length (128)");
+    Require(key.size() <= 128, []{ return "Identifier exceeds maximum length (128)"; });
 
     const auto keys = KeyBreaker(key);
-    Require(!keys.empty() && !keys[0].empty(), "Empty version");
+    Require(!keys.empty() && !keys[0].empty(), []{ return "Empty version"; });
 
     auto iver = allowedVersions().find(keys[0]);
-    Require(iver != allowedVersions().end(), "Unsupported version");
+    Require(iver != allowedVersions().end(), []{ return "Unsupported version"; });
 
     auto version = iver->second;
-    Require(version == VersionTypes::v0, "Unsupported version");
+    Require(version == VersionTypes::v0, []{ return "Unsupported version"; });
 
     Require(keys.size() >= 4 && !keys[1].empty() && !keys[2].empty() && !keys[3].empty(),
-            "Incorrect key for <type>. Object of ['<version>/<type>/ID/<key>','value'] expected");
+            []{ return "Incorrect key for <type>. Object of ['<version>/<type>/ID/<key>','value'] expected"; });
 
     auto itype = allowedTypes().find(keys[1]);
-    Require(itype != allowedTypes().end(), ::ShowError("type", allowedTypes()));
+    Require(itype != allowedTypes().end(), [=]{ return ::ShowError("type", allowedTypes()); });
 
     const auto type = itype->second;
 
     uint32_t typeId{0};
     if (type == AttributeTypes::Param) {
         auto id = allowedParamIDs().find(keys[2]);
-        Require(id != allowedParamIDs().end(), ::ShowError("param", allowedParamIDs()));
+        Require(id != allowedParamIDs().end(), [=]{ return ::ShowError("param", allowedParamIDs()); });
         typeId = id->second;
     } else if (type == AttributeTypes::Locks) {
         auto id = allowedLocksIDs().find(keys[2]);
-        Require(id != allowedLocksIDs().end(), ::ShowError("locks", allowedLocksIDs()));
+        Require(id != allowedLocksIDs().end(), [=]{ return ::ShowError("locks", allowedLocksIDs()); });
         typeId = id->second;
     } else if (type == AttributeTypes::Oracles) {
         auto id = allowedOracleIDs().find(keys[2]);
-        Require(id != allowedOracleIDs().end(), ::ShowError("oracles", allowedOracleIDs()));
+        Require(id != allowedOracleIDs().end(), [=]{ return ::ShowError("oracles", allowedOracleIDs()); });
         typeId = id->second;
     } else if (type == AttributeTypes::Governance) {
         auto id = allowedGovernanceIDs().find(keys[2]);
-        Require(id != allowedGovernanceIDs().end(), ::ShowError("governance", allowedGovernanceIDs()));
+        Require(id != allowedGovernanceIDs().end(), [=]{ return ::ShowError("governance", allowedGovernanceIDs()); });
         typeId = id->second;
     } else {
         auto id = VerifyInt32(keys[2]);
@@ -723,7 +723,7 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
         }
     } else {
         auto ikey = allowedKeys().find(type);
-        Require(ikey != allowedKeys().end(), "Unsupported type {%d}", type);
+        Require(ikey != allowedKeys().end(), [=]{ return strprintf("Unsupported type {%d}", type); });
 
         // Alias of reward_pct in Export.
         if (keys[3] == "fee_pct") {
@@ -731,7 +731,7 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
         }
 
         itype = ikey->second.find(keys[3]);
-        Require(itype != ikey->second.end(), ::ShowError("key", ikey->second));
+        Require(itype != ikey->second.end(), [=]{ return ::ShowError("key", ikey->second); });
 
         typeKey = itype->second;
 
@@ -755,8 +755,8 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
                 }
             } else if (typeId == ParamIDs::DFIP2206A) {
                 Require(typeKey == DFIPKeys::DUSDInterestBurn || typeKey == DFIPKeys::DUSDLoanBurn,
-                        "Unsupported type for DFIP2206A {%d}",
-                        typeKey);
+                        [=]{ return strprintf("Unsupported type for DFIP2206A {%d}",
+                                              typeKey); });
             } else if (typeId == ParamIDs::Feature) {
                 if (typeKey != DFIPKeys::GovUnset && typeKey != DFIPKeys::GovFoundation &&
                     typeKey != DFIPKeys::MNSetRewardAddress && typeKey != DFIPKeys::MNSetOperatorAddress &&
@@ -790,12 +790,12 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
     }
 
     if (attrV0.IsExtendedSize()) {
-        Require(keys.size() == 5 && !keys[4].empty(), "Exact 5 keys are required {%d}", keys.size());
+        Require(keys.size() == 5 && !keys[4].empty(), [=]{ return strprintf("Exact 5 keys are required {%d}", keys.size()); });
         auto id = VerifyInt32(keys[4]);
         Require(id);
         attrV0.keyId = *id.val;
     } else {
-        Require(keys.size() == 4, "Exact 4 keys are required {%d}", keys.size());
+        Require(keys.size() == 4, [=]{ return strprintf("Exact 4 keys are required {%d}", keys.size()); });
     }
 
     if (!value) {
@@ -951,7 +951,7 @@ Res ATTRIBUTES::RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height) 
 }
 
 Res ATTRIBUTES::Import(const UniValue &val) {
-    Require(val.isObject(), "Object of values expected");
+    Require(val.isObject(), []{ return "Object of values expected"; });
 
     std::map<std::string, UniValue> objMap;
     val.getObjMap(objMap);
@@ -1231,72 +1231,72 @@ UniValue ATTRIBUTES::Export() const {
 
 Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
     Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHillHeight,
-            "Cannot be set before FortCanningHill");
+            []{ return "Cannot be set before FortCanningHill"; });
 
     for (const auto &[key, value] : attributes) {
         const auto attrV0 = std::get_if<CDataStructureV0>(&key);
-        Require(attrV0, "Unsupported version");
+        Require(attrV0, []{ return "Unsupported version"; });
         switch (attrV0->type) {
             case AttributeTypes::Token:
                 switch (attrV0->key) {
                     case TokenKeys::LoanPaybackCollateral:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningEpilogueHeight,
-                                "Cannot be set before FortCanningEpilogue");
+                                []{ return "Cannot be set before FortCanningEpilogue"; });
 
                         [[fallthrough]];
                     case TokenKeys::PaybackDFI:
                     case TokenKeys::PaybackDFIFeePCT:
-                        Require(view.GetLoanTokenByID({attrV0->typeId}), "No such loan token (%d)", attrV0->typeId);
+                        Require(view.GetLoanTokenByID({attrV0->typeId}), [=]{ return strprintf("No such loan token (%d)", attrV0->typeId); });
                         break;
                     case TokenKeys::LoanPayback:
                     case TokenKeys::LoanPaybackFeePCT:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningRoadHeight,
-                                "Cannot be set before FortCanningRoad");
+                                []{ return "Cannot be set before FortCanningRoad"; });
                         Require(
                             view.GetLoanTokenByID(DCT_ID{attrV0->typeId}), "No such loan token (%d)", attrV0->typeId);
-                        Require(view.GetToken(DCT_ID{attrV0->keyId}), "No such token (%d)", attrV0->keyId);
+                        Require(view.GetToken(DCT_ID{attrV0->keyId}), [=]{ return strprintf("No such token (%d)", attrV0->keyId); });
                         break;
                     case TokenKeys::DexInFeePct:
                     case TokenKeys::DexOutFeePct:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningRoadHeight,
-                                "Cannot be set before FortCanningRoad");
-                        Require(view.GetToken(DCT_ID{attrV0->typeId}), "No such token (%d)", attrV0->typeId);
+                                []{ return "Cannot be set before FortCanningRoad"; });
+                        Require(view.GetToken(DCT_ID{attrV0->typeId}), [=]{ return strprintf("No such token (%d)", attrV0->typeId); });
                         break;
                     case TokenKeys::LoanCollateralFactor:
                         if (view.GetLastHeight() < Params().GetConsensus().FortCanningEpilogueHeight) {
                             const auto amount = std::get_if<CAmount>(&value);
                             if (amount)
-                                Require(*amount <= COIN, "Percentage exceeds 100%%");
+                                Require(*amount <= COIN, []{ return "Percentage exceeds 100%%"; });
                         }
                         [[fallthrough]];
                     case TokenKeys::LoanMintingInterest:
                         if (view.GetLastHeight() < Params().GetConsensus().FortCanningGreatWorldHeight) {
                             const auto amount = std::get_if<CAmount>(&value);
                             if (amount)
-                                Require(*amount >= 0, "Amount must be a positive value");
+                                Require(*amount >= 0, []{ return "Amount must be a positive value"; });
                         }
                         [[fallthrough]];
                     case TokenKeys::LoanCollateralEnabled:
                     case TokenKeys::LoanMintingEnabled: {
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningCrunchHeight,
-                                "Cannot be set before FortCanningCrunch");
-                        Require(VerifyToken(view, attrV0->typeId), "No such token (%d)", attrV0->typeId);
+                                []{ return "Cannot be set before FortCanningCrunch"; });
+                        Require(VerifyToken(view, attrV0->typeId), [=]{ return strprintf("No such token (%d)", attrV0->typeId); });
                         CDataStructureV0 intervalPriceKey{
                             AttributeTypes::Token, attrV0->typeId, TokenKeys::FixedIntervalPriceId};
                         Require(!(GetValue(intervalPriceKey, CTokenCurrencyPair{}) == CTokenCurrencyPair{}),
-                                "Fixed interval price currency pair must be set first");
+                                []{ return "Fixed interval price currency pair must be set first"; });
                         break;
                     }
                     case TokenKeys::FixedIntervalPriceId:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningCrunchHeight,
-                                "Cannot be set before FortCanningCrunch");
-                        Require(VerifyToken(view, attrV0->typeId), "No such token (%d)", attrV0->typeId);
+                                []{ return "Cannot be set before FortCanningCrunch"; });
+                        Require(VerifyToken(view, attrV0->typeId), [=]{ return strprintf("No such token (%d)", attrV0->typeId); });
                         break;
                     case TokenKeys::DFIP2203Enabled:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningRoadHeight,
-                                "Cannot be set before FortCanningRoad");
+                                []{ return "Cannot be set before FortCanningRoad"; });
                         Require(
-                            view.GetLoanTokenByID(DCT_ID{attrV0->typeId}), "No such loan token (%d)", attrV0->typeId);
+                            view.GetLoanTokenByID(DCT_ID{attrV0->typeId}), [=]{ return strprintf("No such loan token (%d)", attrV0->typeId); });
                         break;
                     case TokenKeys::Ascendant:
                     case TokenKeys::Descendant:
@@ -1355,19 +1355,19 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
 
             case AttributeTypes::Oracles:
                 Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningCrunchHeight,
-                        "Cannot be set before FortCanningCrunch");
+                        []{ return "Cannot be set before FortCanningCrunch"; });
                 if (attrV0->typeId == OracleIDs::Splits) {
                     const auto splitMap = std::get_if<OracleSplits>(&value);
-                    Require(splitMap, "Unsupported value");
+                    Require(splitMap, []{ return "Unsupported value"; });
 
                     for (const auto &[tokenId, multipler] : *splitMap) {
-                        Require(tokenId != 0, "Tokenised DFI cannot be split");
-                        Require(!view.HasPoolPair(DCT_ID{tokenId}), "Pool tokens cannot be split");
+                        Require(tokenId != 0, []{ return "Tokenised DFI cannot be split"; });
+                        Require(!view.HasPoolPair(DCT_ID{tokenId}), []{ return "Pool tokens cannot be split"; });
                         const auto token = view.GetToken(DCT_ID{tokenId});
-                        Require(token, "Token (%d) does not exist", tokenId);
-                        Require(token->IsDAT(), "Only DATs can be split");
+                        Require(token, [tokenId=tokenId]{ return strprintf("Token (%d) does not exist", tokenId); });
+                        Require(token->IsDAT(), []{ return "Only DATs can be split"; });
                         Require(
-                            view.GetLoanTokenByID(DCT_ID{tokenId}).has_value(), "No loan token with id (%d)", tokenId);
+                            view.GetLoanTokenByID(DCT_ID{tokenId}).has_value(), [tokenId=tokenId]{ return strprintf("No loan token with id (%d)", tokenId); });
                     }
                 } else {
                     return Res::Err("Unsupported key");
@@ -1378,13 +1378,13 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                 switch (attrV0->key) {
                     case PoolKeys::TokenAFeePCT:
                     case PoolKeys::TokenBFeePCT:
-                        Require(view.GetPoolPair({attrV0->typeId}), "No such pool (%d)", attrV0->typeId);
+                        Require(view.GetPoolPair({attrV0->typeId}), [=]{ return strprintf("No such pool (%d)", attrV0->typeId); });
                         break;
                     case PoolKeys::TokenAFeeDir:
                     case PoolKeys::TokenBFeeDir:
                         Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningSpringHeight,
-                                "Cannot be set before FortCanningSpringHeight");
-                        Require(view.GetPoolPair({attrV0->typeId}), "No such pool (%d)", attrV0->typeId);
+                                []{ return "Cannot be set before FortCanningSpringHeight"; });
+                        Require(view.GetPoolPair({attrV0->typeId}), [=]{ return strprintf("No such pool (%d)", attrV0->typeId); });
                         break;
                     default:
                         return Res::Err("Unsupported key");
@@ -1412,7 +1412,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                     }
                 } else if (attrV0->typeId == ParamIDs::DFIP2203) {
                     Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningRoadHeight,
-                            "Cannot be set before FortCanningRoadHeight");
+                            []{ return "Cannot be set before FortCanningRoadHeight"; });
                 } else if (attrV0->typeId != ParamIDs::DFIP2201) {
                     return Res::Err("Unrecognised param id");
                 }
@@ -1458,11 +1458,11 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
             if (attrV0->key == PoolKeys::TokenAFeePCT || attrV0->key == PoolKeys::TokenBFeePCT) {
                 auto poolId = DCT_ID{attrV0->typeId};
                 auto pool   = mnview.GetPoolPair(poolId);
-                Require(pool, "No such pool (%d)", poolId.v);
+                Require(pool, [=]{ return strprintf("No such pool (%d)", poolId.v); });
                 auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ? pool->idTokenA : pool->idTokenB;
 
                 const auto valuePct = std::get_if<CAmount>(&attribute.second);
-                Require(valuePct, "Unexpected type");
+                Require(valuePct, []{ return "Unexpected type"; });
                 if (auto res = mnview.SetDexFeePct(poolId, tokenId, *valuePct); !res) {
                     return res;
                 }
@@ -1474,7 +1474,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                     std::swap(tokenA, tokenB);
                 }
                 const auto valuePct = std::get_if<CAmount>(&attribute.second);
-                Require(valuePct, "Unexpected type");
+                Require(valuePct, []{ return "Unexpected type"; });
                 if (auto res = mnview.SetDexFeePct(tokenA, tokenB, *valuePct); !res) {
                     return res;
                 }
@@ -1504,14 +1504,14 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                 }
             } else if (attrV0->key == TokenKeys::DFIP2203Enabled) {
                 const auto value = std::get_if<bool>(&attribute.second);
-                Require(value, "Unexpected type");
+                Require(value, []{ return "Unexpected type"; });
 
                 if (*value) {
                     continue;
                 }
 
                 const auto token = mnview.GetLoanTokenByID(DCT_ID{attrV0->typeId});
-                Require(token, "No such loan token (%d)", attrV0->typeId);
+                Require(token, [=]{ return strprintf("No such loan token (%d)", attrV0->typeId); });
 
                 // Special case: DUSD will be used as a source for swaps but will
                 // be set as disabled for Future swap destination.
@@ -1524,7 +1524,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                 if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningGreatWorldHeight) &&
                     interestTokens.count(attrV0->typeId)) {
                     const auto tokenInterest = std::get_if<CAmount>(&attribute.second);
-                    Require(tokenInterest, "Unexpected type");
+                    Require(tokenInterest, []{ return "Unexpected type"; });
 
                     std::set<CVaultId> affectedVaults;
                     mnview.ForEachLoanTokenAmount([&](const CVaultId &vaultId, const CBalances &balances) {
@@ -1565,10 +1565,10 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                         }
                     } else {
                         const auto factor = std::get_if<CAmount>(&attribute.second);
-                        Require(factor, "Unexpected type");
-                        Require(*factor < *ratio.begin() * CENT,
+                        Require(factor, []{ return "Unexpected type"; });
+                        Require(*factor < *ratio.begin() * CENT, [=]{ return strprintf(
                                 "Factor cannot be more than or equal to the lowest scheme rate of %d\n",
-                                GetDecimaleString(*ratio.begin() * CENT));
+                                GetDecimaleString(*ratio.begin() * CENT)); });
                     }
                 }
             }
@@ -1576,7 +1576,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
             if (attrV0->typeId == ParamIDs::DFIP2203) {
                 if (attrV0->key == DFIPKeys::Active) {
                     const auto value = std::get_if<bool>(&attribute.second);
-                    Require(value, "Unexpected type");
+                    Require(value, []{ return "Unexpected type"; });
 
                     if (*value) {
                         continue;
@@ -1591,12 +1591,12 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                     }
 
                     CDataStructureV0 activeKey{AttributeTypes::Param, ParamIDs::DFIP2203, DFIPKeys::Active};
-                    Require(!GetValue(activeKey, false), "Cannot set block period while DFIP2203 is active");
+                    Require(!GetValue(activeKey, false), []{ return "Cannot set block period while DFIP2203 is active"; });
                 }
             } else if (attrV0->typeId == ParamIDs::DFIP2206F) {
                 if (attrV0->key == DFIPKeys::Active) {
                     const auto value = std::get_if<bool>(&attribute.second);
-                    Require(value, "Unexpected type");
+                    Require(value, []{ return "Unexpected type"; });
 
                     if (*value) {
                         continue;
@@ -1611,19 +1611,19 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                     }
 
                     CDataStructureV0 activeKey{AttributeTypes::Param, ParamIDs::DFIP2206F, DFIPKeys::Active};
-                    Require(!GetValue(activeKey, false), "Cannot set block period while DFIP2206F is active");
+                    Require(!GetValue(activeKey, false), []{ return "Cannot set block period while DFIP2206F is active"; });
                 }
             }
 
         } else if (attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits) {
             const auto value = std::get_if<OracleSplits>(&attribute.second);
-            Require(value, "Unsupported value");
+            Require(value, []{ return "Unsupported value"; });
             for (const auto split : tokenSplits) {
                 if (auto it{value->find(split)}; it == value->end()) {
                     continue;
                 }
 
-                Require(attrV0->key > height, "Cannot be set at or below current height");
+                Require(attrV0->key > height, []{ return "Cannot be set at or below current height"; });
 
                 CDataStructureV0 lockKey{AttributeTypes::Locks, ParamIDs::TokenID, split};
                 if (GetValue(lockKey, false)) {
@@ -1631,15 +1631,15 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                 }
 
                 Require(
-                    mnview.GetLoanTokenByID(DCT_ID{split}).has_value(), "Auto lock. No loan token with id (%d)", split);
+                    mnview.GetLoanTokenByID(DCT_ID{split}).has_value(), [=]{ return strprintf("Auto lock. No loan token with id (%d)", split); });
 
                 const auto startHeight = attrV0->key - Params().GetConsensus().blocksPerDay() / 2;
                 if (height < startHeight) {
                     auto var = GovVariable::Create("ATTRIBUTES");
-                    Require(var, "Failed to create Gov var for lock");
+                    Require(var, []{ return "Failed to create Gov var for lock"; });
 
                     auto govVar = std::dynamic_pointer_cast<ATTRIBUTES>(var);
-                    Require(govVar, "Failed to cast Gov var to ATTRIBUTES");
+                    Require(govVar, []{ return "Failed to cast Gov var to ATTRIBUTES"; });
                     govVar->attributes[lockKey] = true;
 
                     CGovernanceHeightMessage lock;
@@ -1664,12 +1664,12 @@ Res ATTRIBUTES::Erase(CCustomCSView &mnview, uint32_t, const std::vector<std::st
             if (!attrV0) {
                 return Res::Ok();
             }
-            Require(attrV0->type != AttributeTypes::Live, "Live attribute cannot be deleted");
-            Require(EraseKey(attribute), "Attribute {%d} not exists", attrV0->type);
+            Require(attrV0->type != AttributeTypes::Live, []{ return "Live attribute cannot be deleted"; });
+            Require(EraseKey(attribute), [=]{ return strprintf("Attribute {%d} not exists", attrV0->type); });
             if (attrV0->type == AttributeTypes::Poolpairs) {
                 auto poolId = DCT_ID{attrV0->typeId};
                 auto pool   = mnview.GetPoolPair(poolId);
-                Require(pool, "No such pool (%d)", poolId.v);
+                Require(pool, [=]{ return strprintf("No such pool (%d)", poolId.v); });
                 auto tokenId = attrV0->key == PoolKeys::TokenAFeePCT ? pool->idTokenA : pool->idTokenB;
 
                 return mnview.EraseDexFeePct(poolId, tokenId);

--- a/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
+++ b/src/masternodes/govvariables/icx_takerfee_per_btc.cpp
@@ -21,7 +21,7 @@ UniValue ICX_TAKERFEE_PER_BTC::Export() const {
 }
 
 Res ICX_TAKERFEE_PER_BTC::Validate(const CCustomCSView &mnview) const {
-    Require(takerFeePerBTC > 0, "takerFeePerBTC cannot be 0 or less");
+    Require(takerFeePerBTC > 0, []{ return "takerFeePerBTC cannot be 0 or less"; });
     return Res::Ok();
 }
 

--- a/src/masternodes/govvariables/loan_daily_reward.cpp
+++ b/src/masternodes/govvariables/loan_daily_reward.cpp
@@ -22,7 +22,7 @@ UniValue LP_DAILY_LOAN_TOKEN_REWARD::Export() const {
 }
 
 Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, "Cannot be set before FortCanning");
+    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
     return Res::Err("Cannot be set manually.");
 }
 

--- a/src/masternodes/govvariables/loan_liquidation_penalty.cpp
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.cpp
@@ -22,8 +22,8 @@ UniValue LOAN_LIQUIDATION_PENALTY::Export() const {
 }
 
 Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, "Cannot be set before FortCanning");
-    Require(penalty >= COIN / 100, "Penalty cannot be less than 0.01 DFI");
+    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(penalty >= COIN / 100, []{ return "Penalty cannot be less than 0.01 DFI"; });
 
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/loan_splits.cpp
+++ b/src/masternodes/govvariables/loan_splits.cpp
@@ -13,7 +13,7 @@ bool LP_LOAN_TOKEN_SPLITS::IsEmpty() const {
 }
 
 Res LP_LOAN_TOKEN_SPLITS::Import(const UniValue &val) {
-    Require(val.isObject(), "object of {poolId: rate,... } expected");
+    Require(val.isObject(), []{ return "object of {poolId: rate,... } expected"; });
 
     for (const std::string &key : val.getKeys()) {
         auto id = DCT_ID::FromString(key);
@@ -32,20 +32,20 @@ UniValue LP_LOAN_TOKEN_SPLITS::Export() const {
 }
 
 Res LP_LOAN_TOKEN_SPLITS::Validate(const CCustomCSView &mnview) const {
-    Require(mnview.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, "Cannot be set before FortCanning");
+    Require(mnview.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
 
     CAmount total{0};
     for (const auto &kv : splits) {
-        Require(mnview.HasPoolPair(kv.first), "pool with id=%s not found", kv.first.ToString());
+        Require(mnview.HasPoolPair(kv.first), [=]{ return strprintf("pool with id=%s not found", kv.first.ToString()); });
 
         Require(kv.second >= 0 && kv.second <= COIN,
-                "wrong percentage for pool with id=%s, value = %s",
-                kv.first.ToString(),
-                std::to_string(kv.second));
+                [=]{ return strprintf("wrong percentage for pool with id=%s, value = %s",
+                                      kv.first.ToString(),
+                                      std::to_string(kv.second)); });
 
         total += kv.second;
     }
-    Require(total == COIN, "total = %d vs expected %d", total, COIN);
+    Require(total == COIN, [=]{ return strprintf("total = %d vs expected %d", total, COIN); });
 
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
@@ -22,7 +22,7 @@ UniValue LP_DAILY_DFI_REWARD::Export() const {
 }
 
 Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() < Params().GetConsensus().EunosHeight, "Cannot be set manually after Eunos hard fork");
+    Require(view.GetLastHeight() < Params().GetConsensus().EunosHeight, []{ return "Cannot be set manually after Eunos hard fork"; });
     // nothing to do
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/lp_splits.cpp
+++ b/src/masternodes/govvariables/lp_splits.cpp
@@ -14,7 +14,7 @@ bool LP_SPLITS::IsEmpty() const {
 
 Res LP_SPLITS::Import(const UniValue &val) {
     Require(val.isObject(),
-            "object of {poolId: rate,... } expected");  /// throw here? cause "AmountFromValue" can throw!
+            []{ return "object of {poolId: rate,... } expected"; });  /// throw here? cause "AmountFromValue" can throw!
 
     for (const std::string &key : val.getKeys()) {
         auto id = DCT_ID::FromString(key);
@@ -35,16 +35,14 @@ UniValue LP_SPLITS::Export() const {
 Res LP_SPLITS::Validate(const CCustomCSView &mnview) const {
     CAmount total{0};
     for (const auto &[poolId, amount] : splits) {
-        Require(mnview.HasPoolPair(poolId), "pool with id=%s not found", poolId.ToString());
+        Require(mnview.HasPoolPair(poolId), [poolId=poolId]{ return strprintf("pool with id=%s not found", poolId.ToString()); });
 
         Require(amount >= 0 && amount <= COIN,
-                "wrong percentage for pool with id=%s, value = %s",
-                poolId.ToString(),
-                std::to_string(amount));
+                [=, poolId=poolId]{ return strprintf("wrong percentage for pool with id=%s, value = %s", poolId.ToString(), std::to_string(amount)); });
 
         total += amount;
     }
-    Require(total == COIN, "total = %d vs expected %d", total, COIN);
+    Require(total == COIN, [=]{ return strprintf("total = %d vs expected %d", total, COIN); });
 
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/lp_splits.cpp
+++ b/src/masternodes/govvariables/lp_splits.cpp
@@ -38,7 +38,7 @@ Res LP_SPLITS::Validate(const CCustomCSView &mnview) const {
         Require(mnview.HasPoolPair(poolId), [poolId=poolId]{ return strprintf("pool with id=%s not found", poolId.ToString()); });
 
         Require(amount >= 0 && amount <= COIN,
-                [=, poolId=poolId]{ return strprintf("wrong percentage for pool with id=%s, value = %s", poolId.ToString(), std::to_string(amount)); });
+                [amount=amount, poolId=poolId]{ return strprintf("wrong percentage for pool with id=%s, value = %s", poolId.ToString(), std::to_string(amount)); });
 
         total += amount;
     }

--- a/src/masternodes/govvariables/oracle_block_interval.cpp
+++ b/src/masternodes/govvariables/oracle_block_interval.cpp
@@ -13,7 +13,7 @@ bool ORACLE_BLOCK_INTERVAL::IsEmpty() const {
 }
 
 Res ORACLE_BLOCK_INTERVAL::Import(const UniValue &val) {
-    Require(val.isNum(), "Block interval amount is not a number");
+    Require(val.isNum(), []{ return "Block interval amount is not a number"; });
 
     blockInterval = val.get_int();
     return Res::Ok();
@@ -24,8 +24,8 @@ UniValue ORACLE_BLOCK_INTERVAL::Export() const {
 }
 
 Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, "Cannot be set before FortCanning");
-    Require(blockInterval > 0, "Block interval cannot be less than 1");
+    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(blockInterval > 0, []{ return "Block interval cannot be less than 1"; });
 
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/oracle_deviation.cpp
+++ b/src/masternodes/govvariables/oracle_deviation.cpp
@@ -22,8 +22,8 @@ UniValue ORACLE_DEVIATION::Export() const {
 }
 
 Res ORACLE_DEVIATION::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, "Cannot be set before FortCanning");
-    Require(deviation >= COIN / 100, "Deviation cannot be less than 1 percent");
+    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(deviation >= COIN / 100, []{ return "Deviation cannot be less than 1 percent"; });
 
     return Res::Ok();
 }

--- a/src/masternodes/gv.cpp
+++ b/src/masternodes/gv.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<GovVariable> CGovView::GetVariable(const std::string &name) cons
 
 Res CGovView::SetStoredVariables(const std::set<std::shared_ptr<GovVariable>> &govVars, const uint32_t height) {
     for (auto &item : govVars)
-        Require(WriteBy<ByHeightVars>(GovVarKey{height, item->GetName()}, *item), "Cannot write to DB");
+        Require(WriteBy<ByHeightVars>(GovVarKey{height, item->GetName()}, *item), []{ return "Cannot write to DB"; });
 
     return Res::Ok();
 }

--- a/src/masternodes/incentivefunding.cpp
+++ b/src/masternodes/incentivefunding.cpp
@@ -15,7 +15,7 @@ CAmount CCommunityBalancesView::GetCommunityBalance(CommunityAccountType account
 
 Res CCommunityBalancesView::SetCommunityBalance(CommunityAccountType account, CAmount amount) {
     // deny negative values on db level!
-    Require(amount >= 0, "negative amount");
+    Require(amount >= 0, []{ return "negative amount"; });
     WriteBy<ById>(static_cast<unsigned char>(account), amount);
     return Res::Ok();
 }
@@ -42,8 +42,8 @@ Res CCommunityBalancesView::SubCommunityBalance(CommunityAccountType account, CA
     if (amount == 0) {
         return Res::Ok();
     }
-    Require(amount > 0, "negative amount");
+    Require(amount > 0, []{ return "negative amount"; });
     CAmount oldBalance = GetCommunityBalance(account);
-    Require(oldBalance >= amount, "Amount %d is less than %d", oldBalance, amount);
+    Require(oldBalance >= amount, [=]{ return strprintf("Amount %d is less than %d", oldBalance, amount); });
     return SetCommunityBalance(account, oldBalance - amount);
 }

--- a/src/masternodes/loan.cpp
+++ b/src/masternodes/loan.cpp
@@ -13,11 +13,12 @@ std::optional<CLoanView::CLoanSetCollateralTokenImpl> CLoanView::GetLoanCollater
 Res CLoanView::CreateLoanCollateralToken(const CLoanSetCollateralTokenImpl &collToken) {
     // this should not happen, but for sure
     Require(!GetLoanCollateralToken(collToken.creationTx),
-            "setCollateralToken with creation tx %s already exists!",
-            collToken.creationTx.GetHex());
+            [=]{ return strprintf("setCollateralToken with creation tx %s already exists!",
+                                  collToken.creationTx.GetHex()); });
     Require(
-        collToken.factor <= COIN, "setCollateralToken factor must be lower or equal than %s!", GetDecimaleString(COIN));
-    Require(collToken.factor >= 0, "setCollateralToken factor must not be negative!");
+        collToken.factor <= COIN, [=]{ return strprintf("setCollateralToken factor must be lower or equal than %s!",
+                                                         GetDecimaleString(COIN)); });
+    Require(collToken.factor >= 0, []{ return "setCollateralToken factor must not be negative!"; });
 
     WriteBy<LoanSetCollateralTokenCreationTx>(collToken.creationTx, collToken);
 
@@ -57,7 +58,7 @@ std::optional<CLoanView::CLoanSetLoanTokenImpl> CLoanView::GetLoanToken(const ui
 
 Res CLoanView::SetLoanToken(const CLoanSetLoanTokenImpl &loanToken, DCT_ID const &id) {
     // this should not happen, but for sure
-    Require(!GetLoanTokenByID(id), "setLoanToken with creation tx %s already exists!", loanToken.creationTx.GetHex());
+    Require(!GetLoanTokenByID(id), [=]{ return strprintf("setLoanToken with creation tx %s already exists!", loanToken.creationTx.GetHex()); });
 
     WriteBy<LoanSetLoanTokenKey>(id, loanToken);
     WriteBy<LoanSetLoanTokenCreationTx>(loanToken.creationTx, id);
@@ -285,16 +286,16 @@ Res CLoanView::IncreaseInterest(const uint32_t height,
                                 const CAmount tokenInterest,
                                 const CAmount loanIncreased) {
     const auto scheme = GetLoanScheme(loanSchemeID);
-    Require(scheme, "No such scheme id %s", loanSchemeID);
+    Require(scheme, [=]{ return strprintf("No such scheme id %s", loanSchemeID); });
 
     auto token = GetLoanTokenByID(id);
-    Require(token, "No such loan token id %s", id.ToString());
+    Require(token, [=]{ return strprintf("No such loan token id %s", id.ToString()); });
 
     CInterestRateV3 rate{};
     if (auto readRate = GetInterestRate(vaultId, id, height))
         rate = *readRate;
 
-    Require(height >= rate.height, "Cannot store height in the past");
+    Require(height >= rate.height, []{ return "Cannot store height in the past"; });
 
     rate.interestToHeight = TotalInterestCalculation(rate, height);
     rate.height           = height;
@@ -333,18 +334,18 @@ Res CLoanView::DecreaseInterest(const uint32_t height,
                                 const CAmount loanDecreased,
                                 const CAmount interestDecreased) {
     const auto scheme = GetLoanScheme(loanSchemeID);
-    Require(scheme, "No such scheme id %s", loanSchemeID);
+    Require(scheme, [=]{ return strprintf("No such scheme id %s", loanSchemeID); });
 
     auto token = GetLoanTokenByID(id);
-    Require(token, "No such loan token id %s", id.ToString());
+    Require(token, [=]{ return strprintf("No such loan token id %s", id.ToString()); });
 
     CInterestRateV3 rate{};
     if (auto readRate = GetInterestRate(vaultId, id, height))
         rate = *readRate;
 
-    Require(height >= rate.height, "Cannot store height in the past");
+    Require(height >= rate.height, []{ return "Cannot store height in the past"; });
 
-    Require(rate.height != 0, "Data mismatch height == 0");
+    Require(rate.height != 0, []{ return "Data mismatch height == 0"; });
 
     const auto interestToHeight    = TotalInterestCalculation(rate, height);
     const auto interestDecreasedHP = ToHigherPrecision(interestDecreased, height);
@@ -526,7 +527,7 @@ void CLoanView::MigrateInterestRateToV3(CVaultView &view, uint32_t height) {
 }
 
 Res CLoanView::AddLoanToken(const CVaultId &vaultId, CTokenAmount amount) {
-    Require(GetLoanTokenByID(amount.nTokenId), "No such loan token id %s", amount.nTokenId.ToString());
+    Require(GetLoanTokenByID(amount.nTokenId), [=]{ return strprintf("No such loan token id %s", amount.nTokenId.ToString()); });
 
     CBalances amounts;
     ReadBy<LoanTokenAmount>(vaultId, amounts);
@@ -539,10 +540,10 @@ Res CLoanView::AddLoanToken(const CVaultId &vaultId, CTokenAmount amount) {
 }
 
 Res CLoanView::SubLoanToken(const CVaultId &vaultId, CTokenAmount amount) {
-    Require(GetLoanTokenByID(amount.nTokenId), "No such loan token id %s", amount.nTokenId.ToString());
+    Require(GetLoanTokenByID(amount.nTokenId), [=]{ return strprintf("No such loan token id %s", amount.nTokenId.ToString()); });
 
     auto amounts = GetLoanTokens(vaultId);
-    Require(amounts && amounts->Sub(amount), "Loan token for vault <%s> not found", vaultId.GetHex());
+    Require(amounts && amounts->Sub(amount), [=]{ return strprintf("Loan token for vault <%s> not found", vaultId.GetHex()); });
 
     if (amounts->balances.empty())
         EraseBy<LoanTokenAmount>(vaultId);

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -1051,7 +1051,7 @@ Res CCustomCSView::PopulateLoansData(CCollateralLoans &result,
 
     for (const auto &[loanTokenId, loanTokenAmount] : loanTokens->balances) {
         const auto token = GetLoanTokenByID(loanTokenId);
-        Require(token, [=]{ return strprintf("Loan token with id (%s) does not exist!", loanTokenId.ToString()); });
+        Require(token, [loanTokenId=loanTokenId]{ return strprintf("Loan token with id (%s) does not exist!", loanTokenId.ToString()); });
 
         const auto rate = GetInterestRate(vaultId, loanTokenId, height);
         Require(rate, [=]{ return strprintf("Cannot get interest rate for token (%s)!", token->symbol); });

--- a/src/masternodes/oracles.cpp
+++ b/src/masternodes/oracles.cpp
@@ -13,7 +13,7 @@ bool COracle::SupportsPair(const std::string &token, const std::string &currency
 }
 
 Res COracle::SetTokenPrice(const std::string &token, const std::string &currency, CAmount amount, int64_t timestamp) {
-    Require(SupportsPair(token, currency), "token <%s> - currency <%s> is not allowed", token, currency);
+    Require(SupportsPair(token, currency), [=]{ return strprintf("token <%s> - currency <%s> is not allowed", token, currency); });
 
     tokenPrices[token][currency] = std::make_pair(amount, timestamp);
 
@@ -21,22 +21,22 @@ Res COracle::SetTokenPrice(const std::string &token, const std::string &currency
 }
 
 ResVal<CAmount> COracle::GetTokenPrice(const std::string &token, const std::string &currency) {
-    Require(SupportsPair(token, currency), "token <%s> - currency <%s> is not allowed", token, currency);
+    Require(SupportsPair(token, currency), [=]{ return strprintf("token <%s> - currency <%s> is not allowed", token, currency); });
 
     return ResVal<CAmount>(tokenPrices[token][currency].first, Res::Ok());
 }
 
 Res COracleView::AppointOracle(const COracleId &oracleId, const COracle &oracle) {
-    Require(WriteBy<ByName>(oracleId, oracle), "failed to appoint the new oracle <%s>", oracleId.GetHex());
+    Require(WriteBy<ByName>(oracleId, oracle), [=]{ return strprintf("failed to appoint the new oracle <%s>", oracleId.GetHex()); });
 
     return Res::Ok();
 }
 
 Res COracleView::UpdateOracle(const COracleId &oracleId, COracle &&newOracle) {
     COracle oracle;
-    Require(ReadBy<ByName>(oracleId, oracle), "oracle <%s> not found", oracleId.GetHex());
+    Require(ReadBy<ByName>(oracleId, oracle), [=]{ return strprintf("oracle <%s> not found", oracleId.GetHex()); });
 
-    Require(newOracle.tokenPrices.empty(), "oracle <%s> has token prices on update", oracleId.GetHex());
+    Require(newOracle.tokenPrices.empty(), [=]{ return strprintf("oracle <%s> has token prices on update", oracleId.GetHex()); });
 
     oracle.weightage     = newOracle.weightage;
     oracle.oracleAddress = std::move(newOracle.oracleAddress);
@@ -57,23 +57,23 @@ Res COracleView::UpdateOracle(const COracleId &oracleId, COracle &&newOracle) {
     oracle.availablePairs = std::move(newOracle.availablePairs);
 
     // no need to update oracles list
-    Require(WriteBy<ByName>(oracleId, oracle), "failed to save oracle <%s>", oracleId.GetHex());
+    Require(WriteBy<ByName>(oracleId, oracle), [=]{ return strprintf("failed to save oracle <%s>", oracleId.GetHex()); });
 
     return Res::Ok();
 }
 
 Res COracleView::RemoveOracle(const COracleId &oracleId) {
-    Require(ExistsBy<ByName>(oracleId), "oracle <%s> not found", oracleId.GetHex());
+    Require(ExistsBy<ByName>(oracleId), [=]{ return strprintf("oracle <%s> not found", oracleId.GetHex()); });
 
     // remove oracle
-    Require(EraseBy<ByName>(oracleId), "failed to remove oracle <%s>", oracleId.GetHex());
+    Require(EraseBy<ByName>(oracleId), [=]{ return strprintf("failed to remove oracle <%s>", oracleId.GetHex()); });
 
     return Res::Ok();
 }
 
 Res COracleView::SetOracleData(const COracleId &oracleId, int64_t timestamp, const CTokenPrices &tokenPrices) {
     COracle oracle;
-    Require(ReadBy<ByName>(oracleId, oracle), "failed to read oracle %s from database", oracleId.GetHex());
+    Require(ReadBy<ByName>(oracleId, oracle), [=]{ return strprintf("failed to read oracle %s from database", oracleId.GetHex()); });
 
     for (const auto &tokenPrice : tokenPrices) {
         const auto &token = tokenPrice.first;
@@ -83,13 +83,13 @@ Res COracleView::SetOracleData(const COracleId &oracleId, int64_t timestamp, con
         }
     }
 
-    Require(WriteBy<ByName>(oracleId, oracle), "failed to store oracle %s to database", oracleId.GetHex());
+    Require(WriteBy<ByName>(oracleId, oracle), [=]{ return strprintf("failed to store oracle %s to database", oracleId.GetHex()); });
     return Res::Ok();
 }
 
 ResVal<COracle> COracleView::GetOracleData(const COracleId &oracleId) const {
     COracle oracle;
-    Require(ReadBy<ByName>(oracleId, oracle), "oracle <%s> not found", oracleId.GetHex());
+    Require(ReadBy<ByName>(oracleId, oracle), [=]{ return strprintf("oracle <%s> not found", oracleId.GetHex()); });
 
     return ResVal<COracle>(oracle, Res::Ok());
 }
@@ -106,9 +106,9 @@ bool CFixedIntervalPrice::isLive(const CAmount deviationThreshold) const {
 
 Res COracleView::SetFixedIntervalPrice(const CFixedIntervalPrice &fixedIntervalPrice) {
     Require(WriteBy<FixedIntervalPriceKey>(fixedIntervalPrice.priceFeedId, fixedIntervalPrice),
-            "failed to set new price feed <%s/%s>",
-            fixedIntervalPrice.priceFeedId.first,
-            fixedIntervalPrice.priceFeedId.second);
+            [=]{ return strprintf("failed to set new price feed <%s/%s>",
+                                  fixedIntervalPrice.priceFeedId.first,
+                                  fixedIntervalPrice.priceFeedId.second); });
 
     LogPrint(BCLog::ORACLE,
              "%s(): %s/%s, active - %lld, next - %lld\n",
@@ -124,9 +124,9 @@ Res COracleView::SetFixedIntervalPrice(const CFixedIntervalPrice &fixedIntervalP
 ResVal<CFixedIntervalPrice> COracleView::GetFixedIntervalPrice(const CTokenCurrencyPair &fixedIntervalPriceId) {
     CFixedIntervalPrice fixedIntervalPrice;
     Require(ReadBy<FixedIntervalPriceKey>(fixedIntervalPriceId, fixedIntervalPrice),
-            "fixedIntervalPrice with id <%s/%s> not found",
-            fixedIntervalPriceId.first,
-            fixedIntervalPriceId.second);
+            [=]{ return strprintf("fixedIntervalPrice with id <%s/%s> not found",
+                                  fixedIntervalPriceId.first,
+                                  fixedIntervalPriceId.second); });
 
     DCT_ID firstID{}, secondID{};
     const auto firstToken  = GetTokenGuessId(fixedIntervalPriceId.first, firstID);
@@ -141,7 +141,7 @@ ResVal<CFixedIntervalPrice> COracleView::GetFixedIntervalPrice(const CTokenCurre
         loanTokens.insert(secondID.v);
     }
 
-    Require(!AreTokensLocked(loanTokens), "Fixed interval price currently disabled due to locked token");
+    Require(!AreTokensLocked(loanTokens), []{ return "Fixed interval price currently disabled due to locked token"; });
 
     LogPrint(BCLog::ORACLE,
              "%s(): %s/%s, active - %lld, next - %lld\n",

--- a/src/masternodes/rpc_oracles.cpp
+++ b/src/masternodes/rpc_oracles.cpp
@@ -853,8 +853,8 @@ ResVal<CAmount> GetAggregatePrice(CCustomCSView& view, const std::string& token,
     });
 
     static const uint64_t minimumLiveOracles = Params().NetworkIDString() == CBaseChainParams::REGTEST ? 1 : 2;
-    Require(numLiveOracles >= minimumLiveOracles, "no live oracles for specified request");
-    Require(sumWeights > 0, "all live oracles which meet specified request, have zero weight");
+    Require(numLiveOracles >= minimumLiveOracles, []{ return "no live oracles for specified request"; });
+    Require(sumWeights > 0, []{ return "all live oracles which meet specified request, have zero weight"; });
 
     ResVal<CAmount> res((weightedSum / arith_uint256(sumWeights)).GetLow64(), Res::Ok());
 

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -1483,7 +1483,7 @@ static Res VaultSplits(CCustomCSView& view, ATTRIBUTES& attributes, const DCT_ID
         });
     }
 
-    Require(failedVault == CVaultId{}, "Failed to get vault data for: %s", failedVault.ToString());
+    Require(failedVault == CVaultId{}, [=]{ return strprintf("Failed to get vault data for: %s", failedVault.ToString()); });
 
     attributes.EraseKey(CDataStructureV0{AttributeTypes::Locks, ParamIDs::TokenID, oldTokenId.v});
     attributes.SetValue(CDataStructureV0{AttributeTypes::Locks, ParamIDs::TokenID, newTokenId.v}, true);
@@ -1514,7 +1514,7 @@ static Res VaultSplits(CCustomCSView& view, ATTRIBUTES& attributes, const DCT_ID
     }
 
     const auto loanToken = view.GetLoanTokenByID(newTokenId);
-    Require(loanToken, "Failed to get loan token.");
+    Require(loanToken, []{ return "Failed to get loan token."; });
 
     // Pre-populate to save repeated calls to get loan scheme
     std::map<std::string, CAmount> loanSchemes;
@@ -1649,10 +1649,10 @@ static Res GetTokenSuffix(const CCustomCSView& view, const ATTRIBUTES& attribute
     if (attributes.CheckKey(ascendantKey)) {
         const auto& [previousID, str] = attributes.GetValue(ascendantKey, AscendantValue{std::numeric_limits<uint32_t>::max(), ""});
         auto previousToken = view.GetToken(DCT_ID{previousID});
-        Require(previousToken, "Previous token %d not found\n", id);
+        Require(previousToken, [=]{ return strprintf("Previous token %d not found\n", id); });
 
         const auto found = previousToken->symbol.find(newSuffix);
-        Require(found != std::string::npos, "Previous token name not valid: %s\n", previousToken->symbol);
+        Require(found != std::string::npos, [=]{ return strprintf("Previous token name not valid: %s\n", previousToken->symbol); });
 
         const auto versionNumber  = previousToken->symbol.substr(found + newSuffix.size());
         uint32_t previousVersion{};

--- a/src/masternodes/vault.cpp
+++ b/src/masternodes/vault.cpp
@@ -23,7 +23,7 @@ Res CVaultView::StoreVault(const CVaultId &vaultId, const CVaultData &vault) {
 
 Res CVaultView::EraseVault(const CVaultId &vaultId) {
     auto vault = GetVault(vaultId);
-    Require(vault, "Vault <%s> not found", vaultId.GetHex());
+    Require(vault, [=]{ return strprintf("Vault <%s> not found", vaultId.GetHex()); });
 
     EraseBy<VaultKey>(vaultId);
     EraseBy<CollateralKey>(vaultId);
@@ -37,7 +37,7 @@ std::optional<CVaultData> CVaultView::GetVault(const CVaultId &vaultId) const {
 
 Res CVaultView::UpdateVault(const CVaultId &vaultId, const CVaultMessage &newVault) {
     auto vault = GetVault(vaultId);
-    Require(vault, "Vault <%s> not found", vaultId.GetHex());
+    Require(vault, [=]{ return strprintf("Vault <%s> not found", vaultId.GetHex()); });
 
     EraseBy<OwnerVaultKey>(std::make_pair(vault->ownerAddress, vaultId));
 
@@ -73,7 +73,7 @@ Res CVaultView::AddVaultCollateral(const CVaultId &vaultId, CTokenAmount amount)
 
 Res CVaultView::SubVaultCollateral(const CVaultId &vaultId, CTokenAmount amount) {
     auto amounts = GetVaultCollaterals(vaultId);
-    Require(amounts && amounts->Sub(amount), "Collateral for vault <%s> not found", vaultId.GetHex());
+    Require(amounts && amounts->Sub(amount), [=]{ return strprintf("Collateral for vault <%s> not found", vaultId.GetHex()); });
 
     if (amounts->balances.empty()) {
         EraseBy<CollateralKey>(vaultId);

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -61,7 +61,7 @@ ResVal<CTokenAmount> GuessTokenAmount(interfaces::Chain const & chain, std::stri
     } catch (...) {
         // assuming it's token symbol, read DCT_ID from DB
         auto token = chain.existTokenGuessId(parsed.val->second, tokenId);
-        Require(token, "Invalid Defi token: %s", parsed.val->second);
+        Require(token, [=]{ return strprintf("Invalid Defi token: %s", parsed.val->second); });
         return {{tokenId, parsed.val->first}, Res::Ok()};
     }
 }


### PR DESCRIPTION
The adding of Require impacted performance as strings were always created regardless of whether the conditional was true or false. This PR updates all Require statements not with the exception of mn_checks.