### PR TITLE
Fix exposed ports, env path variables

### DIFF
--- a/contrib/dockerfiles/aarch64-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/aarch64-linux-gnu.dockerfile
@@ -25,6 +25,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 ### Actual image that contains defi binaries
 FROM --platform=linux/arm64 ubuntu:latest
 ARG TARGET
+ENV PATH=/app/bin:$PATH
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}
 
@@ -41,4 +42,4 @@ VOLUME ["/data"]
 USER defi:defi
 CMD [ "/app/bin/defid" ]
 
-EXPOSE 8555 8554 18555 18554 19555 19554 20555 20554
+EXPOSE 8554 8550 8551 18554 18550 18551 19554 19550 19551 20554 20550 20551

--- a/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
+++ b/contrib/dockerfiles/arm-linux-gnueabihf.dockerfile
@@ -25,6 +25,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 ### Actual image that contains defi binaries
 FROM --platform=linux/arm/v7 ubuntu:latest
 ARG TARGET
+ENV PATH=/app/bin:$PATH
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}
 
@@ -41,4 +42,4 @@ VOLUME ["/data"]
 USER defi:defi
 CMD [ "/app/bin/defid" ]
 
-EXPOSE 8555 8554 18555 18554 19555 19554 20555 20554
+EXPOSE 8554 8550 8551 18554 18550 18551 19554 19550 19551 20554 20550 20551

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu-clang.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu-clang.dockerfile
@@ -29,6 +29,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 ### Actual image that contains defi binaries
 FROM --platform=linux/amd64 debian:10
 ARG TARGET
+ENV PATH=/app/bin:$PATH
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}
 
@@ -45,4 +46,4 @@ VOLUME ["/data"]
 USER defi:defi
 CMD [ "/app/bin/defid" ]
 
-EXPOSE 8555 8554 18555 18554 19555 19554 20555 20554
+EXPOSE 8554 8550 8551 18554 18550 18551 19554 19550 19551 20554 20550 20551

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -25,6 +25,7 @@ RUN mkdir /app && cd build/${TARGET} && \
 ### Actual image that contains defi binaries
 FROM --platform=linux/amd64 ubuntu:latest
 ARG TARGET
+ENV PATH=/app/bin:$PATH
 LABEL org.defichain.name="defichain"
 LABEL org.defichain.arch=${TARGET}
 
@@ -41,4 +42,4 @@ VOLUME ["/data"]
 USER defi:defi
 CMD [ "/app/bin/defid" ]
 
-EXPOSE 8555 8554 18555 18554 19555 19554 20555 20554
+EXPOSE 8554 8550 8551 18554 18550 18551 19554 19550 19551 20554 20550 20551


### PR DESCRIPTION
## Summary

- Fix missing ENV to configure app bin dir in path env variable.
- Expose correct ports for various network types.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
