### PR TITLE
fix(evm): revert `from` `to` back to optional

### DIFF
--- a/src/rust/crates/ain-grpc/src/rpc.rs
+++ b/src/rust/crates/ain-grpc/src/rpc.rs
@@ -61,6 +61,7 @@ impl EthServiceApi for EthService {
         // Get from wallet
         Ok(EthAccountsResult { accounts: vec![] })
     }
+ 
     fn Eth_GetBalance(
         handler: Arc<Handlers>,
         input: EthGetBalanceInput,

--- a/src/rust/crates/ain-grpc/src/rpc.rs
+++ b/src/rust/crates/ain-grpc/src/rpc.rs
@@ -61,7 +61,7 @@ impl EthServiceApi for EthService {
         // Get from wallet
         Ok(EthAccountsResult { accounts: vec![] })
     }
- 
+
     fn Eth_GetBalance(
         handler: Arc<Handlers>,
         input: EthGetBalanceInput,

--- a/src/rust/crates/ain-grpc/src/tests.rs
+++ b/src/rust/crates/ain-grpc/src/tests.rs
@@ -22,8 +22,8 @@ const BOB: &str = "0x0000000000000000000000000000000000000001";
 fn should_call() {
     let handler = Arc::new(Handlers::new());
     let tx_info = EthTransactionInfo {
-        from: ALICE.to_string(),
-        to: BOB.to_string(),
+        from: Some(ALICE.to_string()),
+        to: Some(BOB.to_string()),
         gas: None,
         price: None,
         value: None,

--- a/src/rust/protobuf/types/eth.proto
+++ b/src/rust/protobuf/types/eth.proto
@@ -6,13 +6,13 @@ message EthAccountsResult {
 }
 
 message EthTransactionInfo {
-    string from = 1; // The address from which the transaction is sent
-    string to = 2; // The address to which the transaction is addressed
+    optional string from = 1; // The address from which the transaction is sent
+    optional string to = 2; // The address to which the transaction is addressed
     optional uint64 gas = 3; // The integer of gas provided for the transaction execution
     optional uint64 price = 4; // The integer of gas price used for each paid gas encoded as hexadecimal
     optional uint64 value = 5; // The integer of value sent with this transaction encoded as hexadecimal
     optional string data = 6; // The hash of the method signature and encoded parameters.
-    optional uint64  nonce = 7; // The integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
+    optional uint64 nonce = 7; // The integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
 }
 
 message EthBlockInfo {


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

Just aware the `EthTransactionInfo` is following Rus impl.. so revert it back
go:
https://github.com/ethereum/go-ethereum/blob/b4dcd1a391f98a92d619966d0606a6b58a019851/ethclient/gethclient/gethclient.go#L204-L207

rust:
https://github.com/paritytech/frontier/blob/d13668c014c229fe786ffff2eed636a3fd2ef67d/client/rpc-core/src/types/call_request.rs#L30-L32
