### PR TITLE
CI workflow for EVM RPC testing

### DIFF
--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -4,7 +4,7 @@ on:
     types: [ labeled ]
 env:
   ETHLIBS_TEST_WS_URL: wss://goerli.infura.io/ws/v3/
-  AUTH_ID: ${{ secrets.INFURE_GOERLI_PROJECT_ID }}
+  AUTH_ID: ${{ secrets.INFURA_GOERLI_PROJECT_ID }}
   AUTH_PASS: ${{ secrets.INFURA_GOERLI_API_KEY }}
 jobs:
   node-rpc-tests:

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,4 +1,4 @@
-name: Tests - EVM/RPC Tests
+name: Tests - EVM
 on:
   pull_request:
     types: [ labeled ]
@@ -7,7 +7,7 @@ env:
   AUTH_ID: ${{ secrets.INFURE_GOERLI_PROJECT_ID }}
   AUTH_PASS: ${{ secrets.INFURA_GOERLI_API_KEY }}
 jobs:
-  unit-tests:
+  node-rpc-tests:
     if: ${{ github.event.label.name == 'test/rpc_evm' }}
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,11 +1,11 @@
-name: tests evm rpc
+name: rpc auth tests
 on:
   pull_request:
     types: [ labeled ]
-
-# env:
- # ETHLIBS_TEST_ROPSTEN_WS_URL: ""
-
+env:
+  ETHLIBS_TEST_WS_URL: wss://goerli.infura.io/ws/v3/
+  AUTH_ID: ${{ secrets.INFURE_GOERLI_PROJECT_ID }}
+  AUTH_PASS: ${{ secrets.INFURA_GOERLI_API_KEY }}
 jobs:
   unit-tests:
     if: ${{ github.event.label.name == 'test/rpc_evm' }}
@@ -18,8 +18,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: 'DeFiCh/go-ethlibs'
-      - name: go version
-        run: go version
       - name: Run unit tests
         run: go test -v ./node/rpc_test.go
-

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,15 +1,13 @@
 name: Tests - EVM
 on:
-  pull_request:
-    types: [ labeled ]
+  workflow_dispatch:
 env:
-  ETHLIBS_TEST_WS_URL: wss://goerli.infura.io/ws/v3/
+  NODE_URL: "http://35.187.53.161:20551/"
   AUTH_ID: ${{ secrets.INFURA_GOERLI_PROJECT_ID }}
   AUTH_PASS: ${{ secrets.INFURA_GOERLI_API_KEY }}
 jobs:
   node-rpc-tests:
-    if: ${{ github.event.label.name == 'evm' }}
-    name: Unit tests
+    name: E2E tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -18,5 +16,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: 'DeFiCh/go-ethlibs'
-      - name: Run unit tests
+      - name: Run e2e tests
         run: go test -v ./node/rpc_test.go

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,0 +1,25 @@
+name: tests evm rpc
+on:
+  pull_request:
+    types: [ labeled ]
+
+# env:
+ # ETHLIBS_TEST_ROPSTEN_WS_URL: ""
+
+jobs:
+  unit-tests:
+    if: ${{ github.event.label.name == 'test/rpc_evm' }}
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17.0'
+      - uses: actions/checkout@v3
+        with:
+          repository: 'DeFiCh/go-ethlibs'
+      - name: go version
+        run: go version
+      - name: Run unit tests
+        run: go test -v ./node/rpc_test.go
+

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,4 +1,4 @@
-name: rpc auth tests
+name: RPC EVM Tests
 on:
   pull_request:
     types: [ labeled ]

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -1,4 +1,4 @@
-name: RPC EVM Tests
+name: Tests - EVM/RPC Tests
 on:
   pull_request:
     types: [ labeled ]

--- a/.github/workflows/tests-evm-rpc.yaml
+++ b/.github/workflows/tests-evm-rpc.yaml
@@ -8,7 +8,7 @@ env:
   AUTH_PASS: ${{ secrets.INFURA_GOERLI_API_KEY }}
 jobs:
   node-rpc-tests:
-    if: ${{ github.event.label.name == 'test/rpc_evm' }}
+    if: ${{ github.event.label.name == 'evm' }}
     name: Unit tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Pull requests without a rationale and clear improvement may be closed. 
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section. 
-->

## Summary

- Add test workflow for EVM RPC. Currently using Infura node running on goerli testnet. Intened to point to our own EVM compatible node when possible. 
- ~~Workflow triggered only when tag `evm` is set in a PR.~~ Workflow triggered on demand with workcflow_dispatch

Update:

- Related work: https://github.com/DeFiCh/go-ethlibs/pull/10

#### To fix:

- [ ] TestConnection_Call_Simple_Contract
- [x] TestConnection_Get_Accounts
- [x] TestConnection_Get_Balance
- [ ] TestConnection_GetTransactionCount
- [x] TestConnection_EstimateGas
- [ ] TestConnection_MaxPriorityFeePerGas
- [x] TestConnection_GasPrice
- [x] TestConnection_NetVersion
- [x] TestConnection_ChainId
- [x] TestConnection_SendRawTransactionInValidEmpty
- [ ] TestConnection_SendRawTransactionInValidOldNonce
- [ ] TestConnection_FutureBlockByNumber
- [ ] TestConnection_InvalidBlockByHash
- [ ] TestConnection_InvalidTransactionByHash
 