### PR TITLE
Fix EthSyncingResult proto message

### DIFF
--- a/src/rust/protobuf/types/eth.proto
+++ b/src/rust/protobuf/types/eth.proto
@@ -350,6 +350,6 @@ message EthSyncingInfo {
 
 // TODO make it oneof
 message EthSyncingResult {
-        bool status = 1;
-        EthSyncingInfo syncInfo = 2;
+    optional bool status = 1;
+    optional EthSyncingInfo syncInfo = 2;
 }


### PR DESCRIPTION
We are using protobuf for the EVM RPC so we have templates for all the input and the result of the differents RPC calls. For the RPC EthSyncing the RPC should be returning the state of the sync OR false with the current code the RPC will return both so i made the two fields optional so that we can return the only value that we need.