### PR TITLE
Add DeFiErrors abstraction for error messages

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -175,6 +175,7 @@ DEFI_CORE_H = \
   masternodes/mn_checks.h \
   masternodes/mn_rpc.h \
   masternodes/res.h \
+  masternodes/errors.h \
   masternodes/oracles.h \
   masternodes/poolpairs.h \
   masternodes/proposals.h \

--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 The DeFi Foundation
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFI_ERRORS_H
+#define DEFI_ERRORS_H
+
+#include <amount.h>
+#include <masternodes/res.h>
+
+class DeFiErrors {
+public:
+    static Res MNInvalid(const std::string &nodeRefString) { 
+        return Res::Err("node %s does not exists", nodeRefString);
+    }
+
+    static Res MNInvalidAltMsg(const std::string &nodeRefString) { 
+        return Res::Err("masternode %s does not exist", nodeRefString);
+    }
+
+    static Res MNStateNotEnabled(const std::string &nodeRefString) { 
+        return Res::Err("Masternode %s is not in 'ENABLED' state", nodeRefString);
+    }
+
+    static Res ICXBTCBelowMinSwap(const CAmount amount, const CAmount minSwap) {
+        // TODO: Change error in later version to include amount. Retaining old msg for compatibility
+        return Res::Err("Below minimum swapable amount, must be at least %s BTC", GetDecimaleString(minSwap));
+    }
+};
+
+#endif  // DEFI_ERRORS_H
+

--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef DEFI_ERRORS_H
-#define DEFI_ERRORS_H
+#ifndef DEFI_MASTERNODES_ERRORS_H
+#define DEFI_MASTERNODES_ERRORS_H
 
 #include <amount.h>
 #include <masternodes/res.h>
@@ -28,5 +28,5 @@ public:
     }
 };
 
-#endif  // DEFI_ERRORS_H
+#endif  // DEFI_MASTERNODES_ERRORS_H
 


### PR DESCRIPTION
/kind refactor

- Add `DeFiErrors` class that abstracts error messages. 
- Provide meaningful parameters and construct errors message from it in a coherent way than similar, but different messages across the codebase. 
- Eventually use this to slowly add error codes than just messages for external APIs to rely on. 