### PR TITLE
Fix functional test config paths

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -88,6 +88,9 @@ def get_default_config_path():
         # aarch64 / arm builds
         current_file_path + "/../../../build/arm-linux-gnueabihf/test/config.ini",
         current_file_path + "/../../../build/aarch64-linux-gnu/test/config.ini",
+        # relative paths
+        current_file_path + "/../../../build/test/config.ini",
+        current_file_path + "/../../config.ini",
     ]
     for p in default_config_paths:
         if os.path.exists(p):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -80,14 +80,15 @@ class DefiTestMetaClass(type):
 def get_default_config_path():
     current_file_path=os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
     default_config_paths = [
+        # default priority to be for build dir specific build
         current_file_path + "/../../../build/test/config.ini",
         current_file_path + "/../../config.ini",
-        # priority build selections for standard dev envs
+        # priority host specific build selection for standard dev envs
         current_file_path + "/../../../build/x86_64-pc-linux-gnu/test/config.ini",
         current_file_path + "/../../../build/aarch64-apple-darwin/test/config.ini",
         current_file_path + "/../../../build/x86_64-apple-darwin/test/config.ini",
         current_file_path + "/../../../build/x86_64-w64-migw32/test/config.ini",
-        # aarch64 / arm builds
+        # aarch64 / arm builds are by default lower priority when selecting host specific build
         current_file_path + "/../../../build/arm-linux-gnueabihf/test/config.ini",
         current_file_path + "/../../../build/aarch64-linux-gnu/test/config.ini",
     ]

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -82,6 +82,7 @@ def get_default_config_path():
     default_config_paths = [
         # default priority to be for build dir specific build
         current_file_path + "/../../../build/test/config.ini",
+        # tree-path specific for build explicitly built in tree
         current_file_path + "/../../config.ini",
         # priority host specific build selection for standard dev envs
         current_file_path + "/../../../build/x86_64-pc-linux-gnu/test/config.ini",

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -80,6 +80,8 @@ class DefiTestMetaClass(type):
 def get_default_config_path():
     current_file_path=os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
     default_config_paths = [
+        current_file_path + "/../../../build/test/config.ini",
+        current_file_path + "/../../config.ini",
         # priority build selections for standard dev envs
         current_file_path + "/../../../build/x86_64-pc-linux-gnu/test/config.ini",
         current_file_path + "/../../../build/aarch64-apple-darwin/test/config.ini",
@@ -88,9 +90,6 @@ def get_default_config_path():
         # aarch64 / arm builds
         current_file_path + "/../../../build/arm-linux-gnueabihf/test/config.ini",
         current_file_path + "/../../../build/aarch64-linux-gnu/test/config.ini",
-        # relative paths
-        current_file_path + "/../../../build/test/config.ini",
-        current_file_path + "/../../config.ini",
     ]
     for p in default_config_paths:
         if os.path.exists(p):


### PR DESCRIPTION
## Summary

- This PR fixes the fucntional test configuration file's relative path when running the various functional tests using test_runner.py.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
