### PR TITLE
Fix Rust warnings

### DIFF
--- a/src/rust/crates/ain-evm-ffi/src/lib.rs
+++ b/src/rust/crates/ain-evm-ffi/src/lib.rs
@@ -39,10 +39,11 @@ pub fn evm_add_balance(
     amount: [u8; 32],
 ) -> Result<(), Box<dyn Error>> {
     let address = address.parse()?;
-    Ok(RUNTIME
-        .handlers
-        .evm
-        .add_balance(context, address, amount.into()))
+    RUNTIME
+    .handlers
+    .evm
+    .add_balance(context, address, amount.into());
+    Ok(())
 }
 
 pub fn evm_sub_balance(

--- a/src/rust/crates/ain-evm-runtime/src/lib.rs
+++ b/src/rust/crates/ain-evm-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 use ain_evm_state::handler::Handlers;
-use ain_evm_state::traits::PersistentState;
+
 use jsonrpsee_http_server::HttpServerHandle;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};

--- a/src/rust/crates/ain-evm-state/src/block.rs
+++ b/src/rust/crates/ain-evm-state/src/block.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::ops::Index;
+
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
@@ -83,13 +83,13 @@ impl BlockHandler {
     }
 
     pub fn flush(&self) {
-        let _ = self
+        self
             .block_map
             .write()
             .unwrap()
             .save_to_disk(BLOCK_MAP_PATH)
             .unwrap();
-        let _ = self
+        self
             .blocks
             .write()
             .unwrap()
@@ -99,7 +99,7 @@ impl BlockHandler {
 
     pub fn get_block_hash(&self, hash: H256) -> Result<BlockAny, Box<dyn Error>> {
         let block_map = self.block_map.read().unwrap();
-        let block_number = block_map.get(&hash).unwrap().clone();
+        let block_number = *block_map.get(&hash).unwrap();
 
         let blocks = self.blocks.read().unwrap();
         let block = blocks.get(block_number.as_usize()).unwrap().clone();

--- a/src/rust/crates/ain-evm-state/src/evm.rs
+++ b/src/rust/crates/ain-evm-state/src/evm.rs
@@ -201,7 +201,7 @@ impl EVMHandler {
 // TBD refine what vicinity we need. gas_price and origin only ?
 fn get_vicinity(origin: Option<H160>, gas_price: Option<U256>) -> MemoryVicinity {
     MemoryVicinity {
-        gas_price: gas_price.unwrap_or_else(|| U256::MAX),
+        gas_price: gas_price.unwrap_or(U256::MAX),
         origin: origin.unwrap_or_default(),
         block_hashes: Vec::new(),
         block_number: Default::default(),

--- a/src/rust/crates/ain-evm-state/src/traits.rs
+++ b/src/rust/crates/ain-evm-state/src/traits.rs
@@ -7,26 +7,13 @@ pub trait PersistentState {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::evm::EVMState;
     use crate::traits::PersistentState;
-    use crate::tx_queue::TransactionQueueMap;
-    use ain_evm::{executor::AinExecutor, traits::Executor, transaction::SignedTx};
-    use anyhow::anyhow;
-    use ethereum::{AccessList, Block, PartialHeader, TransactionV2};
     use evm::backend::MemoryAccount;
-    use evm::{
-        backend::{MemoryBackend, MemoryVicinity},
-        ExitReason,
-    };
-    use hex::FromHex;
     use primitive_types::{H160, H256, U256};
     use std::collections::BTreeMap;
-    use std::error::Error;
     use std::fs::File;
-    use std::io::{Read, Write};
-    use std::path::Path;
-    use std::sync::{Arc, RwLock};
+    use std::io::Write;
 
     fn create_account(
         nonce: U256,

--- a/src/rust/crates/ain-evm-state/tests/block.rs
+++ b/src/rust/crates/ain-evm-state/tests/block.rs
@@ -17,7 +17,7 @@ fn test_finalize_block_and_do_not_update_state() {
 
     let tx1: SignedTx = "f86b02830186a0830186a094a8f7c4c78c36e54c3950ad58dad24ca5e0191b2989056bc75e2d631000008025a0b0842b0c78dd7fc33584ec9a81ab5104fe70169878de188ba6c11fe7605e298aa0735dc483f625f17d68d1e1fae779b7160612628e6dde9eecf087892fe60bba4e".try_into().unwrap();
     println!("tx1 : {:#?}", tx1);
-    handler.evm.tx_queues.add_signed_tx(context, tx1.clone());
+    handler.evm.tx_queues.add_signed_tx(context, tx1);
 
     let old_state = handler.evm.state.read().unwrap();
     let _ = handler.evm.finalize_block(context, false).unwrap();

--- a/src/rust/crates/ain-evm/src/executor.rs
+++ b/src/rust/crates/ain-evm/src/executor.rs
@@ -60,7 +60,7 @@ where
                 value,
                 data.to_vec(),
                 gas_limit,
-                access_list.into(),
+                access_list,
             ),
             None => executor.transact_create(
                 caller.unwrap_or_default(),
@@ -80,7 +80,7 @@ where
         TxResponse {
             exit_reason,
             data,
-            logs: logs,
+            logs,
         }
     }
 

--- a/src/rust/crates/ain-grpc/build.rs
+++ b/src/rust/crates/ain-grpc/build.rs
@@ -106,12 +106,12 @@ const FIELD_ATTRS: &[Attr] = &[
         rename: None,
         skip: &[],
     },
-    Attr {
-        matcher: "currentblocktx|currentblockweight",
-        attr: Some("#[serde(skip_serializing_if = \"is_zero\")]"),
-        rename: None,
-        skip: &[],
-    },
+    // Attr {
+    //     matcher: "currentblocktx|currentblockweight",
+    // attr: Some("#[serde(skip_serializing_if = \"is_zero\")]"),
+    // rename: None,
+    // skip: &[],
+    // },
     Attr {
         matcher: "asm",
         attr: Some("#[serde(rename=\"asm\")]"),
@@ -142,23 +142,6 @@ const FIELD_ATTRS: &[Attr] = &[
         rename: None,
         skip: &[],
     },
-];
-
-const PATCHES: &[(&str, &str)] = &[
-    // We also throw Univalue, so that needs to be handled in addition to exceptions
-    (
-        "} catch (const ::std::exception &e) {",
-        "} catch (const UniValue &e) {
-  auto s = e.write();
-  fail(s.c_str());
-} catch (const ::std::exception &e) {",
-    ),
-    // Univalue header
-    (
-        "#include <utility>",
-        "#include <univalue.h>
-#include <utility>",
-    ),
 ];
 
 // Custom generator to collect RPC call signatures
@@ -370,9 +353,9 @@ fn change_types(file: syn::File) -> (HashMap<String, ItemStruct>, TokenStream, T
         fn ignore_integer<T: num_traits::PrimInt + num_traits::Signed + num_traits::NumCast>(i: &T) -> bool {
             T::from(-1).unwrap() == *i
         }
-        fn is_zero(i: &i64) -> bool {
-            *i == 0
-        }
+        // fn is_zero(i: &i64) -> bool {
+        //     *i == 0
+        // }
     };
 
     let mut copied = quote!();
@@ -497,19 +480,6 @@ fn apply_substitutions(
             Fields::Named(ref f) => f,
             _ => unreachable!(),
         };
-
-        // let s_name = Ident::new(name, Span::call_site());
-        // let fn_name = Ident::new(&("Make".to_owned() + name), Span::call_site());
-        // sigs.extend(quote!(
-        //     fn #fn_name() -> #s_name;
-        // ));
-        // funcs.extend(quote!(
-        //     #[inline]
-        //     #[allow(non_snake_case)]
-        //     fn #fn_name() -> ffi::#s_name {
-        //         Default::default()
-        //     }
-        // ));
 
         for field in &fields.named {
             let name = &field.ident;
@@ -706,7 +676,7 @@ fn apply_substitutions(
                         async fn #name_rs(#input_rs) -> Result<tonic::Response<super::types::#oty>, tonic::Status> {
                             let adapter = self.adapter.clone();
                             let result = tokio::task::spawn_blocking(move || {
-                                let mut out = ffi::#oty::default();
+                                // let out = ffi::#oty::default();
                                 #into_ffi
                                 Self::#name(adapter.clone(), #call_ffi).map_err(|e| tonic::Status::unknown(e.to_string()))
                                 // #name(adapter.clone(), #call_ffi)
@@ -789,37 +759,6 @@ fn get_path_bracketed_ty_simple(ty: &Type) -> Type {
     }
 }
 
-fn generate_cxx_glue(tt: TokenStream, target_dir: &Path) {
-    let mut opt = cxx_gen::Opt::default();
-    let codegen = cxx_gen::generate_header_and_cc(tt.clone(), &opt).unwrap();
-    File::create(target_dir.join("libain_grpc.h"))
-        .unwrap()
-        .write_all(&codegen.header)
-        .unwrap();
-
-    // opt.include.push(cxx_gen::Include {
-    //     path: "libain_grpc.h".to_string(),
-    //     kind: cxx_gen::IncludeKind::Bracketed,
-    // });
-    // opt.include.push(cxx_gen::Include {
-    //     path: "rpc/libain_wrapper.h".to_string(),
-    //     kind: cxx_gen::IncludeKind::Bracketed,
-    // });
-    let codegen = cxx_gen::generate_header_and_cc(tt, &opt).unwrap();
-    let mut cpp_stuff = String::from_utf8(codegen.implementation).unwrap();
-    for (src, dest) in PATCHES {
-        // assert!(cpp_stuff.contains(src));
-        // assert!(!cpp_stuff.contains(dest));
-        cpp_stuff = cpp_stuff.replace(src, dest);
-        // assert!(cpp_stuff.contains(dest));
-    }
-
-    File::create(target_dir.join("libain_grpc.cpp"))
-        .unwrap()
-        .write_all(cpp_stuff.as_bytes())
-        .unwrap();
-}
-
 fn main() {
     let mut root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let parent = root.clone();
@@ -827,7 +766,7 @@ fn main() {
     root.pop();
     let out_dir = env::var("OUT_DIR").unwrap();
     let methods = generate_from_protobuf(&root.join("protobuf"), Path::new(&out_dir));
-    let tt = modify_codegen(
+    let _tt = modify_codegen(
         methods,
         &Path::new(&out_dir).join("types.rs"),
         &Path::new(&out_dir).join("rpc.rs"),
@@ -837,5 +776,4 @@ fn main() {
         "cargo:rerun-if-changed={}",
         parent.join("src").join("rpc.rs").to_string_lossy()
     );
-    // generate_cxx_glue(tt, &root.join("target"));
 }

--- a/src/rust/crates/ain-grpc/src/rpc.rs
+++ b/src/rust/crates/ain-grpc/src/rpc.rs
@@ -6,9 +6,7 @@ use crate::codegen::rpc::{
     EthService,
 };
 use ain_evm_state::handler::Handlers;
-use ethereum::BlockAny;
-use serde::Serialize;
-use std::mem::{size_of, size_of_val};
+use std::mem::size_of_val;
 use std::sync::Arc;
 
 pub trait EthServiceApi {
@@ -37,17 +35,15 @@ impl EthServiceApi for EthService {
         input: EthCallInput,
     ) -> Result<EthCallResult, jsonrpsee_core::Error> {
         let EthCallInput {
-            transaction_info,
-            block_number,
+            transaction_info, ..
         } = input;
         let EthTransactionInfo {
             from,
             to,
             gas,
-            price,
             value,
             data,
-            nonce,
+            ..
         } = transaction_info;
 
         let from = from.parse().ok();
@@ -61,7 +57,7 @@ impl EthServiceApi for EthService {
         })
     }
 
-    fn Eth_Accounts(handler: Arc<Handlers>) -> Result<EthAccountsResult, jsonrpsee_core::Error> {
+    fn Eth_Accounts(_handler: Arc<Handlers>) -> Result<EthAccountsResult, jsonrpsee_core::Error> {
         // Get from wallet
         Ok(EthAccountsResult { accounts: vec![] })
     }
@@ -69,10 +65,7 @@ impl EthServiceApi for EthService {
         handler: Arc<Handlers>,
         input: EthGetBalanceInput,
     ) -> Result<EthGetBalanceResult, jsonrpsee_core::Error> {
-        let EthGetBalanceInput {
-            address,
-            block_number,
-        } = input;
+        let EthGetBalanceInput { address, .. } = input;
         let address = address.parse().expect("Wrong address");
         let balance = handler
             .evm

--- a/src/rust/crates/ain-utils/src/lib.rs
+++ b/src/rust/crates/ain-utils/src/lib.rs
@@ -28,15 +28,13 @@ pub fn public_key_to_address(pubkey: &PublicKey) -> H160 {
     ret
 }
 
+#[cfg(test)]
 mod tests {
-    #[macro_use]
     use hex_literal::hex;
 
-    use libsecp256k1::PublicKey;
-    use primitive_types::{H160, H256};
+    use primitive_types::H256;
 
     use super::{public_key_to_address, recover_public_key};
-    use hex::FromHex;
 
     #[test]
     fn test_recover_public_key_and_address() {


### PR DESCRIPTION
## Summary

- Remove unused import
- Remove unused codegen
- Mark unused variables
- Run clippy