### PR TITLE
Add `-txordering` flag: support for miners to switch TX ordering 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -513,7 +513,7 @@ void SetupServerArgs()
     gArgs.AddArg("-simulatemainnet", "Configure the regtest network to mainnet target timespan and spacing ", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-dexstats", strprintf("Enable storing live dex data in DB (default: %u)", DEFAULT_DEXSTATS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blocktimeordering", strprintf("Whether to order transactions by time, otherwise ordered by fee (default: %u)", DEFAULT_FEE_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-autotxordering", strprintf("Whether to order transactions by time, fee or randomly (auto) (default: %u)", DEFAULT_AUTO_FEE_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-txordering", strprintf("Whether to order transactions by entry time, fee or both randomly (0: mixed, 1: fee based, 2: entry time) (default: %u)", DEFAULT_AUTO_FEE_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -218,9 +218,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         UpdateTime(pblock, consensus, pindexPrev); // update time before tx packaging
     }
 
-    const auto autoOrdering = gArgs.GetBoolArg("-autotxordering", DEFAULT_AUTO_FEE_ORDERING);
-    bool timeOrdering = DEFAULT_FEE_ORDERING;
-    if (autoOrdering) {
+    const auto txOrdering = gArgs.GetArg("-txordering", DEFAULT_AUTO_FEE_ORDERING);
+    bool timeOrdering = gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING);
+
+    if (txOrdering == MIXED_ORDERING) {
         std::random_device rd;
         std::mt19937_64 gen(rd());
         std::uniform_int_distribution<unsigned long long> dis;
@@ -229,9 +230,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             timeOrdering = false;
         else
             timeOrdering = true;
-    } else {
-        timeOrdering = gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING);
-    }
+    } else if (txOrdering == ENTRYTIME_ORDERING) {
+        timeOrdering = true;
+    } else if (gArgs.IsArgSet("-txordering") && txOrdering == FEE_ORDERING) {
+        timeOrdering = false;
+    } // falls back to blocktimeordering arg if txordering is default/fee based
 
     if (timeOrdering) {
         addPackageTxs<entry_time>(nPackagesSelected, nDescendantsUpdated, nHeight, mnview);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -234,7 +234,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         timeOrdering = true;
     } else if (gArgs.IsArgSet("-txordering") && txOrdering == FEE_ORDERING) {
         timeOrdering = false;
-    } // falls back to blocktimeordering arg if txordering is default/fee based
+    } // falls back to blocktimeordering arg if txordering is not set
 
     if (timeOrdering) {
         addPackageTxs<entry_time>(nPackagesSelected, nDescendantsUpdated, nHeight, mnview);

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -790,7 +790,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
 
     // If block ordering by time is enabled return 0 to let fallback or discard fee be used.
     if (gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING) ||
-        gArgs.GetBoolArg("-autotxordering", DEFAULT_AUTO_FEE_ORDERING)) {
+        gArgs.GetBoolArg("-txordering", DEFAULT_AUTO_FEE_ORDERING)) {
         return 0;
     }
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -790,7 +790,8 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
 
     // If block ordering by time is enabled return 0 to let fallback or discard fee be used.
     if (gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING) ||
-        gArgs.GetBoolArg("-txordering", DEFAULT_AUTO_FEE_ORDERING)) {
+        gArgs.GetArg("-txordering", DEFAULT_AUTO_FEE_ORDERING) == MIXED_ORDERING ||
+        gArgs.GetArg("-txordering", DEFAULT_AUTO_FEE_ORDERING) == ENTRYTIME_ORDERING) {
         return 0;
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -980,7 +980,8 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
     if (feeRate != CFeeRate(0)) {
         result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
     } else if (gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING) ||
-               gArgs.GetBoolArg("-txordering", DEFAULT_AUTO_FEE_ORDERING)) {
+               gArgs.GetArg("-txordering", DEFAULT_AUTO_FEE_ORDERING) == MIXED_ORDERING ||
+               gArgs.GetArg("-txordering", DEFAULT_AUTO_FEE_ORDERING) == ENTRYTIME_ORDERING) {
         result.pushKV("feerate", ValueFromAmount(DEFAULT_TRANSACTION_MINFEE));
     } else {
         errors.push_back("Insufficient data or no feerate found");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -980,7 +980,7 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
     if (feeRate != CFeeRate(0)) {
         result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
     } else if (gArgs.GetBoolArg("-blocktimeordering", DEFAULT_FEE_ORDERING) ||
-               gArgs.GetBoolArg("-autotxordering", DEFAULT_AUTO_FEE_ORDERING)) {
+               gArgs.GetBoolArg("-txordering", DEFAULT_AUTO_FEE_ORDERING)) {
         result.pushKV("feerate", ValueFromAmount(DEFAULT_TRANSACTION_MINFEE));
     } else {
         errors.push_back("Insufficient data or no feerate found");

--- a/src/validation.h
+++ b/src/validation.h
@@ -55,6 +55,12 @@ struct DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
 struct LockPoints;
 
+enum TxOrderings {
+    MIXED_ORDERING,
+    FEE_ORDERING,
+    ENTRYTIME_ORDERING
+};
+
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
@@ -133,7 +139,7 @@ static const bool DEFAULT_DEXSTATS = false;
 static const bool DEFAULT_NEGATIVE_INTEREST = false;
 /** Default for using TX fee ordering in blocks */
 static const bool DEFAULT_FEE_ORDERING = false;
-static const bool DEFAULT_AUTO_FEE_ORDERING = false;
+static const TxOrderings DEFAULT_AUTO_FEE_ORDERING = FEE_ORDERING;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind feature

#### What this PR does / why we need it:

- Renames `-autotxordering` argument to `-txordering`
- Accepts `int` instead of `bool` (0: mixed ordering, 1: fee based ordering, 2: time based ordering)
- Defaults to fee based ordering
- Falls back to `-blocktimeordering` if `-txordering` is not set
