### PR TITLE
Fix CLockFreeGuard, introduce AtomicMutex

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -380,6 +380,11 @@ public:
     }
 
     bool try_lock() noexcept {
+        // We locked it if and only if it was a false -> true transition.
+        // Otherwise, we just re-wrote an already existing value as true which is harmless 
+        // We could theoritically use CAS here to prevent the additional write, but
+        // but requires loop on weak, or using strong. Simpler to just use an exchange for
+        // for now, since all ops are seq_cst anyway.
         return !flag.exchange(true, std::memory_order_seq_cst);
     }
 };

--- a/src/sync.h
+++ b/src/sync.h
@@ -338,7 +338,7 @@ private:
     int64_t yields;
 
 public:
-    AtomicMutex(int64_t spins = 10, int64_t yields = 4): 
+    AtomicMutex(int64_t spins = 10, int64_t yields = 16): 
         spins(spins), yields(yields) {}
 
     void lock() {

--- a/src/sync.h
+++ b/src/sync.h
@@ -398,6 +398,7 @@ public:
             // lock in-between since we're now out of the atomic ops. 
             // Reset expected to start from scratch again, since we only want
             // a singular atomic false -> true transition.
+            expected = false;
             std::this_thread::sleep_for(std::chrono::milliseconds(1);
         }
     }

--- a/src/sync.h
+++ b/src/sync.h
@@ -401,7 +401,7 @@ public:
             // Reset expected to start from scratch again, since we only want
             // a singular atomic false -> true transition.
             expected = false;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
     ~CLockFreeGuard()

--- a/src/sync.h
+++ b/src/sync.h
@@ -364,7 +364,9 @@ public:
             expected = false;
             if (i > spins) {
                 if (i > spins + yields) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    // Use larger sleep, in line with the largest quantum, which is 
+                    // Windows with 16ms
+                    std::this_thread::sleep_for(std::chrono::milliseconds(16));
                 } else {
                     std::this_thread::yield();
                 }


### PR DESCRIPTION
/kind fix

- `CLockFreeGuard` uses barrier that's unsuitable for general use case, and results in multiple threads entering critical sections due to premature barrier optimizations. This fixes it. 
- Additionally, the 1ms thread sleep isn't helpful, which on platforms like Linux which default to higher resolution thread quantums might be palatable, but will have heavy regressive behaviour on platforms like Windows which default to 15ms quantum slices.
- Introduce `AtomicMutex` that progressively spins, yields and sleeps to remove this, while also working with regular `unique_lock` patterns.
- The goal is to remove `CLockFreeGuard` entirely in subsequent PRs and replace it with standard patterns of `std::unique_lock` coupled with `AtomicMutex`