### PR TITLE
Add precommit hooks

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -61,6 +61,7 @@ main() {
     cd "$_SCRIPT_DIR"
     _platform_init
     setup_vars
+    git_precommit_hook
 
     # Get all functions declared in this file except ones starting with
     # '_' or the ones in the list
@@ -621,6 +622,31 @@ _get_default_conf_args() {
     conf_args="${conf_args} LDFLAGS=-static-libstdc++";
     # Other potential options: -static-libgcc on gcc, -static on clang
     echo "$conf_args"
+}
+
+
+# Dev tools
+# ---
+
+git_precommit_hook() {
+    local force_update=${1:-0}
+    local file=".git/hooks/pre-commit"
+    if [[ -f "$file" && $force_update == "0" ]]; then 
+        return;
+    fi
+    echo "> adding pre-commit-hook"
+    cat <<END > "$file"
+#!/bin/bash
+set -Eeuo pipefail
+cd lib/
+cargo build && cargo test && cargo clippy  || { 
+    echo "Error: Please resolve compiler checks before commit"; 
+    exit 1; }
+cargo fmt --all --check  || {
+    echo "Error: Please format code before commit"; 
+    exit 1; }
+END
+    chmod +x "$file"
 }
 
 # Platform specifics


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Add a precommit hook that now does the following:

- Auto adds itself on `./make.sh` execution. 
- cargo build, cargo test, cargo clippy (could just be cargo check, but clippy is faster with cargo build, so might as well)
- cargo fmt check

