### PR TITLE
mingw fixes for bcrypt, suppress depends related warnings 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -504,6 +504,7 @@ case $host in
      AC_CHECK_LIB([shlwapi],      [main],, AC_MSG_ERROR(libshlwapi missing))
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(libiphlpapi missing))
      AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(libcrypt32 missing))
+     AC_CHECK_LIB([bcrypt],      [main],, AC_MSG_ERROR(libbcrypt missing))
 
      # -static is interpreted by libtool, where it has a different meaning.
      # In libtool-speak, it's -all-static.

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -36,7 +36,7 @@ if test -z "@allow_host_packages@"; then
   export PKGCONFIG_LIBDIR=
 fi
 
-CPPFLAGS="-I$depends_prefix/include/ $CPPFLAGS"
+CPPFLAGS="-isystem $depends_prefix/include/ $CPPFLAGS"
 LDFLAGS="-L$depends_prefix/lib $LDFLAGS"
 
 if test -n "@CC@" -a -z "${CC}"; then

--- a/make.sh
+++ b/make.sh
@@ -16,6 +16,7 @@ setup_vars() {
     DOCKERFILE=${DOCKERFILE:-""}
     DOCKERFILES_DIR=${DOCKERFILES_DIR:-"./contrib/dockerfiles"}
     RELEASE_DIR=${RELEASE_DIR:-"./build"}
+    CLANG_DEFAULT_VERSION=${CLANG_DEFAULT_VERSION:-"16"}
 
     local default_target="x86_64-pc-linux-gnu"
     if [[ "${OSTYPE}" == "darwin"* ]]; then
@@ -32,7 +33,8 @@ setup_vars() {
     local default_compiler_flags=""
     if [[ "${TARGET}" == "x86_64-pc-linux-gnu" || \
         "${TARGET}" == "x86_64-apple-darwin11" ]]; then
-        default_compiler_flags="CC=clang-16 CXX=clang++-16"
+        local clang_ver="${CLANG_DEFAULT_VERSION}"
+        default_compiler_flags="CC=clang-${clang_ver} CXX=clang++-${clang_ver}"
     fi
 
     if [[ "${OSTYPE}" == "darwin"* ]]; then
@@ -409,7 +411,7 @@ pkg_install_deps_mingw_x86_64() {
 }
 
 pkg_install_llvm() {
-    wget -O - "https://apt.llvm.org/llvm.sh" | bash -s 16
+    wget -O - "https://apt.llvm.org/llvm.sh" | bash -s "${CLANG_DEFAULT_VERSION}"
 }
 
 pkg_ensure_mac_sdk() {

--- a/make.sh
+++ b/make.sh
@@ -411,7 +411,8 @@ pkg_install_deps_mingw_x86_64() {
 }
 
 pkg_install_llvm() {
-    wget -O - "https://apt.llvm.org/llvm.sh" | bash -s "${CLANG_DEFAULT_VERSION}"
+    # shellcheck disable=SC2086
+    wget -O - "https://apt.llvm.org/llvm.sh" | bash -s ${CLANG_DEFAULT_VERSION}
 }
 
 pkg_ensure_mac_sdk() {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -832,7 +832,7 @@ clean-local:
 .rc.o:
 	@test -f $(WINDRES)
 	## FIXME: How to get the appropriate modulename_CPPFLAGS in here?
-	$(AM_V_GEN) $(WINDRES) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) -DWINDRES_PREPROC -i $< -o $@
+	$(AM_V_GEN) $(WINDRES) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(subst -isystem ,-I,$(CPPFLAGS)) -DWINDRES_PREPROC -i $< -o $@
 
 check-symbols: $(bin_PROGRAMS)
 if GLIBC_BACK_COMPAT


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Pull requests without a rationale and clear improvement may be closed. 
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section. 
-->

## Summary

- Fix the mingw build on >= version `20220324`. (Successfully builds on `20220113`)
  - This is due to Win API changes with `bcrypt`.  
- Suppress depends related warnings that are superfluous with `-isystem` instead of `-I flag`
  - This avoids the older boost related warnings with newer compilers. 
- Workaround windres handling of `-isystem` CPPFLAGS

### Notes

- Boost ideally needs to be updated, but has breaking changes at the moment, but these warnings are incredibly noisy to disrupt regular workflow and miss actual issues 

## Implications

- Index changes
  - [ ] Reindex required
  - [ ] Reindex optional
  - [x] Reindex not required

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None