### PR TITLE
Replace CLockFreeGuard with AtomicMutex 

### DIFF
--- a/src/masternodes/threadpool.cpp
+++ b/src/masternodes/threadpool.cpp
@@ -31,12 +31,12 @@ void ShutdownDfTxGlobalTaskPool() {
 
 
 void TaskGroup::AddTask() { 
-    tasks.fetch_add(1, std::memory_order_relaxed);
+    tasks.fetch_add(1, std::memory_order_release);
 }
 
 void TaskGroup::RemoveTask() {
-    if (tasks.fetch_sub(1, std::memory_order_seq_cst) == 1) {
-        cv.notify_one();
+    if (tasks.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        cv.notify_all();
     }
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -717,7 +717,7 @@ namespace pos {
 
     //initialize static variables here
     std::map<uint256, int64_t> Staker::mapMNLastBlockCreationAttemptTs;
-    std::atomic_bool Staker::cs_MNLastBlockCreationAttemptTs(false);
+    AtomicMutex cs_MNLastBlockCreationAttemptTs;
     int64_t Staker::nLastCoinStakeSearchTime{0};
     int64_t Staker::nFutureTime{0};
     uint256 Staker::lastBlockSeen{};
@@ -825,7 +825,7 @@ namespace pos {
         withSearchInterval([&](const int64_t currentTime, const int64_t lastSearchTime, const int64_t futureTime) {
             // update last block creation attempt ts for the master node here
             {
-                CLockFreeGuard lock(pos::Staker::cs_MNLastBlockCreationAttemptTs);
+                std::unique_lock l{pos::cs_MNLastBlockCreationAttemptTs};
                 pos::Staker::mapMNLastBlockCreationAttemptTs[masternodeID] = GetTime();
             }
             CheckContextState ctxState;

--- a/src/miner.h
+++ b/src/miner.h
@@ -224,6 +224,9 @@ namespace pos {
 // The main staking routine.
 // Creates stakes using CWallet API, creates PoS kernels and mints blocks.
 // Uses Args.getWallets() to receive and update wallets list.
+
+    extern AtomicMutex cs_MNLastBlockCreationAttemptTs;
+
     class ThreadStaker {
     public:
 
@@ -258,7 +261,6 @@ namespace pos {
         // declaration static variables
         // Map to store [master node id : last block creation attempt timestamp] for local master nodes
         static std::map<uint256, int64_t> mapMNLastBlockCreationAttemptTs;
-        static std::atomic_bool cs_MNLastBlockCreationAttemptTs;
 
         // Variables to manage search time across threads
         static int64_t nLastCoinStakeSearchTime;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -293,7 +293,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             subObj.pushKV("lastblockcreationattempt", "0");
         } else {
             // get the last block creation attempt by the master node
-            CLockFreeGuard lock(pos::Staker::cs_MNLastBlockCreationAttemptTs);
+            std::unique_lock l{pos::cs_MNLastBlockCreationAttemptTs};
             auto lastBlockCreationAttemptTs = pos::Staker::mapMNLastBlockCreationAttemptTs[mnId.second];
             subObj.pushKV("lastblockcreationattempt", (lastBlockCreationAttemptTs != 0) ? FormatISO8601DateTime(lastBlockCreationAttemptTs) : "0");
         }

--- a/src/rpc/resultcache.h
+++ b/src/rpc/resultcache.h
@@ -35,7 +35,7 @@ public:
     bool InvalidateCaches();
 
 private:
-    std::atomic_bool syncFlag{false};
+    AtomicMutex aMutex;
     std::set<std::string> smartModeList{};
     RPCCacheMode mode{RPCCacheMode::None};
     std::map<std::string, UniValue> cacheMap{};
@@ -60,7 +60,7 @@ public:
     CMemoizedResultValue GetOrDefault(const JSONRPCRequest &request);
     void Set(const JSONRPCRequest &request, const CMemoizedResultValue &value);
 private:
-    std::atomic_bool syncFlag{false};
+    AtomicMutex aMutex;
     std::map<std::string, CMemoizedResultValue> cacheMap{};
     RPCResultCache::RPCCacheMode mode{RPCResultCache::RPCCacheMode::None};
 };

--- a/src/rpc/stats.cpp
+++ b/src/rpc/stats.cpp
@@ -6,7 +6,7 @@ bool CRPCStats::isActive() { return active.load(); }
 void CRPCStats::setActive(bool isActive) { active.store(isActive); }
 
 std::optional<RPCStats> CRPCStats::get(const std::string& name) {
-    CLockFreeGuard lock(lock_stats);
+    std::unique_lock lock(lock_stats);
 
     auto it = map.find(name);
     if (it == map.end()) {
@@ -16,7 +16,7 @@ std::optional<RPCStats> CRPCStats::get(const std::string& name) {
 }
 
 std::map<std::string, RPCStats> CRPCStats::getMap() {
-    CLockFreeGuard lock(lock_stats);
+    std::unique_lock lock(lock_stats);
     return map;
 }
 
@@ -41,7 +41,7 @@ void CRPCStats::load() {
     UniValue arr(UniValue::VARR);
     arr.read((const std::string)line);
 
-    CLockFreeGuard lock(lock_stats);
+    std::unique_lock lock(lock_stats);
     for (const auto &val : arr.getValues()) {
         auto name = val["name"].get_str();
         map[name] = RPCStats::fromJSON(val);
@@ -140,7 +140,7 @@ void CRPCStats::add(const std::string& name, const int64_t latency, const int64_
     }
     stats->history.push_back({ stats->lastUsedTime, latency, payload });
 
-    CLockFreeGuard lock(lock_stats);
+    std::unique_lock lock(lock_stats);
     map[name] = *stats;
 }
 

--- a/src/rpc/stats.h
+++ b/src/rpc/stats.h
@@ -55,7 +55,7 @@ struct RPCStats {
 class CRPCStats
 {
 private:
-    std::atomic_bool lock_stats{false};
+    AtomicMutex lock_stats;
     std::map<std::string, RPCStats> map;
     std::atomic_bool active{DEFAULT_RPC_STATS};
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -337,17 +337,16 @@ class CLockFreeGuard
 public:
     CLockFreeGuard(std::atomic_bool& lock) : lock(lock)
     {
-        bool desired = false;
-        while (!lock.compare_exchange_weak(desired, true,
-                                           std::memory_order_release,
-                                           std::memory_order_relaxed)) {
-            desired = false;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        bool expected = false;
+        while (!lock.compare_exchange_weak(expected, true)) {
+            expected = false;
+            // std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
+
     ~CLockFreeGuard()
     {
-        lock.store(false, std::memory_order_release);
+        lock.store(false);
     }
 };
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -331,22 +331,54 @@ struct SCOPED_LOCKABLE LockAssertion
     ~LockAssertion() UNLOCK_FUNCTION() {}
 };
 
-class CLockFreeGuard
-{
-    std::atomic_bool& lock;
+class AtomicMutex {
+private:
+    std::atomic<bool> flag{false};
+    int64_t spins;
+    int64_t yields;
+
 public:
-    CLockFreeGuard(std::atomic_bool& lock) : lock(lock)
-    {
+    AtomicMutex(int64_t spins = 10, int64_t yields = 4): 
+        spins(spins), yields(yields) {}
+
+    void lock() {
+        // Note: The loop here addresses both, spurious failures as well
+        // as to suspend or spin wait until it's set
+        // Additional:
+        // - We use this a lock for external critical section, so we use
+        // seq ordering, to ensure it provides the right ordering guarantees
+        // for the others
+        // On failure of CAS, we don't care about the existing value, we just
+        // discard it, so relaxed ordering is sufficient.
         bool expected = false;
-        while (!lock.compare_exchange_weak(expected, true)) {
+        auto i = 0;
+        while (std::atomic_compare_exchange_weak_explicit(
+                   &flag,
+                   &expected, true,
+                   std::memory_order_seq_cst,
+                   std::memory_order_relaxed) == false) {
+            // Could have been a spurious failure or another thread could have taken the
+            // lock in-between since we're now out of the atomic ops. 
+            // Reset expected to start from scratch again, since we only want
+            // a singular atomic false -> true transition.
             expected = false;
-            // std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            if (i > spins) {
+                if (i > spins + yields) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                } else {
+                    std::this_thread::yield();
+                }
+            }
+            i++;
         }
     }
 
-    ~CLockFreeGuard()
-    {
-        lock.store(false);
+    void unlock() {
+        flag.store(false, std::memory_order_seq_cst);
+    }
+
+    bool try_lock() noexcept {
+        return !flag.exchange(true, std::memory_order_seq_cst);
     }
 };
 

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -55,13 +55,13 @@ BOOST_AUTO_TEST_CASE(lock_free)
     constexpr int num_threads = 10;
 
     auto testFunc = []() {
-        static std::atomic_bool cs_lock;
+        static AtomicMutex m;
         static std::atomic_int context(0);
         static std::atomic_int threads(num_threads);
 
         threads--; // every thread decrements count
 
-        CLockFreeGuard lock(cs_lock);
+        std::unique_lock lock{m};
         context++;
         while (threads > 0); // wait all threads to be here
         BOOST_CHECK_EQUAL(threads.load(), 0); // now they wait for lock


### PR DESCRIPTION
/kind fix

- `CLockFreeGuard` uses barrier that's unsuitable for general use case, and results in multiple threads entering critical sections due to premature barrier optimizations
- Additionally, remove the 1ms thread sleep, which on platforms like Linux which default to higher resolution thread quantums might be palatable, but will have heavy regressive behaviour on platforms like Windows which default to 15ms quantum slices.
- Since CLockFree is primarily used for extremely cheap ops, spin waiting is just simpler // though likely have to reassess it's use cases later on if it's even useful here.  