### PR TITLE
RPC: call and estimateGas at specific block height

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -98,13 +98,17 @@ impl EVMHandler {
         data: &[u8],
         gas_limit: u64,
         access_list: AccessList,
+        block_number: U256,
     ) -> Result<TxResponse, Box<dyn Error>> {
         let (state_root, block_number) = self
             .storage
-            .get_latest_block()
+            .get_block_by_number(&block_number)
             .map(|block| (block.header.state_root, block.header.number))
             .unwrap_or_default();
-        println!("state_root : {:#?}", state_root);
+        debug!(
+            "Calling EVM at block number : {:#x}, state_root : {:#x}",
+            block_number, state_root
+        );
 
         let vicinity = Vicinity {
             block_number,
@@ -183,6 +187,7 @@ impl EVMHandler {
             signed_tx.data(),
             signed_tx.gas_limit().as_u64(),
             signed_tx.access_list(),
+            block_number,
         ) {
             Ok(TxResponse { exit_reason, .. }) if exit_reason.is_succeed() => Ok(signed_tx),
             Ok(TxResponse { exit_reason, .. }) => {

--- a/lib/ain-grpc/src/rpc.rs
+++ b/lib/ain-grpc/src/rpc.rs
@@ -137,16 +137,8 @@ pub trait MetachainRPC {
     #[method(name = "eth_getTransactionReceipt")]
     fn get_receipt(&self, hash: H256) -> RpcResult<Option<ReceiptResult>>;
 
-    /// Retrieves the number of transactions sent from a specific address.
-    #[method(name = "eth_getTransactionCount")]
-    fn get_transaction_count(
-        &self,
-        address: H160,
-        block_number: Option<BlockNumber>,
-    ) -> RpcResult<U256>;
-
     // ----------------------------------------
-    // State
+    // Account state
     // ----------------------------------------
 
     /// Retrieves the balance of a specific Ethereum address at a given block number.
@@ -166,6 +158,14 @@ pub trait MetachainRPC {
         position: U256,
         block_number: Option<BlockNumber>,
     ) -> RpcResult<H256>;
+
+    /// Retrieves the number of transactions sent from a specific address.
+    #[method(name = "eth_getTransactionCount")]
+    fn get_transaction_count(
+        &self,
+        address: H160,
+        block_number: Option<BlockNumber>,
+    ) -> RpcResult<U256>;
 
     // ----------------------------------------
     // Send
@@ -187,7 +187,11 @@ pub trait MetachainRPC {
 
     /// Estimate gas needed for execution of given contract.
     #[method(name = "eth_estimateGas")]
-    fn estimate_gas(&self, input: CallRequest) -> RpcResult<U256>;
+    fn estimate_gas(
+        &self,
+        input: CallRequest,
+        block_number: Option<BlockNumber>,
+    ) -> RpcResult<U256>;
 
     /// Returns current gas_price.
     #[method(name = "eth_gasPrice")]
@@ -243,7 +247,7 @@ impl MetachainRPCModule {
 }
 
 impl MetachainRPCServer for MetachainRPCModule {
-    fn call(&self, input: CallRequest, _block_number: Option<BlockNumber>) -> RpcResult<Bytes> {
+    fn call(&self, input: CallRequest, block_number: Option<BlockNumber>) -> RpcResult<Bytes> {
         debug!(target:"rpc", "[RPC] Call input {:#?}", input);
         let CallRequest {
             from,
@@ -263,6 +267,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 &data.map(|d| d.0).unwrap_or_default(),
                 gas.unwrap_or_default().as_u64(),
                 vec![],
+                self.block_number_to_u256(block_number),
             )
             .map_err(|e| Error::Custom(format!("Error calling EVM : {e:?}")))?;
 
@@ -615,7 +620,11 @@ impl MetachainRPCServer for MetachainRPCModule {
         Ok(nonce)
     }
 
-    fn estimate_gas(&self, input: CallRequest) -> RpcResult<U256> {
+    fn estimate_gas(
+        &self,
+        input: CallRequest,
+        block_number: Option<BlockNumber>,
+    ) -> RpcResult<U256> {
         let CallRequest {
             from,
             to,
@@ -625,6 +634,7 @@ impl MetachainRPCServer for MetachainRPCModule {
             ..
         } = input;
 
+        let block_number = self.block_number_to_u256(block_number);
         let TxResponse { used_gas, .. } = self
             .handler
             .evm
@@ -635,10 +645,11 @@ impl MetachainRPCServer for MetachainRPCModule {
                 &data.map(|d| d.0).unwrap_or_default(),
                 gas.unwrap_or(U256::from(u64::MAX)).as_u64(),
                 vec![],
+                block_number,
             )
             .map_err(|e| Error::Custom(format!("Error calling EVM : {e:?}")))?;
 
-        debug!(target:"rpc","estimateGas: {:#?}", used_gas);
+        debug!(target:"rpc", "estimateGas: {:#?} at block {:#x}", used_gas, block_number);
         Ok(U256::from(used_gas))
     }
 


### PR DESCRIPTION
## Summary

- Additional input parameter Option<blockNumber> to restore state trie to a particular block height. Defaults to "latest" block

## RPCs

- `eth_call` and `eth_estimateGas` accepts additional optional parameter blockNumber
