### PR TITLE
Move sleep-time from node argument to rpc argument

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -637,7 +637,6 @@ void SetupServerArgs()
     gArgs.AddArg("-dftxworkers=<n>", strprintf("No. of parallel workers associated with the DfTx related work pool. Stock splits, parallel processing of the chain where appropriate, etc use this worker pool (default: %d)", DEFAULT_DFTX_WORKERS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-sleep-time=<n>", "Sets sleeping time for voteGovBatch, by default the value is set to 500ms", ArgsManager::ALLOW_ANY, OptionsCategory::HIDDEN);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -596,7 +596,8 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
                              {"masternodeId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The masternode ID, operator or owner address"},
                              {"decision", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The vote decision (yes/no/neutral)"},
                      }},
-                 },
+                    {"sleepTime", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Sets sleeping time for voteGovBatch, by default the value is set to 500ms"}
+            },
             RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
             RPCExamples{HelpExampleCli("votegovbatch", "{{proposalId, masternodeId, yes}...}") +
                         HelpExampleRpc("votegovbatch", "{{proposalId, masternodeId, yes}...}")},
@@ -611,7 +612,7 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
     RPCTypeCheck(request.params, {UniValue::VARR}, false);
 
     const auto &keys = request.params[0].get_array();
-    auto sleepTime = gArgs.GetBoolArg("-sleep-time", SLEEP_TIME_MILLIS);
+    auto sleepTime = request.params[1].isNull() ? SLEEP_TIME_MILLIS : request.params[1].get_int();
     auto neutralVotesAllowed = gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL);
 
     int targetHeight;

--- a/src/masternodes/rpc_proposals.cpp
+++ b/src/masternodes/rpc_proposals.cpp
@@ -595,7 +595,8 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
                              {"proposalId", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The proposal txid"},
                              {"masternodeId", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "The masternode ID, operator or owner address"},
                              {"decision", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The vote decision (yes/no/neutral)"},
-                     }},
+                            }
+                    },
                     {"sleepTime", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Sets sleeping time for voteGovBatch, by default the value is set to 500ms"}
             },
             RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
@@ -612,7 +613,7 @@ UniValue votegovbatch(const JSONRPCRequest &request) {
     RPCTypeCheck(request.params, {UniValue::VARR}, false);
 
     const auto &keys = request.params[0].get_array();
-    auto sleepTime = request.params[1].isNull() ? SLEEP_TIME_MILLIS : request.params[1].get_int();
+    auto sleepTime = (request.params.size() > 1 && request.params[1].isNull()) ? SLEEP_TIME_MILLIS : request.params[1].get_int();
     auto neutralVotesAllowed = gArgs.GetBoolArg("-rpc-governance-accept-neutral", DEFAULT_RPC_GOV_NEUTRAL);
 
     int targetHeight;


### PR DESCRIPTION
Previously added a sleep_time node parameter for votegovbatch. Moved it as an RPC parameter instead of node parameter.