### PR TITLE
WIP: Add HD Wallet Ethereum address support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -532,6 +532,8 @@ crypto_libdefi_crypto_base_a_SOURCES = \
   crypto/ripemd160.h \
   crypto/sha1.cpp \
   crypto/sha1.h \
+  crypto/sha3.cpp \
+  crypto/sha3.h \
   crypto/sha256.cpp \
   crypto/sha256.h \
   crypto/sha512.cpp \

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -130,6 +130,9 @@ const auto SMART_CONTRACT_DFIP_2201 = "DFIP2201";
 const auto SMART_CONTRACT_DFIP_2203 = "DFIP2203";
 const auto SMART_CONTRACT_DFIP2206F = "DFIP2206F";
 
+constexpr auto ETH_ADDR_PREFIX = "0x";
+constexpr auto ETH_ADDR_LENGTH_INC_PREFIX = 42;
+
 /**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
  * @returns a CChainParams* of the chosen chain.

--- a/src/crypto/sha3.cpp
+++ b/src/crypto/sha3.cpp
@@ -1,0 +1,182 @@
+/** libkeccak-tiny
+ *
+ * A single-file implementation of SHA-3 and SHAKE.
+ *
+ * Implementor: David Leon Gil
+ * License: CC0, attribution kindly requested. Blame taken too,
+ * but not liability.
+ * Source: https://github.com/coruus/keccak-tiny
+ */
+
+#include <crypto/sha3.h>
+#include <cstdint>
+#include <cstring>
+
+#define decshake(bits) \
+  int shake##bits(uint8_t*, size_t, const uint8_t*, size_t);
+
+#define decsha3(bits) \
+  int sha3_##bits(uint8_t*, size_t, const uint8_t*, size_t);
+
+decshake(128)
+decshake(256)
+decsha3(224)
+decsha3(256)
+decsha3(384)
+decsha3(512)
+
+/******** The Keccak-f[1600] permutation ********/
+
+/*** Constants. ***/
+static const uint8_t rho[24] = \
+  { 1,  3,   6, 10, 15, 21,
+	28, 36, 45, 55,  2, 14,
+	27, 41, 56,  8, 25, 43,
+	62, 18, 39, 61, 20, 44};
+static const uint8_t pi[24] = \
+  {10,  7, 11, 17, 18, 3,
+	5, 16,  8, 21, 24, 4,
+   15, 23, 19, 13, 12, 2,
+   20, 14, 22,  9, 6,  1};
+static const uint64_t RC[24] = \
+  {1ULL, 0x8082ULL, 0x800000000000808aULL, 0x8000000080008000ULL,
+   0x808bULL, 0x80000001ULL, 0x8000000080008081ULL, 0x8000000000008009ULL,
+   0x8aULL, 0x88ULL, 0x80008009ULL, 0x8000000aULL,
+   0x8000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL, 0x8000000000008003ULL,
+   0x8000000000008002ULL, 0x8000000000000080ULL, 0x800aULL, 0x800000008000000aULL,
+   0x8000000080008081ULL, 0x8000000000008080ULL, 0x80000001ULL, 0x8000000080008008ULL};
+
+/*** Helper macros to unroll the permutation. ***/
+#define rol(x, s) (((x) << s) | ((x) >> (64 - s)))
+#define REPEAT6(e) e e e e e e
+#define REPEAT24(e) REPEAT6(e e e e)
+#define REPEAT5(e) e e e e e
+#define FOR5(v, s, e) \
+  v = 0;            \
+  REPEAT5(e; v += s;)
+
+/*** Keccak-f[1600] ***/
+static inline void keccakf(void* state) {
+  uint64_t* a = (uint64_t*)state;
+  uint64_t b[5] = {0};
+  uint64_t t = 0;
+  uint8_t x, y;
+
+  for (int i = 0; i < 24; i++) {
+	// Theta
+	FOR5(x, 1,
+		 b[x] = 0;
+		 FOR5(y, 5,
+			  b[x] ^= a[x + y]; ))
+	FOR5(x, 1,
+		 FOR5(y, 5,
+			  a[y + x] ^= b[(x + 4) % 5] ^ rol(b[(x + 1) % 5], 1); ))
+	// Rho and pi
+	t = a[1];
+	x = 0;
+	REPEAT24(b[0] = a[pi[x]];
+			 a[pi[x]] = rol(t, rho[x]);
+			 t = b[0];
+			 x++; )
+	// Chi
+	FOR5(y,
+	   5,
+	   FOR5(x, 1,
+			b[x] = a[y + x];)
+	   FOR5(x, 1,
+			a[y + x] = b[x] ^ ((~b[(x + 1) % 5]) & b[(x + 2) % 5]); ))
+	// Iota
+	a[0] ^= RC[i];
+  }
+}
+
+/******** The FIPS202-defined functions. ********/
+
+/*** Some helper macros. ***/
+
+#define _(S) do { S } while (0)
+#define FOR(i, ST, L, S) \
+  _(for (size_t i = 0; i < L; i += ST) { S; })
+#define mkapply_ds(NAME, S)                                          \
+  static inline void NAME(uint8_t* dst,                              \
+						  const uint8_t* src,                        \
+						  size_t len) {                              \
+	FOR(i, 1, len, S);                                               \
+  }
+#define mkapply_sd(NAME, S)                                          \
+  static inline void NAME(const uint8_t* src,                        \
+						  uint8_t* dst,                              \
+						  size_t len) {                              \
+	FOR(i, 1, len, S);                                               \
+  }
+
+mkapply_ds(xorin, dst[i] ^= src[i])  // xorin
+mkapply_sd(setout, dst[i] = src[i])  // setout
+
+#define P keccakf
+#define Plen 200
+
+// Fold P*F over the full blocks of an input.
+#define foldP(I, L, F) \
+  while (L >= rate) {  \
+	F(a, I, rate);     \
+	P(a);              \
+	I += rate;         \
+	L -= rate;         \
+  }
+
+/** The sponge-based hash construction. **/
+static inline int hash(uint8_t* out, size_t outlen,
+					   const uint8_t* in, size_t inlen,
+					   size_t rate, uint8_t delim) {
+  if ((out == NULL) || ((in == NULL) && inlen != 0) || (rate >= Plen)) {
+	return -1;
+  }
+  uint8_t a[Plen] = {0};
+  // Absorb input.
+  foldP(in, inlen, xorin);
+  // Xor in the DS and pad frame.
+  a[inlen] ^= delim;
+  a[rate - 1] ^= 0x80;
+  // Xor in the last block.
+  xorin(a, in, inlen);
+  // Apply P
+  P(a);
+  // Squeeze output.
+  foldP(out, outlen, setout);
+  setout(a, out, outlen);
+  memset(a, 0, 200);
+  return 0;
+}
+
+/*** Helper macros to define SHA3 and SHAKE instances. ***/
+#define defshake(bits)                                            \
+  int shake##bits(uint8_t* out, size_t outlen,                    \
+				  const uint8_t* in, size_t inlen) {              \
+	return hash(out, outlen, in, inlen, 200 - (bits / 4), 0x1f);  \
+  }
+#define defsha3(bits)                                             \
+  int sha3_##bits(uint8_t* out, size_t outlen,                    \
+				  const uint8_t* in, size_t inlen) {              \
+	if (outlen > (bits/8)) {                                      \
+	  return -1;                                                  \
+	}                                                             \
+	return hash(out, outlen, in, inlen, 200 - (bits / 4), 0x01);  \
+  }
+
+/*** FIPS202 SHAKE VOFs ***/
+defshake(128)
+defshake(256)
+
+/*** FIPS202 SHA3 FOFs ***/
+defsha3(224)
+defsha3(256)
+defsha3(384)
+defsha3(512)
+
+bool sha3(const std::vector<unsigned char> &input, std::vector<unsigned char> &output)
+{
+    output.resize(32);
+	sha3_256(output.data(), 32, input.data(), input.size());
+	return true;
+}

--- a/src/crypto/sha3.h
+++ b/src/crypto/sha3.h
@@ -1,0 +1,8 @@
+#ifndef DEFI_CRYPTO_SHA3_H
+#define DEFI_CRYPTO_SHA3_H
+
+#include <vector>
+
+bool sha3(const std::vector<unsigned char> &input, std::vector<unsigned char> &output);
+
+#endif // DEFI_CRYPTO_SHA3_H

--- a/src/hash.h
+++ b/src/hash.h
@@ -9,6 +9,7 @@
 #include <crypto/common.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha256.h>
+#include <crypto/sha3.h>
 #include <prevector.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -125,6 +126,13 @@ template<unsigned int N>
 inline uint160 Hash160(const prevector<N, unsigned char>& vch)
 {
     return Hash160(vch.begin(), vch.end());
+}
+
+inline uint160 Sha3(const std::vector<unsigned char> &input) {
+    std::vector<unsigned char> output;
+    sha3(input, output);
+    const size_t ADDRESS_OFFSET{12};
+    return uint160({output.begin() + ADDRESS_OFFSET, output.end()});
 }
 
 /** A writer stream (for serialization) that computes a 256-bit hash. */

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -270,7 +270,7 @@ bool CKey::Load(const CPrivKey &privkey, const CPubKey &vchPubKey, bool fSkipChe
     return VerifyPubKey(vchPubKey);
 }
 #include <logging.h>
-bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, const bool uncompressed) const {
+bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, const bool ethAddress) const {
     assert(IsValid());
     assert(IsCompressed());
     std::vector<unsigned char, secure_allocator<unsigned char>> vout(64);
@@ -285,17 +285,17 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
     memcpy(ccChild.begin(), vout.data()+32, 32);
     memcpy((unsigned char*)keyChild.begin(), begin(), 32);
     bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
-    keyChild.fCompressed = !uncompressed;
+    keyChild.fCompressed = !ethAddress;
     keyChild.fValid = ret;
     return ret;
 }
 
-bool CExtKey::Derive(CExtKey &out, unsigned int _nChild, const bool uncompressed) const {
+bool CExtKey::Derive(CExtKey &out, unsigned int _nChild, const bool ethAddress) const {
     out.nDepth = nDepth + 1;
     CKeyID id = key.GetPubKey().GetID();
     memcpy(&out.vchFingerprint[0], &id, 4);
     out.nChild = _nChild;
-    return key.Derive(out.key, out.chaincode, _nChild, chaincode, uncompressed);
+    return key.Derive(out.key, out.chaincode, _nChild, chaincode, ethAddress);
 }
 
 void CExtKey::SetSeed(const unsigned char *seed, unsigned int nSeedLen) {

--- a/src/key.h
+++ b/src/key.h
@@ -129,7 +129,7 @@ public:
     bool SignCompact(const uint256& hash, std::vector<unsigned char>& vchSig) const;
 
     //! Derive BIP32 child key.
-    bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, const bool uncompressed = false) const;
+    bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, const bool ethAddress = false) const;
 
     /**
      * Verify thoroughly whether a private key and a public key match.
@@ -159,7 +159,7 @@ struct CExtKey {
 
     void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
-    bool Derive(CExtKey& out, unsigned int nChild, const bool uncompressed = false) const;
+    bool Derive(CExtKey& out, unsigned int nChild, const bool ethAddress = false) const;
     CExtPubKey Neuter() const;
     void SetSeed(const unsigned char* seed, unsigned int nSeedLen);
     template <typename Stream>

--- a/src/key.h
+++ b/src/key.h
@@ -129,7 +129,7 @@ public:
     bool SignCompact(const uint256& hash, std::vector<unsigned char>& vchSig) const;
 
     //! Derive BIP32 child key.
-    bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;
+    bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc, const bool uncompressed = false) const;
 
     /**
      * Verify thoroughly whether a private key and a public key match.
@@ -159,7 +159,7 @@ struct CExtKey {
 
     void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
-    bool Derive(CExtKey& out, unsigned int nChild) const;
+    bool Derive(CExtKey& out, unsigned int nChild, const bool uncompressed = false) const;
     CExtPubKey Neuter() const;
     void SetSeed(const unsigned char* seed, unsigned int nSeedLen);
     template <typename Stream>

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -61,7 +61,7 @@ public:
         return bech32::Encode(m_params.Bech32HRP(), data);
     }
 
-    std::string operator()(const EthHash& id) const
+    std::string operator()(const WitnessV16EthHash& id) const
     {
         return ETH_ADDR_PREFIX + HexStr(id);
     }
@@ -80,7 +80,7 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
             return CNoDestination();
         }
         data = ParseHex(hex);
-        return EthHash(uint160(data));
+        return WitnessV16EthHash(uint160(data));
     }
     if (DecodeBase58Check(str, data)) {
         // base58-encoded DFI addresses.

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -63,7 +63,7 @@ public:
 
     std::string operator()(const EthHash& id) const
     {
-        return "0x" + HexStr(id);
+        return ETH_ADDR_PREFIX + HexStr(id);
     }
 
     std::string operator()(const CNoDestination& no) const { return {}; }
@@ -74,6 +74,14 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
 {
     std::vector<unsigned char> data;
     uint160 hash;
+    if (str.size() == ETH_ADDR_LENGTH_INC_PREFIX && str.substr(0, 2) == ETH_ADDR_PREFIX) {
+        const auto hex = str.substr(2);
+        if (!IsHex(str.substr(2))) {
+            return CNoDestination();
+        }
+        data = ParseHex(hex);
+        return EthHash(uint160(data));
+    }
     if (DecodeBase58Check(str, data)) {
         // base58-encoded DFI addresses.
         // Public-key-hash-addresses have version 0 (or 111 testnet).

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include "logging.h"
 
 namespace {
 class DestinationEncoder
@@ -58,6 +59,11 @@ public:
         data.reserve(1 + (id.length * 8 + 4) / 5);
         ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, id.program, id.program + id.length);
         return bech32::Encode(m_params.Bech32HRP(), data);
+    }
+
+    std::string operator()(const EthHash& id) const
+    {
+        return "0x" + HexStr(id);
     }
 
     std::string operator()(const CNoDestination& no) const { return {}; }

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -63,7 +63,7 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
             return witdest;
         }
     }
-    case OutputType::ETH: return EthHash(key);
+    case OutputType::ETH: return WitnessV16EthHash(key);
     default: assert(false);
     }
 }

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -17,6 +17,7 @@
 static const std::string OUTPUT_TYPE_STRING_LEGACY = "legacy";
 static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
+static const std::string OUTPUT_TYPE_STRING_ETH = "eth";
 
 bool ParseOutputType(const std::string& type, OutputType& output_type)
 {
@@ -29,6 +30,9 @@ bool ParseOutputType(const std::string& type, OutputType& output_type)
     } else if (type == OUTPUT_TYPE_STRING_BECH32) {
         output_type = OutputType::BECH32;
         return true;
+    } else if (type == OUTPUT_TYPE_STRING_ETH) {
+        output_type = OutputType::ETH;
+        return true;
     }
     return false;
 }
@@ -39,6 +43,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::LEGACY: return OUTPUT_TYPE_STRING_LEGACY;
     case OutputType::P2SH_SEGWIT: return OUTPUT_TYPE_STRING_P2SH_SEGWIT;
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
+    case OutputType::ETH: return OUTPUT_TYPE_STRING_ETH;
     default: assert(false);
     }
 }
@@ -58,6 +63,7 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
             return witdest;
         }
     }
+    case OutputType::ETH: return EthHash(key);
     default: assert(false);
     }
 }

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -17,6 +17,7 @@ enum class OutputType {
     LEGACY,
     P2SH_SEGWIT,
     BECH32,
+    ETH,
 
     /**
      * Special output type for change outputs only. Automatically choose type

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -7,7 +7,6 @@
 #ifndef DEFI_PUBKEY_H
 #define DEFI_PUBKEY_H
 
-#include <crypto/sha3.h>
 #include <hash.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -163,14 +162,8 @@ public:
 
     CKeyID GetEthID() const
     {
-        std::vector<unsigned char> input(vch + 1, vch + size());
-        std::vector<unsigned char> output;
-
-        sha3(input, output);
-
-        std::vector<unsigned char> address(output.begin() + 12, output.end());
-
-        return CKeyID(uint160(address));
+        const size_t HEADER_OFFSET{1};
+        return CKeyID(Sha3({vch + HEADER_OFFSET, vch + size()}));
     }
 
     //! Get the 256-bit hash of this public key.

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -7,12 +7,16 @@
 #ifndef DEFI_PUBKEY_H
 #define DEFI_PUBKEY_H
 
+#include <crypto/sha3.h>
 #include <hash.h>
 #include <serialize.h>
 #include <uint256.h>
 
 #include <stdexcept>
 #include <vector>
+
+#include "logging.h"
+#include <util/strencodings.h>
 
 const unsigned int BIP32_EXTKEY_SIZE = 74;
 
@@ -155,6 +159,18 @@ public:
     CKeyID GetID() const
     {
         return CKeyID(Hash160(vch, vch + size()));
+    }
+
+    CKeyID GetEthID() const
+    {
+        std::vector<unsigned char> input(vch + 1, vch + size());
+        std::vector<unsigned char> output;
+
+        sha3(input, output);
+
+        std::vector<unsigned char> address(output.begin() + 12, output.end());
+
+        return CKeyID(uint160(address));
     }
 
     //! Get the 256-bit hash of this public key.

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -252,6 +252,11 @@ public:
         obj.pushKV("witness_program", HexStr(id.program, id.program + id.length));
         return obj;
     }
+
+    UniValue operator()(const EthHash& id) const
+    {
+        return UniValue(UniValue::VOBJ);
+    }
 };
 
 UniValue DescribeAddress(const CTxDestination& dest)

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -253,9 +253,14 @@ public:
         return obj;
     }
 
-    UniValue operator()(const EthHash& id) const
+    UniValue operator()(const WitnessV16EthHash& id) const
     {
-        return UniValue(UniValue::VOBJ);
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("isscript", false);
+        obj.pushKV("iswitness", true);
+        obj.pushKV("witness_version", 16);
+        obj.pushKV("witness_program", HexStr(id.begin(), id.end()));
+        return obj;
     }
 };
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -137,6 +137,7 @@ enum class SigVersion
 /** Signature hash sizes */
 static constexpr size_t WITNESS_V0_SCRIPTHASH_SIZE = 32;
 static constexpr size_t WITNESS_V0_KEYHASH_SIZE = 20;
+static constexpr size_t WITNESS_V16_ETHHASH_SIZE = 20;
 
 template <class T>
 uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -71,11 +71,11 @@ protected:
     KeyMap mapKeys GUARDED_BY(cs_KeyStore);
     ScriptMap mapScripts GUARDED_BY(cs_KeyStore);
 
-    void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
+    void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey, const bool ethAddress = false) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
 public:
-    virtual bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
-    virtual bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey()); }
+    virtual bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey, const bool ethAddress);
+    virtual bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey(), false); }
     virtual bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
     virtual bool HaveKey(const CKeyID &address) const override;
     virtual std::set<CKeyID> GetKeys() const;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -25,6 +25,8 @@ WitnessV0ScriptHash::WitnessV0ScriptHash(const CScript& in)
     CSHA256().Write(in.data(), in.size()).Finalize(begin());
 }
 
+EthHash::EthHash(const CPubKey& pubkey) : uint160(pubkey.GetEthID()) {}
+
 const char* GetTxnOutputType(txnouttype t)
 {
     switch (t)
@@ -269,6 +271,11 @@ public:
     CScript operator()(const WitnessUnknown& id) const
     {
         return CScript() << CScript::EncodeOP_N(id.version) << std::vector<unsigned char>(id.program, id.program + id.length);
+    }
+
+    CScript operator()(const EthHash& id) const
+    {
+        return CScript() << OP_16 << ToByteVector(id);
     }
 };
 } // namespace

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -25,7 +25,7 @@ WitnessV0ScriptHash::WitnessV0ScriptHash(const CScript& in)
     CSHA256().Write(in.data(), in.size()).Finalize(begin());
 }
 
-EthHash::EthHash(const CPubKey& pubkey) : uint160(pubkey.GetEthID()) {}
+WitnessV16EthHash::WitnessV16EthHash(const CPubKey& pubkey) : uint160(pubkey.GetEthID()) {}
 
 const char* GetTxnOutputType(txnouttype t)
 {
@@ -39,6 +39,7 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_NULL_DATA: return "nulldata";
     case TX_WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
     case TX_WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
+    case TX_WITNESS_V16_ETHHASH: return "witness_v16_ethhash";
     case TX_WITNESS_UNKNOWN: return "witness_unknown";
     }
     return nullptr;
@@ -114,6 +115,10 @@ txnouttype Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned 
             vSolutionsRet.push_back(witnessprogram);
             return TX_WITNESS_V0_SCRIPTHASH;
         }
+        if (witnessversion == 16 && witnessprogram.size() == WITNESS_V16_ETHHASH_SIZE) {
+            vSolutionsRet.push_back(witnessprogram);
+            return TX_WITNESS_V16_ETHHASH;
+        }
         if (witnessversion != 0) {
             vSolutionsRet.push_back(std::vector<unsigned char>{(unsigned char)witnessversion});
             vSolutionsRet.push_back(std::move(witnessprogram));
@@ -184,6 +189,11 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         return true;
     } else if (whichType == TX_WITNESS_V0_SCRIPTHASH) {
         WitnessV0ScriptHash hash;
+        std::copy(vSolutions[0].begin(), vSolutions[0].end(), hash.begin());
+        addressRet = hash;
+        return true;
+    } else if (whichType == TX_WITNESS_V16_ETHHASH) {
+        WitnessV16EthHash hash;
         std::copy(vSolutions[0].begin(), vSolutions[0].end(), hash.begin());
         addressRet = hash;
         return true;
@@ -273,7 +283,7 @@ public:
         return CScript() << CScript::EncodeOP_N(id.version) << std::vector<unsigned char>(id.program, id.program + id.length);
     }
 
-    CScript operator()(const EthHash& id) const
+    CScript operator()(const WitnessV16EthHash& id) const
     {
         return CScript() << OP_16 << ToByteVector(id);
     }

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -63,6 +63,7 @@ enum txnouttype
     TX_NULL_DATA, //!< unspendable OP_RETURN script that carries data
     TX_WITNESS_V0_SCRIPTHASH,
     TX_WITNESS_V0_KEYHASH,
+    TX_WITNESS_V16_ETHHASH,
     TX_WITNESS_UNKNOWN, //!< Only for Witness versions not already defined above
 };
 
@@ -103,11 +104,11 @@ struct WitnessV0KeyHash : public uint160
     using uint160::uint160;
 };
 
-struct EthHash : public uint160
+struct WitnessV16EthHash : public uint160
 {
-    EthHash() : uint160() {}
-    explicit EthHash(const uint160& hash) : uint160(hash) {}
-    explicit EthHash(const CPubKey& pubkey);
+    WitnessV16EthHash() : uint160() {}
+    explicit WitnessV16EthHash(const uint160& hash) : uint160(hash) {}
+    explicit WitnessV16EthHash(const CPubKey& pubkey);
     using uint160::uint160;
 };
 
@@ -141,10 +142,10 @@ struct WitnessUnknown
  *  * WitnessV0ScriptHash: TX_WITNESS_V0_SCRIPTHASH destination (P2WSH)
  *  * WitnessV0KeyHash: TX_WITNESS_V0_KEYHASH destination (P2WPKH)
  *  * WitnessUnknown: TX_WITNESS_UNKNOWN destination (P2W???)
- *  * EthHash: Eth address type. Not a valid destination, here for address support anly.
+ *  * WitnessV16EthHash: Eth address type. Not a valid destination, here for address support anly.
  *  A CTxDestination is the internal data type encoded in a DFI address
  */
-using CTxDestination = std::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown, EthHash>;
+using CTxDestination = std::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown, WitnessV16EthHash>;
 
 enum TxDestType {
     NoDestType,
@@ -152,7 +153,8 @@ enum TxDestType {
     ScriptHashType,
     WitV0ScriptHashType,
     WitV0KeyHashType,
-    WitUnknownType
+    WitUnknownType,
+    WitV16KeyEthHashType,
 };
 
 /** Check whether a CTxDestination is a CNoDestination. */

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -103,6 +103,14 @@ struct WitnessV0KeyHash : public uint160
     using uint160::uint160;
 };
 
+struct EthHash : public uint160
+{
+    EthHash() : uint160() {}
+    explicit EthHash(const uint160& hash) : uint160(hash) {}
+    explicit EthHash(const CPubKey& pubkey);
+    using uint160::uint160;
+};
+
 //! CTxDestination subtype to encode any future Witness version
 struct WitnessUnknown
 {
@@ -133,9 +141,10 @@ struct WitnessUnknown
  *  * WitnessV0ScriptHash: TX_WITNESS_V0_SCRIPTHASH destination (P2WSH)
  *  * WitnessV0KeyHash: TX_WITNESS_V0_KEYHASH destination (P2WPKH)
  *  * WitnessUnknown: TX_WITNESS_UNKNOWN destination (P2W???)
+ *  * EthHash: Eth address type. Not a valid destination, here for address support anly.
  *  A CTxDestination is the internal data type encoded in a DFI address
  */
-using CTxDestination = std::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown>;
+using CTxDestination = std::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown, EthHash>;
 
 enum TxDestType {
     NoDestType,

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     CKey key;
     key.MakeNewKey(true); // Need to use compressed keys in segwit or the signing will fail
     FillableSigningProvider keystore;
-    BOOST_CHECK(keystore.AddKeyPubKey(key, key.GetPubKey()));
+    BOOST_CHECK(keystore.AddKeyPubKey(key, key.GetPubKey(), false));
     CKeyID hash = key.GetPubKey().GetID();
     CScript scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(hash.begin(), hash.end());
 
@@ -517,10 +517,10 @@ BOOST_AUTO_TEST_CASE(test_witness)
     pubkey3 = key3.GetPubKey();
     pubkey1L = key1L.GetPubKey();
     pubkey2L = key2L.GetPubKey();
-    BOOST_CHECK(keystore.AddKeyPubKey(key1, pubkey1));
-    BOOST_CHECK(keystore.AddKeyPubKey(key2, pubkey2));
-    BOOST_CHECK(keystore.AddKeyPubKey(key1L, pubkey1L));
-    BOOST_CHECK(keystore.AddKeyPubKey(key2L, pubkey2L));
+    BOOST_CHECK(keystore.AddKeyPubKey(key1, pubkey1, false));
+    BOOST_CHECK(keystore.AddKeyPubKey(key2, pubkey2, false));
+    BOOST_CHECK(keystore.AddKeyPubKey(key1L, pubkey1L, false));
+    BOOST_CHECK(keystore.AddKeyPubKey(key2L, pubkey2L, false));
     CScript scriptPubkey1, scriptPubkey2, scriptPubkey1L, scriptPubkey2L, scriptMulti;
     scriptPubkey1 << ToByteVector(pubkey1) << OP_CHECKSIG;
     scriptPubkey2 << ToByteVector(pubkey2) << OP_CHECKSIG;
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptMulti)));
     BOOST_CHECK(keystore2.AddCScript(scriptMulti));
     BOOST_CHECK(keystore2.AddCScript(GetScriptForWitness(scriptMulti)));
-    BOOST_CHECK(keystore2.AddKeyPubKey(key3, pubkey3));
+    BOOST_CHECK(keystore2.AddKeyPubKey(key3, pubkey3, false));
 
     CTransactionRef output1, output2;
     CMutableTransaction input1, input2;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3697,7 +3697,14 @@ public:
 
     UniValue operator()(const WitnessUnknown& id) const { return UniValue(UniValue::VOBJ); }
 
-    UniValue operator()(const EthHash& dest) const { return UniValue(UniValue::VOBJ); }
+    UniValue operator()(const WitnessV16EthHash& id) const {
+        UniValue obj(UniValue::VOBJ);
+        CPubKey pubkey;
+        if (pwallet && pwallet->GetPubKey(CKeyID(id), pubkey)) {
+            obj.pushKV("pubkey", HexStr(pubkey));
+        }
+        return obj;
+    }
 };
 
 static UniValue DescribeWalletAddress(CWallet* pwallet, const CTxDestination& dest)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -207,7 +207,7 @@ static UniValue getnewaddress(const JSONRPCRequest& request)
                 "so payments received with the address will be associated with 'label'.\n",
                 {
                     {"label", RPCArg::Type::STR, /* default */ "\"\"", "The label name for the address to be linked to. It can also be set to the empty string \"\" to represent the default label. The label does not need to exist, it will be created if there is no label by the given name."},
-                    {"address_type", RPCArg::Type::STR, /* default */ "set by -addresstype", "The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
+                    {"address_type", RPCArg::Type::STR, /* default */ "set by -addresstype", R"(The address type to use. Options are "legacy", "p2sh-segwit", "bech32" and "eth".)"},
                 },
                 RPCResult{
             "\"address\"    (string) The new defi address\n"
@@ -3696,6 +3696,8 @@ public:
     }
 
     UniValue operator()(const WitnessUnknown& id) const { return UniValue(UniValue::VOBJ); }
+
+    UniValue operator()(const EthHash& dest) const { return UniValue(UniValue::VOBJ); }
 };
 
 static UniValue DescribeWalletAddress(CWallet* pwallet, const CTxDestination& dest)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -30,7 +30,7 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 static void AddKey(CWallet& wallet, const CKey& key)
 {
     LOCK(wallet.cs_wallet);
-    wallet.AddKeyPubKey(key, key.GetPubKey());
+    wallet.AddKeyPubKey(key, key.GetPubKey(), false);
 }
 
 static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t index, const CKey& key, const CScript& pubkey)
@@ -219,7 +219,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(chain.get(), WalletLocation(), WalletDatabase::CreateDummy());
         LOCK(wallet->cs_wallet);
         wallet->mapKeyMetadata[coinbaseKey.GetPubKey().GetID()].nCreateTime = KEY_TIME;
-        wallet->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        wallet->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey(), false);
 
         JSONRPCRequest request;
         request.params.setArray();
@@ -283,7 +283,7 @@ BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
     // Invalidate the cached value, add the key, and make sure a new immature
     // credit amount is calculated.
     wtx.MarkDirty();
-    wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+    wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey(), false);
     BOOST_CHECK_EQUAL(wtx.GetImmatureCredit(*locked_chain), 50*COIN);
     wallet.NotifyUnload();
 }
@@ -519,7 +519,7 @@ static size_t CalculateNestedKeyhashInputSize(bool use_max_sig)
     // Add inner-script to key store and key to watchonly
     FillableSigningProvider keystore;
     keystore.AddCScript(inner_script);
-    keystore.AddKeyPubKey(key, pubkey);
+    keystore.AddKeyPubKey(key, pubkey, false);
 
     // Fill in dummy signatures for fee calculation.
     SignatureData sig_data;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -261,12 +261,12 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(*it);
 }
 
-CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal, const bool uncompressed)
+CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal, const bool ethAddress)
 {
     assert(!IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     assert(!IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET));
     AssertLockHeld(cs_wallet);
-    bool fCompressed = !uncompressed && CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
+    bool fCompressed = !ethAddress && CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
 
     CKey secret;
 
@@ -276,7 +276,7 @@ CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal, const bool un
 
     // use HD key derivation if HD was enabled during wallet creation and a seed is present
     if (IsHDEnabled()) {
-        DeriveNewChildKey(batch, metadata, secret, (CanSupportFeature(FEATURE_HD_SPLIT) ? internal : false), uncompressed);
+        DeriveNewChildKey(batch, metadata, secret, (CanSupportFeature(FEATURE_HD_SPLIT) ? internal : false), ethAddress);
     } else {
         secret.MakeNewKey(fCompressed);
     }
@@ -292,13 +292,13 @@ CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal, const bool un
     mapKeyMetadata[pubkey.GetID()] = metadata;
     UpdateTimeFirstKey(nCreationTime);
 
-    if (!AddKeyPubKeyWithDB(batch, secret, pubkey)) {
+    if (!AddKeyPubKeyWithDB(batch, secret, pubkey, ethAddress)) {
         throw std::runtime_error(std::string(__func__) + ": AddKey failed");
     }
     return pubkey;
 }
 
-void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey& secret, bool internal, const bool uncompressed)
+void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey& secret, bool internal, const bool ethAddress)
 {
     // for now we use a fixed keypath scheme of m/0'/0'/k
     CKey seed;                     //seed (256bit)
@@ -327,7 +327,7 @@ void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey
         // childIndex | BIP32_HARDENED_KEY_LIMIT = derive childIndex in hardened child-index-range
         // example: 1 | BIP32_HARDENED_KEY_LIMIT == 0x80000001 == 2147483649
         if (internal) {
-            chainChildKey.Derive(childKey, hdChain.nInternalChainCounter | BIP32_HARDENED_KEY_LIMIT, uncompressed);
+            chainChildKey.Derive(childKey, hdChain.nInternalChainCounter | BIP32_HARDENED_KEY_LIMIT, ethAddress);
             metadata.hdKeypath = "m/0'/1'/" + std::to_string(hdChain.nInternalChainCounter) + "'";
             metadata.key_origin.path.push_back(0 | BIP32_HARDENED_KEY_LIMIT);
             metadata.key_origin.path.push_back(1 | BIP32_HARDENED_KEY_LIMIT);
@@ -335,7 +335,7 @@ void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey
             hdChain.nInternalChainCounter++;
         }
         else {
-            chainChildKey.Derive(childKey, hdChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT, uncompressed);
+            chainChildKey.Derive(childKey, hdChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT, ethAddress);
             metadata.hdKeypath = "m/0'/0'/" + std::to_string(hdChain.nExternalChainCounter) + "'";
             metadata.key_origin.path.push_back(0 | BIP32_HARDENED_KEY_LIMIT);
             metadata.key_origin.path.push_back(0 | BIP32_HARDENED_KEY_LIMIT);
@@ -353,7 +353,7 @@ void CWallet::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
 }
 
-bool CWallet::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& secret, const CPubKey& pubkey)
+bool CWallet::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& secret, const CPubKey& pubkey, const bool ethAddress)
 {
     AssertLockHeld(cs_wallet);
 
@@ -367,7 +367,7 @@ bool CWallet::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& secret, const C
     if (needsDB) {
         encrypted_batch = &batch;
     }
-    if (!AddKeyPubKeyInner(secret, pubkey)) {
+    if (!AddKeyPubKeyInner(secret, pubkey, ethAddress)) {
         if (needsDB) encrypted_batch = nullptr;
         return false;
     }
@@ -399,10 +399,10 @@ bool CWallet::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& secret, const C
     return true;
 }
 
-bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
+bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey, const bool ethAddress)
 {
     WalletBatch batch(*database);
-    return CWallet::AddKeyPubKeyWithDB(batch, secret, pubkey);
+    return CWallet::AddKeyPubKeyWithDB(batch, secret, pubkey, ethAddress);
 }
 
 bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
@@ -1653,7 +1653,7 @@ CPubKey CWallet::DeriveNewSeed(const CKey& key)
         mapKeyMetadata[seed.GetID()] = metadata;
 
         // write the key&metadata to the database
-        if (!AddKeyPubKey(key, seed))
+        if (!AddKeyPubKey(key, seed, false))
             throw std::runtime_error(std::string(__func__) + ": AddKeyPubKey failed");
     }
 
@@ -3767,7 +3767,7 @@ void CWallet::ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey)
     WalletLogPrintf("keypool return %d\n", nIndex);
 }
 
-bool CWallet::GetKeyFromPool(CPubKey& result, const bool uncompressed)
+bool CWallet::GetKeyFromPool(CPubKey& result, const bool ethAddress)
 {
     if (!CanGetAddresses(/*internal=*/ false)) {
         return false;
@@ -3777,10 +3777,10 @@ bool CWallet::GetKeyFromPool(CPubKey& result, const bool uncompressed)
     {
         LOCK(cs_wallet);
         int64_t nIndex;
-        if (uncompressed || (!ReserveKeyFromKeyPool(nIndex, keypool, /*fRequestedInternal=*/ false) && !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS))) {
+        if (ethAddress || (!ReserveKeyFromKeyPool(nIndex, keypool, /*fRequestedInternal=*/ false) && !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS))) {
             if (IsLocked()) return false;
             WalletBatch batch(*database);
-            result = GenerateNewKey(batch, /*internal=*/ false, uncompressed);
+            result = GenerateNewKey(batch, /*internal=*/ false, ethAddress);
             return true;
         }
         KeepKey(nIndex);
@@ -3807,9 +3807,9 @@ bool CWallet::GetNewDestination(const OutputType type, const std::string label, 
     dest = GetDestinationForKey(new_key, type);
 
     if (type != OutputType::ETH) {
-        SetAddressBook(dest, "eth", "eth");
-    } else {
         SetAddressBook(dest, label, "receive");
+    } else {
+        SetAddressBook(dest, "eth", "eth");
     }
 
     return true;
@@ -4763,6 +4763,9 @@ void CWallet::LearnRelatedScripts(const CPubKey& key, OutputType type)
         // Make sure the resulting program is solvable.
         assert(IsSolvable(*this, witprog));
         AddCScript(witprog);
+    } else if (!key.IsCompressed() && type == OutputType::ETH) {
+        CScript script = GetScriptForDestination(WitnessV16EthHash(key));
+        AddCScript(script);
     }
 }
 
@@ -4993,11 +4996,11 @@ bool CWallet::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     return true;
 }
 
-bool CWallet::AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey)
+bool CWallet::AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey, const bool ethAddress)
 {
     LOCK(cs_KeyStore);
     if (!IsCrypted()) {
-        return FillableSigningProvider::AddKeyPubKey(key, pubkey);
+        return FillableSigningProvider::AddKeyPubKey(key, pubkey, ethAddress);
     }
 
     if (IsLocked()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -799,7 +799,7 @@ private:
     CHDChain hdChain;
 
     /* HD derive new child key (on internal or external chain) */
-    void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, bool internal, const bool uncompressed) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::set<int64_t> setInternalKeyPool GUARDED_BY(cs_wallet);
     std::set<int64_t> setExternalKeyPool GUARDED_BY(cs_wallet);
@@ -1000,7 +1000,7 @@ public:
      * keystore implementation
      * Generate a new key
      */
-    CPubKey GenerateNewKey(WalletBatch& batch, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    CPubKey GenerateNewKey(WalletBatch& batch, bool internal = false, const bool uncompressed = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
@@ -1188,7 +1188,7 @@ public:
     std::set<CTxDestination> GetLabelAddresses(const std::string& label) const;
 
     //! Fetches a key from the keypool. Public for use in SPV.
-    bool GetKeyFromPool(CPubKey &key, bool internal = false);
+    bool GetKeyFromPool(CPubKey &key, bool uncompressed = false);
 
     bool GetNewDestination(const OutputType type, const std::string label, CTxDestination& dest, std::string& error);
     bool GetNewChangeDestination(const OutputType type, CTxDestination& dest, std::string& error);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -735,7 +735,7 @@ private:
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
 
     bool AddCryptedKeyInner(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
-    bool AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey);
+    bool AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey, const bool ethAddress = false);
 
     std::atomic<bool> fAbortRescan{false};
     std::atomic<bool> fScanningWallet{false}; // controlled by WalletRescanReserver
@@ -799,7 +799,7 @@ private:
     CHDChain hdChain;
 
     /* HD derive new child key (on internal or external chain) */
-    void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, bool internal, const bool uncompressed) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, bool internal, const bool ethAddress) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::set<int64_t> setInternalKeyPool GUARDED_BY(cs_wallet);
     std::set<int64_t> setExternalKeyPool GUARDED_BY(cs_wallet);
@@ -827,7 +827,7 @@ private:
     bool AddKeyOriginWithDB(WalletBatch& batch, const CPubKey& pubkey, const KeyOriginInfo& info);
 
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKeyWithDB(WalletBatch &batch,const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddKeyPubKeyWithDB(WalletBatch &batch,const CKey& key, const CPubKey &pubkey, const bool ethAddress = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds a watch-only address to the store, and saves it to disk.
     bool AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest, int64_t create_time) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -1000,9 +1000,9 @@ public:
      * keystore implementation
      * Generate a new key
      */
-    CPubKey GenerateNewKey(WalletBatch& batch, bool internal = false, const bool uncompressed = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    CPubKey GenerateNewKey(WalletBatch& batch, bool internal = false, const bool ethAddress = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey, const bool ethAddress) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return AddKeyPubKeyInner(key, pubkey); }
     //! Load metadata (used by LoadWallet)

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -156,5 +156,16 @@ class WalletHDTest(DefiTestFramework):
         assert_raises_rpc_error(-5, "Already have this key", self.nodes[1].sethdseed, False, new_seed)
         assert_raises_rpc_error(-5, "Already have this key", self.nodes[1].sethdseed, False, self.nodes[1].dumpprivkey(self.nodes[1].getnewaddress()))
 
+        eth_addr = self.nodes[0].getnewaddress("", "eth")
+        result = self.nodes[0].validateaddress(eth_addr)
+        assert_equal(result['isvalid'], True)
+
+        result = self.nodes[0].getaddressinfo(eth_addr)
+        assert_equal(result['ismine'], True)
+        assert_equal(result['solvable'], False)
+        assert_equal(result['iswitness'], True)
+        assert_equal(result['witness_version'], 16)
+        assert_equal(result['labels'][0]['purpose'], 'eth')
+
 if __name__ == '__main__':
     WalletHDTest().main ()


### PR DESCRIPTION
Adds Ethereum address generation to the wallet via getnewaddress command. This will get private keys from the same HD wallet that is used to generate native DeFiChain addresses. For Keccak the same keccak-tiny library is used as in cpp-ethereum.