### PR TITLE
Switch assert to propogating error so it doesn't crash on corrupt data

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3401,7 +3401,9 @@ void CChainState::PruneBlockIndexCandidates() {
         setBlockIndexCandidates.erase(it++);
     }
     // Either the current tip or a successor of it we're working towards is left in setBlockIndexCandidates.
-    assert(!setBlockIndexCandidates.empty());
+    if (setBlockIndexCandidates.empty()) {
+        throw std::runtime_error("ERROR:: Data corruption detected. Please resync or use a snapshot");
+    }
 //    LogPrintf("TRACE PruneBlockIndexCandidates() after: setBlockIndexCandidates: %i\n", setBlockIndexCandidates.size());
 }
 


### PR DESCRIPTION
/kind fix

- If the snapshot or node isn't shutdown, it gets caught on an assert instead of a graceful error. This is undesirable for multiple reasons, that logs are incomplete, crashes are often not noticed on stdouts, etc. 
- This removes the assert and turns it into an error that's caught by the main thread and shutdown