### PR TITLE
evm: eth_getBlockTransactionCountBy RPC implementations

### DIFF
--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -243,14 +243,14 @@ impl EthServiceApi for EthService {
         handler: Arc<Handlers>,
         input: EthGetBlockTransactionCountByNumberInput,
     ) -> Result<EthGetBlockTransactionCountByNumberResult, jsonrpsee_core::Error> {
-        let EthGetBlockTransactionCountByNumberInput { block_number, .. } = input;
+        let EthGetBlockTransactionCountByNumberInput { block_number } = input;
 
         let number: usize = block_number.parse().ok().unwrap();
         let block = handler.block.get_block_by_number(number).unwrap();
         let count = block.transactions.len();
 
         Ok(EthGetBlockTransactionCountByNumberResult {
-            number_transaction: format!("0x{:x}", count),
+            number_transaction: format!("{:#x}", count),
         })
     }
 }

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -2,9 +2,9 @@ use crate::codegen::rpc::{
     ffi::{
         EthAccountsResult, EthBlockInfo, EthBlockNumberResult, EthCallInput, EthCallResult,
         EthChainIdResult, EthGetBalanceInput, EthGetBalanceResult, EthGetBlockByHashInput,
-        EthGetBlockByNumberInput, EthMiningResult, EthTransactionInfo,
-        EthGetBlockTransactionCountByHashInput, EthGetBlockTransactionCountByHashResult,
-        EthGetBlockTransactionCountByNumberInput,EthGetBlockTransactionCountByNumberResult,
+        EthGetBlockByNumberInput, EthGetBlockTransactionCountByHashInput,
+        EthGetBlockTransactionCountByHashResult, EthGetBlockTransactionCountByNumberInput,
+        EthGetBlockTransactionCountByNumberResult, EthMiningResult, EthTransactionInfo,
     },
     EthService,
 };

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -236,7 +236,7 @@ impl EthServiceApi for EthService {
         let count = block.transactions.len();
 
         Ok(EthGetBlockTransactionCountByHashResult {
-            number_transaction: format!("0x{:x}", count),
+            number_transaction: format!("{:#x}", count),
         })
     }
 

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -3,6 +3,8 @@ use crate::codegen::rpc::{
         EthAccountsResult, EthBlockInfo, EthBlockNumberResult, EthCallInput, EthCallResult,
         EthChainIdResult, EthGetBalanceInput, EthGetBalanceResult, EthGetBlockByHashInput,
         EthGetBlockByNumberInput, EthMiningResult, EthTransactionInfo,
+        EthGetBlockTransactionCountByHashInput, EthGetBlockTransactionCountByHashResult,
+        EthGetBlockTransactionCountByNumberInput,EthGetBlockTransactionCountByNumberResult,
     },
     EthService,
 };
@@ -45,6 +47,17 @@ pub trait EthServiceApi {
     ) -> Result<EthBlockInfo, jsonrpsee_core::Error>;
 
     fn Eth_Mining(handler: Arc<Handlers>) -> Result<EthMiningResult, jsonrpsee_core::Error>;
+
+    fn Eth_GetBlockTransactionCountByHash(
+        handler: Arc<Handlers>,
+        input: EthGetBlockTransactionCountByHashInput,
+    ) -> Result<EthGetBlockTransactionCountByHashResult, jsonrpsee_core::Error>;
+
+    fn Eth_GetBlockTransactionCountByNumber(
+        handler: Arc<Handlers>,
+        input: EthGetBlockTransactionCountByNumberInput,
+    ) -> Result<EthGetBlockTransactionCountByNumberResult, jsonrpsee_core::Error>;
+
 }
 
 impl EthServiceApi for EthService {
@@ -210,6 +223,36 @@ impl EthServiceApi for EthService {
         let mining = ain_cpp_imports::is_mining().unwrap();
 
         Ok(EthMiningResult { is_mining: mining })
+    }
+
+    fn Eth_GetBlockTransactionCountByHash(
+        handler: Arc<Handlers>,
+        input: EthGetBlockTransactionCountByHashInput,
+    ) -> Result<EthGetBlockTransactionCountByHashResult, jsonrpsee_core::Error> {
+        let EthGetBlockTransactionCountByHashInput { block_hash, .. } = input;
+
+        let block_hash = block_hash.parse().expect("Invalid hash");
+        let block = handler.block.get_block_by_hash(block_hash).unwrap();
+        let count = block.transactions.len();
+
+        Ok(EthGetBlockTransactionCountByHashResult {
+            number_transaction: format!("0x{:x}", count),
+        })
+    }
+
+    fn Eth_GetBlockTransactionCountByNumber(
+        handler: Arc<Handlers>,
+        input: EthGetBlockTransactionCountByNumberInput,
+    ) -> Result<EthGetBlockTransactionCountByNumberResult, jsonrpsee_core::Error> {
+        let EthGetBlockTransactionCountByNumberInput { block_number, .. } = input;
+
+        let number: usize = block_number.parse().ok().unwrap();
+        let block = handler.block.get_block_by_number(number).unwrap();
+        let count = block.transactions.len();
+
+        Ok(EthGetBlockTransactionCountByNumberResult {
+            number_transaction: format!("0x{:x}", count),
+        })
     }
 }
 

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -57,7 +57,6 @@ pub trait EthServiceApi {
         handler: Arc<Handlers>,
         input: EthGetBlockTransactionCountByNumberInput,
     ) -> Result<EthGetBlockTransactionCountByNumberResult, jsonrpsee_core::Error>;
-
 }
 
 impl EthServiceApi for EthService {

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -229,7 +229,7 @@ impl EthServiceApi for EthService {
         handler: Arc<Handlers>,
         input: EthGetBlockTransactionCountByHashInput,
     ) -> Result<EthGetBlockTransactionCountByHashResult, jsonrpsee_core::Error> {
-        let EthGetBlockTransactionCountByHashInput { block_hash, .. } = input;
+        let EthGetBlockTransactionCountByHashInput { block_hash } = input;
 
         let block_hash = block_hash.parse().expect("Invalid hash");
         let block = handler.block.get_block_by_hash(block_hash).unwrap();

--- a/lib/proto/rpc/eth.proto
+++ b/lib/proto/rpc/eth.proto
@@ -29,4 +29,9 @@ service eth {
   rpc Eth_GetBlockByNumber(types.EthGetBlockByNumberInput) returns (types.EthBlockInfo);
 
   rpc Eth_Mining(google.protobuf.Empty) returns (types.EthMiningResult);
+
+  rpc Eth_GetBlockTransactionCountByHash(types.EthGetBlockTransactionCountByHashInput) returns (types.EthGetBlockTransactionCountByHashResult);
+
+  rpc Eth_GetBlockTransactionCountByNumber(types.EthGetBlockTransactionCountByNumberInput) returns (types.EthGetBlockTransactionCountByNumberResult);
+
 }


### PR DESCRIPTION
## Summary

- Changes in #1902 with cleaner history avoiding merge conflicts

