### PR TITLE
Refactor test framework and common utility functions used in test cases

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -42,7 +42,7 @@ jobs:
           docker tag defichain-x86_64-pc-linux-gnu:${ver} defi/defichain:${tag}
         done
         docker push defi/defichain:${ver}
-    
+
   linux-armhf:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -61,20 +61,6 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf
         path: ./build/defichain-${{ env.BUILD_VERSION }}-arm-linux-gnueabihf.tar.gz
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ env.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-    - name: Push to Docker Hub
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        for tag in $(echo $ver latest); do 
-          docker tag defichain-arm-linux-gnueabihf:${ver} defi/defichain:${tag}
-        done
-        docker push defi/defichain:${ver}
 
   linux-aarch64:
     runs-on: ubuntu-latest

--- a/make.sh
+++ b/make.sh
@@ -224,7 +224,7 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_release_dir}"
 
     _ensure_enter_dir "${versioned_release_dir}"
-    tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
+    _tar ${versioned_name} ${pkg_path}
     _exit_dir
 
     echo "> package: ${pkg_path}"
@@ -450,7 +450,10 @@ pkg_local_ensure_osx_sysroot() {
     local release_depends_dir=${DEPENDS_DIR}
 
     _ensure_enter_dir "$release_depends_dir/SDKs"
-    if [[ -d "${sdk_name}" ]]; then return; fi
+    if [[ -d "${sdk_name}" ]]; then 
+        _exit_dir
+        return
+    fi
 
     _fold_start "pkg-local-mac-sdk"
 
@@ -649,6 +652,23 @@ _platform_init() {
         _canonicalize() {
             readlink -m "$@"
         }
+    fi
+
+    if [[ $(command -v gtar) ]]; then
+        _tar() {
+            gtar --transform "s,^./,${1}/," -czf "${2}" ./*
+        }
+    else
+        if [[ $(command -v tar ) ]]; then
+            _tar() {
+                tar --transform "s,^./,${1}/," -czf "${2}" ./*
+            }
+        else
+            echo "error: GNU version of tar is required for \`--transform\` support"
+            echo "tip: debian/ubunti: apt install tar"
+            echo "tip: osx: brew install gnu-tar"
+            exit 1
+        fi
     fi
 }
 

--- a/make.sh
+++ b/make.sh
@@ -224,7 +224,7 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_release_dir}"
 
     _ensure_enter_dir "${versioned_release_dir}"
-    _tar --transform "s,^./,${versioned_name}/," -czf ${pkg_path} ./*
+    _tar "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
     _exit_dir
 
     echo "> package: ${pkg_path}"
@@ -460,7 +460,7 @@ pkg_local_ensure_osx_sysroot() {
     if [[ ! -f "${pkg}" ]]; then 
         wget https://bitcoincore.org/depends-sources/sdks/${pkg}
     fi
-    _tar -zxf "${pkg}"
+    tar -zxf "${pkg}"
     rm "${pkg}" 2>/dev/null || true
     _exit_dir
 
@@ -654,14 +654,14 @@ _platform_init() {
         }
     fi
 
-    if [[ $(command -v gtar) ]]; then
+    if [[ $(tar --help | grep -cwF "transform")  -gt 0 ]]; then
         _tar() {
-            gtar "$@"
+            tar --transform "$@"
         }
     else
-        if [[ $(command -v tar ) ]]; then
+        if [[ $(gtar --help | grep -cwF "transform") -gt 0 ]]; then
             _tar() {
-                tar "$@"
+                gtar --transform "$@"
             }
         else
             echo "error: GNU version of tar is required for \`--transform\` support"

--- a/make.sh
+++ b/make.sh
@@ -224,7 +224,7 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_release_dir}"
 
     _ensure_enter_dir "${versioned_release_dir}"
-    _tar ${versioned_name} ${pkg_path}
+    _tar --transform "s,^./,${versioned_name}/," -czf ${pkg_path} ./*
     _exit_dir
 
     echo "> package: ${pkg_path}"
@@ -460,7 +460,7 @@ pkg_local_ensure_osx_sysroot() {
     if [[ ! -f "${pkg}" ]]; then 
         wget https://bitcoincore.org/depends-sources/sdks/${pkg}
     fi
-    tar -zxf "${pkg}"
+    _tar -zxf "${pkg}"
     rm "${pkg}" 2>/dev/null || true
     _exit_dir
 
@@ -656,12 +656,12 @@ _platform_init() {
 
     if [[ $(command -v gtar) ]]; then
         _tar() {
-            gtar --transform "s,^./,${1}/," -czf "${2}" ./*
+            gtar "$@"
         }
     else
         if [[ $(command -v tar ) ]]; then
             _tar() {
-                tar --transform "s,^./,${1}/," -czf "${2}" ./*
+                tar "$@"
             }
         else
             echo "error: GNU version of tar is required for \`--transform\` support"

--- a/make.sh
+++ b/make.sh
@@ -224,7 +224,7 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_release_dir}"
 
     _ensure_enter_dir "${versioned_release_dir}"
-    _tar "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
+    tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
     _exit_dir
 
     echo "> package: ${pkg_path}"
@@ -450,10 +450,7 @@ pkg_local_ensure_osx_sysroot() {
     local release_depends_dir=${DEPENDS_DIR}
 
     _ensure_enter_dir "$release_depends_dir/SDKs"
-    if [[ -d "${sdk_name}" ]]; then 
-        _exit_dir
-        return
-    fi
+    if [[ -d "${sdk_name}" ]]; then return; fi
 
     _fold_start "pkg-local-mac-sdk"
 
@@ -652,23 +649,6 @@ _platform_init() {
         _canonicalize() {
             readlink -m "$@"
         }
-    fi
-
-    if [[ $(tar --help | grep -cwF "transform")  -gt 0 ]]; then
-        _tar() {
-            tar --transform "$@"
-        }
-    else
-        if [[ $(gtar --help | grep -cwF "transform") -gt 0 ]]; then
-            _tar() {
-                gtar --transform "$@"
-            }
-        else
-            echo "error: GNU version of tar is required for \`--transform\` support"
-            echo "tip: debian/ubunti: apt install tar"
-            echo "tip: osx: brew install gnu-tar"
-            exit 1
-        fi
     fi
 }
 

--- a/test/functional/feature_accounts_n_utxos.py
+++ b/test/functional/feature_accounts_n_utxos.py
@@ -9,10 +9,14 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, assert_raises_rpc_error, \
-    connect_nodes_bi
+from test_framework.fixture_util import CommonFixture
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    connect_nodes_bi,
+    get_id_token,
+)
 
 
 class AccountsAndUTXOsTest(DefiTestFramework):
@@ -29,13 +33,13 @@ class AccountsAndUTXOsTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listtokens()), 1)  # only one token == DFI
 
         print("Generating initial chain...")
-        self.setup_tokens()
+        CommonFixture.setup_default_tokens(self)
 
         # Stop node #2 for future revert
         self.stop_node(2)
 
-        symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token("GOLD")
+        symbolSILVER = "SILVER#" + get_id_token("SILVER")
 
         idGold = list(self.nodes[0].gettoken(symbolGOLD).keys())[0]
         idSilver = list(self.nodes[0].gettoken(symbolSILVER).keys())[0]

--- a/test/functional/feature_accounts_n_utxos.py
+++ b/test/functional/feature_accounts_n_utxos.py
@@ -38,8 +38,8 @@ class AccountsAndUTXOsTest(DefiTestFramework):
         # Stop node #2 for future revert
         self.stop_node(2)
 
-        symbolGOLD = "GOLD#" + get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token(self.nodes[0], "GOLD")
+        symbolSILVER = "SILVER#" + get_id_token(self.nodes[0], "SILVER")
 
         idGold = list(self.nodes[0].gettoken(symbolGOLD).keys())[0]
         idSilver = list(self.nodes[0].gettoken(symbolSILVER).keys())[0]

--- a/test/functional/feature_any_accounts_to_accounts.py
+++ b/test/functional/feature_any_accounts_to_accounts.py
@@ -9,10 +9,12 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, \
-    connect_nodes_bi
+from test_framework.fixture_util import CommonFixture
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+)
 
 from decimal import Decimal
 
@@ -67,7 +69,7 @@ class AnyAccountsToAccountsTest(DefiTestFramework):
             }
         ]
         # inside this function "tokenId" and "symbolId" will be assigned for each token obj
-        self.setup_tokens(tokens)
+        CommonFixture.setup_default_tokens(self, tokens)
 
         # list_tokens = self.nodes[0].listtokens()
         # pprint(list_tokens)

--- a/test/functional/feature_dusd_loans.py
+++ b/test/functional/feature_dusd_loans.py
@@ -6,22 +6,16 @@
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    token_index_in_account,
+    get_decimal_amount,
+)
+
 import calendar
 import time
 from decimal import Decimal
-
-
-def get_decimal_amount(amount):
-    account_tmp = amount.split('@')[0]
-    return Decimal(account_tmp)
-
-
-def token_index_in_account(accounts, symbol):
-    for id in range(len(accounts)):
-        if symbol in accounts[id]:
-            return id
-    return -1
 
 
 ERR_STRING_MIN_COLLATERAL_DFI_PCT = "At least 50% of the minimum required collateral must be in DFI"

--- a/test/functional/feature_negative_interest.py
+++ b/test/functional/feature_negative_interest.py
@@ -6,18 +6,15 @@
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
-
-from test_framework.util import assert_equal, assert_greater_than_or_equal
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    get_decimal_amount,
+)
 
 import calendar
 import time
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
-
-
-def getDecimalAmount(amount):
-    amountTmp = amount.split('@')[0]
-    return Decimal(amountTmp)
-
 
 class NegativeInterestTest(DefiTestFramework):
     def set_test_params(self):
@@ -770,14 +767,14 @@ class NegativeInterestTest(DefiTestFramework):
 
         amounts0 = []
         for amount in vault["loanAmounts"]:
-            amounts0.append(getDecimalAmount(amount))
+            amounts0.append(get_decimal_amount(amount))
 
         self.nodes[0].generate(1)
 
         vault = self.nodes[0].getvault(self.vaultId7, verbose)
         amounts1 = []
         for amount in vault["loanAmounts"]:
-            amounts1.append(getDecimalAmount(amount))
+            amounts1.append(get_decimal_amount(amount))
 
         for amount in amounts0:
             assert_greater_than_or_equal(amount, amounts1[amounts0.index(amount)])
@@ -791,7 +788,7 @@ class NegativeInterestTest(DefiTestFramework):
         vault = self.nodes[0].getvault(self.vaultId7, verbose)
         amounts2 = []
         for amount in vault["loanAmounts"]:
-            amounts2.append(getDecimalAmount(amount))
+            amounts2.append(get_decimal_amount(amount))
 
         for amount in amounts1:
             assert_greater_than_or_equal(amount, amounts2[amounts1.index(amount)])
@@ -870,7 +867,7 @@ class NegativeInterestTest(DefiTestFramework):
         assert_equal(storedInterest["interestToHeight"], '0.000000000000000000000000')
 
         storedLoans = loanTokens
-        storedAmount = getDecimalAmount(storedLoans[0])
+        storedAmount = get_decimal_amount(storedLoans[0])
         self.nodes[0].generate(10)
 
         self.nodes[0].takeloan({
@@ -878,7 +875,7 @@ class NegativeInterestTest(DefiTestFramework):
             'amounts': "0.00000001@" + self.symboldUSD})
         self.nodes[0].generate(1)
         storedLoans1 = self.nodes[0].getloantokens(self.vaultId8)
-        storedAmount1 = getDecimalAmount(storedLoans1[0])
+        storedAmount1 = get_decimal_amount(storedLoans1[0])
         storedInterest1 = self.nodes[0].getstoredinterest(self.vaultId8, self.symboldUSD)
 
         assert (storedAmount > storedAmount1)
@@ -918,7 +915,7 @@ class NegativeInterestTest(DefiTestFramework):
         assert_equal(vault["interestPerBlockValue"], '-0.095129280821917808219178')
 
         storedLoans = self.nodes[0].getloantokens(self.vaultId9)
-        storedAmount = getDecimalAmount(storedLoans[0])
+        storedAmount = get_decimal_amount(storedLoans[0])
         assert_equal(storedAmount, Decimal('10.00000000'))
 
         [balanceDUSDbefore, _] = self.nodes[0].getaccount(self.account)[0].split('@')
@@ -946,13 +943,13 @@ class NegativeInterestTest(DefiTestFramework):
         self.nodes[0].generate(10)
 
         accountInfo = self.nodes[0].getaccount(self.account)
-        assert_equal(getDecimalAmount(accountInfo[0]), Decimal('10.00000000') + Decimal(balanceDUSDafter))
+        assert_equal(get_decimal_amount(accountInfo[0]), Decimal('10.00000000') + Decimal(balanceDUSDafter))
         vault = self.nodes[0].getvault(self.vaultId9, verbose)
         assert_equal(vault["loanValue"], Decimal('9.04870720'))
         assert_equal(vault["interestPerBlockValue"], '-0.095129280821917808219178')
 
         storedLoans = self.nodes[0].getloantokens(self.vaultId9)
-        storedAmount = getDecimalAmount(storedLoans[0])
+        storedAmount = get_decimal_amount(storedLoans[0])
         storedInterest = self.nodes[0].getstoredinterest(self.vaultId9, self.symboldUSD)
         assert_equal(storedAmount, Decimal('10.00000000'))
 
@@ -973,7 +970,7 @@ class NegativeInterestTest(DefiTestFramework):
         assert_equal(Decimal(loanAmount), Decimal(loanAmountBefore) - Decimal('0.00000001') + Decimal(interestAmount))
 
         storedLoans1 = self.nodes[0].getloantokens(self.vaultId9)
-        storedAmount1 = getDecimalAmount(storedLoans1[0])
+        storedAmount1 = get_decimal_amount(storedLoans1[0])
         expectedAmount = Decimal(
             Decimal('10') + 10 * Decimal(storedInterest["interestPerBlock"]) - Decimal('0.00000001')).quantize(
             Decimal('1E-8'), ROUND_UP)

--- a/test/functional/feature_poolpair_liquidity.py
+++ b/test/functional/feature_poolpair_liquidity.py
@@ -9,10 +9,13 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, \
-    connect_nodes_bi
+from test_framework.fixture_util import CommonFixture
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    get_id_token,
+)
 
 from decimal import Decimal, ROUND_DOWN
 
@@ -40,14 +43,14 @@ class PoolLiquidityTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].listtokens()), 1)  # only one token == DFI
 
         print("Generating initial chain...")
-        self.setup_tokens()
+        CommonFixture.setup_default_tokens(self)
 
         # stop node #2 for future revert
         self.stop_node(2)
         connect_nodes_bi(self.nodes, 0, 3)
 
-        symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token("GOLD")
+        symbolSILVER = "SILVER#" + get_id_token("SILVER")
 
         idGold = list(self.nodes[0].gettoken(symbolGOLD).keys())[0]
         idSilver = list(self.nodes[0].gettoken(symbolSILVER).keys())[0]

--- a/test/functional/feature_poolpair_liquidity.py
+++ b/test/functional/feature_poolpair_liquidity.py
@@ -49,8 +49,8 @@ class PoolLiquidityTest(DefiTestFramework):
         self.stop_node(2)
         connect_nodes_bi(self.nodes, 0, 3)
 
-        symbolGOLD = "GOLD#" + get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token(self.nodes[0], "GOLD")
+        symbolSILVER = "SILVER#" + get_id_token(self.nodes[0], "SILVER")
 
         idGold = list(self.nodes[0].gettoken(symbolGOLD).keys())[0]
         idSilver = list(self.nodes[0].gettoken(symbolSILVER).keys())[0]

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -41,8 +41,8 @@ class PoolPairTest(DefiTestFramework):
     def setup(self):
         assert_equal(len(self.nodes[0].listtokens()), 1)  # only one token == DFI
         CommonFixture.setup_default_tokens(self)
-        self.symbolGOLD = "GOLD#" + get_id_token("GOLD")
-        self.symbolSILVER = "SILVER#" + get_id_token("SILVER")
+        self.symbolGOLD = "GOLD#" + get_id_token(self.nodes[0], "GOLD")
+        self.symbolSILVER = "SILVER#" + get_id_token(self.nodes[0], "SILVER")
         self.idGold = list(self.nodes[0].gettoken(self.symbolGOLD).keys())[0]
         self.idSilver = list(self.nodes[0].gettoken(self.symbolSILVER).keys())[0]
 

--- a/test/functional/feature_poolswap.py
+++ b/test/functional/feature_poolswap.py
@@ -9,12 +9,13 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
+from test_framework.fixture_util import CommonFixture
 from test_framework.util import (
     assert_equal,
     disconnect_nodes,
     assert_raises_rpc_error,
+    get_id_token,
 )
 
 from decimal import Decimal
@@ -39,9 +40,9 @@ class PoolPairTest(DefiTestFramework):
 
     def setup(self):
         assert_equal(len(self.nodes[0].listtokens()), 1)  # only one token == DFI
-        self.setup_tokens()
-        self.symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
-        self.symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+        CommonFixture.setup_default_tokens(self)
+        self.symbolGOLD = "GOLD#" + get_id_token("GOLD")
+        self.symbolSILVER = "SILVER#" + get_id_token("SILVER")
         self.idGold = list(self.nodes[0].gettoken(self.symbolGOLD).keys())[0]
         self.idSilver = list(self.nodes[0].gettoken(self.symbolSILVER).keys())[0]
 

--- a/test/functional/feature_poolswap_composite.py
+++ b/test/functional/feature_poolswap_composite.py
@@ -6,12 +6,13 @@
 """Test poolpair composite swap RPC."""
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
+from test_framework.fixture_util import CommonFixture
 from test_framework.util import (
     assert_equal,
     disconnect_nodes,
-    assert_raises_rpc_error
+    assert_raises_rpc_error,
+    get_id_token,
 )
 
 from decimal import Decimal
@@ -68,14 +69,14 @@ class PoolPairCompositeTest(DefiTestFramework):
                 "amount": 1000000
             },
         ]
-        self.setup_tokens(tokens)
+        CommonFixture.setup_default_tokens(self, tokens)
         disconnect_nodes(self.nodes[0], 1)
 
-        symbolDOGE = "DOGE#" + self.get_id_token("DOGE")
-        symbolTSLA = "TSLA#" + self.get_id_token("TSLA")
-        symbolDUSD = "DUSD#" + self.get_id_token("DUSD")
-        symbolLTC = "LTC#" + self.get_id_token("LTC")
-        symbolUSDC = "USDC#" + self.get_id_token("USDC")
+        symbolDOGE = "DOGE#" + get_id_token("DOGE")
+        symbolTSLA = "TSLA#" + get_id_token("TSLA")
+        symbolDUSD = "DUSD#" + get_id_token("DUSD")
+        symbolLTC = "LTC#" + get_id_token("LTC")
+        symbolUSDC = "USDC#" + get_id_token("USDC")
 
         idDOGE = list(self.nodes[0].gettoken(symbolDOGE).keys())[0]
         idTSLA = list(self.nodes[0].gettoken(symbolTSLA).keys())[0]

--- a/test/functional/feature_poolswap_composite.py
+++ b/test/functional/feature_poolswap_composite.py
@@ -72,11 +72,11 @@ class PoolPairCompositeTest(DefiTestFramework):
         CommonFixture.setup_default_tokens(self, tokens)
         disconnect_nodes(self.nodes[0], 1)
 
-        symbolDOGE = "DOGE#" + get_id_token("DOGE")
-        symbolTSLA = "TSLA#" + get_id_token("TSLA")
-        symbolDUSD = "DUSD#" + get_id_token("DUSD")
-        symbolLTC = "LTC#" + get_id_token("LTC")
-        symbolUSDC = "USDC#" + get_id_token("USDC")
+        symbolDOGE = "DOGE#" + get_id_token(self.nodes[0], "DOGE")
+        symbolTSLA = "TSLA#" + get_id_token(self.nodes[0], "TSLA")
+        symbolDUSD = "DUSD#" + get_id_token(self.nodes[0], "DUSD")
+        symbolLTC = "LTC#" + get_id_token(self.nodes[0], "LTC")
+        symbolUSDC = "USDC#" + get_id_token(self.nodes[0], "USDC")
 
         idDOGE = list(self.nodes[0].gettoken(symbolDOGE).keys())[0]
         idTSLA = list(self.nodes[0].gettoken(symbolTSLA).keys())[0]

--- a/test/functional/feature_poolswap_mainnet.py
+++ b/test/functional/feature_poolswap_mainnet.py
@@ -54,9 +54,9 @@ class PoolPairTest(DefiTestFramework):
             "collateralAddress": self.account0
         })
         self.nodes[0].generate(1)
-        self.symbol_key_GOLD = "GOLD#" + str(get_id_token(self.symbolGOLD))
-        self.symbol_key_SILVER = "SILVER#" + str(get_id_token(self.symbolSILVER))
-        self.symbol_key_DOGE = "DOGE#" + str(get_id_token(self.symbolDOGE))
+        self.symbol_key_GOLD = "GOLD#" + str(get_id_token(self.nodes[0], self.symbolGOLD))
+        self.symbol_key_SILVER = "SILVER#" + str(get_id_token(self.nodes[0], self.symbolSILVER))
+        self.symbol_key_DOGE = "DOGE#" + str(get_id_token(self.nodes[0], self.symbolDOGE))
 
     def mint_tokens(self, amount=1000):
 

--- a/test/functional/feature_poolswap_mainnet.py
+++ b/test/functional/feature_poolswap_mainnet.py
@@ -10,7 +10,11 @@
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    get_id_token,
+)
+
 from decimal import Decimal
 
 
@@ -50,9 +54,9 @@ class PoolPairTest(DefiTestFramework):
             "collateralAddress": self.account0
         })
         self.nodes[0].generate(1)
-        self.symbol_key_GOLD = "GOLD#" + str(self.get_id_token(self.symbolGOLD))
-        self.symbol_key_SILVER = "SILVER#" + str(self.get_id_token(self.symbolSILVER))
-        self.symbol_key_DOGE = "DOGE#" + str(self.get_id_token(self.symbolDOGE))
+        self.symbol_key_GOLD = "GOLD#" + str(get_id_token(self.symbolGOLD))
+        self.symbol_key_SILVER = "SILVER#" + str(get_id_token(self.symbolSILVER))
+        self.symbol_key_DOGE = "DOGE#" + str(get_id_token(self.symbolDOGE))
 
     def mint_tokens(self, amount=1000):
 

--- a/test/functional/feature_poolswap_mechanism.py
+++ b/test/functional/feature_poolswap_mechanism.py
@@ -9,9 +9,11 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
-from test_framework.util import assert_equal, \
-    connect_nodes_bi
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    get_id_token,
+)
 
 import random
 import time
@@ -58,12 +60,6 @@ class PoolSwapTest(DefiTestFramework):
 
         # self.COUNT_TX = count_create_pool_tx + count_mint_and_sent + count_add_liquidity + 2 + self.COUNT_POOLSWAP
 
-    def get_id_token(self, symbol):
-        list_tokens = self.nodes[0].listtokens()
-        for idx, token in list_tokens.items():
-            if (token["symbol"] == symbol):
-                return str(idx)
-
     def generate_accounts(self):
         for i in range(self.COUNT_ACCOUNT):
             self.accounts.append(self.nodes[0].getnewaddress("", "legacy"))
@@ -96,8 +92,8 @@ class PoolSwapTest(DefiTestFramework):
             tokenB = "SILVER" + str(i)
             self.create_token(tokenA, owner)
             self.create_token(tokenB, owner)
-            tokenA = tokenA + "#" + self.get_id_token(tokenA)
-            tokenB = tokenB + "#" + self.get_id_token(tokenB)
+            tokenA = tokenA + "#" + get_id_token(tokenA)
+            tokenB = tokenB + "#" + get_id_token(tokenB)
             self.create_pool(tokenA, tokenB, owner)
 
     def mint_tokens(self, owner):
@@ -105,7 +101,7 @@ class PoolSwapTest(DefiTestFramework):
         for item in self.tokens:
             self.nodes[0].sendmany("", {owner: 0.02})
             self.nodes[0].generate(1)
-            self.nodes[0].minttokens(mint_amount + "@" + self.get_id_token(item), [])
+            self.nodes[0].minttokens(mint_amount + "@" + get_id_token(item), [])
             self.nodes[0].generate(1)
             self.sync_blocks()
         return mint_amount
@@ -120,7 +116,7 @@ class PoolSwapTest(DefiTestFramework):
                 else:
                     end = start + 10
                 for idx in range(start, end):
-                    outputs[self.accounts[idx]] = send_amount + "@" + self.get_id_token(token)
+                    outputs[self.accounts[idx]] = send_amount + "@" + get_id_token(token)
                 self.nodes[0].sendmany("", {owner: 0.02})
                 self.nodes[0].generate(1)
                 self.nodes[0].accounttoaccount(owner, outputs, [])
@@ -131,8 +127,8 @@ class PoolSwapTest(DefiTestFramework):
         for item in range(self.COUNT_POOLS):
             tokenA = "GOLD" + str(item)
             tokenB = "SILVER" + str(item)
-            self.liquidity[self.get_id_token(tokenA)] = 0
-            self.liquidity[self.get_id_token(tokenB)] = 0
+            self.liquidity[get_id_token(tokenA)] = 0
+            self.liquidity[get_id_token(tokenB)] = 0
             for start in range(0, self.COUNT_ACCOUNT, 10):
                 if start + 10 > self.COUNT_ACCOUNT:
                     end = self.COUNT_ACCOUNT
@@ -144,10 +140,10 @@ class PoolSwapTest(DefiTestFramework):
                 for idx in range(start, end):
                     amountA = random.randint(1, self.AMOUNT_TOKEN // 2)
                     amountB = random.randint(1, self.AMOUNT_TOKEN // 2)
-                    self.liquidity[self.get_id_token(tokenA)] += amountA
-                    self.liquidity[self.get_id_token(tokenB)] += amountB
-                    amountA = str(amountA) + "@" + self.get_id_token(tokenA)
-                    amountB = str(amountB) + "@" + self.get_id_token(tokenB)
+                    self.liquidity[get_id_token(tokenA)] += amountA
+                    self.liquidity[get_id_token(tokenB)] += amountB
+                    amountA = str(amountA) + "@" + get_id_token(tokenA)
+                    amountB = str(amountB) + "@" + get_id_token(tokenB)
                     self.nodes[0].addpoolliquidity({
                         self.accounts[idx]: [amountA, amountB]
                     }, self.accounts[idx], [])
@@ -188,15 +184,15 @@ class PoolSwapTest(DefiTestFramework):
 
                 for idx in range(start, end):
                     poolRewards[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)['0']
-                    amountsB[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)[self.get_id_token(tokenB)]
+                    amountsB[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(tokenB)]
                     blockCommissionB += (amount * self.DECIMAL) * (
                                 commission * self.DECIMAL) / self.DECIMAL / self.DECIMAL
                     self.nodes[0].poolswap({
                         "from": self.accounts[idx],
-                        "tokenFrom": self.get_id_token(tokenB),
+                        "tokenFrom": get_id_token(tokenB),
                         "amountFrom": amount,
                         "to": self.accounts[idx],
-                        "tokenTo": str(self.get_id_token(tokenA)),
+                        "tokenTo": str(get_id_token(tokenA)),
                     }, [])
                 self.nodes[0].generate(1)
                 self.sync_blocks(nodes)
@@ -214,7 +210,7 @@ class PoolSwapTest(DefiTestFramework):
                     newReserveB = reserveB
 
                     assert_equal(amountsB[idx] - amount + Decimal(str(feeB / self.DECIMAL)),
-                                 self.nodes[0].getaccount(self.accounts[idx], {}, True)[self.get_id_token(tokenB)])
+                                 self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(tokenB)])
 
                     realPoolReward = self.nodes[0].getaccount(self.accounts[idx], {}, True)['0'] - poolRewards[idx]
 
@@ -272,7 +268,7 @@ class PoolSwapTest(DefiTestFramework):
         print("Sending tokens...")
         self.send_tokens(owner)
         for account in self.accounts:
-            assert_equal(self.nodes[0].getaccount(account, {}, True)[self.get_id_token(self.tokens[0])],
+            assert_equal(self.nodes[0].getaccount(account, {}, True)[get_id_token(self.tokens[0])],
                          self.AMOUNT_TOKEN)
         print("Tokens sent out")
 

--- a/test/functional/feature_poolswap_mechanism.py
+++ b/test/functional/feature_poolswap_mechanism.py
@@ -92,8 +92,8 @@ class PoolSwapTest(DefiTestFramework):
             tokenB = "SILVER" + str(i)
             self.create_token(tokenA, owner)
             self.create_token(tokenB, owner)
-            tokenA = tokenA + "#" + get_id_token(tokenA)
-            tokenB = tokenB + "#" + get_id_token(tokenB)
+            tokenA = tokenA + "#" + get_id_token(self.nodes[0], tokenA)
+            tokenB = tokenB + "#" + get_id_token(self.nodes[0], tokenB)
             self.create_pool(tokenA, tokenB, owner)
 
     def mint_tokens(self, owner):
@@ -101,7 +101,7 @@ class PoolSwapTest(DefiTestFramework):
         for item in self.tokens:
             self.nodes[0].sendmany("", {owner: 0.02})
             self.nodes[0].generate(1)
-            self.nodes[0].minttokens(mint_amount + "@" + get_id_token(item), [])
+            self.nodes[0].minttokens(mint_amount + "@" + get_id_token(self.nodes[0], item), [])
             self.nodes[0].generate(1)
             self.sync_blocks()
         return mint_amount
@@ -116,7 +116,7 @@ class PoolSwapTest(DefiTestFramework):
                 else:
                     end = start + 10
                 for idx in range(start, end):
-                    outputs[self.accounts[idx]] = send_amount + "@" + get_id_token(token)
+                    outputs[self.accounts[idx]] = send_amount + "@" + get_id_token(self.nodes[0], token)
                 self.nodes[0].sendmany("", {owner: 0.02})
                 self.nodes[0].generate(1)
                 self.nodes[0].accounttoaccount(owner, outputs, [])
@@ -127,8 +127,8 @@ class PoolSwapTest(DefiTestFramework):
         for item in range(self.COUNT_POOLS):
             tokenA = "GOLD" + str(item)
             tokenB = "SILVER" + str(item)
-            self.liquidity[get_id_token(tokenA)] = 0
-            self.liquidity[get_id_token(tokenB)] = 0
+            self.liquidity[get_id_token(self.nodes[0], tokenA)] = 0
+            self.liquidity[get_id_token(self.nodes[0], tokenB)] = 0
             for start in range(0, self.COUNT_ACCOUNT, 10):
                 if start + 10 > self.COUNT_ACCOUNT:
                     end = self.COUNT_ACCOUNT
@@ -140,10 +140,10 @@ class PoolSwapTest(DefiTestFramework):
                 for idx in range(start, end):
                     amountA = random.randint(1, self.AMOUNT_TOKEN // 2)
                     amountB = random.randint(1, self.AMOUNT_TOKEN // 2)
-                    self.liquidity[get_id_token(tokenA)] += amountA
-                    self.liquidity[get_id_token(tokenB)] += amountB
-                    amountA = str(amountA) + "@" + get_id_token(tokenA)
-                    amountB = str(amountB) + "@" + get_id_token(tokenB)
+                    self.liquidity[get_id_token(self.nodes[0], tokenA)] += amountA
+                    self.liquidity[get_id_token(self.nodes[0], tokenB)] += amountB
+                    amountA = str(amountA) + "@" + get_id_token(self.nodes[0], tokenA)
+                    amountB = str(amountB) + "@" + get_id_token(self.nodes[0], tokenB)
                     self.nodes[0].addpoolliquidity({
                         self.accounts[idx]: [amountA, amountB]
                     }, self.accounts[idx], [])
@@ -184,15 +184,15 @@ class PoolSwapTest(DefiTestFramework):
 
                 for idx in range(start, end):
                     poolRewards[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)['0']
-                    amountsB[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(tokenB)]
+                    amountsB[idx] = self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(self.nodes[0], tokenB)]
                     blockCommissionB += (amount * self.DECIMAL) * (
                                 commission * self.DECIMAL) / self.DECIMAL / self.DECIMAL
                     self.nodes[0].poolswap({
                         "from": self.accounts[idx],
-                        "tokenFrom": get_id_token(tokenB),
+                        "tokenFrom": get_id_token(self.nodes[0], tokenB),
                         "amountFrom": amount,
                         "to": self.accounts[idx],
-                        "tokenTo": str(get_id_token(tokenA)),
+                        "tokenTo": str(get_id_token(self.nodes[0], tokenA)),
                     }, [])
                 self.nodes[0].generate(1)
                 self.sync_blocks(nodes)
@@ -210,7 +210,7 @@ class PoolSwapTest(DefiTestFramework):
                     newReserveB = reserveB
 
                     assert_equal(amountsB[idx] - amount + Decimal(str(feeB / self.DECIMAL)),
-                                 self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(tokenB)])
+                                 self.nodes[0].getaccount(self.accounts[idx], {}, True)[get_id_token(self.nodes[0], tokenB)])
 
                     realPoolReward = self.nodes[0].getaccount(self.accounts[idx], {}, True)['0'] - poolRewards[idx]
 
@@ -268,7 +268,7 @@ class PoolSwapTest(DefiTestFramework):
         print("Sending tokens...")
         self.send_tokens(owner)
         for account in self.accounts:
-            assert_equal(self.nodes[0].getaccount(account, {}, True)[get_id_token(self.tokens[0])],
+            assert_equal(self.nodes[0].getaccount(account, {}, True)[get_id_token(self.nodes[0], self.tokens[0])],
                          self.AMOUNT_TOKEN)
         print("Tokens sent out")
 

--- a/test/functional/feature_sendtokenstoaddress.py
+++ b/test/functional/feature_sendtokenstoaddress.py
@@ -9,7 +9,7 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
+from test_framework.fixture_util import CommonFixture
 from test_framework.util import assert_equal
 from decimal import Decimal
 
@@ -46,7 +46,7 @@ class SendTokensToAddressTest(DefiTestFramework):
             },
         ]
         # inside this function "tokenId" and "symbolId" will be assigned for each token obj
-        self.setup_tokens(tokens)
+        CommonFixture.setup_default_tokens(self, tokens)
 
         token0_symbol = tokens[0]["symbolId"]
         token1_symbol = tokens[1]["symbolId"]

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -9,10 +9,16 @@
 """
 
 from test_framework.test_framework import DefiTestFramework
-
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import \
-    connect_nodes, disconnect_nodes, assert_equal, assert_raises_rpc_error
+from test_framework.fixture_util import CommonFixture
+from test_framework.util import (
+    connect_nodes,
+    disconnect_nodes,
+    assert_equal,
+    assert_raises_rpc_error,
+    get_id_token,
+)
+
 from decimal import Decimal
 import time
 
@@ -30,7 +36,7 @@ class GovsetTest(DefiTestFramework):
              '-fortcanningspringheight=1250', '-grandcentralheight=1300', '-subsidytest=1']]
 
     def run_test(self):
-        self.setup_tokens()
+        CommonFixture.setup_default_tokens(self)
 
         # Stop node #1 for future revert
         self.stop_node(1)
@@ -50,8 +56,8 @@ class GovsetTest(DefiTestFramework):
         #
         # prepare the pools for LP_SPLITS
         #
-        symbolGOLD = "GOLD#" + self.get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + self.get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token("GOLD")
+        symbolSILVER = "SILVER#" + get_id_token("SILVER")
 
         owner = self.nodes[0].getnewaddress("", "legacy")
 

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -56,8 +56,8 @@ class GovsetTest(DefiTestFramework):
         #
         # prepare the pools for LP_SPLITS
         #
-        symbolGOLD = "GOLD#" + get_id_token("GOLD")
-        symbolSILVER = "SILVER#" + get_id_token("SILVER")
+        symbolGOLD = "GOLD#" + get_id_token(self.nodes[0], "GOLD")
+        symbolSILVER = "SILVER#" + get_id_token(self.nodes[0], "SILVER")
 
         owner = self.nodes[0].getnewaddress("", "legacy")
 

--- a/test/functional/feature_token_merge.py
+++ b/test/functional/feature_token_merge.py
@@ -12,10 +12,6 @@ import time
 from test_framework.test_framework import DefiTestFramework
 
 
-def truncate(str, decimal):
-    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
-
-
 class TokenMergeTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1

--- a/test/functional/feature_token_merge_usd_value.py
+++ b/test/functional/feature_token_merge_usd_value.py
@@ -3,19 +3,18 @@
 # Copyright (c) DeFi Blockchain Developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-
 """Test token merge"""
 
 from test_framework.test_framework import DefiTestFramework
-from test_framework.util import assert_equal, assert_greater_than_or_equal, almost_equal
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    almost_equal,
+)
 
 from decimal import Decimal
 import time
 import random
-
-
-def truncate(str, decimal):
-    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
 
 
 class TokenMergeUSDValueTest(DefiTestFramework):

--- a/test/functional/feature_token_split.py
+++ b/test/functional/feature_token_split.py
@@ -6,15 +6,15 @@
 """Test token split"""
 
 from test_framework.test_framework import DefiTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    truncate,
+)
 
-from test_framework.util import assert_equal, assert_raises_rpc_error
 from decimal import Decimal
 import time
 import random
-
-
-def truncate(str, decimal):
-    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
 
 
 class TokenSplitTest(DefiTestFramework):

--- a/test/functional/feature_token_split_mechanism.py
+++ b/test/functional/feature_token_split_mechanism.py
@@ -12,10 +12,6 @@ from decimal import Decimal
 import time
 
 
-def truncate(str, decimal):
-    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
-
-
 class TokenSplitMechanismTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1

--- a/test/functional/feature_token_split_usd_value.py
+++ b/test/functional/feature_token_split_usd_value.py
@@ -3,23 +3,18 @@
 # Copyright (c) DeFi Blockchain Developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-
 """Test token split"""
 
 from test_framework.test_framework import DefiTestFramework
-from test_framework.util import assert_equal, assert_greater_than_or_equal
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    almost_equal,
+)
 
 from decimal import Decimal
 import time
 import random
-
-
-def truncate(str, decimal):
-    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
-
-
-def almost_equal(x, y, threshold=0.0001):
-    return abs(x - y) < threshold
 
 
 class TokenSplitUSDValueTest(DefiTestFramework):

--- a/test/functional/feature_vault_pct_check_factor.py
+++ b/test/functional/feature_vault_pct_check_factor.py
@@ -6,22 +6,15 @@
 
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    token_index_in_account,
+    get_decimal_amount,
+)
+
 import calendar
 import time
 from decimal import Decimal
-
-
-def get_decimal_amount(amount):
-    account_tmp = amount.split('@')[0]
-    return Decimal(account_tmp)
-
-
-def token_index_in_account(accounts, symbol):
-    for id in range(len(accounts)):
-        if symbol in accounts[id]:
-            return id
-    return -1
 
 
 ERR_STRING_MIN_COLLATERAL_DFI_PCT = "At least 50% of the minimum required collateral must be in DFI"

--- a/test/functional/rpc_getstoredinterest.py
+++ b/test/functional/rpc_getstoredinterest.py
@@ -7,18 +7,17 @@
 from test_framework.test_framework import DefiTestFramework
 from test_framework.authproxy import JSONRPCException
 
-from test_framework.util import assert_equal, assert_greater_than_or_equal
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    get_decimal_amount,
+)
 
 import calendar
 import time
 from decimal import ROUND_DOWN, Decimal
 
 BLOCKS_PER_YEAR = Decimal(1051200)
-
-
-def get_decimal_amount(amount):
-    account_tmp = amount.split('@')[0]
-    return Decimal(account_tmp)
 
 
 class GetStoredInterestTest(DefiTestFramework):

--- a/test/functional/test_framework/fixture_util.py
+++ b/test/functional/test_framework/fixture_util.py
@@ -15,7 +15,7 @@ from .util import (
 
 class CommonFixture:
     """Class for common utility fixture setup functions for function testing."""
-    
+
     def setup_default_tokens(test : DefiTestFramework, my_tokens=None):
         assert (test.setup_clean_chain == True)
         assert ('-txnotokens=0' in test.extra_args[0])

--- a/test/functional/test_framework/fixture_util.py
+++ b/test/functional/test_framework/fixture_util.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Fixture utility functions for containing common fixtures for functional testing. The fixture helper functions will
+by default always use nodes beginning from index 0 onwards."""
+
+from .test_framework import DefiTestFramework
+from .util import (
+    assert_equal,
+    get_id_token,
+)
+
+
+class CommonFixture:
+    """Class for common utility fixture setup functions for function testing."""
+    
+    def setup_default_tokens(test : DefiTestFramework, my_tokens=None):
+        assert (test.setup_clean_chain == True)
+        assert ('-txnotokens=0' in test.extra_args[0])
+        assert ('-txnotokens=0' in test.extra_args[1])
+        test.nodes[0].generate(25)
+        test.nodes[1].generate(25)
+        test.sync_blocks()
+        test.nodes[0].generate(98)
+        test.sync_blocks()
+
+        if my_tokens is not None:
+            '''
+                my_tokens list should contain objects with following structure:
+                {
+                    "wallet": node_obj,             # The test node obj with "collateralAddress" secret key in wallet
+                    "symbol": "SYMBOL",             # The token symbol
+                    "name": "token name",           # The token name
+                    "collateralAddress": "address", # The token collateral address
+                    "amount": amount,               # The token amount for minting
+                }
+            '''
+            # create tokens
+            for token in my_tokens:
+                token["wallet"].createtoken({
+                    "symbol": token["symbol"],
+                    "name": token["name"],
+                    "collateralAddress": token["collateralAddress"]
+                })
+            test.sync_mempools()
+            test.nodes[0].generate(1)
+            tokens = test.nodes[1].listtokens()
+            assert_equal(len(tokens), len(my_tokens) + 1)
+
+            # mint tokens
+            for token in my_tokens:
+                token["tokenId"] = get_id_token(test.nodes[0], token["symbol"])
+                token["symbolId"] = token["symbol"] + "#" + token["tokenId"]
+                token["wallet"].minttokens(str(token["amount"]) + "@" + token["symbolId"])
+
+            test.sync_mempools()
+            test.nodes[0].generate(1)
+        else:
+            # creates two tokens: GOLD for node#0 and SILVER for node1. Mint by 1000 for them
+            test.nodes[0].createtoken({
+                "symbol": "GOLD",
+                "name": "shiny gold",
+                "collateralAddress": test.nodes[0].get_genesis_keys().ownerAuthAddress  # collateralGold
+            })
+            test.nodes[0].generate(1)
+            test.sync_blocks()
+            test.nodes[1].createtoken({
+                "symbol": "SILVER",
+                "name": "just silver",
+                "collateralAddress": test.nodes[1].get_genesis_keys().ownerAuthAddress  # collateralSilver
+            })
+            test.nodes[1].generate(1)
+            test.sync_blocks()
+            # At this point, tokens was created
+            tokens = test.nodes[0].listtokens()
+            assert_equal(len(tokens), 3)
+
+            symbolGOLD = "GOLD#" + get_id_token(test.nodes[0], "GOLD")
+            symbolSILVER = "SILVER#" + get_id_token(test.nodes[0], "SILVER")
+
+            test.nodes[0].minttokens("1000@" + symbolGOLD)
+            test.nodes[0].generate(1)
+            test.sync_blocks()
+            test.nodes[1].minttokens("2000@" + symbolSILVER)
+            test.nodes[1].generate(1)
+            test.sync_blocks()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -80,14 +80,14 @@ class DefiTestMetaClass(type):
 def get_default_config_path():
     current_file_path=os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
     default_config_paths = [
-        current_file_path + "/../../../build/test/config.ini",
-        current_file_path + "/../../config.ini",
+        # priority build selections for standard dev envs
         current_file_path + "/../../../build/x86_64-pc-linux-gnu/test/config.ini",
+        current_file_path + "/../../../build/aarch64-apple-darwin/test/config.ini",
+        current_file_path + "/../../../build/x86_64-apple-darwin/test/config.ini",
+        current_file_path + "/../../../build/x86_64-w64-migw32/test/config.ini",
+        # aarch64 / arm builds
         current_file_path + "/../../../build/arm-linux-gnueabihf/test/config.ini",
         current_file_path + "/../../../build/aarch64-linux-gnu/test/config.ini",
-        current_file_path + "/../../../build/x86_64-w64-mingw32/test/config.ini",
-        current_file_path + "/../../../build/x86_64-apple-darwin/test/config.ini",
-        current_file_path + "/../../../build/aarch64-apple-darwin/test/config.ini",
     ]
     for p in default_config_paths:
         if os.path.exists(p):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -689,6 +689,9 @@ def find_vout_for_address(node, txid, addr):
     raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
 
 
+# Token functions
+#############################
+
 def get_id_token(node, symbol):
     """
     Get the token ID

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -217,6 +217,11 @@ def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 
+def get_decimal_amount(amount):
+    account_tmp = amount.split('@')[0]
+    return Decimal(account_tmp)
+
+
 def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None):
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
@@ -710,8 +715,3 @@ def token_index_in_account(account, symbol):
         if symbol in account[id]:
             return id
     return -1
-
-
-def get_decimal_amount(amount):
-    account_tmp = amount.split('@')[0]
-    return Decimal(account_tmp)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -673,8 +673,6 @@ def fund_tx(node, address, amount):
     return missing_auth_tx, missing_input_vout
 
 
-# Create a spend of each passed-in utxo, splicing in "txouts" to each raw
-# transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
     """
     Create a spend of each passed-in utxo, splicing in "txouts" to each raw transaction to make

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -612,3 +612,13 @@ def find_vout_for_address(node, txid, addr):
         if any([addr == a for a in tx["vout"][i]["scriptPubKey"]["addresses"]]):
             return i
     raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
+
+
+def get_id_token(node, symbol):
+    """
+    Get the token ID
+    """
+    list_tokens = node.listtokens()
+    for idx, token in list_tokens.items():
+        if (token["symbol"] == symbol):
+            return str(idx)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -51,10 +51,6 @@ def assert_greater_than_or_equal(thing1, thing2):
         raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
 
 
-def almost_equal(x, y, threshold=0.0001):
-    return abs(x - y) < threshold
-
-
 def assert_raises(exc, fun, *args, **kwds):
     assert_raises_message(exc, None, fun, *args, **kwds)
 
@@ -195,6 +191,14 @@ def check_json_precision():
     satoshis = int(json.loads(json.dumps(float(n))) * 1.0e8)
     if satoshis != 2000000000000003:
         raise RuntimeError("JSON encode/decode loses precision")
+
+
+def almost_equal(x, y, threshold=0.0001):
+    return abs(x - y) < threshold
+
+
+def truncate(str, decimal):
+    return str if not str.find('.') + 1 else str[:str.find('.') + decimal + 1]
 
 
 def count_bytes(hex_string):
@@ -362,8 +366,10 @@ def get_auth_cookie(datadir, chain):
     return user, password
 
 
-# If a cookie file exists in the given datadir, delete it.
 def delete_cookie_file(datadir, chain):
+    """
+    If a cookie file exists in the given datadir, delete it.
+    """
     if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
         logger.debug("Deleting leftover cookie file")
         os.remove(os.path.join(datadir, chain, ".cookie"))
@@ -508,9 +514,60 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
     return (txid, signresult["hex"], fee)
 
 
-# Helper to create at least "count" utxos
-# Pass in a fee that is sufficient for relay and mining new transactions.
+def make_utxo(node, amount, confirmed=True, scriptPubKey=None):
+    """
+    Create a txout with a given amount and scriptPubKey that mines coins as needed.
+    confirmed txouts created will be confirmed in the blockchain.
+    """
+    from .script import CScript
+    from .messages import COIN, CTransaction, CTxIn, COutPoint, CTxOut, ToHex
+
+    if not scriptPubKey:
+        scriptPubKey = CScript([1])
+    
+    fee = 1 * COIN
+    while node.getbalance() < satoshi_round((amount + fee) / COIN):
+        node.generate(100)
+
+    new_addr = node.getnewaddress()
+    txid = node.sendtoaddress(new_addr, satoshi_round((amount + fee) / COIN))
+    tx1 = node.getrawtransaction(txid, 1)
+    txid = int(txid, 16)
+    i = None
+
+    for i, txout in enumerate(tx1['vout']):
+        if txout['scriptPubKey']['addresses'] == [new_addr]:
+            break
+    assert i is not None
+
+    tx2 = CTransaction()
+    tx2.vin = [CTxIn(COutPoint(txid, i))]
+    tx2.vout = [CTxOut(amount, scriptPubKey)]
+    tx2.rehash()
+
+    signed_tx = node.signrawtransactionwithwallet(ToHex(tx2))
+
+    txid = node.sendrawtransaction(signed_tx['hex'], 0)
+
+    # If requested, ensure txouts are confirmed.
+    if confirmed:
+        mempool_size = len(node.getrawmempool())
+        while mempool_size > 0:
+            node.generate(1)
+            new_size = len(node.getrawmempool())
+            # Error out if we have something stuck in the mempool, as this
+            # would likely be a bug.
+            assert new_size < mempool_size
+            mempool_size = new_size
+
+    return COutPoint(int(txid, 16), 0)
+
+
 def create_confirmed_utxos(fee, node, count):
+    """
+    Helper function to create at least "count" utxos.
+    Pass in a fee that is sufficient for relaying and mining new transactions.
+    """
     to_generate = int(0.5 * count) + 101
     while to_generate > 0:
         node.generate(min(25, to_generate))
@@ -541,9 +598,11 @@ def create_confirmed_utxos(fee, node, count):
     return utxos
 
 
-# Create large OP_RETURN txouts that can be appended to a transaction
-# to make it large (helper for constructing large transactions).
 def gen_return_txouts():
+    """
+    Create a large OP_RETURN txouts that can append to a transaction to make it large (helper for
+    constructing large transactions).
+    """
     # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
     # So we have big transactions (and therefore can't fit very many into each block)
     # create one script_pubkey
@@ -559,9 +618,24 @@ def gen_return_txouts():
     return txouts
 
 
+def find_spendable_utxo(node, min_value):
+    """
+    Get utxo with a value equal to or higher than the minimum value.
+    """
+    for utxo in node.listunspent(query_options={'minimumAmount': min_value}):
+        if utxo['spendable']:
+            return utxo
+
+    raise AssertionError("Unspent output equal or higher than %s not found" % min_value)
+
+
 # Create a spend of each passed-in utxo, splicing in "txouts" to each raw
 # transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
+    """
+    Create a spend of each passed-in utxo, splicing in "txouts" to each raw transaction to make
+    it large. See gen_return_txouts() above.
+    """
     addr = node.getnewaddress()
     txids = []
     from .messages import CTransaction
@@ -584,8 +658,9 @@ def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
 
 
 def mine_large_block(node, utxos=None):
-    # generate a ~1M transaction,
-    # and 16 of them is close to the 16MB block limit
+    """
+    Generate a ~1M transaction, and 16 of them will be close to the the 16MB block limit.
+    """
     num = 16  # old value 14
 
     from .messages import CTxOut

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -529,7 +529,7 @@ def make_utxo(node, amount, confirmed=True, scriptPubKey=None):
 
     if not scriptPubKey:
         scriptPubKey = CScript([1])
-    
+
     fee = 1 * COIN
     while node.getbalance() < satoshi_round((amount + fee) / COIN):
         node.generate(100)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -622,3 +622,18 @@ def get_id_token(node, symbol):
     for idx, token in list_tokens.items():
         if (token["symbol"] == symbol):
             return str(idx)
+
+
+def token_index_in_account(account, symbol):
+    """
+    Get token id in a given account
+    """
+    for id in range(len(account)):
+        if symbol in account[id]:
+            return id
+    return -1
+
+
+def get_decimal_amount(amount):
+    account_tmp = amount.split('@')[0]
+    return Decimal(account_tmp)


### PR DESCRIPTION
## Summary

This PR is a clean up and continuation of #1886, refactoring of all the functional tests and common utility functions being used.

- Refactor test framework to shift the function get_id_token() into the new token utilities segment in util.py.
- Refactor test framework to shift the function setup_tokens() into the new CommonFixture class to setup default fixture for various test cases.
- Refactor the common utility functions defined repeatedly in various functional tests get_decimal_amount(), truncate() and almost_equal() into common utilities in util.py.
- Refactor token utility function token_index_in_account() into common utilities in util.py.
- Refactor common transaction utility functions make_utxo(), find_spendable_utxo(), list_unspent_tx(), unspent_amount(), fund_tx() into common utilities in util.py.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
