### PR TITLE
Track reward addresses in settings

### DIFF
--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -755,6 +755,15 @@ void CSettingsView::SetDexStatsEnabled(const bool enabled) {
 std::optional<bool> CSettingsView::GetDexStatsEnabled() {
     return ReadBy<KVSettings, bool>(DEX_STATS_ENABLED);
 }
+
+std::optional<std::set<CScript>> CSettingsView::SettingsGetRewardAddresses() {
+    return ReadBy<KVSettings, std::set<CScript>>(MN_REWARD_ADDRESSES);
+}
+
+void CSettingsView::SettingsSetRewardAddresses(const std::set<CScript> &addresses) {
+    WriteBy<KVSettings>(MN_REWARD_ADDRESSES, addresses);
+}
+
 /*
  *  CCustomCSView
  */
@@ -1345,4 +1354,12 @@ void CalcMissingRewardTempFix(CCustomCSView &mnview, const uint32_t targetHeight
 
         return true;
     });
+
+    if (const auto addresses = mnview.SettingsGetRewardAddresses()) {
+        for (const auto &rewardAddress : *addresses) {
+            if (IsMineCached(wallet, rewardAddress) == ISMINE_SPENDABLE) {
+                mnview.CalculateOwnerRewards(rewardAddress, targetHeight);
+            }
+        }
+    }
 }

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -378,11 +378,15 @@ class CSettingsView : public virtual CStorageView {
 public:
     const std::string DEX_STATS_LAST_HEIGHT = "DexStatsLastHeight";
     const std::string DEX_STATS_ENABLED     = "DexStatsEnabled";
+    const std::string MN_REWARD_ADDRESSES   = "MNRewardAddresses";
 
     void SetDexStatsLastHeight(int32_t height);
     std::optional<int32_t> GetDexStatsLastHeight();
     void SetDexStatsEnabled(bool enabled);
     std::optional<bool> GetDexStatsEnabled();
+
+    std::optional<std::set<CScript>> SettingsGetRewardAddresses();
+    void SettingsSetRewardAddresses(const std::set<CScript> &addresses);
 
     struct KVSettings {
         static constexpr uint8_t prefix() { return '0'; }


### PR DESCRIPTION
As a workaround for missing balances in gettokenbalances and other locations that rely on ForEachAccount we call CalculateOwnerRewards on all MN reward and owner addresses owner by the local wallet. This does not include reward addresses that are have been unset or replaced. This PR adds a store of all reward addresses into KVSettings to compensate for this issue. Once we are past the next hard fork this can be removed.