### PR TITLE
Bump jellyfish-workflow settings

### DIFF
--- a/.github/workflows/jellyfish-tests.yml
+++ b/.github/workflows/jellyfish-tests.yml
@@ -25,14 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: '18'
 
       - name: Set build version
         run: |
@@ -51,5 +44,4 @@ jobs:
       - name: Run tests
         run: |
           npm ci
-          npm run all:build
           DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

- remove `actions/cache`, it's deprecated, that logic is now embedded within setup-node
- bump `setup-node@v3` to `node-version: 18`
- remove `npm run all:build`
