### PR TITLE
Trickle down block timestamp to EVM

### DIFF
--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -15,7 +15,6 @@ use log::debug;
 use primitive_types::H256;
 use std::error::Error;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const GENESIS_STATE_ROOT: &str =
     "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a";
@@ -49,7 +48,8 @@ impl Handlers {
         context: u64,
         update_state: bool,
         difficulty: u32,
-        miner_address: Option<H160>,
+        beneficiary: H160,
+        timestamp: u64,
     ) -> Result<(BlockAny, Vec<String>), Box<dyn Error>> {
         let mut all_transactions = Vec::with_capacity(self.evm.tx_queues.len(context));
         let mut failed_transactions = Vec::with_capacity(self.evm.tx_queues.len(context));
@@ -134,7 +134,7 @@ impl Handlers {
         let block = Block::new(
             PartialHeader {
                 parent_hash,
-                beneficiary: miner_address.unwrap_or_default(),
+                beneficiary,
                 state_root: if update_state {
                     backend.commit()
                 } else {
@@ -146,10 +146,7 @@ impl Handlers {
                 number: parent_number + 1,
                 gas_limit: U256::from(30_000_000),
                 gas_used: U256::from(gas_used),
-                timestamp: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64,
+                timestamp,
                 extra_data: Vec::default(),
                 mix_hash: H256::default(),
                 nonce: H64::default(),

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -248,7 +248,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     std::vector<uint8_t> evmHeader{};
     if (IsEVMEnabled(nHeight, mnview)) {
         std::array<uint8_t, 20> dummyAddress{};
-        auto blockResult = evm_finalize(evmContext, false, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), dummyAddress);
+        auto blockResult = evm_finalize(evmContext, false, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), dummyAddress, blockTime);
         evmHeader.resize(blockResult.block_header.size());
         std::copy(blockResult.block_header.begin(), blockResult.block_header.end(), evmHeader.begin());
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2906,7 +2906,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             std::copy(minter.begin(), minter.end(), minerAddress.begin());
         }
 
-        const auto blockResult = evm_finalize(evmContext, true, block.nBits, minerAddress);
+        const auto blockResult = evm_finalize(evmContext, true, block.nBits, minerAddress, block.GetBlockTime());
 
         if (!blockResult.failed_transactions.empty()) {
             std::vector<std::string> failedTransactions;


### PR DESCRIPTION
- Passes `blockTime` to `finalize_block`
- Fixes mismatch import `init_evm_runtime`
