### PR TITLE
Add self contained rust and protobuf to depends

### DIFF
--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost libevent
+packages:=boost libevent rust protobuf
 
 rapidcheck_packages = rapidcheck
 

--- a/depends/packages/protobuf.mk
+++ b/depends/packages/protobuf.mk
@@ -1,0 +1,50 @@
+package=protobuf
+$(package)_version=22.2
+$(package)_download_path=https://github.com/protocolbuffers/protobuf/releases/download/v22.2/
+
+# Note we only support limited platforms due to protobuf binary constraint
+# If we enable source build for this later, this can unblock most other platform
+# builds. For now, it's aarch64 for arm and x86_64 for win and linux
+
+# NOTE: protoc gets invoked on the BUILD OS during compile. So, we don't
+# care about HOST OS, unlike all other dependencies
+
+# TODO: Fill up hashes later
+ifeq ($(build_os)-$(build_arch),linux-x86_64)
+  $(package)_file_name=protoc-$($(package)_version)-linux-x86_64.zip
+  $(package)_sha256_hash=15f281b36897e0ffbbe3a02f687ff9108c7a0f98bb653fb433e4bd62e698abe7
+endif
+ifeq ($(build_os)-$(build_arch),linux-aarch64)
+  $(package)_file_name=protoc-$($(package)_version)-linux-aarch_64.zip
+  $(package)_sha256_hash=
+endif
+ifeq ($(build_os)-$(build_arch),darwin-x86_64)
+  $(package)_file_name=protoc-$($(package)_version)-osx-x86_64.zip
+  $(package)_sha256_hash=
+endif
+ifeq ($(build_os)-$(build_arch),darwin-arm)
+  $(package)_file_name=protoc-$($(package)_version)-osx-aarch_64.zip
+  $(package)_sha256_hash=
+endif
+
+ifeq ($($(package)_file_name),)
+    $(error Unsupported build platform: $(BUILD))
+endif
+
+define $(package)_extract_cmds
+  mkdir -p $$($(package)_extract_dir) && echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash &&  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash && unzip $$($(package)_source) && pwd && ls -l .
+endef
+
+define $(package)_set_vars
+  $(package)_ROOT="$($(package)_staging_dir)/$(host_prefix)"
+endef
+
+define $(package)_preprocess_cmds
+  rm -f readme.txt
+endef
+
+define $(package)_build_cmds
+  mkdir -p $($(package)_ROOT) && \
+  mv bin include $($(package)_ROOT)/
+endef
+

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,0 +1,57 @@
+package=rust
+$(package)_version=1.25.2
+$(package)_download_path=https://github.com/rust-lang/rustup/archive
+$(package)_sha256_hash=dc9bb5d3dbac5cea9afa9b9c3c96fcf644a1e7ed6188a6b419dfe3605223b5f3
+$(package)_file_name=$($(package)_version).tar.gz
+
+# Note we don't support arm that doesn't have hf. So any armv7 or below
+# wihtout hard floats, we just ignore it
+define $(package)_set_vars
+  $(package)_ROOT="$($(package)_staging_dir)/$(host_prefix)"
+  $(package)_RUSTUP_HOME="$($(package)_staging_dir)/$(host_prefix)/.rustup"
+  $(package)_CARGO_HOME="$($(package)_staging_dir)/$(host_prefix)/"
+
+  ifeq ($(host_os)-$(host_arch),linux-x86_64)
+    $(package)_target=x86_64-unknown-linux-gnu
+  endif 
+  ifeq ($(host_os)-$(host_arch),linux-aarch64)
+    $(package)_target=aarch64-unknown-linux-gnu
+  endif
+  ifeq ($(host_os)-$(host_arch),linux-arm)
+    $(package)_target=armv7-unknown-linux-gnueabihf
+  endif
+  ifeq ($(host_os)-$(host_arch),darwin-x86_64)
+    $(package)_target=x86_64-apple-darwin
+  endif
+  ifeq ($(host_os)-$(host_arch),darwin-arm)
+    $(package)_target=aarch64-apple-darwin
+  endif
+endef
+
+# We don't limit at the moment
+# define $(package)_preprocess_cmds
+#   test "x$($(package)_target)" = "x" && \
+#     echo "Unsupported host platform: $(HOST)" && \
+#     exit 1 || exit 0
+# endef
+
+# This autoinstalls the build os target
+define $(package)_build_cmds
+  RUSTUP_HOME="$($(package)_RUSTUP_HOME)" \
+  CARGO_HOME="$($(package)_CARGO_HOME)" \
+  ./rustup-init.sh --no-modify-path -y
+endef
+
+# We add the host os target
+define $(package)_stage_cmds
+    RUSTUP_HOME="$($(package)_RUSTUP_HOME)" \
+    CARGO_HOME="$($(package)_CARGO_HOME)" \
+    $($(package)_CARGO_HOME)/bin/rustup target add $($(package)_target)
+endef
+
+define $(package)_postprocess_cmds
+  mkdir -p $($(package)_ROOT)/share/cargo && \
+  mv $($(package)_ROOT)/env $($(package)_ROOT)/share/cargo/env && \
+  sed -i'' 's#$($(package)_staging_dir)/##' $($(package)_ROOT)/share/cargo/env
+endef
+

--- a/make.sh
+++ b/make.sh
@@ -394,7 +394,7 @@ pkg_install_deps() {
         libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev \
         libminiupnpc-dev libzmq3-dev libqrencode-dev wget \
         libdb-dev libdb++-dev libdb5.3 libdb5.3-dev libdb5.3++ libdb5.3++-dev \
-        curl cmake
+        curl cmake unzip
 }
 
 pkg_install_deps_mingw_x86_64() {


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Add `rust` lang toolchain to the depends system. 
  - `RUST_HOME`: `/depends/<host-triplet>/.rustup`
  - `CARGO_HOME`: `/depends/<host-triplet>/` - so bin is reused, and any additional cargo binaries are available directly for the build toolchain
- Add `protobuf` to the depends system
  - Currently uses the binaries from the releases instead of compiling from source since this requires bazel to build and we don't have to end up taking a suite of bazelisk, bazel and it's dependencies

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
