### PR TITLE
EVM RPC improvements

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "quote",
  "regex",
  "rlp",
+ "rustc-hex",
  "serde",
  "serde_json",
  "syn 2.0.15",

--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -117,10 +117,12 @@ impl EVMBackend {
 
 impl Backend for EVMBackend {
     fn gas_price(&self) -> U256 {
+        debug!(target: "backend", "[EVMBackend] Getting gas");
         unimplemented!()
     }
 
     fn origin(&self) -> H160 {
+        debug!(target: "backend", "[EVMBackend] Getting origin");
         unimplemented!()
     }
 
@@ -149,7 +151,9 @@ impl Backend for EVMBackend {
     }
 
     fn block_base_fee_per_gas(&self) -> U256 {
-        unimplemented!("Implement block_base_fee_per_gas function")
+        debug!(target: "backend", "[EVMBackend] Getting block_base_fee_per_gas");
+        U256::default()
+        // unimplemented!("Implement block_base_fee_per_gas function")
     }
 
     fn chain_id(&self) -> U256 {
@@ -161,6 +165,7 @@ impl Backend for EVMBackend {
     }
 
     fn basic(&self, address: H160) -> Basic {
+        debug!(target: "backend", "[EVMBackend] basic for address {:x?}", address);
         self.get_account(address)
             .map(|account| Basic {
                 balance: account.balance,
@@ -170,12 +175,14 @@ impl Backend for EVMBackend {
     }
 
     fn code(&self, address: H160) -> Vec<u8> {
+        debug!(target: "backend", "[EVMBackend] code for address {:x?}", address);
         self.get_account(address)
             .and_then(|account| self.storage.get_code_by_hash(account.code_hash))
             .unwrap_or_default()
     }
 
     fn storage(&self, address: H160, index: H256) -> H256 {
+        debug!(target: "backend", "[EVMBackend] Getting storage for address {:x?} at index {:x?}", address, index);
         self.get_account(address)
             .and_then(|account| {
                 self.trie_store
@@ -189,6 +196,7 @@ impl Backend for EVMBackend {
     }
 
     fn original_storage(&self, address: H160, index: H256) -> Option<H256> {
+        debug!(target: "backend", "[EVMBackend] Getting original storage for address {:x?} at index {:x?}", address, index);
         Some(self.storage(address, index))
     }
 }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -91,6 +91,7 @@ impl EVMHandler {
             .get_latest_block()
             .map(|block| block.header.state_root)
             .unwrap_or_default();
+        println!("state_root : {:#?}", state_root);
         let vicinity = Vicinity {};
         let mut backend = EVMBackend::from_root(
             state_root,

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::{
     backend::EVMBackendError,
     evm::EVMHandler,
@@ -14,6 +12,7 @@ use evm::{
     Config, ExitReason,
 };
 use primitive_types::H160;
+use std::collections::BTreeMap;
 
 #[derive(Debug)]
 pub struct AinExecutor<'backend, B: Backend> {

--- a/lib/ain-evm/src/storage/mod.rs
+++ b/lib/ain-evm/src/storage/mod.rs
@@ -164,3 +164,12 @@ impl Storage {
         self.blockchain_data_handler.put_code(&hash, &code)
     }
 }
+
+impl Storage {
+    pub fn dump_db(&self) {
+        println!(
+            "self.block_data_handler : {:#?}",
+            self.blockchain_data_handler
+        );
+    }
+}

--- a/lib/ain-evm/src/traits.rs
+++ b/lib/ain-evm/src/traits.rs
@@ -3,6 +3,7 @@ use ethereum::AccessList;
 use evm::Config;
 use primitive_types::{H160, U256};
 
+#[derive(Debug)]
 pub struct ExecutorContext<'a> {
     pub caller: Option<H160>,
     pub to: Option<H160>,

--- a/lib/ain-grpc/Cargo.toml
+++ b/lib/ain-grpc/Cargo.toml
@@ -24,6 +24,7 @@ hex = "0.4.3"
 async-trait = "0.1.68"
 rlp = "0.5.2"
 protobuf-src = "1.1.0"
+rustc-hex = "2.1.0"
 
 [build-dependencies]
 cxx-gen = "0.7"

--- a/lib/ain-grpc/src/bytes.rs
+++ b/lib/ain-grpc/src/bytes.rs
@@ -1,0 +1,117 @@
+use rustc_hex::{FromHex, ToHex};
+use serde::{
+    de::{Error, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt;
+
+/// Wrapper structure around vector of bytes.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct Bytes(pub Vec<u8>);
+
+impl Bytes {
+    /// Simple constructor.
+    pub fn new(bytes: Vec<u8>) -> Bytes {
+        Bytes(bytes)
+    }
+    /// Convert back to vector
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for Bytes {
+    fn from(bytes: Vec<u8>) -> Bytes {
+        Bytes(bytes)
+    }
+}
+
+impl From<Bytes> for Vec<u8> {
+    fn from(bytes: Bytes) -> Vec<u8> {
+        bytes.0
+    }
+}
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serialized = "0x".to_owned();
+        serialized.push_str(self.0.to_hex::<String>().as_ref());
+        serializer.serialize_str(serialized.as_ref())
+    }
+}
+
+impl<'a> Deserialize<'a> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Bytes, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        deserializer.deserialize_any(BytesVisitor)
+    }
+}
+
+struct BytesVisitor;
+
+impl<'a> Visitor<'a> for BytesVisitor {
+    type Value = Bytes;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a 0x-prefixed, hex-encoded vector of bytes")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if value.len() >= 2 && value.starts_with("0x") && value.len() & 1 == 0 {
+            Ok(Bytes::new(FromHex::from_hex(&value[2..]).map_err(|e| {
+                Error::custom(format!("Invalid hex: {}", e))
+            })?))
+        } else {
+            Err(Error::custom(
+                "Invalid bytes format. Expected a 0x-prefixed hex string with even length",
+            ))
+        }
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_str(value.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes_serialize() {
+        let bytes = Bytes("0123456789abcdef".from_hex().unwrap());
+        let serialized = serde_json::to_string(&bytes).unwrap();
+        assert_eq!(serialized, r#""0x0123456789abcdef""#);
+    }
+
+    #[test]
+    fn test_bytes_deserialize() {
+        let bytes0: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""∀∂""#);
+        let bytes1: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""""#);
+        let bytes2: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""0x123""#);
+        let bytes3: Result<Bytes, serde_json::Error> = serde_json::from_str(r#""0xgg""#);
+
+        let bytes4: Bytes = serde_json::from_str(r#""0x""#).unwrap();
+        let bytes5: Bytes = serde_json::from_str(r#""0x12""#).unwrap();
+        let bytes6: Bytes = serde_json::from_str(r#""0x0123""#).unwrap();
+
+        assert!(bytes0.is_err());
+        assert!(bytes1.is_err());
+        assert!(bytes2.is_err());
+        assert!(bytes3.is_err());
+        assert_eq!(bytes4, Bytes(vec![]));
+        assert_eq!(bytes5, Bytes(vec![0x12]));
+        assert_eq!(bytes6, Bytes(vec![0x1, 0x23]));
+    }
+}

--- a/lib/ain-grpc/src/call_request.rs
+++ b/lib/ain-grpc/src/call_request.rs
@@ -2,6 +2,8 @@ use ethereum::AccessListItem;
 use primitive_types::{H160, U256};
 use serde::Deserialize;
 
+use crate::bytes::Bytes;
+
 /// Call request
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -22,7 +24,7 @@ pub struct CallRequest {
     /// Value
     pub value: Option<U256>,
     /// Data
-    pub data: Option<Vec<u8>>,
+    pub data: Option<Bytes>,
     /// Nonce
     pub nonce: Option<U256>,
     /// AccessList

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -3,6 +3,7 @@ extern crate serde;
 extern crate serde_json;
 
 pub mod block;
+mod bytes;
 pub mod call_request;
 pub mod codegen;
 mod impls;

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -181,6 +181,10 @@ pub trait MetachainRPC {
     /// Returns current gas_price.
     #[method(name = "eth_gasPrice")]
     fn gas_price(&self) -> RpcResult<U256>;
+
+    // Dump full db
+    #[method(name = "dumpdb")]
+    fn dump_db(&self) -> RpcResult<()>;
 }
 
 pub struct MetachainRPCModule {
@@ -570,5 +574,10 @@ impl MetachainRPCServer for MetachainRPCModule {
 
     fn eth_submithashrate(&self, _hashrate: String, _id: String) -> RpcResult<bool> {
         Ok(false)
+    }
+
+    fn dump_db(&self) -> RpcResult<()> {
+        self.handler.storage.dump_db();
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Fixes eth_call input type
- Adds debug RPC `dump_db` call which prints full in-memory state
- Adds debug with target `rpc`
