### PR TITLE
Add RPC metadata capability and coin selection options

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -181,6 +181,7 @@ DEFI_CORE_H = \
   masternodes/proposals.h \
   masternodes/tokens.h \
   masternodes/threadpool.h \
+  masternodes/coinselect.h \ 
   masternodes/undo.h \
   masternodes/undos.h \
   masternodes/validation.h \

--- a/src/defi-cli.cpp
+++ b/src/defi-cli.cpp
@@ -347,7 +347,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
     
     const auto meta = RPCMetadata::CreateDefault();
     const auto writerFunc = [&](const std::string& key, const std::string& val) { evhttp_add_header(output_headers, key.c_str(), val.c_str()); };
-    RPCMetadata::ToHTTPHeaderFunc(meta, writerFunc);
+    RPCMetadata::ToHTTPHeader(meta, writerFunc);
 
     // Attach request data
     std::string strRequest = rh->PrepareRequest(strMethod, args).write() + "\n";

--- a/src/defi-cli.cpp
+++ b/src/defi-cli.cpp
@@ -27,6 +27,7 @@
 #include <support/events.h>
 
 #include <univalue.h>
+#include <masternodes/coinselect.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
@@ -60,6 +61,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to defid). This changes the RPC endpoint used, e.g. http://127.0.0.1:8554/wallet/<walletname>", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases). When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdinrpcpass", "Read RPC password from standard input as a single line. When combined with -stdin, the first line from standard input is used for the RPC password.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    RPCMetadata::SetupArgs(gArgs);
 }
 
 /** libevent event log callback */
@@ -342,6 +344,10 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
     evhttp_add_header(output_headers, "Host", host.c_str());
     evhttp_add_header(output_headers, "Connection", "close");
     evhttp_add_header(output_headers, "Authorization", (std::string("Basic ") + EncodeBase64(strRPCUserColonPass)).c_str());
+    
+    const auto meta = RPCMetadata::CreateDefault();
+    const auto writerFunc = [&](const std::string& key, const std::string& val) { evhttp_add_header(output_headers, key.c_str(), val.c_str()); };
+    RPCMetadata::ToHTTPHeaderFunc(meta, writerFunc);
 
     // Attach request data
     std::string strRequest = rh->PrepareRequest(strMethod, args).write() + "\n";

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -214,7 +214,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
         jreq.URI = req->GetURI();
         // Parse the metadata from request
         auto func = [&](const std::string& h) { return req->GetHeader(h); };
-        RPCMetadata::FromHTTPHeaderFunc(jreq.metadata, func);
+        RPCMetadata::FromHTTPHeader(jreq.metadata, func);
 
         std::string strReply;
         // singleton request

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -212,6 +212,9 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
         // Set the URI
         jreq.URI = req->GetURI();
+        // Parse the metadata from request
+        auto func = [&](const std::string& h) { return req->GetHeader(h); };
+        RPCMetadata::FromHTTPHeaderFunc(jreq.metadata, func);
 
         std::string strReply;
         // singleton request

--- a/src/masternodes/coinselect.h
+++ b/src/masternodes/coinselect.h
@@ -13,22 +13,22 @@ static const bool DEFAULT_COIN_SELECT_FAST_SELECT = false;
 /** Default for skipping IsSolvable */
 static const bool DEFAULT_COIN_SELECT_SKIP_SOLVABLE = false;
 /** Default for returning on first valid auth */
-static const bool DEFAULT_COIN_SELECT_EAGER_EXIT = false;
+static const bool DEFAULT_COIN_SELECT_EAGER_SELECT = false;
 
 static const std::string& ARG_STR_WALLET_FAST_SELECT = "-walletfastselect";
 static const std::string& ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE = "-walletcoinoptskipsolvable";
-static const std::string& ARG_STR_WALLET_COIN_OPT_EAGER_EXIT = "-walletcoinopteagerexit";
+static const std::string& ARG_STR_WALLET_COIN_OPT_EAGER_SELECT = "-walletcoinopteagerselect";
 
 struct CoinSelectionOptions {
     public:
         bool fastSelect{};
         bool skipSolvable{};
-        bool eagerExit{};
+        bool eagerSelect{};
 
     static void SetupArgs(ArgsManager& args) {
-        args.AddArg(ARG_STR_WALLET_FAST_SELECT, strprintf("Faster coin select - Enables walletcoinoptskipsolvable and walletcoinopteagerexit. This ends up in faster selection but has the disadvantage of not being able to pick complex input scripts (default: %u)", DEFAULT_COIN_SELECT_FAST_SELECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        args.AddArg(ARG_STR_WALLET_FAST_SELECT, strprintf("Faster coin select - Enables walletcoinoptskipsolvable and walletcoinopteagerselect. This ends up in faster selection but has the disadvantage of not being able to pick complex input scripts (default: %u)", DEFAULT_COIN_SELECT_FAST_SELECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
         args.AddArg(ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, strprintf("Coin select option: Skips IsSolvable signable UTXO check (default: %u)", DEFAULT_COIN_SELECT_SKIP_SOLVABLE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-        args.AddArg(ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, strprintf("Coin select option: Take fast path and eagerly exit on match even without having through the entire set (default: %u)", DEFAULT_COIN_SELECT_EAGER_EXIT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        args.AddArg(ARG_STR_WALLET_COIN_OPT_EAGER_SELECT, strprintf("Coin select option: Take fast path and eagerly exit on match even without having through the entire set (default: %u)", DEFAULT_COIN_SELECT_EAGER_SELECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     }
 
     static CoinSelectionOptions CreateDefault() {
@@ -46,7 +46,7 @@ struct CoinSelectionOptions {
         for (auto &[v, str, def]: {
             V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT, DEFAULT_COIN_SELECT_FAST_SELECT},
             V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, DEFAULT_COIN_SELECT_SKIP_SOLVABLE},
-            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, DEFAULT_COIN_SELECT_EAGER_EXIT},
+            V { m.eagerSelect, ARG_STR_WALLET_COIN_OPT_EAGER_SELECT, DEFAULT_COIN_SELECT_EAGER_SELECT},
         }) {
             v = args.GetBoolArg(str, def);
         }
@@ -60,7 +60,7 @@ struct CoinSelectionOptions {
         for (auto &[v, str]: {
             V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT},
             V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE},
-            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT},
+            V { m.eagerSelect, ARG_STR_WALLET_COIN_OPT_EAGER_SELECT},
         }) {
             const auto &[present, val] = headerFunc("x" + str);
             if (present) v = val == "1" ? true : false;
@@ -75,7 +75,7 @@ struct CoinSelectionOptions {
         for (auto &[v, str]: {
             V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT},
             V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE},
-            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT},
+            V { m.eagerSelect, ARG_STR_WALLET_COIN_OPT_EAGER_SELECT},
         }) {
             writer("x" + str, v ? "1" : "0");
         }

--- a/src/masternodes/coinselect.h
+++ b/src/masternodes/coinselect.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFI_MASTERNODES_COINSELECT_H
+#define DEFI_MASTERNODES_COINSELECT_H
+
+#include <util/system.h>
+
+/** Default for skipping IsSolvable and return on first valid auth */
+static const bool DEFAULT_COIN_SELECT_FAST_SELECT = false;
+/** Default for skipping IsSolvable */
+static const bool DEFAULT_COIN_SELECT_SKIP_SOLVABLE = false;
+/** Default for returning on first valid auth */
+static const bool DEFAULT_COIN_SELECT_EAGER_EXIT = false;
+
+static const std::string& ARG_STR_WALLET_FAST_SELECT = "-walletfastselect";
+static const std::string& ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE = "-walletcoinoptskipsolvable";
+static const std::string& ARG_STR_WALLET_COIN_OPT_EAGER_EXIT = "-walletcoinopteagerexit";
+
+struct CoinSelectionOptions {
+    public:
+        bool fastSelect{};
+        bool skipSolvable{};
+        bool eagerExit{};
+
+    static void SetupArgs(ArgsManager& args) {
+        args.AddArg(ARG_STR_WALLET_FAST_SELECT, strprintf("Faster coin select - Enables walletcoinoptskipsolvable and walletcoinopteagerexit. This ends up in faster selection but has the disadvantage of not being able to pick complex input scripts (default: %u)", DEFAULT_COIN_SELECT_FAST_SELECT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        args.AddArg(ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, strprintf("Coin select option: Skips IsSolvable signable UTXO check (default: %u)", DEFAULT_COIN_SELECT_SKIP_SOLVABLE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+        args.AddArg(ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, strprintf("Coin select option: Take fast path and eagerly exit on match even without having through the entire set (default: %u)", DEFAULT_COIN_SELECT_EAGER_EXIT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    }
+
+    static CoinSelectionOptions CreateDefault() {
+        CoinSelectionOptions opts;
+        FromArgs(opts, gArgs);
+        return opts;
+    }
+
+    static void FromArgs(CoinSelectionOptions& m, ArgsManager& args) {
+           m.fastSelect = args.GetBoolArg(ARG_STR_WALLET_FAST_SELECT, DEFAULT_COIN_SELECT_FAST_SELECT);
+           m.skipSolvable = args.GetBoolArg(ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, DEFAULT_COIN_SELECT_SKIP_SOLVABLE);
+           m.eagerExit = args.GetBoolArg(ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, DEFAULT_COIN_SELECT_EAGER_EXIT);
+    }
+
+    static void FromHTTPHeaderFunc(CoinSelectionOptions &m, const HTTPHeaderQueryFunc headerFunc) {
+        {
+            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_FAST_SELECT);
+            if (present) m.fastSelect = val == "1" ? true : false;
+        }
+        {
+            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE);
+            if (present) m.skipSolvable = val == "1" ? true : false;
+        }
+        {
+            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_EAGER_EXIT);
+            if (present) m.eagerExit = val == "1" ? true : false;
+        }
+    }
+
+    static void ToHTTPHeaderFunc(const CoinSelectionOptions& m, const HTTPHeaderWriterFunc writer) {
+        writer("x" + ARG_STR_WALLET_FAST_SELECT, m.fastSelect ? "1" : "0");
+        writer("x" + ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, m.skipSolvable ? "1" : "0");
+        writer("x" + ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, m.eagerExit ? "1" : "0");
+    }
+};
+
+#endif // DEFI_MASTERNODES_COINSELECT_H

--- a/src/masternodes/coinselect.h
+++ b/src/masternodes/coinselect.h
@@ -46,15 +46,15 @@ struct CoinSelectionOptions {
     static void FromHTTPHeaderFunc(CoinSelectionOptions &m, const HTTPHeaderQueryFunc headerFunc) {
         {
             const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_FAST_SELECT);
-            if (present) m.fastSelect = val == "1" ? true : false;
+            if (present) m.fastSelect = val == "1";
         }
         {
             const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE);
-            if (present) m.skipSolvable = val == "1" ? true : false;
+            if (present) m.skipSolvable = val == "1";
         }
         {
             const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_EAGER_EXIT);
-            if (present) m.eagerExit = val == "1" ? true : false;
+            if (present) m.eagerExit = val == "1";
         }
     }
 

--- a/src/masternodes/coinselect.h
+++ b/src/masternodes/coinselect.h
@@ -38,30 +38,47 @@ struct CoinSelectionOptions {
     }
 
     static void FromArgs(CoinSelectionOptions& m, ArgsManager& args) {
-           m.fastSelect = args.GetBoolArg(ARG_STR_WALLET_FAST_SELECT, DEFAULT_COIN_SELECT_FAST_SELECT);
-           m.skipSolvable = args.GetBoolArg(ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, DEFAULT_COIN_SELECT_SKIP_SOLVABLE);
-           m.eagerExit = args.GetBoolArg(ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, DEFAULT_COIN_SELECT_EAGER_EXIT);
-    }
-
-    static void FromHTTPHeaderFunc(CoinSelectionOptions &m, const HTTPHeaderQueryFunc headerFunc) {
-        {
-            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_FAST_SELECT);
-            if (present) m.fastSelect = val == "1";
-        }
-        {
-            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE);
-            if (present) m.skipSolvable = val == "1";
-        }
-        {
-            const auto &[present, val] = headerFunc("x" + ARG_STR_WALLET_COIN_OPT_EAGER_EXIT);
-            if (present) m.eagerExit = val == "1";
+        struct V {
+            bool& target;
+            const std::string& arg;
+            const bool& def;
+        };
+        for (auto &[v, str, def]: {
+            V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT, DEFAULT_COIN_SELECT_FAST_SELECT},
+            V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, DEFAULT_COIN_SELECT_SKIP_SOLVABLE},
+            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, DEFAULT_COIN_SELECT_EAGER_EXIT},
+        }) {
+            v = args.GetBoolArg(str, def);
         }
     }
 
-    static void ToHTTPHeaderFunc(const CoinSelectionOptions& m, const HTTPHeaderWriterFunc writer) {
-        writer("x" + ARG_STR_WALLET_FAST_SELECT, m.fastSelect ? "1" : "0");
-        writer("x" + ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE, m.skipSolvable ? "1" : "0");
-        writer("x" + ARG_STR_WALLET_COIN_OPT_EAGER_EXIT, m.eagerExit ? "1" : "0");
+    static void FromHTTPHeader(CoinSelectionOptions &m, const HTTPHeaderQueryFunc headerFunc) {
+        struct V {
+            bool& target;
+            const std::string& arg;
+        };
+        for (auto &[v, str]: {
+            V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT},
+            V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE},
+            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT},
+        }) {
+            const auto &[present, val] = headerFunc("x" + str);
+            if (present) v = val == "1" ? true : false;
+        }
+    }
+
+    static void ToHTTPHeader(const CoinSelectionOptions& m, const HTTPHeaderWriterFunc writer) {
+        struct V {
+            const bool& val;
+            const std::string& arg;
+        };
+        for (auto &[v, str]: {
+            V { m.fastSelect, ARG_STR_WALLET_FAST_SELECT},
+            V { m.skipSolvable, ARG_STR_WALLET_COIN_OPT_SKIP_SOLVABLE},
+            V { m.eagerExit, ARG_STR_WALLET_COIN_OPT_EAGER_EXIT},
+        }) {
+            writer("x" + str, v ? "1" : "0");
+        }
     }
 };
 

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -303,7 +303,11 @@ static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxD
     auto locked_chain = pwallet->chain().lock();
     LOCK2(pwallet->cs_wallet, locked_chain->mutex());
 
-    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, MAX_MONEY, 1);
+    // See comment in GetDustThreshold
+    // https://github.com/DeFiCh/ain/blob/0edc8e002ddc634dcb80785b9e9e01606fd8e4f7/src/policy/policy.cpp#L16-L29
+    const CAmount segwitDust = 98 * DUST_RELAY_TX_FEE / 1000;
+
+    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, segwitDust, 1);
 
     if (vecOutputs.empty()) {
         return {};

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -292,7 +292,7 @@ std::optional<CScript> AmIFounder(CWallet* const pwallet) {
     return {};
 }
 
-static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxDestination const& auth) {
+static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxDestination const& auth, const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault()) {
 
     std::vector<COutput> vecOutputs;
     CCoinControl cctl;
@@ -381,7 +381,7 @@ static std::optional<CTxIn> GetAnyFoundationAuthInput(CWalletCoinsUnlocker& pwal
     return {};
 }
 
-std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txVersion, std::set<CScript>& auths, bool needFounderAuth, CTransactionRef & optAuthTx, UniValue const& explicitInputs) {
+std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txVersion, std::set<CScript>& auths, bool needFounderAuth, CTransactionRef & optAuthTx, UniValue const& explicitInputs, const CoinSelectionOptions &coinSelectOpts) {
 
     if (!explicitInputs.isNull() && !explicitInputs.empty()) {
         return GetInputs(explicitInputs);
@@ -398,7 +398,10 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
         if (IsMineCached(*pwallet, auth) != ISMINE_SPENDABLE) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Incorrect authorization for " + EncodeDestination(destination));
         }
-        auto authInput = GetAuthInputOnly(pwallet, destination);
+        auto authInput = GetAuthInputOnly(
+            pwallet, 
+            destination, 
+            coinSelectOpts);
         if (authInput) {
             result.push_back(authInput.value());
         }

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -302,12 +302,9 @@ static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxD
 
     auto locked_chain = pwallet->chain().lock();
     LOCK2(pwallet->cs_wallet, locked_chain->mutex());
-
-    // See comment in GetDustThreshold
-    // https://github.com/DeFiCh/ain/blob/0edc8e002ddc634dcb80785b9e9e01606fd8e4f7/src/policy/policy.cpp#L16-L29
-    const CAmount segwitDust = 98 * DUST_RELAY_TX_FEE / 1000;
-
-    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, segwitDust, 1);
+    
+    // Note, for auth, we call this with 1 as max count, so should early exit
+    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, MAX_MONEY, 1);
 
     if (vecOutputs.empty()) {
         return {};

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -110,7 +110,7 @@ CAccounts SelectAccountsByTargetBalances(const CAccounts& accounts, const CBalan
     return selectedAccountsBalances;
 }
 
-CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx, CCoinControl* coin_control) {
+CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwallet, CTransactionRef optAuthTx, CCoinControl* coin_control, const CoinSelectionOptions &coinSelectOpts) {
     CAmount fee_out;
     int change_position = mtx.vout.size();
 

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -72,7 +72,8 @@ int chainHeight(interfaces::Chain::Lock &locked_chain);
 CMutableTransaction fund(CMutableTransaction &mtx,
                          CWalletCoinsUnlocker &pwallet,
                          CTransactionRef optAuthTx,
-                         CCoinControl *coin_control = nullptr);
+                         CCoinControl *coin_control = nullptr,
+                         const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault());
 CTransactionRef signsend(CMutableTransaction &mtx, CWalletCoinsUnlocker &pwallet, CTransactionRef optAuthTx);
 CWalletCoinsUnlocker GetWallet(const JSONRPCRequest &request);
 std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker &pwallet,

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -10,6 +10,7 @@
 
 #include <masternodes/masternodes.h>
 #include <masternodes/mn_checks.h>
+#include <masternodes/coinselect.h>
 
 #include <rpc/rawtransaction_util.h>
 #include <rpc/resultcache.h>
@@ -79,7 +80,8 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker &pwallet,
                                       std::set<CScript> &auths,
                                       bool needFounderAuth,
                                       CTransactionRef &optAuthTx,
-                                      const UniValue &explicitInputs);
+                                      const UniValue &explicitInputs,
+                                      const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault());
 std::string ScriptToString(const CScript &script);
 CAccounts GetAllMineAccounts(CWallet *const pwallet);
 CAccounts SelectAccountsByTargetBalances(const CAccounts &accounts,

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -573,7 +573,7 @@ UniValue votegov(const JSONRPCRequest &request) {
         coinControl.destChange = ownerDest;
     }
 
-    fund(rawTx, pwallet, optAuthTx, &coinControl);
+    fund(rawTx, pwallet, optAuthTx, &coinControl, request.metadata.coinSelectOpts);
 
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
@@ -733,7 +733,7 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
             coinControl.destChange = ownerDest;
         }
 
-        fund(rawTx, pwallet, optAuthTx, &coinControl);
+        fund(rawTx, pwallet, optAuthTx, &coinControl, request.metadata.coinSelectOpts);
 
         // check execution
         execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -720,7 +720,12 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
 
         CTransactionRef optAuthTx;
         std::set<CScript> auths = {GetScriptForDestination(ownerDest)};
-        rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, {});
+        rawTx.vin = GetAuthInputsSmart(pwallet, 
+            rawTx.nVersion, 
+            auths, false /*needFoundersAuth*/, 
+            optAuthTx, 
+            {}, 
+            request.metadata.coinSelectOpts);
         rawTx.vout.emplace_back(0, scriptMeta);
 
         CCoinControl coinControl;

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -7,8 +7,9 @@
 #define DEFI_RPC_REQUEST_H
 
 #include <string>
-
 #include <univalue.h>
+#include <masternodes/coinselect.h>
+#include <util/system.h>
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);
 UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const UniValue& id);
@@ -24,6 +25,35 @@ void DeleteAuthCookie();
 /** Parse JSON-RPC batch reply into a vector */
 std::vector<UniValue> JSONRPCProcessBatchReply(const UniValue &in, size_t num);
 
+
+struct RPCMetadata {
+    public:
+    CoinSelectionOptions coinSelectOpts;
+
+    static RPCMetadata CreateDefault() {
+        RPCMetadata m;
+        FromArgs(m, gArgs);
+        return m;
+    }
+
+    static void SetupArgs(ArgsManager& args) {
+        CoinSelectionOptions::SetupArgs(args);
+    }
+
+    static void FromArgs(RPCMetadata &m, ArgsManager& args) {
+        CoinSelectionOptions::FromArgs(m.coinSelectOpts, args);
+    }
+
+    static void FromHTTPHeaderFunc(RPCMetadata &m, const HTTPHeaderQueryFunc headerFunc) {
+        CoinSelectionOptions::FromHTTPHeaderFunc(m.coinSelectOpts, headerFunc);
+    }
+
+    static void ToHTTPHeaderFunc(const RPCMetadata& m, const HTTPHeaderWriterFunc writer) {
+        CoinSelectionOptions::ToHTTPHeaderFunc(m.coinSelectOpts, writer);
+    }
+};
+    // UniValue metadata;
+
 class JSONRPCRequest
 {
 public:
@@ -34,6 +64,7 @@ public:
     std::string URI;
     std::string authUser;
     std::string peerAddr;
+    RPCMetadata metadata;
 
     JSONRPCRequest() : id(NullUniValue), params(NullUniValue), fHelp(false) {}
     void parse(const UniValue& valRequest);

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -44,12 +44,12 @@ struct RPCMetadata {
         CoinSelectionOptions::FromArgs(m.coinSelectOpts, args);
     }
 
-    static void FromHTTPHeaderFunc(RPCMetadata &m, const HTTPHeaderQueryFunc headerFunc) {
-        CoinSelectionOptions::FromHTTPHeaderFunc(m.coinSelectOpts, headerFunc);
+    static void FromHTTPHeader(RPCMetadata &m, const HTTPHeaderQueryFunc headerFunc) {
+        CoinSelectionOptions::FromHTTPHeader(m.coinSelectOpts, headerFunc);
     }
 
-    static void ToHTTPHeaderFunc(const RPCMetadata& m, const HTTPHeaderWriterFunc writer) {
-        CoinSelectionOptions::ToHTTPHeaderFunc(m.coinSelectOpts, writer);
+    static void ToHTTPHeader(const RPCMetadata& m, const HTTPHeaderWriterFunc writer) {
+        CoinSelectionOptions::ToHTTPHeader(m.coinSelectOpts, writer);
     }
 };
     // UniValue metadata;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -47,6 +47,8 @@ bool error(const char* fmt, const Args&... args)
     return false;
 }
 
+// Adding some generic function pointers to keep things contained without taking 
+// dependencies on HTTPServer on libs that don't need it
 typedef std::function<std::pair<bool, std::string>(const std::string&)> HTTPHeaderQueryFunc;
 typedef std::function<void(const std::string&, const std::string&)> HTTPHeaderWriterFunc;
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -47,6 +47,9 @@ bool error(const char* fmt, const Args&... args)
     return false;
 }
 
+typedef std::function<std::pair<bool, std::string>(const std::string&)> HTTPHeaderQueryFunc;
+typedef std::function<void(const std::string&, const std::string&)> HTTPHeaderWriterFunc;
+
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 bool FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -332,7 +332,7 @@ static UniValue setlabel(const JSONRPCRequest& request)
 }
 
 
-CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet * const pwallet, const CTxDestination &address, CAmount nValue, DCT_ID tokenId, bool fSubtractFeeFromAmount, const CCoinControl& coin_control, mapValue_t mapValue)
+CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet * const pwallet, const CTxDestination &address, CAmount nValue, DCT_ID tokenId, bool fSubtractFeeFromAmount, const CCoinControl& coin_control, mapValue_t mapValue, const CoinSelectionOptions &coinSelectOpts)
 {
     TAmounts curBalance = pwallet->GetBalance(0, coin_control.m_avoid_address_reuse).m_mine_trusted;
 
@@ -354,7 +354,7 @@ CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet * const
     CRecipient recipient = {scriptPubKey, nValue, tokenId, tokenId == DCT_ID{0} ? fSubtractFeeFromAmount : false }; // turn off `fSubtractFeeFromAmount` for tokens
     vecSend.push_back(recipient);
     CTransactionRef tx;
-    if (!pwallet->CreateTransaction(locked_chain, vecSend, tx, nFeeRequired, nChangePosRet, strError, coin_control)) {
+    if (!pwallet->CreateTransaction(locked_chain, vecSend, tx, nFeeRequired, nChangePosRet, strError, coin_control, true, coinSelectOpts)) {
         if (!fSubtractFeeFromAmount && (tokenId == DCT_ID{0} ? nValue : 0) + nFeeRequired > curBalance[DCT_ID{0}])
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s", FormatMoney(nFeeRequired));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
@@ -457,7 +457,7 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    CTransactionRef tx = SendMoney(*locked_chain, pwallet, dest, tokenAmount.nValue, tokenAmount.nTokenId, fSubtractFeeFromAmount, coin_control, std::move(mapValue));
+    CTransactionRef tx = SendMoney(*locked_chain, pwallet, dest, tokenAmount.nValue, tokenAmount.nTokenId, fSubtractFeeFromAmount, coin_control, std::move(mapValue), request.metadata.coinSelectOpts);
     return tx->GetHash().GetHex();
 }
 

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -41,5 +41,5 @@ bool EnsureWalletIsAvailable(const CWallet*, bool avoidException);
 UniValue getaddressinfo(const JSONRPCRequest& request);
 UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
 
-CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet * const pwallet, const CTxDestination &address, CAmount nValue, DCT_ID tokenId, bool fSubtractFeeFromAmount, const CCoinControl& coin_control, mapValue_t mapValue);
+CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet * const pwallet, const CTxDestination &address, CAmount nValue, DCT_ID tokenId, bool fSubtractFeeFromAmount, const CCoinControl& coin_control, mapValue_t mapValue, const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault());
 #endif //DEFI_WALLET_RPCWALLET_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2854,7 +2854,7 @@ bool CWallet::SignTransaction(CMutableTransaction& tx)
     return true;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl& coinControl)
+bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl& coinControl, const CoinSelectionOptions &coinSelectOpts)
 {
     std::vector<CRecipient> vecSend;
 
@@ -2877,7 +2877,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
     LOCK2(cs_wallet, locked_chain->mutex());
 
     CTransactionRef tx_new;
-    if (!CreateTransaction(*locked_chain, vecSend, tx_new, nFeeRet, nChangePosInOut, strFailReason, coinControl, false)) {
+    if (!CreateTransaction(*locked_chain, vecSend, tx_new, nFeeRet, nChangePosInOut, strFailReason, coinControl, false, coinSelectOpts)) {
         return false;
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3023,11 +3023,11 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
         }
     }
 
-    bool eagerExit = coinSelectOpts.eagerExit;
-    if (!eagerExit) {
-        eagerExit = coinSelectOpts.fastSelect;
+    bool eagerSelect = coinSelectOpts.eagerSelect;
+    if (!eagerSelect) {
+        eagerSelect = coinSelectOpts.fastSelect;
     }
-    const auto sumAmountToSelect = eagerExit ? nValue + DEFAULT_TRANSACTION_MAXFEE : MAX_MONEY;
+    const auto sumAmountToSelect = eagerSelect ? nValue + DEFAULT_TRANSACTION_MAXFEE : MAX_MONEY;
 
     if (vecSend.empty())
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3116,7 +3116,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
         LOCK2(cs_wallet, locked_chain->mutex());
         {
             std::vector<COutput> vAvailableCoins;
-            AvailableCoins(*locked_chain, vAvailableCoins, true, &coin_control, 1, MAX_MONEY, MAX_MONEY, 0);
+            AvailableCoins(*locked_chain, vAvailableCoins, true, &coin_control, 1, MAX_MONEY, sumAmountToSelect, 0);
             CoinSelectionParams coin_selection_params; // Parameters for coin selection, init with dummy
 
             // Create change script that will be used if we need change

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1110,7 +1110,7 @@ public:
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl& coinControl);
+    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl& coinControl, const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault());
     bool SignTransaction(CMutableTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -43,6 +43,8 @@
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/signals2/signal.hpp>
 
+#include <masternodes/coinselect.h>
+
 //! Explicitly unload and delete the wallet.
 //! Blocks the current thread after signaling the unload intent so that all
 //! wallet clients release the wallet.
@@ -949,7 +951,7 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault()) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1119,7 +1119,7 @@ public:
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
     bool CreateTransaction(interfaces::Chain::Lock& locked_chain, const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CAmount& nFeeRet, int& nChangePosInOut,
-                           std::string& strFailReason, const CCoinControl& coin_control, bool sign = true);
+                           std::string& strFailReason, const CCoinControl& coin_control, bool sign = true, const CoinSelectionOptions &coinSelectOpts = CoinSelectionOptions::CreateDefault());
     bool CommitTransaction(CTransactionRef tx, mapValue_t mapValue, CValidationState& state);
 
     bool DummySignTx(CMutableTransaction &txNew, const std::set<CTxOut> &txouts, bool use_max_sig = false) const


### PR DESCRIPTION
/kind feature

- Add a metadata capability to RPCs which can carry coin selection on options, and in the future enable things like `-v2` and more per RPC flags.   
- Add coin select metadata for experimental faster coin selection