### PR TITLE
Fixes to CI build workflows for dev, staging and production pipelines

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -62,7 +62,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
 
-  mac-x64:
+  osx-x64:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Push to Docker Hub
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
-        docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${ver}
+        docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${ver}-linux-x64
         docker push defi/defichain:${ver}
 
   win-x64:

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -45,23 +45,6 @@ jobs:
         docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${ver}
         docker push defi/defichain:${ver}
 
-  linux-armhf:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Populate environment
-      run: GIT_VERSION=1 ./make.sh ci-export-vars
-
-    - name: Build and package
-      run: GIT_VERSION=1 TARGET="arm-linux-gnueabihf" ./make.sh docker-release
-
-    - name: Publish artifact - arm-linux-gnueabihf
-      uses: actions/upload-artifact@v3
-      with:
-        name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
-
   win-x64:
     runs-on: ubuntu-latest
     steps:
@@ -95,20 +78,3 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
-
-  mac-aarch64:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Populate environment
-      run: GIT_VERSION=1 ./make.sh ci-export-vars
-
-    - name: Build and package
-      run: GIT_VERSION=1 TARGET="aarch64-apple-darwin" ./make.sh docker-release
-
-    - name: Publish artifact - aarch64-apple-darwin
-      uses: actions/upload-artifact@v3
-      with:
-        name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Push to Docker Hub
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
-        docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${ver}-linux-x64
+        docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${ver}
         docker push defi/defichain:${ver}
 
   win-x64:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -282,7 +282,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
         asset_content_type: application/gzip
 
-    - name: Upload checksum asset - macos
+    - name: Upload checksum asset - mac-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,7 +39,7 @@ jobs:
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
         for tag in $(echo $ver latest); do 
-          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
+          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}-linux-x64
         done
         docker push defi/defichain:${ver}
     
@@ -61,6 +61,20 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf
         path: ./build/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    - name: Push to Docker Hub
+      run: |
+        set -e; ver=${{ env.BUILD_VERSION }}
+        for tag in $(echo $ver latest); do 
+          docker tag defichain-arm-linux-gnueabihf:${ver} defi/defichain:${tag}-linux-arm
+        done
+        docker push defi/defichain:${ver}
 
   linux-aarch64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,7 +10,7 @@ env:
   DOCKER_HUB_USER: defi
 
 jobs:
-  linux:
+  linux-x64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -42,8 +42,46 @@ jobs:
           docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
         done
         docker push defi/defichain:${ver}
+    
+  linux-armhf:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
 
-  windows:
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="arm-linux-gnueabihf" ./make.sh docker-release
+
+    - name: Publish artifact - arm-linux-gnueabihf
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
+
+  linux-aarch64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+    
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="aarch64-linux-gnu" ./make.sh docker-release
+
+    - name: Publish artifact - aarch64-linux-gnu
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz
+
+  win-x64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -62,7 +100,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
 
-  macos:
+  mac-x64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -81,11 +119,33 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
 
+  mac-aarch64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="aarch64-apple-darwin" ./make.sh docker-release
+
+    - name: Publish artifact - aarch64-apple-darwin
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz
+
   create-release:
     needs:
-      - linux
-      - windows
-      - macos
+      - linux-x64
+      - linux-armhf
+      - linux-aarch64
+      - win-x64
+      - mac-x64
+      - mac-aarch64
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -101,7 +161,7 @@ jobs:
     - name: Get artifacts
       uses: actions/download-artifact@v3
 
-    - name: zip package for windows
+    - name: zip package for win-x64
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
         cd defichain-${ver}-x86_64-w64-mingw32
@@ -121,12 +181,18 @@ jobs:
         set -e; ver=${{ env.BUILD_VERSION }}
         cd ./defichain-${ver}-x86_64-pc-linux-gnu
         sha256sum ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz > ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz.SHA256
+        cd ./defichain-${ver}-arm-linux-gnueabihf
+        sha256sum ./defichain-${ver}-arm-linux-gnueabihf.tar.gz > ./defichain-${ver}-arm-linux-gnueabihf.tar.gz.SHA256
+        cd ./defichain-${ver}-aarch64-linux-gnu
+        sha256sum ./defichain-${ver}-aarch64-linux-gnu.tar.gz > ./defichain-${ver}-aarch64-linux-gnu.tar.gz.SHA256
         cd .. && cd ./defichain-${ver}-x86_64-w64-mingw32
         sha256sum ./defichain-${ver}-x86_64-w64-mingw32.zip > ./defichain-${ver}-x86_64-w64-mingw32.zip.SHA256
         cd .. && cd ./defichain-${ver}-x86_64-apple-darwin
         sha256sum ./defichain-${ver}-x86_64-apple-darwin.tar.gz > ././defichain-${ver}-x86_64-apple-darwin.tar.gz.SHA256
+        cd .. && cd ./defichain-${ver}-aarch64-apple-darwin
+        sha256sum ./defichain-${ver}-aarch64-apple-darwin.tar.gz > ././defichain-${ver}-aarch64-apple-darwin.tar.gz.SHA256
 
-    - name: Upload release asset - linux
+    - name: Upload release asset - linux-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -136,7 +202,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
         asset_content_type: application/gzip
 
-    - name: Upload checksum - linux
+    - name: Upload checksum - linux-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -145,8 +211,48 @@ jobs:
         asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz.SHA256
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz.SHA256
         asset_content_type: text/plain
+    
+    - name: Upload release asset - linux-armhf
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
+        asset_name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
+        asset_content_type: application/gzip
+    
+    - name: Upload checksum - linux-armhf
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz.SHA256
+        asset_name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz.SHA256
+        asset_content_type: text/plain
+    
+    - name: Upload release asset - linux-aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu/defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz
+        asset_name: defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz
+        asset_content_type: application/gzip
+    
+    - name: Upload checksum - linux-aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu/defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz.SHA256
+        asset_name: defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz.SHA256
+        asset_content_type: text/plain
 
-    - name: Upload release asset - windows
+    - name: Upload release asset - win-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +262,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip
         asset_content_type: application/zip
 
-    - name: Upload checksum asset - windows
+    - name: Upload checksum asset - win-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -166,7 +272,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip.SHA256
         asset_content_type: text/plain
 
-    - name: Upload release asset - macos
+    - name: Upload release asset - mac-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -184,4 +290,24 @@ jobs:
         upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
         asset_path: ./defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz.SHA256
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz.SHA256
+        asset_content_type: text/plain
+    
+    - name: Upload release asset - mac-aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz
+        asset_name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload checksum asset - mac-aarch64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_by_tag.outputs.upload_url }}
+        asset_path: ./defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz.SHA256
+        asset_name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz.SHA256
         asset_content_type: text/plain

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,7 +39,7 @@ jobs:
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
         for tag in $(echo $ver latest); do 
-          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}-linux-x64
+          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
         done
         docker push defi/defichain:${ver}
     
@@ -72,7 +72,7 @@ jobs:
       run: |
         set -e; ver=${{ env.BUILD_VERSION }}
         for tag in $(echo $ver latest); do 
-          docker tag defichain-arm-linux-gnueabihf:${ver} defi/defichain:${tag}-linux-arm
+          docker tag defichain-arm-linux-gnueabihf:${ver} defi/defichain:${tag}
         done
         docker push defi/defichain:${ver}
 

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -100,7 +100,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
 
-  mac-x64:
+  osx-x64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -119,7 +119,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
 
-  mac-aarch64:
+  osx-aarch64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -144,8 +144,8 @@ jobs:
       - linux-armhf
       - linux-aarch64
       - win-x64
-      - mac-x64
-      - mac-aarch64
+      - osx-x64
+      - osx-aarch64
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -272,7 +272,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip.SHA256
         asset_content_type: text/plain
 
-    - name: Upload release asset - mac-x64
+    - name: Upload release asset - osx-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -282,7 +282,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
         asset_content_type: application/gzip
 
-    - name: Upload checksum asset - mac-x64
+    - name: Upload checksum asset - osx-x64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -292,7 +292,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz.SHA256
         asset_content_type: text/plain
     
-    - name: Upload release asset - mac-aarch64
+    - name: Upload release asset - osx-aarch64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -302,7 +302,7 @@ jobs:
         asset_name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz
         asset_content_type: application/gzip
 
-    - name: Upload checksum asset - mac-aarch64
+    - name: Upload checksum asset - osx-aarch64
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -2,8 +2,6 @@ name: Build - Staging
 
 on:
   workflow_dispatch:
-  release:
-    types: [created]
 
 jobs:
   linux-x64:

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -5,10 +5,6 @@ on:
   release:
     types: [created]
 
-env:
-  BUILD_VERSION: latest # Computed
-  DOCKER_HUB_USER: defi
-
 jobs:
   linux-x64:
     runs-on: ubuntu-latest
@@ -28,20 +24,6 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ env.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-    - name: Push to Docker Hub
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        for tag in $(echo $ver latest); do 
-          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
-        done
-        docker push defi/defichain:${ver}
     
   linux-armhf:
     runs-on: ubuntu-latest
@@ -100,7 +82,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
 
-  mac-x64:
+  osx-x64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -119,7 +101,7 @@ jobs:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
         path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
 
-  mac-aarch64:
+  osx-aarch64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
 

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -1,0 +1,139 @@
+name: Build - Staging
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+env:
+  BUILD_VERSION: latest # Computed
+  DOCKER_HUB_USER: defi
+
+jobs:
+  linux-x64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 DOCKERFILE="x86_64-pc-linux-gnu-clang" TARGET="x86_64-pc-linux-gnu" ./make.sh docker-release
+
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-pc-linux-gnu.tar.gz
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    - name: Push to Docker Hub
+      run: |
+        set -e; ver=${{ env.BUILD_VERSION }}
+        for tag in $(echo $ver latest); do 
+          docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
+        done
+        docker push defi/defichain:${ver}
+    
+  linux-armhf:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="arm-linux-gnueabihf" ./make.sh docker-release
+
+    - name: Publish artifact - arm-linux-gnueabihf
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
+
+  linux-aarch64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+    
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="aarch64-linux-gnu" ./make.sh docker-release
+
+    - name: Publish artifact - aarch64-linux-gnu
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-linux-gnu.tar.gz
+
+  win-x64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="x86_64-w64-mingw32" ./make.sh docker-release
+
+    - name: Publish artifact - x86_64-w64-mingw32
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
+
+  mac-x64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="x86_64-apple-darwin" ./make.sh docker-release
+
+    - name: Publish artifact - x86_64-apple-darwin
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-apple-darwin.tar.gz
+
+  mac-aarch64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Populate environment
+      run: GIT_VERSION=1 ./make.sh ci-export-vars
+
+    - name: Build and package
+      run: GIT_VERSION=1 TARGET="aarch64-apple-darwin" ./make.sh docker-release
+
+    - name: Publish artifact - aarch64-apple-darwin
+      uses: actions/upload-artifact@v3
+      with:
+        name: defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-aarch64-apple-darwin.tar.gz


### PR DESCRIPTION
## Summary

- Limit platform architecture builds to linux-x64, win-x64 and mac-x64 for build-dev workflow.
- Include support for building linux-arm, linux-aarch64 and mac-aarch64 in build-release workflow.
- New build-staging workflow which is triggered when a new Release is drafted, or when triggered manually. Build stage workflow runs the build tests for all support target platform architectures.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
