### PR TITLE
Fix eth json RPC issue when running DFI in containerized environment

### DIFF
--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -18,9 +18,7 @@ use log::Level;
 use crate::rpc::{MetachainRPCModule, MetachainRPCServer};
 
 use std::error::Error;
-use std::ffi::CStr;
 use std::net::SocketAddr;
-use std::os::raw::c_char;
 use std::sync::Arc;
 
 use ain_evm::runtime::{Runtime, RUNTIME};
@@ -54,17 +52,11 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-/// # Safety
-/// Ensure that argc passed counts the exact number of argument variables that is passed into init
-pub unsafe fn init(_argc: i32, _argv: *const *const c_char) {
+pub fn init(argc: i32, argv: &Vec<&str>) {
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)
         .init();
     log::info!("Initializing");
-
-    let _args: Vec<&str> = (0.._argc)
-        .map(|i| unsafe { CStr::from_ptr(*_argv.add(i as usize)).to_str().unwrap() })
-        .collect();
 }
 
 pub fn init_evm_runtime() {

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -18,10 +18,10 @@ use log::Level;
 use crate::rpc::{MetachainRPCModule, MetachainRPCServer};
 
 use std::error::Error;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::os::raw::c_char;
 use std::ffi::CStr;
+use std::net::SocketAddr;
+use std::os::raw::c_char;
+use std::sync::Arc;
 
 use ain_evm::runtime::{Runtime, RUNTIME};
 
@@ -54,6 +54,8 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
     Ok(())
 }
 
+// # Safety
+// Ensure that argc passed counts the exact number of argument variables that is passed into init
 pub unsafe fn init(_argc: i32, _argv: *const *const c_char) {
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)
@@ -61,7 +63,8 @@ pub unsafe fn init(_argc: i32, _argv: *const *const c_char) {
     log::info!("Initializing");
 
     let _args: Vec<&str> = (0.._argc)
-        .map(|i| unsafe { CStr::from_ptr(*_argv.add(i as usize)).to_str().unwrap() }).collect();
+        .map(|i| unsafe { CStr::from_ptr(*_argv.add(i as usize)).to_str().unwrap() })
+        .collect();
 }
 
 pub fn init_evm_runtime() {

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -53,10 +53,10 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
 }
 
 pub fn init_runtime() {
-    log::info!("Starting gRPC and JSON RPC servers");
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)
         .init();
+    log::info!("Starting gRPC and JSON RPC servers");
     let _ = &*RUNTIME;
 }
 

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -52,7 +52,7 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-pub fn init(argc: i32, argv: &Vec<&str>) {
+pub fn init(_argc: i32, _argv: &[&str]) {
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)
         .init();

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -20,6 +20,8 @@ use crate::rpc::{MetachainRPCModule, MetachainRPCServer};
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::os::raw::c_char;
+use std::ffi::CStr;
 
 use ain_evm::runtime::{Runtime, RUNTIME};
 
@@ -52,11 +54,18 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-pub fn init_runtime() {
+pub unsafe fn init(_argc: i32, _argv: *const *const c_char) {
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)
         .init();
-    log::info!("Starting gRPC and JSON RPC servers");
+    log::info!("Initializing");
+
+    let _args: Vec<&str> = (0.._argc)
+        .map(|i| unsafe { CStr::from_ptr(*_argv.add(i as usize)).to_str().unwrap() }).collect();
+}
+
+pub fn init_evm_runtime() {
+    log::info!("Initializing evm runtime");
     let _ = &*RUNTIME;
 }
 

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -54,8 +54,8 @@ pub fn add_grpc_server(_runtime: &Runtime, _addr: &str) -> Result<(), Box<dyn Er
     Ok(())
 }
 
-// # Safety
-// Ensure that argc passed counts the exact number of argument variables that is passed into init
+/// # Safety
+/// Ensure that argc passed counts the exact number of argument variables that is passed into init
 pub unsafe fn init(_argc: i32, _argv: *const *const c_char) {
     LogBuilder::from_env(Env::default().default_filter_or(Level::Info.as_str()))
         .target(Target::Stdout)

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -4,8 +4,6 @@ use ain_grpc::*;
 use ain_evm::runtime::RUNTIME;
 use log::debug;
 use std::error::Error;
-use std::os::raw::c_char;
-use std::ffi::CStr;
 
 use ethereum::{EnvelopedEncodable, TransactionAction, TransactionSignature};
 use primitive_types::{H160, H256, U256};

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -167,6 +167,5 @@ pub unsafe fn init(argc: i32, argv: *const *const c_char) {
     let args: Vec<&str> = (0..argc)
         .map(|i| unsafe { CStr::from_ptr(*argv.add(i as usize)).to_str().unwrap() })
         .collect();
-    
     ain_grpc::init(argc, &args);
 }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -4,6 +4,8 @@ use ain_grpc::*;
 use ain_evm::runtime::RUNTIME;
 use log::debug;
 use std::error::Error;
+use std::ffi::CStr;
+use std::os::raw::c_char;
 
 use ethereum::{EnvelopedEncodable, TransactionAction, TransactionSignature};
 use primitive_types::{H160, H256, U256};
@@ -157,4 +159,14 @@ fn evm_finalize(
             .handlers
             .finalize_block(context, update_state, difficulty, Some(eth_address))?;
     Ok(block.header.rlp_bytes().into())
+}
+
+/// # Safety
+/// Ensure that argc passed counts the exact number of argument variables that is passed into init
+pub unsafe fn init(argc: i32, argv: *const *const c_char) {
+    let args: Vec<&str> = (0..argc)
+        .map(|i| unsafe { CStr::from_ptr(*argv.add(i as usize)).to_str().unwrap() })
+        .collect();
+    
+    ain_grpc::init(argc, &args);
 }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -4,6 +4,8 @@ use ain_grpc::*;
 use ain_evm::runtime::RUNTIME;
 use log::debug;
 use std::error::Error;
+use std::os::raw::c_char;
+use std::ffi::CStr;
 
 use ethereum::{EnvelopedEncodable, TransactionAction, TransactionSignature};
 use primitive_types::{H160, H256, U256};
@@ -41,7 +43,8 @@ pub mod ffi {
             miner_address: [u8; 20],
         ) -> Result<Vec<u8>>;
 
-        fn init_runtime();
+        unsafe fn init(_argc: i32, _argv: *const *const c_char);
+        fn init_evm_runtime();
         fn start_servers(json_addr: &str, grpc_addr: &str) -> Result<()>;
         fn stop_runtime();
 

--- a/src/defid.cpp
+++ b/src/defid.cpp
@@ -60,6 +60,7 @@ static void WaitForShutdown()
 //
 static bool AppInit(int argc, char* argv[])
 {
+    init(argc, argv);
     InitInterfaces interfaces;
     interfaces.chain = interfaces::MakeChain();
 
@@ -94,6 +95,8 @@ static bool AppInit(int argc, char* argv[])
         tfm::format(std::cout, "%s", strUsage.c_str());
         return true;
     }
+
+    init_evm_runtime();
 
     try
     {

--- a/src/defid.cpp
+++ b/src/defid.cpp
@@ -96,8 +96,6 @@ static bool AppInit(int argc, char* argv[])
         return true;
     }
 
-    init_evm_runtime();
-
     try
     {
         if (!CheckDataDirOption()) {
@@ -166,6 +164,8 @@ static bool AppInit(int argc, char* argv[])
             // If locking the data directory failed, exit immediately
             return false;
         }
+        
+        init_evm_runtime();
         fRet = AppInitMain(interfaces);
     }
     catch (const std::exception& e) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1556,7 +1556,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     init_runtime();
     int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
     int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
-    start_servers("127.0.0.1:" + std::to_string(eth_rpc_port), "127.0.0.1:" +  std::to_string(grpc_port));
+    start_servers("0.0.0.0:" + std::to_string(eth_rpc_port), "0.0.0.0:" +  std::to_string(grpc_port));
 
 
     // ********************************************************* Step 5: verify wallet database integrity

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1567,7 +1567,6 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // Determine which addresses to bind to ETH RPC server
     if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-ethrpcbind"))) { // Default to loopback if not allowing external IPs
-        eth_endpoints.push_back(std::make_pair("::1", eth_rpc_port));
         eth_endpoints.push_back(std::make_pair("127.0.0.1", eth_rpc_port));
         if (gArgs.IsArgSet("-rpcallowip")) {
             LogPrintf("WARNING: option -rpcallowip was specified without -ethrpcbind; this doesn't usually make sense\n");
@@ -1586,7 +1585,6 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // Determine which addresses to bind to gRPC server
     if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-grpcbind"))) { // Default to loopback if not allowing external IPs
-        g_endpoints.push_back(std::make_pair("::1", grpc_port));
         g_endpoints.push_back(std::make_pair("127.0.0.1", grpc_port));
         if (gArgs.IsArgSet("-rpcallowip")) {
             LogPrintf("WARNING: option -rpcallowip was specified without -grpcbind; this doesn't usually make sense\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -638,9 +638,9 @@ void SetupServerArgs()
     gArgs.AddArg("-dftxworkers=<n>", strprintf("No. of parallel workers associated with the DfTx related work pool. Stock splits, parallel processing of the chain where appropriate, etc use this worker pool (default: %d)", DEFAULT_DFTX_WORKERS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-grpcbind=<addr>[:port]", "Bind to given address to listen for JSON-gRPC connections. Do not expose the gRPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -grpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-grpcbind=<addr>[:port]", "Bind to given address to listen for JSON-gRPC connections. Do not expose the gRPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -grpcport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-grpcport=<port>", strprintf("Start GRPC connections on <port> and <port + 1> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
-    gArgs.AddArg("-ethrpcbind=<addr>[:port]", "Bind to given address to listen for ETH-JSON-RPC connections. Do not expose the ETH-RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -ethrpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-ethrpcbind=<addr>[:port]", "Bind to given address to listen for ETH-JSON-RPC connections. Do not expose the ETH-RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -ethrpcport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethrpcport=<port>", strprintf("Listen for ETH-JSON-RPC connections on <port>> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->ETHRPCPort(), testnetBaseParams->ETHRPCPort(), devnetBaseParams->ETHRPCPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON
@@ -1559,7 +1559,6 @@ bool AppInitMain(InitInterfaces& interfaces)
      * RPC/gRPC server to bind to one address. By default, we will only take 
      * the first address, if multiple addresses are specified.
     */
-    init_runtime();
     int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
     int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
     std::vector<std::pair<std::string, uint16_t> > eth_endpoints;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -638,6 +638,7 @@ void SetupServerArgs()
     gArgs.AddArg("-dftxworkers=<n>", strprintf("No. of parallel workers associated with the DfTx related work pool. Stock splits, parallel processing of the chain where appropriate, etc use this worker pool (default: %d)", DEFAULT_DFTX_WORKERS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-grpcbind=<addr>[:port]", "Bind to given address to listen for JSON-gRPC connections. Do not expose the gRPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -grpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-grpcport=<port>", strprintf("Start GRPC connections on <port> and <port + 1> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethrpcbind=<addr>[:port]", "Bind to given address to listen for ETH-JSON-RPC connections. Do not expose the ETH-RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -ethrpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethrpcport=<port>", strprintf("Listen for ETH-JSON-RPC connections on <port>> (default: %u, testnet: %u, devnet: %u, regtest: %u)", defaultBaseParams->ETHRPCPort(), testnetBaseParams->ETHRPCPort(), devnetBaseParams->ETHRPCPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
@@ -1554,19 +1555,20 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // ********************************************************* Step 4b: application initialization
 
-    /* Start the ETH RPC server. Current API only allows for one ETH RPC server 
-     * to bind to one address. By default, we will only take the first address,
-     * if multiple addresses were specified.
+    /* Start the ETH RPC and gRPC servers. Current API only allows for one ETH 
+     * RPC/gRPC server to bind to one address. By default, we will only take 
+     * the first address, if multiple addresses are specified.
     */
     init_runtime();
-    int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
     int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
-    std::vector<std::pair<std::string, uint16_t> > endpoints;
+    int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
+    std::vector<std::pair<std::string, uint16_t> > eth_endpoints;
+    std::vector<std::pair<std::string, uint16_t> > g_endpoints;
 
-    // Determine which addresses to bind to
+    // Determine which addresses to bind to ETH RPC server
     if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-ethrpcbind"))) { // Default to loopback if not allowing external IPs
-        endpoints.push_back(std::make_pair("::1", eth_rpc_port));
-        endpoints.push_back(std::make_pair("127.0.0.1", eth_rpc_port));
+        eth_endpoints.push_back(std::make_pair("::1", eth_rpc_port));
+        eth_endpoints.push_back(std::make_pair("127.0.0.1", eth_rpc_port));
         if (gArgs.IsArgSet("-rpcallowip")) {
             LogPrintf("WARNING: option -rpcallowip was specified without -ethrpcbind; this doesn't usually make sense\n");
         }
@@ -1578,12 +1580,31 @@ bool AppInitMain(InitInterfaces& interfaces)
             int port = eth_rpc_port;
             std::string host;
             SplitHostPort(strETHRPCBind, port, host);
-            endpoints.push_back(std::make_pair(host, port));
+            eth_endpoints.push_back(std::make_pair(host, port));
         }
     }
 
-    // Default to using the first address passed to bind
-    start_servers(endpoints[0].first + ":" + std::to_string(endpoints[0].second), "127.0.0.1:" +  std::to_string(grpc_port));
+    // Determine which addresses to bind to gRPC server
+    if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-grpcbind"))) { // Default to loopback if not allowing external IPs
+        g_endpoints.push_back(std::make_pair("::1", grpc_port));
+        g_endpoints.push_back(std::make_pair("127.0.0.1", grpc_port));
+        if (gArgs.IsArgSet("-rpcallowip")) {
+            LogPrintf("WARNING: option -rpcallowip was specified without -grpcbind; this doesn't usually make sense\n");
+        }
+        if (gArgs.IsArgSet("-grpcbind")) {
+            LogPrintf("WARNING: option -grpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
+        }
+    } else if (gArgs.IsArgSet("-grpcbind")) { // Specific bind address
+        for (const std::string& strGRPCBind : gArgs.GetArgs("-grpcbind")) {
+            int port = grpc_port;
+            std::string host;
+            SplitHostPort(strGRPCBind, port, host);
+            g_endpoints.push_back(std::make_pair(host, port));
+        }
+    }
+
+    // Default to using the first address passed to bind to ETH RPC server and gRPC server
+    start_servers(eth_endpoints[0].first + ":" + std::to_string(eth_endpoints[0].second), g_endpoints[0].first + "." + std::to_string(g_endpoints[0].second));
 
     // ********************************************************* Step 5: verify wallet database integrity
     for (const auto& client : interfaces.chain_clients) {


### PR DESCRIPTION
## Summary

This PR fixes the IP address binded to the eth json rpc server and grpc server from the hardcoded loopback interface (127.0.0.1) to read args "-ethrpcbind" and "-grpcbind".

1. Refactored init_runtime into init and init_evm_runtime.
- init function call will pass argc and argv from the C++ side, and convert the arg variables into Rust's &str.
- init_evm_runtime will initialize the Rust logger and runtime.
- fixed logging in init_evm_runtime.
2. Include args to bind eth_rpc server and grpc server to addresses. (-ethrpcbind, grpcbind)
- by default if address to bind is not specified or -rpcallowip arg is not set, we will use the standard lo interfafce (127.0.0.1)

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
