### PR TITLE
Check pointer is valid before accessing method

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -536,7 +536,7 @@ void BlockAssembler::RemoveFailedTransactions(const std::vector<std::string> &fa
     for (const auto &txStr : failedTransactions) {
         const auto failedHash = uint256S(txStr);
         for (const auto &tx : pblock->vtx) {
-            if (tx->GetHash() == failedHash) {
+            if (tx && tx->GetHash() == failedHash) {
                 std::vector<unsigned char> metadata;
                 const auto txType = GuessCustomTxType(*tx, metadata, false);
                 if (txType == CustomTxType::TransferDomain) {


### PR DESCRIPTION
This PR avoids a segfault when the miner removes an invalid TX from a block.