### PR TITLE
Fix getburninfo memoization

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -337,16 +337,17 @@ class CLockFreeGuard
 public:
     CLockFreeGuard(std::atomic_bool& lock) : lock(lock)
     {
-        bool expected = false;
-        while (!lock.compare_exchange_weak(expected, true)) {
-            expected = false;
-            // std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        bool desired = false;
+        while (!lock.compare_exchange_weak(desired, true,
+                                           std::memory_order_release,
+                                           std::memory_order_relaxed)) {
+            desired = false;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
-
     ~CLockFreeGuard()
     {
-        lock.store(false);
+        lock.store(false, std::memory_order_release);
     }
 };
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -337,17 +337,16 @@ class CLockFreeGuard
 public:
     CLockFreeGuard(std::atomic_bool& lock) : lock(lock)
     {
-        bool desired = false;
-        while (!lock.compare_exchange_weak(desired, true,
-                                           std::memory_order_release,
-                                           std::memory_order_relaxed)) {
-            desired = false;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        bool expected = false;
+        while (!lock.compare_exchange_weak(expected, true)) {
+            expected = false;
+            // std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
+
     ~CLockFreeGuard()
     {
-        lock.store(false, std::memory_order_release);
+        lock.store(false);
     }
 };
 


### PR DESCRIPTION
/kind fix

- Fix getburninfo consortium tokens by adjusting the memoization result
- Use correct behavior of shared pointers (https://github.com/DeFiCh/ain/pull/1794 behaviour appears to work due to copying of the values including recreating the internal maps again, but uses shared pointers incorrectly.

Note: This also expects other later PRs:
- https://github.com/DeFiCh/ain/pull/1797 (fixes bug in CLockFreeGuard)
- Switch out WorkerResultsPool to the generic pool introduced in https://github.com/DeFiCh/ain/pull/1798