### PR TITLE
Fix spv blocking out of source tree build process

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,6 @@ EXTRA_LIBRARIES =
 
 if EMBEDDED_UNIVALUE
 LIBUNIVALUE = univalue/libunivalue.la
-
 $(LIBUNIVALUE): $(wildcard univalue/lib/*) $(wildcard univalue/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 else
@@ -20,7 +19,11 @@ LIBUNIVALUE = $(UNIVALUE_LIBS)
 endif
 
 LIBDEFI_SPV=libdefi_spv.a
-SPV_INCLUDES=-I. -I./spv -I./spv/support -I./spv/bitcoin -I./spv/bcash
+SPV_INCLUDES = -I$(srcdir) \
+	-I$(srcdir)/spv \
+	-I$(srcdir)/spv/support \
+	-I$(srcdir)/spv/bitcoin \
+	-I$(srcdir)/spv/bcash
 
 DEFI_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS)
 
@@ -285,31 +288,15 @@ obj/build.h: FORCE
 	  "$(abs_top_srcdir)"
 libdefi_util_a-clientversion.$(OBJEXT): obj/build.h
 
-libdefi_spv_a_CPPFLAGS = $(AM_CPPFLAGS) -Wpointer-arith -fpermissive -I./spv -I./spv/support -I./secp256k1 -I./secp256k1/src -Wno-format-extra-args -lm -lbsd
+libdefi_spv_a_CPPFLAGS = $(AM_CPPFLAGS) -Wpointer-arith -fpermissive \
+  -I$(srcdir)/spv \
+  -I$(srcdir)/spv/support \
+  -I$(srcdir)/secp256k1 \
+  -I$(srcdir)/secp256k1/src \
+  -Wno-format-extra-args -lm -lbsd
+  
 libdefi_spv_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libdefi_spv_a_SOURCES = \
-  spv/bcash/BRBCashAddr.cpp \
-  spv/bcash/BRBCashAddr.h \
-  spv/bcash/BRBCashParams.cpp \
-  spv/bcash/BRBCashParams.h \
-  spv/bitcoin/BRBIP38Key.cpp \
-  spv/bitcoin/BRBIP38Key.h \
-  spv/bitcoin/BRBloomFilter.cpp \
-  spv/bitcoin/BRBloomFilter.h \
-  spv/bitcoin/BRChainParams.cpp \
-  spv/bitcoin/BRChainParams.h \
-  spv/bitcoin/BRMerkleBlock.cpp \
-  spv/bitcoin/BRMerkleBlock.h \
-  spv/bitcoin/BRPaymentProtocol.cpp \
-  spv/bitcoin/BRPaymentProtocol.h \
-  spv/bitcoin/BRPeer.cpp \
-  spv/bitcoin/BRPeer.h \
-  spv/bitcoin/BRPeerManager.cpp \
-  spv/bitcoin/BRPeerManager.h \
-  spv/bitcoin/BRTransaction.cpp \
-  spv/bitcoin/BRTransaction.h \
-  spv/bitcoin/BRWallet.cpp \
-  spv/bitcoin/BRWallet.h \
   spv/support/BRAddress.cpp \
   spv/support/BRAddress.h \
   spv/support/BRArray.h \
@@ -331,7 +318,29 @@ libdefi_spv_a_SOURCES = \
   spv/support/BRKey.h \
   spv/support/BRLargeInt.h \
   spv/support/BRSet.cpp \
-  spv/support/BRSet.h
+  spv/support/BRSet.h \
+  spv/bcash/BRBCashAddr.cpp \
+  spv/bcash/BRBCashAddr.h \
+  spv/bcash/BRBCashParams.cpp \
+  spv/bcash/BRBCashParams.h \
+  spv/bitcoin/BRBIP38Key.cpp \
+  spv/bitcoin/BRBIP38Key.h \
+  spv/bitcoin/BRBloomFilter.cpp \
+  spv/bitcoin/BRBloomFilter.h \
+  spv/bitcoin/BRChainParams.cpp \
+  spv/bitcoin/BRChainParams.h \
+  spv/bitcoin/BRMerkleBlock.cpp \
+  spv/bitcoin/BRMerkleBlock.h \
+  spv/bitcoin/BRPaymentProtocol.cpp \
+  spv/bitcoin/BRPaymentProtocol.h \
+  spv/bitcoin/BRPeer.cpp \
+  spv/bitcoin/BRPeer.h \
+  spv/bitcoin/BRPeerManager.cpp \
+  spv/bitcoin/BRPeerManager.h \
+  spv/bitcoin/BRTransaction.cpp \
+  spv/bitcoin/BRTransaction.h \
+  spv/bitcoin/BRWallet.cpp \
+  spv/bitcoin/BRWallet.h
 #  spv/support/BRAssert.cpp
 #  spv/support/BRAssert.h
 #  spv/support/BRFileService.cpp

--- a/src/spv/bcash/BRBCashAddr.cpp
+++ b/src/spv/bcash/BRBCashAddr.cpp
@@ -23,15 +23,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBCashAddr.h"
-#include "support/BRAddress.h"
-#include "support/BRBase58.h"
-#include "support/BRCrypto.h"
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>
+
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRBase58.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/bcash/BRBCashAddr.h>
 
 // b-cash address format: https://github.com/bitcoincashorg/spec/blob/master/cashaddr.md
 

--- a/src/spv/bcash/BRBCashParams.cpp
+++ b/src/spv/bcash/BRBCashParams.cpp
@@ -23,10 +23,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "support/BRInt.h"
-#include "support/BRSet.h"
-#include "bitcoin/BRPeer.h"
-#include "BRBCashParams.h"
+#include <spv/support/BRInt.h>
+#include <spv/support/BRSet.h>
+#include <spv/bitcoin/BRPeer.h>
+#include <spv/bcash/BRBCashParams.h>
 
 static const char *BRBCashDNSSeeds[] = {
     "seed-abc.breadwallet.com.", "seed.bitcoinabc.org.", "seed-abc.bitcoinforks.org.", "seed.bitcoinunlimited.info.",

--- a/src/spv/bcash/BRBCashParams.h
+++ b/src/spv/bcash/BRBCashParams.h
@@ -25,7 +25,7 @@
 #ifndef BRBCashParams_h
 #define BRBCashParams_h
 
-#include "bitcoin/BRChainParams.h"
+#include <spv/bitcoin/BRChainParams.h>
 
 extern const BRChainParams *BRBCashParams;
 extern const BRChainParams *BRBCashTestNetParams;

--- a/src/spv/bitcoin/BRBIP38Key.cpp
+++ b/src/spv/bitcoin/BRBIP38Key.cpp
@@ -22,14 +22,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBIP38Key.h"
-#include "BRAddress.h"
-#include "BRCrypto.h"
-#include "BRBase58.h"
-#include "BRInt.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <spv/bitcoin/BRBIP38Key.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRBase58.h>
+#include <spv/support/BRInt.h>
 
 #define BIP38_NOEC_PREFIX      0x0142
 #define BIP38_EC_PREFIX        0x0143

--- a/src/spv/bitcoin/BRBIP38Key.h
+++ b/src/spv/bitcoin/BRBIP38Key.h
@@ -25,7 +25,7 @@
 #ifndef BRBIP38Key_h
 #define BRBIP38Key_h
 
-#include "BRKey.h"
+#include <spv/support/BRKey.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/bitcoin/BRBloomFilter.cpp
+++ b/src/spv/bitcoin/BRBloomFilter.cpp
@@ -22,14 +22,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBloomFilter.h"
-#include "BRCrypto.h"
-#include "BRAddress.h"
-#include "BRInt.h"
 #include <stdlib.h>
 #include <float.h>
 #include <math.h>
 #include <assert.h>
+#include <spv/bitcoin/BRBloomFilter.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRInt.h>
 
 #define BLOOM_MAX_HASH_FUNCS 50
 

--- a/src/spv/bitcoin/BRChainParams.cpp
+++ b/src/spv/bitcoin/BRChainParams.cpp
@@ -25,7 +25,7 @@
 
 //
 
-#include "BRChainParams.h"
+#include <spv/bitcoin/BRChainParams.h>
 
 static const char *BRMainNetDNSSeeds[] = {
     "seed.breadwallet.com.", "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.",

--- a/src/spv/bitcoin/BRChainParams.h
+++ b/src/spv/bitcoin/BRChainParams.h
@@ -25,10 +25,11 @@
 #ifndef BRChainParams_h
 #define BRChainParams_h
 
-#include "BRMerkleBlock.h"
-#include "BRSet.h"
-#include "BRPeer.h"
 #include <assert.h>
+
+#include <spv/bitcoin/BRMerkleBlock.h>
+#include <spv/bitcoin/BRPeer.h>
+#include <spv/support/BRSet.h>
 
 typedef struct {
     uint32_t height;

--- a/src/spv/bitcoin/BRMerkleBlock.cpp
+++ b/src/spv/bitcoin/BRMerkleBlock.cpp
@@ -22,15 +22,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRMerkleBlock.h"
-#include "BRInt.h"
-#include "BRCrypto.h"
-#include "BRAddress.h"
 #include <stdlib.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <string.h>
 #include <assert.h>
+
+#include <spv/bitcoin/BRMerkleBlock.h>
+#include <spv/support/BRInt.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRAddress.h>
 
 #define MAX_PROOF_OF_WORK 0x1d00ffff    // highest value for difficulty target (higher values are less difficult)
 #define TARGET_TIMESPAN   (14*24*60*60) // the targeted timespan between difficulty target adjustments

--- a/src/spv/bitcoin/BRMerkleBlock.h
+++ b/src/spv/bitcoin/BRMerkleBlock.h
@@ -25,9 +25,10 @@
 #ifndef BRMerkleBlock_h
 #define BRMerkleBlock_h
 
-#include "BRLargeInt.h"
 #include <stddef.h>
 #include <inttypes.h>
+
+#include <spv/support/BRLargeInt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/bitcoin/BRPaymentProtocol.cpp
+++ b/src/spv/bitcoin/BRPaymentProtocol.cpp
@@ -22,12 +22,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRPaymentProtocol.h"
-#include "BRCrypto.h"
-#include "BRArray.h"
 #include <string.h>
 #include <inttypes.h>
 #include <stdio.h>
+
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRArray.h>
+#include <spv/bitcoin/BRPaymentProtocol.h>
 
 // BIP70 payment protocol: https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki
 // BIP75 payment protocol encryption: https://github.com/bitcoin/bips/blob/master/bip-0075.mediawiki

--- a/src/spv/bitcoin/BRPaymentProtocol.h
+++ b/src/spv/bitcoin/BRPaymentProtocol.h
@@ -25,10 +25,11 @@
 #ifndef BRPaymentProtocol_h
 #define BRPaymentProtocol_h
 
-#include "BRTransaction.h"
-#include "BRAddress.h"
-#include "BRKey.h"
 #include <inttypes.h>
+
+#include <spv/bitcoin/BRTransaction.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRKey.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/bitcoin/BRPeer.cpp
+++ b/src/spv/bitcoin/BRPeer.cpp
@@ -22,13 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRPeer.h"
-#include "BRAddress.h"
-#include "BRArray.h"
-#include "BRCrypto.h"
-#include "BRInt.h"
-#include "BRMerkleBlock.h"
-#include "BRSet.h"
 #include <netbase.h>
 #include <protocol.h>
 
@@ -37,10 +30,18 @@
 #include <inttypes.h>
 #include <string.h>
 #include <thread>
-
 #include <compat.h>
-
 #include <sys/time.h>
+
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRArray.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRInt.h>
+#include <spv/support/BRSet.h>
+
+#include <spv/bitcoin/BRPeer.h>
+#include <spv/bitcoin/BRMerkleBlock.h>
+
 
 #define HEADER_LENGTH      24
 #define MAX_MSG_LENGTH     0x02000000

--- a/src/spv/bitcoin/BRPeer.h
+++ b/src/spv/bitcoin/BRPeer.h
@@ -25,14 +25,14 @@
 #ifndef BRPeer_h
 #define BRPeer_h
 
-#include "BRTransaction.h"
-#include "BRMerkleBlock.h"
-#include "BRAddress.h"
-#include "BRInt.h"
-
 #include <stddef.h>
 #include <inttypes.h>
 #include <mutex>
+
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRInt.h>
+#include <spv/bitcoin/BRTransaction.h>
+#include <spv/bitcoin/BRMerkleBlock.h>
 
 /// define logs
 #define console_peer_log(peer, ...) { \

--- a/src/spv/bitcoin/BRPeerManager.cpp
+++ b/src/spv/bitcoin/BRPeerManager.cpp
@@ -22,11 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRPeerManager.h"
-#include "BRBloomFilter.h"
-#include "BRSet.h"
-#include "BRArray.h"
-#include "BRInt.h"
 #include <logging.h>
 #include <shutdown.h>
 #include <stdlib.h>
@@ -36,8 +31,14 @@
 #include <time.h>
 #include <assert.h>
 #include <thread>
-
 #include <compat.h>
+
+#include <spv/support/BRSet.h>
+#include <spv/support/BRArray.h>
+#include <spv/support/BRInt.h>
+
+#include <spv/bitcoin/BRPeerManager.h>
+#include <spv/bitcoin/BRBloomFilter.h>
 
 //#include <pthread.h>
 //#include <errno.h>

--- a/src/spv/bitcoin/BRPeerManager.h
+++ b/src/spv/bitcoin/BRPeerManager.h
@@ -25,15 +25,15 @@
 #ifndef BRPeerManager_h
 #define BRPeerManager_h
 
-#include "BRPeer.h"
-#include "BRMerkleBlock.h"
-#include "BRTransaction.h"
-#include "BRWallet.h"
-#include "BRChainParams.h"
-
 #include <map>
 #include <stddef.h>
 #include <inttypes.h>
+
+#include <spv/bitcoin/BRPeer.h>
+#include <spv/bitcoin/BRMerkleBlock.h>
+#include <spv/bitcoin/BRTransaction.h>
+#include <spv/bitcoin/BRChainParams.h>
+#include <spv/bitcoin/BRWallet.h>
 
 #define PEER_MAX_CONNECTIONS 3
 

--- a/src/spv/bitcoin/BRTransaction.cpp
+++ b/src/spv/bitcoin/BRTransaction.cpp
@@ -22,15 +22,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRTransaction.h"
-#include "BRKey.h"
-#include "BRArray.h"
 #include <stdlib.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <time.h>
 
 #include <util/strencodings.h>
+
+#include <spv/support/BRKey.h>
+#include <spv/support/BRArray.h>
+#include <spv/bitcoin/BRTransaction.h>
 
 #define TX_LOCKTIME          0x00000000
 #define SIGHASH_ALL          0x01 // default, sign all of the outputs

--- a/src/spv/bitcoin/BRTransaction.h
+++ b/src/spv/bitcoin/BRTransaction.h
@@ -25,13 +25,13 @@
 #ifndef BRTransaction_h
 #define BRTransaction_h
 
-#include "BRKey.h"
-#include "BRAddress.h"
-#include "BRInt.h"
-
 #include <stddef.h>
 #include <inttypes.h>
 #include <string>
+
+#include <spv/support/BRKey.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRInt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/bitcoin/BRWallet.cpp
+++ b/src/spv/bitcoin/BRWallet.cpp
@@ -22,11 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRWallet.h"
-#include "BRSet.h"
-#include "BRAddress.h"
-#include "BRArray.h"
-
 #include <logging.h>
 #include <util/strencodings.h>
 
@@ -35,6 +30,11 @@
 #include <inttypes.h>
 
 #include <assert.h>
+
+#include <spv/support/BRSet.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRArray.h>
+#include <spv/bitcoin/BRWallet.h>
 
 uint256 to_uint256(const UInt256 & i)
 {

--- a/src/spv/bitcoin/BRWallet.h
+++ b/src/spv/bitcoin/BRWallet.h
@@ -25,10 +25,10 @@
 #ifndef BRWallet_h
 #define BRWallet_h
 
-#include "BRTransaction.h"
-#include "BRAddress.h"
-#include "BRBIP32Sequence.h"
-#include "BRInt.h"
+#include <spv/bitcoin/BRTransaction.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRBIP32Sequence.h>
+#include <spv/support/BRInt.h>
 
 #include <string>
 #include <set>

--- a/src/spv/spv_rpc.cpp
+++ b/src/spv/spv_rpc.cpp
@@ -10,8 +10,6 @@
 #include <rpc/util.h>
 #include <masternodes/anchors.h>
 #include <masternodes/mn_rpc.h>
-#include <spv/btctransaction.h>
-#include <spv/spv_wrapper.h>
 #include <univalue/include/univalue.h>
 
 //#ifdef ENABLE_WALLET
@@ -21,6 +19,9 @@
 
 #include <stdexcept>
 #include <future>
+
+#include <spv/btctransaction.h>
+#include <spv/spv_wrapper.h>
 
 // Minimum allowed block count in HTLC contract
 const uint32_t HTLC_MINIMUM_BLOCK_COUNT{9};

--- a/src/spv/spv_wrapper.h
+++ b/src/spv/spv_wrapper.h
@@ -10,8 +10,6 @@
 #include <shutdown.h>
 #include <uint256.h>
 
-#include <spv/support/BRLargeInt.h>
-
 #include <future>
 #include <map>
 #include <string>
@@ -25,6 +23,8 @@
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/composite_key.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+
+#include <spv/support/BRLargeInt.h>
 
 // Anchor DB storage version, increment to wipe anchor and SPV data.
 #define SPV_DB_VERSION 1

--- a/src/spv/support/BRAddress.cpp
+++ b/src/spv/support/BRAddress.cpp
@@ -22,13 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRAddress.h"
-#include "../bitcoin/BRChainParams.h"
-#include "BRBase58.h"
-#include "BRBech32.h"
-#include "BRInt.h"
 #include <inttypes.h>
 #include <assert.h>
+
+#include <spv/support/BRAddress.h>
+#include <spv/bitcoin/BRChainParams.h>
+#include <spv/support/BRBase58.h>
+#include <spv/support/BRBech32.h>
+#include <spv/support/BRInt.h>
+
 
 #define VAR_INT16_HEADER  0xfd
 #define VAR_INT32_HEADER  0xfe

--- a/src/spv/support/BRAddress.h
+++ b/src/spv/support/BRAddress.h
@@ -25,11 +25,12 @@
 #ifndef BRAddress_h
 #define BRAddress_h
 
-#include "BRCrypto.h"
-#include "BRInt.h"
 #include <string.h>
 #include <stddef.h>
 #include <inttypes.h>
+
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRInt.h>
 
 enum HTLCScriptType {
     ScriptTypeNone,

--- a/src/spv/support/BRBIP32Sequence.cpp
+++ b/src/spv/support/BRBIP32Sequence.cpp
@@ -22,12 +22,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBIP32Sequence.h"
-#include "bitcoin/BRChainParams.h"
-#include "BRCrypto.h"
-#include "BRBase58.h"
+
 #include <string.h>
 #include <assert.h>
+
+#include <spv/support/BRBIP32Sequence.h>
+#include <spv/bitcoin/BRChainParams.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRBase58.h>
+
 
 #define BIP32_SEED_KEY "Bitcoin seed"
 

--- a/src/spv/support/BRBIP32Sequence.h
+++ b/src/spv/support/BRBIP32Sequence.h
@@ -25,11 +25,12 @@
 #ifndef BRBIP32Sequence_h
 #define BRBIP32Sequence_h
 
-#include "BRKey.h"
-#include "BRInt.h"
 #include <stdarg.h>
 #include <stddef.h>
 #include <inttypes.h>
+
+#include <spv/support/BRKey.h>
+#include <spv/support/BRInt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/support/BRBIP39Mnemonic.cpp
+++ b/src/spv/support/BRBIP39Mnemonic.cpp
@@ -22,11 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBIP39Mnemonic.h"
-#include "BRCrypto.h"
-#include "BRInt.h"
 #include <string.h>
 #include <assert.h>
+
+#include <spv/support/BRBIP39Mnemonic.h>
+#include <spv/support/BRCrypto.h>
+#include <spv/support/BRInt.h>
 
 // returns number of bytes written to phrase including NULL terminator, or phraseLen needed if phrase is NULL
 size_t BRBIP39Encode(char *phrase, size_t phraseLen, const char *wordList[], const uint8_t *data, size_t dataLen)

--- a/src/spv/support/BRBIP39WordsEn.h
+++ b/src/spv/support/BRBIP39WordsEn.h
@@ -25,7 +25,7 @@
 #ifndef BRBIP39WordsEn_h
 #define BRBIP39WordsEn_h
 
-#include "BRBIP39Mnemonic.h"
+#include <spv/support/BRBIP39Mnemonic.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/support/BRBase58.cpp
+++ b/src/spv/support/BRBase58.cpp
@@ -23,14 +23,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBase58.h"
-#include "BRCrypto.h"
+
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-
 #include <vector>
+
+#include <spv/support/BRBase58.h>
+#include <spv/support/BRCrypto.h>
 
 // base58 and base58check encoding: https://en.bitcoin.it/wiki/Base58Check_encoding
 

--- a/src/spv/support/BRBech32.cpp
+++ b/src/spv/support/BRBech32.cpp
@@ -23,14 +23,15 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRBech32.h"
-#include "BRAddress.h"
-#include "BRCrypto.h"
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>
+
+#include <spv/support/BRBech32.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRCrypto.h>
 
 // bech32 address format: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
 

--- a/src/spv/support/BRCrypto.cpp
+++ b/src/spv/support/BRCrypto.cpp
@@ -22,12 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRCrypto.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-
 #include <vector>
+
+#include <spv/support/BRCrypto.h>
 
 // endian swapping
 #if __BIG_ENDIAN__ || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)

--- a/src/spv/support/BRInt.h
+++ b/src/spv/support/BRInt.h
@@ -25,10 +25,10 @@
 #ifndef BRInt_h
 #define BRInt_h
 
-#include "BRLargeInt.h"
-
 #include <inttypes.h>
 #include <string>
+
+#include <spv/support/BRLargeInt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/support/BRKey.cpp
+++ b/src/spv/support/BRKey.cpp
@@ -22,10 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRKey.h"
-#include "BRAddress.h"
-#include "BRBase58.h"
-#include "../bitcoin/BRChainParams.h"
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -35,6 +31,11 @@
 
 #include <mutex> // for std::once_flag / std::call_once - not the 'boost' cause bitcore uses std:: for this calls (?)
 //#include <pthread.h>
+
+#include <spv/support/BRKey.h>
+#include <spv/support/BRAddress.h>
+#include <spv/support/BRBase58.h>
+#include <spv/bitcoin/BRChainParams.h>
 
 #if __BIG_ENDIAN__ || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) ||\
     __ARMEB__ || __THUMBEB__ || __AARCH64EB__ || __MIPSEB__

--- a/src/spv/support/BRKey.h
+++ b/src/spv/support/BRKey.h
@@ -25,9 +25,10 @@
 #ifndef BRKey_h
 #define BRKey_h
 
-#include "BRInt.h"
 #include <stddef.h>
 #include <inttypes.h>
+
+#include <spv/support/BRInt.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/support/BRKeyECIES.cpp
+++ b/src/spv/support/BRKeyECIES.cpp
@@ -22,11 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRKeyECIES.h"
-#include "BRCrypto.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+
+#include <spv/support/BRKeyECIES.h>
+#include <spv/support/BRCrypto.h>
 
 // ecies-aes128-sha256 as specified in SEC 1, 5.1: http://www.secg.org/SEC1-Ver-1.0.pdf
 // NOTE: these are not implemented using constant time algorithms

--- a/src/spv/support/BRKeyECIES.h
+++ b/src/spv/support/BRKeyECIES.h
@@ -25,7 +25,7 @@
 #ifndef BRKeyECIES_h
 #define BRKeyECIES_h
 
-#include "BRKey.h"
+#include <spv/support/BRKey.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/spv/support/BRSet.cpp
+++ b/src/spv/support/BRSet.cpp
@@ -22,10 +22,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#include "BRSet.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+
+#include <spv/support/BRSet.h>
 
 // linear probed hashtable for good cache performance, maximum load factor is 2/3
 


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Fix make file to use the correct autotool variables
- Introduce header hygiene into spv
- This allows the build process to be self contained in an out of source tree dir 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
