### PR TITLE
Introduce a generic thread-safe buffer pool

### DIFF
--- a/src/masternodes/threadpool.h
+++ b/src/masternodes/threadpool.h
@@ -2,7 +2,9 @@
 #define DEFI_MASTERNODES_THREADPOOL_H
 
 #include <boost/asio.hpp>
+#include <atomic>
 #include <condition_variable>
+#include <sync.h>
 
 static const int DEFAULT_DFTX_WORKERS=0;
 
@@ -33,11 +35,44 @@ class TaskGroup {
     public:
         void AddTask();
         void RemoveTask();
-        void WaitForCompletion();
+        void WaitForCompletion(bool checkForPrematureCompletion = true);
+        void MarkCancellation() { is_cancelled.store(true); }
+        bool IsCancelled() { return is_cancelled.load(); }
+
     private:
         std::atomic<uint64_t> tasks{0};
         std::mutex cv_m;
         std::condition_variable cv;
+        std::atomic_bool is_cancelled{false};
+};
+
+template <typename T>
+class BufferPool {
+    public:
+    explicit BufferPool(size_t size) {
+        pool.reserve(size);
+        for (size_t i = 0; i < size; i++) {
+            pool.push_back(std::make_shared<T>());
+        }
+    }
+
+    std::shared_ptr<T> Acquire() {
+        std::unique_lock l{m};
+        auto res = pool.back();
+        pool.pop_back();
+        return res;
+    }
+
+    void Release(std::shared_ptr<T> res) {
+        std::unique_lock l{m};
+        pool.push_back(res);
+    }
+
+    std::vector<std::shared_ptr<T>> &GetBuffer() { return pool; }
+
+    private:
+    AtomicMutex m{};
+    std::vector<std::shared_ptr<T>> pool;
 };
 
 extern std::unique_ptr<TaskPool> DfTxTaskPool;

--- a/src/sync.h
+++ b/src/sync.h
@@ -380,6 +380,11 @@ public:
     }
 
     bool try_lock() noexcept {
+        // We locked it if and only if it was a false -> true transition.
+        // Otherwise, we just re-wrote an already existing value as true which is harmless 
+        // We could theoritically use CAS here to prevent the additional write, but
+        // but requires loop on weak, or using strong. Simpler to just use an exchange for
+        // for now, since all ops are seq_cst anyway.
         return !flag.exchange(true, std::memory_order_seq_cst);
     }
 };

--- a/src/sync.h
+++ b/src/sync.h
@@ -338,7 +338,7 @@ private:
     int64_t yields;
 
 public:
-    AtomicMutex(int64_t spins = 10, int64_t yields = 4): 
+    AtomicMutex(int64_t spins = 10, int64_t yields = 16): 
         spins(spins), yields(yields) {}
 
     void lock() {

--- a/src/sync.h
+++ b/src/sync.h
@@ -398,6 +398,7 @@ public:
             // lock in-between since we're now out of the atomic ops. 
             // Reset expected to start from scratch again, since we only want
             // a singular atomic false -> true transition.
+            expected = false;
             std::this_thread::sleep_for(std::chrono::milliseconds(1);
         }
     }

--- a/src/sync.h
+++ b/src/sync.h
@@ -401,7 +401,7 @@ public:
             // Reset expected to start from scratch again, since we only want
             // a singular atomic false -> true transition.
             expected = false;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
     ~CLockFreeGuard()

--- a/src/sync.h
+++ b/src/sync.h
@@ -364,7 +364,9 @@ public:
             expected = false;
             if (i > spins) {
                 if (i > spins + yields) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    // Use larger sleep, in line with the largest quantum, which is 
+                    // Windows with 16ms
+                    std::this_thread::sleep_for(std::chrono::milliseconds(16));
                 } else {
                     std::this_thread::yield();
                 }


### PR DESCRIPTION
/kind feature

- Introduce a generic thread safe buffer pool for fixed buffer acquisition when spreading tasks across threads
- Additionally, let TaskGroup monitor for cancellation to propagate errors or exit early