### PR TITLE
Set GRPC ports with start up flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ compile_commands.json
 src/secp256k1/gen_context
 src/secp256k1/src/ecmult_static_context.h
 
+# EVM
+src/evm/Cargo.lock
+src/evm/target/

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -37,17 +37,17 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN) {
-        return std::make_unique<CBaseChainParams>("", 8554);
+        return std::make_unique<CBaseChainParams>("", 8554, 8559);
     } else if (chain == CBaseChainParams::TESTNET) {
-        return std::make_unique<CBaseChainParams>("testnet3", 18554);
+        return std::make_unique<CBaseChainParams>("testnet3", 18554, 9558);
     } else if (chain == CBaseChainParams::DEVNET) {
         if (gArgs.IsArgSet("-devnet-bootstrap")) {
-            return std::make_unique<CBaseChainParams>("devnet", 18554);
+            return std::make_unique<CBaseChainParams>("devnet", 18554, 9558);
         } else {
-            return std::make_unique<CBaseChainParams>("devnet", 20554);
+            return std::make_unique<CBaseChainParams>("devnet", 20554, 10558);
         }
     } else if (chain == CBaseChainParams::REGTEST) {
-        return std::make_unique<CBaseChainParams>("regtest", 19554);
+        return std::make_unique<CBaseChainParams>("regtest", 19554, 10558);
     } else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
     }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -23,12 +23,14 @@ public:
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
+    int GRPCPort() const { return nGRPCPort; }
 
     CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, int rpc_port) : nRPCPort(rpc_port), strDataDir(data_dir) {}
+    CBaseChainParams(const std::string& data_dir, int rpc_port, int grpc_port) : nRPCPort(rpc_port), nGRPCPort(grpc_port), strDataDir(data_dir) {}
 
 private:
     int nRPCPort;
+    int nGRPCPort;
     std::string strDataDir;
 };
 

--- a/src/defid.cpp
+++ b/src/defid.cpp
@@ -68,8 +68,6 @@ static bool AppInit(int argc, char* argv[])
     util::ThreadRename("init");
     init_runtime();
 
-    start_servers("127.0.0.1:50050", "127.0.0.1:50051");
-
     //
     // Parameters
     //
@@ -112,6 +110,10 @@ static bool AppInit(int argc, char* argv[])
         } catch (const std::exception& e) {
             return InitError(strprintf("%s\n", e.what()));
         }
+
+        // Start GRPC after BaseParams() has been initialised
+        int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
+        start_servers("127.0.0.1:" + std::to_string(grpc_port), "127.0.0.1:" +  std::to_string(grpc_port + 1));
 
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -638,6 +638,7 @@ void SetupServerArgs()
     gArgs.AddArg("-dftxworkers=<n>", strprintf("No. of parallel workers associated with the DfTx related work pool. Stock splits, parallel processing of the chain where appropriate, etc use this worker pool (default: %d)", DEFAULT_DFTX_WORKERS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-grpcport=<port>", strprintf("Start GRPC connections on <port> and <port + 1> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -267,6 +267,9 @@ def p2p_port(n):
 def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
+def grpc_port(n):
+    return PORT_MIN + PORT_RANGE + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
 def rpc_url(datadir, i, chain, rpchost):
     rpc_u, rpc_p = get_auth_cookie(datadir, chain)
     host = '127.0.0.1'
@@ -291,6 +294,7 @@ def initialize_datadir(dirname, n, chain):
         f.write("[{}]\n".format(chain))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
+        f.write("grpcport=" + str(grpc_port(n)) + "\n")
         f.write("server=1\n")
         f.write("keypool=1\n")
         f.write("discover=0\n")


### PR DESCRIPTION
GRPC servers conflicts if more than one node runs on a machine. This PR adds the grpcport start up flag to allow settings of different ports.