### PR TITLE
Add EVM JSON RPC port into chain param

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -37,17 +37,17 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN) {
-        return std::make_unique<CBaseChainParams>("", 8554, 8559);
+        return std::make_unique<CBaseChainParams>("", 8554, 8559, put-number);
     } else if (chain == CBaseChainParams::TESTNET) {
-        return std::make_unique<CBaseChainParams>("testnet3", 18554, 9558);
+        return std::make_unique<CBaseChainParams>("testnet3", 18554, 9558, put-number);
     } else if (chain == CBaseChainParams::DEVNET) {
         if (gArgs.IsArgSet("-devnet-bootstrap")) {
-            return std::make_unique<CBaseChainParams>("devnet", 18554, 9558);
+            return std::make_unique<CBaseChainParams>("devnet", 18554, 9558, put-number);
         } else {
-            return std::make_unique<CBaseChainParams>("devnet", 20554, 10558);
+            return std::make_unique<CBaseChainParams>("devnet", 20554, 10558, put-number);
         }
     } else if (chain == CBaseChainParams::REGTEST) {
-        return std::make_unique<CBaseChainParams>("regtest", 19554, 11558);
+        return std::make_unique<CBaseChainParams>("regtest", 19554, 11558, put-number);
     } else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
     }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -37,17 +37,17 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN) {
-        return std::make_unique<CBaseChainParams>("", 8554, 8559, put-number);
+        return std::make_unique<CBaseChainParams>("", 8554, 8550, 8551);
     } else if (chain == CBaseChainParams::TESTNET) {
-        return std::make_unique<CBaseChainParams>("testnet3", 18554, 9558, put-number);
+        return std::make_unique<CBaseChainParams>("testnet3", 18554, 9550, 9551);
     } else if (chain == CBaseChainParams::DEVNET) {
         if (gArgs.IsArgSet("-devnet-bootstrap")) {
-            return std::make_unique<CBaseChainParams>("devnet", 18554, 9558, put-number);
+            return std::make_unique<CBaseChainParams>("devnet", 18554, 9550, 9551);
         } else {
-            return std::make_unique<CBaseChainParams>("devnet", 20554, 10558, put-number);
+            return std::make_unique<CBaseChainParams>("devnet", 20554, 10550, 10551);
         }
     } else if (chain == CBaseChainParams::REGTEST) {
-        return std::make_unique<CBaseChainParams>("regtest", 19554, 11558, put-number);
+        return std::make_unique<CBaseChainParams>("regtest", 19554, 11550, 11551);
     } else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
     }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -24,13 +24,15 @@ public:
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
     int GRPCPort() const { return nGRPCPort; }
+    int ETHRPCPort() const { return nETHRPCPort; }
 
     CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, int rpc_port, int grpc_port) : nRPCPort(rpc_port), nGRPCPort(grpc_port), strDataDir(data_dir) {}
+    CBaseChainParams(const std::string& data_dir, int rpc_port, int grpc_port, int ethrpc_port) : nRPCPort(rpc_port), nGRPCPort(grpc_port), nETHRPCPort(ethrpc_port), strDataDir(data_dir) {}
 
 private:
     int nRPCPort;
     int nGRPCPort;
+    int nETHRPCPort;
     std::string strDataDir;
 };
 

--- a/src/defid.cpp
+++ b/src/defid.cpp
@@ -113,7 +113,8 @@ static bool AppInit(int argc, char* argv[])
         // Start GRPC after BaseParams() has been initialised
         init_runtime();
         int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
-        start_servers("127.0.0.1:" + std::to_string(grpc_port), "127.0.0.1:" +  std::to_string(grpc_port + 1));
+        int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
+        start_servers("127.0.0.1:" + std::to_string(eth_rpc_port), "127.0.0.1:" +  std::to_string(grpc_port));
 
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -639,6 +639,7 @@ void SetupServerArgs()
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-grpcport=<port>", strprintf("Start GRPC connections on <port> and <port + 1> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-ethrpcport=<port>", strprintf("Listen for ETH-JASON-RPC connections on <port>> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->ETHRPCPort(), testnetBaseParams->ETHRPCPort(), devnetBaseParams->ETHRPCPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
     gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);


### PR DESCRIPTION
## Summary

- Add new port in base chain params for eth-json-rpc.
- New pipeline to read new arg "ethrpcport" when starting defid node.
- Use ..50 for GRPC port (changed) and ..51 for ETHRPC port.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
