### PR TITLE
Use if conditionals in amount

### DIFF
--- a/src/masternodes/accounts.cpp
+++ b/src/masternodes/accounts.cpp
@@ -91,7 +91,7 @@ void CAccountsView::ForEachFuturesUserValues(
 }
 
 Res CAccountsView::EraseFuturesUserValues(const CFuturesUserKey &key) {
-    Require(EraseBy<ByFuturesSwapKey>(key), [=]{ return "Failed to erase futures"; });
+    Require(EraseBy<ByFuturesSwapKey>(key), []{ return "Failed to erase futures"; });
     return Res::Ok();
 }
 


### PR DESCRIPTION
For performance in amounts which is heavily utilised use if conditionals to avoid the extra cost of a lambda or string as a secondary argument to Require.