### PR TITLE
Arm64 MacOS build workflow

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -95,3 +95,20 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
+
+  mac-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="aarch64-apple-darwin" ./make.sh docker-release
+
+    - name: Publish artifact - aarch64-apple-darwin
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz

--- a/contrib/dockerfiles/aarch64-apple-darwin.dockerfile
+++ b/contrib/dockerfiles/aarch64-apple-darwin.dockerfile
@@ -1,4 +1,4 @@
-ARG TARGET=x86_64-w64-mingw32
+ARG TARGET=aarch64-apple-darwin
 
 # -----------
 FROM --platform=linux/amd64 ubuntu:latest as builder
@@ -11,10 +11,7 @@ COPY ./make.sh .
 
 RUN export DEBIAN_FRONTEND=noninteractive && ./make.sh pkg_update_base
 RUN export DEBIAN_FRONTEND=noninteractive && ./make.sh pkg_install_deps
-RUN export DEBIAN_FRONTEND=noninteractive && ./make.sh pkg_install_deps_mingw_x86_64
-
-RUN update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
-RUN update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+RUN export DEBIAN_FRONTEND=noninteractive && ./make.sh pkg_install_deps_osx_tools
 
 COPY . .
 RUN ./make.sh clean-depends && ./make.sh build-deps

--- a/contrib/dockerfiles/aarch64-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/aarch64-linux-gnu.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=aarch64-linux-gnu
 
 # -----------
-FROM ubuntu:latest as builder
+FROM --platform=linux/amd64 ubuntu:latest as builder
 ARG TARGET
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}

--- a/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
+++ b/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=arm-linux-gnueabihf
 
 # -----------
-FROM ubuntu:latest as builder
+FROM --platform=linux/amd64 ubuntu:latest as builder
 ARG TARGET
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}

--- a/contrib/dockerfiles/x86_64-apple-darwin.dockerfile
+++ b/contrib/dockerfiles/x86_64-apple-darwin.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=x86_64-apple-darwin
 
 # -----------
-FROM ubuntu:latest as builder
+FROM --platform=linux/amd64 ubuntu:latest as builder
 ARG TARGET
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu-clang.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu-clang.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=x86_64-pc-linux-gnu
 
 # -----------
-FROM debian:10 as builder
+FROM --platform=linux/amd64 debian:10 as builder
 ARG TARGET
 ARG CLANG_VERSION=15
 LABEL org.defichain.name="defichain-builder"
@@ -31,7 +31,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 
 # -----------
 ### Actual image that contains defi binaries
-FROM debian:10
+FROM --platform=linux/amd64 debian:10
 ARG TARGET
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=x86_64-pc-linux-gnu
 
 # -----------
-FROM ubuntu:latest as builder
+FROM --platform=linux/amd64 ubuntu:latest as builder
 ARG TARGET
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}
@@ -23,7 +23,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 
 # -----------
 ### Actual image that contains defi binaries
-FROM ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:latest
 ARG TARGET
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}

--- a/doc/build-quick.md
+++ b/doc/build-quick.md
@@ -61,7 +61,7 @@ an environment with correct arch and pre-requisites configured.
 
 - aarch64-linux-gnu
 - arm-linux-gnueabihf
-- arm-apple-darwin
+- aarch64-apple-darwin
 
 ## Defined `env` variables
 

--- a/make.sh
+++ b/make.sh
@@ -584,7 +584,13 @@ clean() {
 _get_default_target() {
     local default_target=""
     if [[ "${OSTYPE}" == "darwin"* ]]; then
-        default_target="x86_64-apple-darwin"
+        local macos_arch=""
+        macos_arch=$(uname -m || true)
+        if [[ "$macos_arch" == "x86_64" ]]; then
+            default_target="x86_64-apple-darwin"
+        else
+            default_target="aarch64-apple-darwin"
+        fi
     elif [[ "${OSTYPE}" == "msys" ]]; then
         default_target="x86_64-w64-mingw32"
     else


### PR DESCRIPTION
## Summary

- Clean up build pipeline for MacOS for arm64 architecture.
- Implementation of new build-dev CI workflow to build Aarch64 MacOS binaries.
- Clean up Dockerfiles to explicitly state build platform architecture when performing cross compilation.

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
