### PR TITLE
fix(evm): fix eth block type `nonce` & `extra_data`

### DIFF
--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -1,3 +1,4 @@
+use crate::bytes::Bytes;
 use ethereum::{BlockAny, TransactionV2};
 use primitive_types::{H160, H256, U256};
 use rlp::Encodable;
@@ -20,7 +21,7 @@ pub struct RpcBlock {
     pub number: U256,
     pub gas_used: U256,
     pub gas_limit: U256,
-    pub extra_data: Vec<u8>,
+    pub extra_data: Bytes,
     pub timestamp: U256,
     pub difficulty: U256,
     pub total_difficulty: U256,
@@ -73,7 +74,7 @@ impl RpcBlock {
             },
             uncles: vec![],
             nonce: U256::zero(),
-            extra_data: block.header.extra_data,
+            extra_data: Bytes(block.header.extra_data.clone()),
             sha3_uncles: H256::default(),
             logs_bloom: format!("{:#x}", block.header.logs_bloom),
             size: format!("{header_size:#x}"),

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -75,7 +75,7 @@ impl RpcBlock {
             },
             uncles: vec![],
             nonce: block.header.nonce,
-            extra_data: Bytes(block.header.extra_data.clone()),
+            extra_data: Bytes::from(block.header.extra_data),
             sha3_uncles: H256::default(),
             logs_bloom: format!("{:#x}", block.header.logs_bloom),
             size: format!("{header_size:#x}"),

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -1,5 +1,6 @@
 use crate::bytes::Bytes;
 use ethereum::{BlockAny, TransactionV2};
+use ethereum_types::H64;
 use primitive_types::{H160, H256, U256};
 use rlp::Encodable;
 use serde::{
@@ -28,7 +29,7 @@ pub struct RpcBlock {
     pub seal_fields: Vec<Vec<u8>>,
     pub uncles: Vec<H256>,
     pub transactions: BlockTransactions,
-    pub nonce: U256,
+    pub nonce: H64,
     pub sha3_uncles: H256,
     pub logs_bloom: String,
     pub size: String,
@@ -73,7 +74,7 @@ impl RpcBlock {
                 }
             },
             uncles: vec![],
-            nonce: U256::zero(),
+            nonce: block.header.nonce,
             extra_data: Bytes(block.header.extra_data.clone()),
             sha3_uncles: H256::default(),
             logs_bloom: format!("{:#x}", block.header.logs_bloom),


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

Wrong type discovered from eth convention test-suites: https://github.com/DeFiCh/go-ethlibs/pull/11

Vec\<u8\> -> Bytes
extra_data: [] ❌ 
extra_data: "0x" ✅ 

U256 -> H64 ([u8;32])
nonce: "0x00" ❌
nonce: "0x0000000000000000" ✅ 

```
{"jsonrpc":"2.0","result":{"hash":"0x6f777e9c82961cee1e047177ec8676d238870c4082739f5e9dd0c2accaf814f2","mixHash":"0x6f777e9c82961cee1e047177ec8676d238870c4082739f5e9dd0c2accaf814f2","parentHash":"0x6417c97d7a1a846308ff06f32e0b64f3ceb04f3a2767663ae02a3a03e8f4ffc7","miner":"0xb36814fd26190b321aa985809293a41273cfe15e","stateRoot":"0xc627b2a0def66ce77cccdb16ad691c2e523bc0e4bc82ab5bcc329bf5b3421cd8","transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","number":"0x647","gasUsed":"0x0","gasLimit":"0x1c9c380","extraData":"0x","timestamp":"0x64705cc8","difficulty":"0x207fffff","totalDifficulty":"0x0","sealFields":[],"uncles":[],"transactions":[],"nonce":"0x0000000000000000","sha3Uncles":"0x0000000000000000000000000000000000000000000000000000000000000000","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","size":"0x1fe"},"id":"fixture"}
```

```
➜  go-ethlibs git:(canonbrother/add-meta-ci) ✗ go test -v ./node/rpc_meta_test.go -run TestMetaRpc_Block_GetBlockByNumber
=== RUN   TestMetaRpc_Block_GetBlockByNumber
block:  0x14000196000 (0x0,0x0)
--- PASS: TestMetaRpc_Block_GetBlockByNumber (0.02s)
PASS
ok      command-line-arguments  0.447s
```