### PR TITLE
Remove usage of ForEachAccount

### DIFF
--- a/src/masternodes/accounts.cpp
+++ b/src/masternodes/accounts.cpp
@@ -63,11 +63,6 @@ Res CAccountsView::SubBalances(const CScript &owner, const CBalances &balances) 
     return Res::Ok();
 }
 
-void CAccountsView::ForEachAccount(std::function<bool(const CScript &)> callback, const CScript &start) {
-    ForEach<ByHeightKey, CScript, uint32_t>(
-        [&callback](const CScript &owner, CLazySerialize<uint32_t>) { return callback(owner); }, start);
-}
-
 Res CAccountsView::UpdateBalancesHeight(const CScript &owner, uint32_t height) {
     WriteBy<ByHeightKey>(owner, height);
     return Res::Ok();

--- a/src/masternodes/accounts.h
+++ b/src/masternodes/accounts.h
@@ -55,7 +55,6 @@ struct CFuturesUserValue {
 
 class CAccountsView : public virtual CStorageView {
 public:
-    void ForEachAccount(std::function<bool(const CScript &)> callback, const CScript &start = {});
     void ForEachBalance(std::function<bool(const CScript &, const CTokenAmount &)> callback,
                         const BalanceKey &start = {});
     CTokenAmount GetBalance(const CScript &owner, DCT_ID tokenID) const;

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -19,13 +19,16 @@ CAccounts GetAllMineAccounts(CWallet * const pwallet) {
     CCustomCSView mnview(*pcustomcsview);
     auto targetHeight = ::ChainActive().Height() + 1;
 
-    CScript calculatedOwner;
+    // ForEachBalance is in account order, so we only need to check if the
+    // last record is the same as the current one to know whether we can skip
+    // CalculateOwnerRewards or if it needs to be called.
+    CScript lastCalculatedOwner;
 
     mnview.ForEachBalance([&](const CScript &owner, const CTokenAmount &balance) {
         if (IsMineCached(*pwallet, owner) == ISMINE_SPENDABLE) {
-            if (calculatedOwner != owner) {
+            if (lastCalculatedOwner != owner) {
                 mnview.CalculateOwnerRewards(owner, targetHeight);
-                calculatedOwner = owner;
+                lastCalculatedOwner = owner;
             }
             walletAccounts[owner].Add(balance);
         }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -553,7 +553,7 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
 
     mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
         if (IsMineCached(*pwallet, owner)) {
-            if (calculatedOwners.find(owner) == calculatedOwners.end()) {
+            if (calculatedOwners.count(owner) == 0) {
                 mnview.CalculateOwnerRewards(owner, targetHeight);
                 calculatedOwners.emplace(owner);
             }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -549,13 +549,13 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     CCustomCSView mnview(*pcustomcsview);
     auto targetHeight = ::ChainActive().Height() + 1;
 
-    std::set<CScript> calculatedOwners;
+    CScript calculatedOwner;
 
     mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
         if (IsMineCached(*pwallet, owner)) {
-            if (calculatedOwners.count(owner) == 0) {
+            if (calculatedOwner != owner) {
                 mnview.CalculateOwnerRewards(owner, targetHeight);
-                calculatedOwners.emplace(owner);
+                calculatedOwner = owner;
             }
             totalBalances.Add(balance);
         }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -550,8 +550,10 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     auto targetHeight = ::ChainActive().Height() + 1;
 
     mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
-        if (IsMineCached(*pwallet, owner))
+        if (IsMineCached(*pwallet, owner)) {
+            mnview.CalculateOwnerRewards(owner, targetHeight);
             totalBalances.Add(balance);
+        }
 
         return true;
     });

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -549,15 +549,13 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     CCustomCSView mnview(*pcustomcsview);
     auto targetHeight = ::ChainActive().Height() + 1;
 
-    mnview.ForEachAccount([&](CScript const & account) {
-        if (IsMineCached(*pwallet, account) == ISMINE_SPENDABLE) {
-            mnview.CalculateOwnerRewards(account, targetHeight);
-            mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
-                return account == owner && totalBalances.Add(balance);
-            }, {account, DCT_ID{}});
-        }
+    mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
+        if (IsMineCached(*pwallet, owner))
+            totalBalances.Add(balance);
+
         return true;
     });
+
     auto it = totalBalances.balances.lower_bound(start);
     for (size_t i = 0; it != totalBalances.balances.end() && i < limit; it++, i++) {
         auto bal = CTokenAmount{(*it).first, (*it).second};

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -549,9 +549,14 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     CCustomCSView mnview(*pcustomcsview);
     auto targetHeight = ::ChainActive().Height() + 1;
 
+    std::set<CScript> calculatedOwners;
+
     mnview.ForEachBalance([&](CScript const & owner, CTokenAmount balance) {
         if (IsMineCached(*pwallet, owner)) {
-            mnview.CalculateOwnerRewards(owner, targetHeight);
+            if (calculatedOwners.find(owner) == calculatedOwners.end()) {
+                mnview.CalculateOwnerRewards(owner, targetHeight);
+                calculatedOwners.emplace(owner);
+            }
             totalBalances.Add(balance);
         }
 

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -192,7 +192,6 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.test_cfp_fee_distribution(amount=1000, expectedFee=20, burnPct=30, vote="yes", cycles=1)
         self.test_cfp_fee_distribution(amount=1000, expectedFee=20, burnPct=30, vote="yes", cycles=3,
                                        changeFeeAndBurnPCT=True)
-        self.test_spendable_fee()
 
 if __name__ == '__main__':
     CFPFeeDistributionTest().main ()

--- a/test/functional/feature_on_chain_government_fee_distribution.py
+++ b/test/functional/feature_on_chain_government_fee_distribution.py
@@ -91,6 +91,7 @@ class CFPFeeDistributionTest(DefiTestFramework):
             mn0 = self.nodes[0].getmasternode(self.mn0)[self.mn0]
             account0 = self.nodes[0].getaccount(mn0['ownerAuthAddress'])
             assert_equal(account0[0], '{}@DFI'.format(expectedAmount * votingCycles))
+            assert_equal(self.nodes[0].gettokenbalances(), [f"{expectedAmount * votingCycles}@0"])
             history = self.nodes[0].listaccounthistory(mn0['ownerAuthAddress'], {"txtype": "ProposalFeeRedistribution"})
             assert_equal(len(history), votingCycles)
             for i in range(votingCycles):
@@ -98,7 +99,8 @@ class CFPFeeDistributionTest(DefiTestFramework):
 
             mn1 = self.nodes[0].getmasternode(self.mn1)[self.mn1]
             account1 = self.nodes[0].getaccount(mn1['ownerAuthAddress'])
-            assert_equal(account1[0], '{}@DFI'.format(expectedAmount* votingCycles))
+            assert_equal(account1[0], '{}@DFI'.format(expectedAmount * votingCycles))
+            assert_equal(self.nodes[1].gettokenbalances(), [f"{expectedAmount * votingCycles}@0"])
             history = self.nodes[0].listaccounthistory(mn1['ownerAuthAddress'], {"txtype": "ProposalFeeRedistribution"})
             assert_equal(len(history), votingCycles)
             for i in range(votingCycles):
@@ -107,7 +109,8 @@ class CFPFeeDistributionTest(DefiTestFramework):
             # Fee should be redistributed to reward address
             mn2 = self.nodes[0].getmasternode(self.mn2)[self.mn2]
             account2 = self.nodes[0].getaccount(mn2['ownerAuthAddress'])
-            assert_equal(account2[0], '{}@DFI'.format(expectedAmount* votingCycles))
+            assert_equal(account2[0], '{}@DFI'.format(expectedAmount * votingCycles))
+            assert_equal(self.nodes[2].gettokenbalances(), [f"{expectedAmount * votingCycles}@0"])
             history = self.nodes[0].listaccounthistory(mn2['ownerAuthAddress'], {"txtype": "ProposalFeeRedistribution"})
             assert_equal(len(history), votingCycles)
             for i in range(votingCycles):
@@ -158,11 +161,11 @@ class CFPFeeDistributionTest(DefiTestFramework):
         assert_equal(self.nodes[0].getblockcount(), 101)
 
         # activate on-chain governance
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/params/feature/gov':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES": {'v0/params/feature/gov': 'true'}})
         self.nodes[0].generate(1)
 
         # activate fee redistribution
-        self.nodes[0].setgov({"ATTRIBUTES":{'v0/gov/proposals/fee_redistribution':'true'}})
+        self.nodes[0].setgov({"ATTRIBUTES": {'v0/gov/proposals/fee_redistribution': 'true'}})
         self.nodes[0].generate(1)
 
         self.sync_blocks()
@@ -187,7 +190,9 @@ class CFPFeeDistributionTest(DefiTestFramework):
         self.sync_blocks()
 
         self.test_cfp_fee_distribution(amount=1000, expectedFee=20, burnPct=30, vote="yes", cycles=1)
-        self.test_cfp_fee_distribution(amount=1000, expectedFee=20, burnPct=30, vote="yes", cycles=3, changeFeeAndBurnPCT=True)
+        self.test_cfp_fee_distribution(amount=1000, expectedFee=20, burnPct=30, vote="yes", cycles=3,
+                                       changeFeeAndBurnPCT=True)
+        self.test_spendable_fee()
 
 if __name__ == '__main__':
     CFPFeeDistributionTest().main ()


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md

Pull requests without a rationale and clear improvement may be closed immediately.
DeFiChain has a thorough review process and even the most trivial change needs to pass a lot of eyes and requires non-zero or even substantial time effort to review.
-->

#### What kind of PR is this?:

<!--
Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind fix

#### What this PR does / why we need it:

Masternode operator addresses receiving voting rewards do not show up on `gettokenbalances`. This PR fixes the issue so that voting rewards show up in `gettokenbalances`.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1763
