### PR TITLE
In CreateTransaction pass coinSelectOpts to AvailableCoin. Remove dead code.

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -304,7 +304,7 @@ static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxD
     LOCK2(pwallet->cs_wallet, locked_chain->mutex());
     
     // Note, for auth, we call this with 1 as max count, so should early exit
-    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, MAX_MONEY, 1);
+    pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, MAX_MONEY, 1, coinSelectOpts);
 
     if (vecOutputs.empty()) {
         return {};

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -132,7 +132,7 @@ CMutableTransaction fund(CMutableTransaction & mtx, CWalletCoinsUnlocker& pwalle
     // we does not honor non locking spends anymore
     // it ensures auto auth not overlap regular tx inputs
     const bool lockUnspents = true;
-    if (!pwallet->FundTransaction(mtx, fee_out, change_position, strFailReason, lockUnspents, {} /*setSubtractFeeFromOutputs*/, coinControl)) {
+    if (!pwallet->FundTransaction(mtx, fee_out, change_position, strFailReason, lockUnspents, {} /*setSubtractFeeFromOutputs*/, coinControl, coinSelectOpts)) {
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }
     for (auto& txin : mtx.vin) {

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -564,7 +564,7 @@ UniValue votegov(const JSONRPCRequest &request) {
     CTransactionRef optAuthTx;
     std::set<CScript> auths = {GetScriptForDestination(ownerDest)};
     rawTx.vin =
-        GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, request.params[3]);
+        GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false /*needFoundersAuth*/, optAuthTx, request.params[3], request.metadata.coinSelectOpts);
 
     rawTx.vout.emplace_back(CTxOut(0, scriptMeta));
 


### PR DESCRIPTION
Skips dummy signing in AvailableCoin() when being called with -walletfastselect or -walletcoinoptskipsolvable for applicable RPC calls, also pass on opts from calls to fund() to CreateTransaction(). Remove non-DFI UTXO dead code in CreateTransaction.