### PR TITLE
Limit parallel script processing thread pool to 4 by default

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1473,13 +1473,14 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     int script_threads = gArgs.GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
     if (script_threads <= 0) {
-        // -par=0 means autodetect (number of cores - 1 script threads)
-        // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)
-        script_threads += GetNumCores();
         // DeFiChain specific:
         // Set this to a max value, since most custom TXs don't utilize this unfortunately 
-        // and is just a waste of resources. 
-        script_threads = std::min(script_threads, 4);
+        // and is just a waste of resources.
+        auto defaultThreads = std::min(script_threads, 4);
+
+        // -par=0 means autodetect (number of cores - 1 script threads)
+        // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)
+        script_threads += defaultThreads;
     }
 
     // Subtract 1 because the main thread counts towards the par threads

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1476,7 +1476,7 @@ bool AppInitMain(InitInterfaces& interfaces)
         // DeFiChain specific:
         // Set this to a max value, since most custom TXs don't utilize this unfortunately 
         // and is just a waste of resources.
-        auto defaultThreads = std::min(script_threads, 4);
+        auto defaultThreads = std::min(GetNumCores(), 4);
 
         // -par=0 means autodetect (number of cores - 1 script threads)
         // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1476,6 +1476,10 @@ bool AppInitMain(InitInterfaces& interfaces)
         // -par=0 means autodetect (number of cores - 1 script threads)
         // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)
         script_threads += GetNumCores();
+        // DeFiChain specific:
+        // Set this to a max of 2, since most custom TXs don't utilize this unfortunately 
+        // and is just a waste of resources. 
+        script_threads = std::min(script_threads, 2);
     }
 
     // Subtract 1 because the main thread counts towards the par threads

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1473,14 +1473,13 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     int script_threads = gArgs.GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
     if (script_threads <= 0) {
-        // DeFiChain specific:
-        // Set this to a max value, since most custom TXs don't utilize this unfortunately 
-        // and is just a waste of resources.
-        auto defaultThreads = std::min(GetNumCores(), 4);
-
         // -par=0 means autodetect (number of cores - 1 script threads)
         // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)
-        script_threads += defaultThreads;
+        script_threads += GetNumCores();
+        // DeFiChain specific:
+        // Set this to a max value, since most custom TXs don't utilize this unfortunately 
+        // and is just a waste of resources. 
+        script_threads = std::min(script_threads, 4);
     }
 
     // Subtract 1 because the main thread counts towards the par threads

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1477,9 +1477,9 @@ bool AppInitMain(InitInterfaces& interfaces)
         // -par=-n means "leave n cores free" (number of cores - n - 1 script threads)
         script_threads += GetNumCores();
         // DeFiChain specific:
-        // Set this to a max of 2, since most custom TXs don't utilize this unfortunately 
+        // Set this to a max value, since most custom TXs don't utilize this unfortunately 
         // and is just a waste of resources. 
-        script_threads = std::min(script_threads, 2);
+        script_threads = std::min(script_threads, 4);
     }
 
     // Subtract 1 because the main thread counts towards the par threads


### PR DESCRIPTION
/kind chore

- Limits parallel execution threads of Bitcoin threads to 4 by default.
- We do not utilise this for DeFi TXs (unfortunately), and usually is just a wasted threads sitting around unless there are many many pure UTXO TXs. 4 threads should be sufficient for most practical purposes. 
- Doing this cleanup as a precursor to add a common worker pool for most other thread related activites