### PR TITLE
Add transferbalance and evmtx custom transactions.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,7 +167,10 @@ DEFI_CORE_H = \
   masternodes/anchors.h \
   masternodes/auctionhistory.h \
   masternodes/balances.h \
+  masternodes/coinselect.h \
   masternodes/communityaccounttypes.h \
+  masternodes/errors.h \
+  masternodes/evm.h \
   masternodes/factory.h \
   masternodes/govvariables/attributes.h \
   masternodes/govvariables/icx_takerfee_per_btc.h \
@@ -187,7 +190,6 @@ DEFI_CORE_H = \
   masternodes/mn_checks.h \
   masternodes/mn_rpc.h \
   masternodes/res.h \
-  masternodes/errors.h \
   masternodes/oracles.h \
   masternodes/poolpairs.h \
   masternodes/proposals.h \
@@ -395,7 +397,6 @@ libdefi_server_a_SOURCES = \
   masternodes/accountshistory.cpp \
   masternodes/anchors.cpp \
   masternodes/auctionhistory.cpp \
-  masternodes/oracles.cpp \
   masternodes/govvariables/attributes.cpp \
   masternodes/govvariables/icx_takerfee_per_btc.cpp \
   masternodes/govvariables/loan_daily_reward.cpp \
@@ -413,8 +414,12 @@ libdefi_server_a_SOURCES = \
   masternodes/masternodes.cpp \
   masternodes/mn_checks.cpp \
   masternodes/mn_rpc.cpp \
+  masternodes/oracles.cpp \
+  masternodes/poolpairs.cpp \
+  masternodes/proposals.cpp \
   masternodes/rpc_accounts.cpp \
   masternodes/rpc_customtx.cpp \
+  masternodes/rpc_evm.cpp \
   masternodes/rpc_masternodes.cpp \
   masternodes/rpc_icxorderbook.cpp \
   masternodes/rpc_loan.cpp \
@@ -423,11 +428,9 @@ libdefi_server_a_SOURCES = \
   masternodes/rpc_proposals.cpp \
   masternodes/rpc_tokens.cpp \
   masternodes/rpc_vault.cpp \
+  masternodes/skipped_txs.cpp \
   masternodes/tokens.cpp \
   masternodes/threadpool.cpp \
-  masternodes/poolpairs.cpp \
-  masternodes/proposals.cpp \
-  masternodes/skipped_txs.cpp \
   masternodes/undos.cpp \
   masternodes/validation.cpp \
   masternodes/vault.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1252,7 +1252,6 @@ bool AppInitParameterInteraction()
     }
 
     maxAddrRatePerSecond = gArgs.GetDoubleArg("-maxaddrratepersecond", Params().NetworkIDString() == CBaseChainParams::REGTEST ? MAX_ADDR_RATE_PER_SECOND_REGTEST : MAX_ADDR_RATE_PER_SECOND);
-    std::cout << maxAddrRatePerSecond << std::endl;
     if (maxAddrRatePerSecond <= static_cast<double>(0)) {
         return InitError("maxaddrratepersecond cannot be configured with a negative value.");
     }

--- a/src/masternodes/balances.h
+++ b/src/masternodes/balances.h
@@ -208,6 +208,27 @@ struct CUtxosToAccountMessage {
     }
 };
 
+enum CTransferBalanceType : uint8_t {
+    AccountToAccount = 0x00,
+    EvmIn            = 0x01,
+    EvmOut           = 0x02,
+};
+
+struct CTransferBalanceMessage {
+    uint8_t type;
+    CAccounts from;  // from -> balances
+    CAccounts to;    // to -> balances
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(type);
+        READWRITE(from);
+        READWRITE(to);
+    }
+};
+
 struct CSmartContractMessage {
     std::string name;
     CAccounts accounts;

--- a/src/masternodes/evm.h
+++ b/src/masternodes/evm.h
@@ -1,0 +1,29 @@
+#ifndef DEFI_MASTERNODES_EVM_H
+#define DEFI_MASTERNODES_EVM_H
+
+#include <amount.h>
+#include <flushablestorage.h>
+#include <masternodes/balances.h>
+#include <masternodes/res.h>
+#include <script/script.h>
+#include <serialize.h>
+#include <uint256.h>
+
+constexpr const uint16_t EVM_TX_SIZE = 32768;
+
+using CRawEvmTx = TBytes;
+
+extern std::string CTransferBalanceTypeToString(const CTransferBalanceType type);
+
+struct CEvmTxMessage {
+    CRawEvmTx evmTx;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(evmTx);
+    }
+};
+
+#endif // DEFI_MASTERNODES_EVM_H

--- a/src/masternodes/masternodes.h
+++ b/src/masternodes/masternodes.h
@@ -9,6 +9,7 @@
 #include <flushablestorage.h>
 #include <masternodes/accounts.h>
 #include <masternodes/anchors.h>
+#include <masternodes/evm.h>
 #include <masternodes/gv.h>
 #include <masternodes/historywriter.h>
 #include <masternodes/icxorder.h>
@@ -476,7 +477,7 @@ class CCustomCSView : public CMasternodesView,
                                         LoanInterestV3ByVault,
             CVaultView              ::  VaultKey, OwnerVaultKey, CollateralKey, AuctionBatchKey, AuctionHeightKey, AuctionBidKey,
             CSettingsView           ::  KVSettings,
-            CProposalView              ::  ByType, ByCycle, ByMnVote, ByStatus
+            CProposalView           ::  ByType, ByCycle, ByMnVote, ByStatus
         >();
     }
     // clang-format on

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -142,6 +142,9 @@ enum class CustomTxType : uint8_t {
     CreateVoc                 = 'E',  // NOTE: Check whether this overlapping with DestroyOrder above is fine
     ProposalFeeRedistribution = 'Y',
     UnsetGovVariable          = 'Z',
+    // EVM
+    TransferBalance                  = '8',
+    EvmTx                     = '9',
 };
 
 inline CustomTxType CustomTxCodeToType(uint8_t ch) {
@@ -206,6 +209,8 @@ inline CustomTxType CustomTxCodeToType(uint8_t ch) {
         case CustomTxType::Vote:
         case CustomTxType::CreateVoc:
         case CustomTxType::UnsetGovVariable:
+        case CustomTxType::TransferBalance:
+        case CustomTxType::EvmTx:
         case CustomTxType::None:
             return type;
     }
@@ -443,7 +448,9 @@ using CCustomTxMessage = std::variant<CCustomTxMessageNone,
                                       CLoanPaybackLoanV2Message,
                                       CAuctionBidMessage,
                                       CCreateProposalMessage,
-                                      CProposalVoteMessage>;
+                                      CProposalVoteMessage,
+                                      CTransferBalanceMessage,
+                                      CEvmTxMessage>;
 
 CCustomTxMessage customTypeToMessage(CustomTxType txType);
 bool IsMempooledCustomTxCreate(const CTxMemPool &pool, const uint256 &txid);

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -302,7 +302,7 @@ static std::optional<CTxIn> GetAuthInputOnly(CWalletCoinsUnlocker& pwallet, CTxD
 
     auto locked_chain = pwallet->chain().lock();
     LOCK2(pwallet->cs_wallet, locked_chain->mutex());
-    
+
     // Note, for auth, we call this with 1 as max count, so should early exit
     pwallet->AvailableCoins(*locked_chain, vecOutputs, true, &cctl, 1, MAX_MONEY, MAX_MONEY, 1, coinSelectOpts);
 
@@ -400,8 +400,8 @@ std::vector<CTxIn> GetAuthInputsSmart(CWalletCoinsUnlocker& pwallet, int32_t txV
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Incorrect authorization for " + EncodeDestination(destination));
         }
         auto authInput = GetAuthInputOnly(
-            pwallet, 
-            destination, 
+            pwallet,
+            destination,
             coinSelectOpts);
         if (authInput) {
             result.push_back(authInput.value());
@@ -497,6 +497,18 @@ std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId)
     return FutureSwapHeightInfo{attributes->GetValue(startKey, CAmount{}), attributes->GetValue(blockKey, CAmount{})};
 }
 
+std::string CTransferBalanceTypeToString(const CTransferBalanceType type) {
+    switch (type) {
+        case CTransferBalanceType::AccountToAccount:
+            return "AccountToAccount";
+        case CTransferBalanceType::EvmIn:
+            return "EvmIn";
+        case CTransferBalanceType::EvmOut:
+            return "EvmOut";
+    }
+    return "Unknown";
+}
+
 UniValue setgov(const JSONRPCRequest& request) {
     auto pwallet = GetWallet(request);
 
@@ -552,7 +564,7 @@ UniValue setgov(const JSONRPCRequest& request) {
                 if (!attributes) {
                     throw JSONRPCError(RPC_INVALID_REQUEST, "Failed to convert Gov var to attributes");
                 }
-                
+
                 LOCK(cs_main);
                 const auto attrMap = attributes->GetAttributesMap();
                 for (const auto& [key, value] : attrMap) {

--- a/src/masternodes/mn_rpc.h
+++ b/src/masternodes/mn_rpc.h
@@ -93,5 +93,5 @@ CScript CreateScriptForHTLC(const JSONRPCRequest &request, uint32_t &blocks, std
 CPubKey PublickeyFromString(const std::string &pubkey);
 std::optional<CScript> AmIFounder(CWallet *const pwallet);
 std::optional<FutureSwapHeightInfo> GetFuturesBlock(const uint32_t typeId);
-
+std::string CTransferBalanceTypeToString(const CTransferBalanceType type);
 #endif  // DEFI_MASTERNODES_MN_RPC_H

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -546,6 +546,16 @@ public:
         rpcInfo.pushKV("vote", CProposalVoteToString(vote));
     }
 
+    void operator()(const CTransferBalanceMessage &obj) const {
+        rpcInfo.pushKV("type", CTransferBalanceTypeToString(static_cast<CTransferBalanceType>(obj.type)));
+        rpcInfo.pushKV("from", accountsInfo(obj.from));
+        rpcInfo.pushKV("to", accountsInfo(obj.to));
+    }
+
+    void operator()(const CEvmTxMessage &obj) const {
+        rpcInfo.pushKV("evmTx", HexStr(obj.evmTx.begin(),obj.evmTx.end()));
+    }
+
     void operator()(const CCustomTxMessageNone &) const {}
 };
 

--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -1,0 +1,91 @@
+#include <masternodes/mn_rpc.h>
+
+UniValue evmtx(const JSONRPCRequest& request) {
+    auto pwallet = GetWallet(request);
+
+    RPCHelpMan{"evmtx",
+                "Creates (and submits to local node and network) a tx to send DFI token to EVM address.\n" +
+                HelpRequiringPassphrase(pwallet) + "\n",
+                {
+                    {"rawEvmTx", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Raw tx in hex"},
+                    {"inputs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED_NAMED_ARG,
+                        "A json array of json objects",
+                        {
+                            {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                                {
+                                    {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id"},
+                                    {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number"},
+                                },
+                            },
+                        },
+                    },
+                },
+                RPCResult{
+                        "\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"
+                },
+                RPCExamples{
+                        HelpExampleCli("evmtx", R"('"<hex>"')")
+                        },
+    }.Check(request);
+
+    if (pwallet->chain().isInitialBlockDownload())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot evmin while still in Initial Block Download");
+
+    pwallet->BlockUntilSyncedToCurrentChain();
+
+    if (request.params[0].isNull())
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           "Invalid parameters, argument 1 must be non-null and expected as hex string");
+    auto evmTx = ParseHex(request.params[0].get_str());
+
+    int targetHeight;
+    {
+        LOCK(cs_main);
+        targetHeight = ::ChainActive().Height() + 1;
+    }
+
+    CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
+    metadata << static_cast<unsigned char>(CustomTxType::EvmTx)
+                << CEvmTxMessage{evmTx};
+
+    CScript scriptMeta;
+    scriptMeta << OP_RETURN << ToByteVector(metadata);
+
+    const auto txVersion = GetTransactionVersion(targetHeight);
+    CMutableTransaction rawTx(txVersion);
+
+    CTransactionRef optAuthTx;
+    std::set<CScript> auths;
+
+    const UniValue &txInputs = request.params[1];
+    rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, false, optAuthTx, txInputs);
+
+    rawTx.vout.emplace_back(0, scriptMeta);
+
+    CCoinControl coinControl;
+
+    // Return change to auth address
+    CTxDestination dest;
+    ExtractDestination(*auths.cbegin(), dest);
+    if (IsValidDestination(dest))
+        coinControl.destChange = dest;
+
+    fund(rawTx, pwallet, optAuthTx, &coinControl);
+
+    // check execution
+    execTestTx(CTransaction(rawTx), targetHeight, optAuthTx);
+
+    return signsend(rawTx, pwallet, optAuthTx)->GetHash().GetHex();
+}
+
+static const CRPCCommand commands[] =
+{
+//  category        name                         actor (function)        params
+//  --------------- ----------------------       ---------------------   ----------
+    {"evm",         "evmtx",                     &evmtx,                 {"rawEvmTx", "inputs"}},
+};
+
+void RegisterEVMRPCCommands(CRPCTable& tableRPC) {
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
+        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+}

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -522,7 +522,7 @@ static void ProcessLoanEvents(const CBlockIndex* pindex, CCustomCSView& cache, c
                     vaultIdCopy, collateralsCopy,
                     &cache, pindex,
                     useNextPrice, requireLivePrice,
-                    &g, &lv, &markCompleted] {
+                    &lv, &markCompleted] {
 
                     auto vaultId = vaultIdCopy;
                     auto collaterals = collateralsCopy;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -323,6 +323,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "isappliedcustomtx", 1, "blockHeight" },
     { "sendtokenstoaddress", 0, "from" },
     { "sendtokenstoaddress", 1, "to" },
+    { "transferbalance", 1, "from" },
+    { "transferbalance", 2, "to" },
     { "getanchorteams", 0, "blockHeight" },
     { "getactivemasternodecount", 0, "blockCount" },
     { "appointoracle", 1, "pricefeeds" },

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -43,7 +43,8 @@ void RegisterICXOrderbookRPCCommands(CRPCTable &tableRPC);
 void RegisterLoanRPCCommands(CRPCTable &tableRPC);
 /** Register Vault RPC commands */
 void RegisterVaultRPCCommands(CRPCTable &tableRPC);
-
+/** Register EVM RPC commands */
+void RegisterEVMRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -64,6 +65,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
     RegisterICXOrderbookRPCCommands(t);
     RegisterLoanRPCCommands(t);
     RegisterVaultRPCCommands(t);
+    RegisterEVMRPCCommands(t);
 }
 
 #endif // DEFI_RPC_REGISTER_H

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test EVM behaviour"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error
+)
+
+from decimal import Decimal
+
+class EVMTest(DefiTestFramework):
+    mns = None
+    proposalId = ""
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-fortcanningepilogueheight=96', '-grandcentralheight=101', '-nextnetworkupgradeheight=105', '-subsidytest=1', '-txindex=1']
+        ]
+
+    def run_test(self):
+        address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+        ethAddress = self.nodes[0].getnewaddress("","eth")
+
+        # Generate chain
+        self.nodes[0].generate(105)
+        self.sync_blocks()
+
+        self.nodes[0].getbalance()
+        self.nodes[0].utxostoaccount({address: "101@DFI"})
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        DFIbalance = self.nodes[0].getaccount(address, {}, True)['0']
+        ETHbalance = self.nodes[0].getaccount(ethAddress, {}, True)
+
+        assert_equal(DFIbalance, Decimal('101'))
+        assert_equal(len(ETHbalance), 0)
+
+        self.nodes[0].transferbalance("evmin",{address:["100@DFI"]}, {ethAddress:["100@DFI"]})
+        self.nodes[0].evmtx("AABBCCDDEEFF00112233445566778899")
+
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        newDFIbalance = self.nodes[0].getaccount(address, {}, True)['0']
+        newETHbalance = self.nodes[0].getaccount(ethAddress, {}, True)
+
+        assert_equal(newDFIbalance, DFIbalance - Decimal('100'))
+        assert_equal(len(newETHbalance), 0)
+
+        self.nodes[0].transferbalance("evmout", {ethAddress:["100@DFI"]}, {address:["100@DFI"]})
+
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        newDFIbalance = self.nodes[0].getaccount(address, {}, True)['0']
+        # newETHbalance = self.nodes[0].getaccount(ethAddress, {}, True)['0']
+
+        assert_equal(newDFIbalance, DFIbalance)
+        # assert_equal(newETHbalance, ETHbalance)
+
+if __name__ == '__main__':
+    EVMTest().main()


### PR DESCRIPTION
## Summary

- Adding two custom txs on Defichain side for evm
- Transfer Balance tx: it will be used for various balance transfers, among which evm-in and evm-out. Those will be used to transfer funds to and from ETH addresses.
- Evm tx: will hold raw evm tx which will be passed to evm to process

## RPCs

- transferbalance: <type> {"from_address":"amount@token"} {"to_address":"amount@token"}
- evmtx: <raw_evm_tx_bytes>