### PR TITLE
evm: EIP1559 support

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "serde",
  "sha3",
  "sp-core",
+ "statrs",
  "tempdir",
  "tokio",
  "vsdb_core",
@@ -203,6 +204,15 @@ name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "array-bytes"
@@ -3527,6 +3537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3693,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nalgebra"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ndk"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,6 +3816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +3863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4467,6 +4526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4558,12 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rdrand"
@@ -4767,6 +4842,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -5113,6 +5197,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,6 +5547,19 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d08e5e1748192713cc281da8b16924fb46be7b0c2431854eadc785823e5696e"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "stretch2"
@@ -6829,6 +6939,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0496a71f3cc6bc4bf0ed91346426a5099e93d89807e663162dc5a1069ff65"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/lib/ain-evm/Cargo.toml
+++ b/lib/ain-evm/Cargo.toml
@@ -22,6 +22,7 @@ keccak-hash = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 ethbloom = "0.13.0"
 ethereum-types = "0.14.1"
+statrs = "0.16.0"
 
 # Trie dependencies
 hash-db = "0.16.0"

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -247,4 +247,17 @@ impl BlockHandler {
 
         U256::from(data.percentile(60).ceil() as u64)
     }
+
+    pub fn get_legacy_fee(&self) -> U256 {
+        let priority_fee = self.suggested_priority_fee();
+        let latest_block_hash = self
+            .storage
+            .get_latest_block()
+            .expect("Unable to get latest block")
+            .header
+            .hash();
+        let base_fee = self.storage.get_base_fee(&latest_block_hash).unwrap();
+
+        base_fee + priority_fee
+    }
 }

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -202,15 +202,16 @@ impl BlockHandler {
             .get_latest_block()
             .expect("Unable to find latest block");
         blocks.push(block.clone());
+        let mut parent_hash = block.header.parent_hash;
 
-        loop {
-            let parent_hash = block.header.hash();
-            let blk = self.storage.get_block_by_hash(&parent_hash);
-            if blk.is_none() || blocks.len() == blocks.capacity() {
-                break;
+        while blocks.len() <= blocks.capacity() {
+            match self.storage.get_block_by_hash(&parent_hash) {
+                Some(block) => {
+                    blocks.push(block.clone());
+                    parent_hash = block.header.parent_hash;
+                }
+                None => break,
             }
-
-            blocks.push(block.clone());
         }
 
         /*

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -110,10 +110,7 @@ impl BlockHandler {
             block_number -= U256::from(1);
         }
 
-        let oldest_block = match descending {
-            true => blocks.last().unwrap().header.hash(),
-            false => blocks.first().unwrap().header.hash(),
-        };
+        let oldest_block = blocks.last().unwrap().header.hash();
 
         let (base_fee_per_gas, gas_used_ratio): (Vec<U256>, Vec<f64>) = blocks
             .iter()

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -29,8 +29,9 @@ impl BlockHandler {
             .unwrap_or_default()
     }
 
-    pub fn connect_block(&self, block: BlockAny) {
+    pub fn connect_block(&self, block: BlockAny, base_fee: U256) {
         self.storage.put_latest_block(Some(&block));
         self.storage.put_block(&block);
+        self.storage.set_base_fee(block.header.hash(), base_fee);
     }
 }

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -1,6 +1,7 @@
 use ethereum::BlockAny;
 use keccak_hash::H256;
 use primitive_types::U256;
+use std::cmp::max;
 use std::sync::Arc;
 
 use crate::storage::{traits::BlockStorage, Storage};
@@ -33,5 +34,51 @@ impl BlockHandler {
         self.storage.put_latest_block(Some(&block));
         self.storage.put_block(&block);
         self.storage.set_base_fee(block.header.hash(), base_fee);
+    }
+
+    pub fn calculate_base_fee(&self, parent_hash: H256) -> U256 {
+        // constants
+        let initial_base_fee: U256 = U256::from(1_000_000_000); // wei
+        let base_fee_max_change_denominator: U256 = U256::from(8);
+        let elasticity_multiplier: U256 = U256::from(2);
+
+        // first block has 1 gwei base fee
+        if parent_hash == H256::zero() {
+            return initial_base_fee;
+        }
+
+        // get parent gas usage,
+        // https://eips.ethereum.org/EIPS/eip-1559#:~:text=fee%20is%20correct-,if%20INITIAL_FORK_BLOCK_NUMBER%20%3D%3D%20block.number%3A,-expected_base_fee_per_gas%20%3D%20INITIAL_BASE_FEE
+        let parent_block = self
+            .storage
+            .get_block_by_hash(&parent_hash)
+            .expect("Parent block not found");
+        let parent_base_fee = self
+            .storage
+            .get_base_fee(&parent_block.header.hash())
+            .expect("Parent base fee not found");
+        let parent_gas_used = parent_block.header.gas_used;
+        let parent_gas_target = parent_block.header.gas_limit / elasticity_multiplier;
+
+        return if parent_gas_used == parent_gas_target {
+            parent_base_fee
+        } else if parent_gas_used > parent_gas_target {
+            let gas_used_delta = parent_gas_used - parent_gas_target;
+            let base_fee_per_gas_delta = max(
+                parent_base_fee * gas_used_delta
+                    / parent_gas_target
+                    / base_fee_max_change_denominator,
+                U256::from(1),
+            );
+
+            parent_base_fee + base_fee_per_gas_delta
+        } else {
+            let gas_used_delta = parent_gas_target - parent_gas_used;
+            let base_fee_per_gas_delta = parent_base_fee * gas_used_delta
+                / parent_gas_target
+                / base_fee_max_change_denominator;
+
+            parent_base_fee - base_fee_per_gas_delta
+        };
     }
 }

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -69,7 +69,7 @@ impl BlockHandler {
         let parent_gas_used = parent_block.header.gas_used;
         let parent_gas_target = parent_block.header.gas_limit / elasticity_multiplier;
 
-        return if parent_gas_used == parent_gas_target {
+        if parent_gas_used == parent_gas_target {
             parent_base_fee
         } else if parent_gas_used > parent_gas_target {
             let gas_used_delta = parent_gas_used - parent_gas_target;
@@ -88,7 +88,7 @@ impl BlockHandler {
                 / base_fee_max_change_denominator;
 
             parent_base_fee - base_fee_per_gas_delta
-        };
+        }
     }
 
     pub fn fee_history(
@@ -184,12 +184,12 @@ impl BlockHandler {
             Some(reward)
         };
 
-        return FeeHistoryData {
+        FeeHistoryData {
             oldest_block,
             base_fee_per_gas,
             gas_used_ratio,
             reward,
-        };
+        }
     }
 
     /// Returns the 60th percentile priority fee for the last 20 blocks

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -1,10 +1,10 @@
 use ethereum::{BlockAny, TransactionAny};
 use keccak_hash::H256;
+use log::debug;
 use primitive_types::U256;
+use statrs::statistics::{Data, OrderStatistics};
 use std::cmp::max;
 use std::sync::Arc;
-use log::debug;
-use statrs::statistics::{Data, OrderStatistics};
 
 use crate::storage::{traits::BlockStorage, Storage};
 
@@ -175,7 +175,10 @@ impl BlockHandler {
                 }
 
                 let mut block_rewards = Vec::new();
-                let priority_fees = block_eip_tx.iter().map(|tx| tx.max_priority_fee_per_gas.as_u64() as f64).collect::<Vec<f64>>();
+                let priority_fees = block_eip_tx
+                    .iter()
+                    .map(|tx| tx.max_priority_fee_per_gas.as_u64() as f64)
+                    .collect::<Vec<f64>>();
                 let mut data = Data::new(priority_fees);
 
                 for pct in priority_fee_percentile.iter() {

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -95,7 +95,6 @@ impl BlockHandler {
         &self,
         block_count: usize,
         first_block: U256,
-        descending: bool,
         priority_fee_percentile: Vec<usize>,
     ) -> FeeHistoryData {
         let mut blocks = Vec::with_capacity(block_count);
@@ -108,10 +107,7 @@ impl BlockHandler {
                     .expect(&format!("Block {} out of range", block_number)),
             );
 
-            match descending {
-                true => block_number -= U256::from(1),
-                false => block_number += U256::from(1),
-            }
+            block_number -= U256::from(1);
         }
 
         let oldest_block = match descending {
@@ -190,10 +186,6 @@ impl BlockHandler {
 
             Some(reward)
         };
-
-        for x in gas_used_ratio.iter() {
-            debug!("used ratio: {}", x);
-        }
 
         return FeeHistoryData {
             oldest_block,

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -176,13 +176,14 @@ impl Handlers {
         );
 
         // calculate base fee
+        let base_fee = self.block.calculate_base_fee(parent_hash);
 
         if update_state {
             debug!(
                 "[finalize_block] Finalizing block number {:#x}, state_root {:#x}",
                 block.header.number, block.header.state_root
             );
-            self.block.connect_block(block.clone(), U256::zero()); // TODO: replace with base fee
+            self.block.connect_block(block.clone(), base_fee);
             self.receipt.put_receipts(receipts);
         }
 

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -55,7 +55,7 @@ impl Handlers {
         let mut failed_transactions = Vec::with_capacity(self.evm.tx_queues.len(context));
         let mut receipts_v3: Vec<ReceiptV3> = Vec::with_capacity(self.evm.tx_queues.len(context));
         let mut gas_used = 0u64;
-        let mut total_gas_limit = 0u64;
+        let mut total_gas_limit = U256::zero();
         let mut logs_bloom: Bloom = Bloom::default();
 
         let (parent_hash, parent_number) = self.block.get_latest_block_hash_and_number();
@@ -105,7 +105,9 @@ impl Handlers {
                     all_transactions.push(signed_tx.clone());
 
                     total_gas_limit += match signed_tx.transaction {
-                        TransactionV2::Legacy(t) | TransactionV2::EIP2930(t) | TransactionV2::EIP1559(t) => {t.gas_limit}
+                        TransactionV2::Legacy(t) => t.gas_limit,
+                        TransactionV2::EIP2930(t) => t.gas_limit,
+                        TransactionV2::EIP1559(t) => t.gas_limit,
                     };
                     gas_used += used_gas;
                     EVMHandler::logs_bloom(logs, &mut logs_bloom);
@@ -152,7 +154,7 @@ impl Handlers {
                 logs_bloom,
                 difficulty: U256::from(difficulty),
                 number: parent_number + 1,
-                gas_limit: U256::from(total_gas_limit),
+                gas_limit: total_gas_limit,
                 gas_used: U256::from(gas_used),
                 timestamp,
                 extra_data: Vec::default(),

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -9,7 +9,7 @@ use crate::traits::Executor;
 use crate::transaction::bridge::{BalanceUpdate, BridgeTx};
 use crate::tx_queue::QueueTx;
 
-use ethereum::{Block, PartialHeader, ReceiptV3, TransactionV2};
+use ethereum::{Block, PartialHeader, ReceiptV3};
 use ethereum_types::{Bloom, H160, H64, U256};
 use log::debug;
 use primitive_types::H256;

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -102,13 +102,13 @@ impl Handlers {
                         failed_transactions.push(hex::encode(hash));
                     }
 
-                    all_transactions.push(signed_tx.clone());
-
-                    total_gas_limit += match signed_tx.transaction {
+                    total_gas_limit += match &signed_tx.transaction {
                         TransactionV2::Legacy(t) => t.gas_limit,
                         TransactionV2::EIP2930(t) => t.gas_limit,
                         TransactionV2::EIP1559(t) => t.gas_limit,
                     };
+
+                    all_transactions.push(signed_tx.clone());
                     gas_used += used_gas;
                     EVMHandler::logs_bloom(logs, &mut logs_bloom);
                     receipts_v3.push(receipt);
@@ -175,14 +175,14 @@ impl Handlers {
             block.header.number,
         );
 
-        // calculate base fee
-        let base_fee = self.block.calculate_base_fee(parent_hash);
-
         if update_state {
             debug!(
                 "[finalize_block] Finalizing block number {:#x}, state_root {:#x}",
                 block.header.number, block.header.state_root
             );
+            // calculate base fee
+            let base_fee = self.block.calculate_base_fee(parent_hash);
+
             self.block.connect_block(block.clone(), base_fee);
             self.receipt.put_receipts(receipts);
         }

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -175,12 +175,14 @@ impl Handlers {
             block.header.number,
         );
 
+        // calculate base fee
+
         if update_state {
             debug!(
                 "[finalize_block] Finalizing block number {:#x}, state_root {:#x}",
                 block.header.number, block.header.state_root
             );
-            self.block.connect_block(block.clone());
+            self.block.connect_block(block.clone(), U256::zero()); // TODO: replace with base fee
             self.receipt.put_receipts(receipts);
         }
 

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -55,7 +55,6 @@ impl Handlers {
         let mut failed_transactions = Vec::with_capacity(self.evm.tx_queues.len(context));
         let mut receipts_v3: Vec<ReceiptV3> = Vec::with_capacity(self.evm.tx_queues.len(context));
         let mut gas_used = 0u64;
-        let mut total_gas_limit = U256::zero();
         let mut logs_bloom: Bloom = Bloom::default();
 
         let (parent_hash, parent_number) = self.block.get_latest_block_hash_and_number();
@@ -101,12 +100,6 @@ impl Handlers {
                     if !exit_reason.is_succeed() {
                         failed_transactions.push(hex::encode(hash));
                     }
-
-                    total_gas_limit += match &signed_tx.transaction {
-                        TransactionV2::Legacy(t) => t.gas_limit,
-                        TransactionV2::EIP2930(t) => t.gas_limit,
-                        TransactionV2::EIP1559(t) => t.gas_limit,
-                    };
 
                     all_transactions.push(signed_tx.clone());
                     gas_used += used_gas;
@@ -154,7 +147,7 @@ impl Handlers {
                 logs_bloom,
                 difficulty: U256::from(difficulty),
                 number: parent_number + 1,
-                gas_limit: total_gas_limit,
+                gas_limit: U256::from(30_000_000),
                 gas_used: U256::from(gas_used),
                 timestamp,
                 extra_data: Vec::default(),

--- a/lib/ain-evm/src/lib.rs
+++ b/lib/ain-evm/src/lib.rs
@@ -1,5 +1,5 @@
 mod backend;
-mod block;
+pub mod block;
 mod ecrecover;
 pub mod evm;
 pub mod executor;

--- a/lib/ain-evm/src/storage/cache.rs
+++ b/lib/ain-evm/src/storage/cache.rs
@@ -12,6 +12,7 @@ pub struct Cache {
     transactions: RwLock<LruCache<H256, TransactionV2>>,
     blocks: RwLock<LruCache<U256, BlockAny>>,
     block_hashes: RwLock<LruCache<H256, U256>>,
+    base_fee: RwLock<LruCache<H256, U256>>,
     latest_block: RwLock<Option<BlockAny>>,
 }
 
@@ -27,6 +28,9 @@ impl Cache {
                 NonZeroUsize::new(cache_size.unwrap_or(Self::DEFAULT_CACHE_SIZE)).unwrap(),
             )),
             block_hashes: RwLock::new(LruCache::new(
+                NonZeroUsize::new(cache_size.unwrap_or(Self::DEFAULT_CACHE_SIZE)).unwrap(),
+            )),
+            base_fee: RwLock::new(LruCache::new(
                 NonZeroUsize::new(cache_size.unwrap_or(Self::DEFAULT_CACHE_SIZE)).unwrap(),
             )),
             latest_block: RwLock::new(None),
@@ -74,6 +78,15 @@ impl BlockStorage for Cache {
     fn put_latest_block(&self, block: Option<&BlockAny>) {
         let mut cache = self.latest_block.write().unwrap();
         *cache = block.cloned();
+    }
+
+    fn get_base_fee(&self, block_hash: &H256) -> Option<U256> {
+        self.base_fee.write().unwrap().get(block_hash).map(ToOwned::to_owned)
+    }
+
+    fn set_base_fee(&self, block_hash: H256, base_fee: U256) {
+        let mut cache = self.base_fee.write().unwrap();
+        cache.put(block_hash, base_fee);
     }
 }
 

--- a/lib/ain-evm/src/storage/cache.rs
+++ b/lib/ain-evm/src/storage/cache.rs
@@ -81,7 +81,11 @@ impl BlockStorage for Cache {
     }
 
     fn get_base_fee(&self, block_hash: &H256) -> Option<U256> {
-        self.base_fee.write().unwrap().get(block_hash).map(ToOwned::to_owned)
+        self.base_fee
+            .write()
+            .unwrap()
+            .get(block_hash)
+            .map(ToOwned::to_owned)
     }
 
     fn set_base_fee(&self, block_hash: H256, base_fee: U256) {

--- a/lib/ain-evm/src/storage/data_handler.rs
+++ b/lib/ain-evm/src/storage/data_handler.rs
@@ -224,7 +224,10 @@ impl FlushableStorage for BlockchainDataHandler {
             .unwrap()
             .save_to_disk(TRANSACTION_DATA_PATH)?;
         self.code_map.write().unwrap().save_to_disk(CODE_MAP_PATH)?;
-        self.base_fee_map.write().unwrap().save_to_disk(BASE_FEE_MAP_PATH)
+        self.base_fee_map
+            .write()
+            .unwrap()
+            .save_to_disk(BASE_FEE_MAP_PATH)
     }
 }
 

--- a/lib/ain-evm/src/storage/data_handler.rs
+++ b/lib/ain-evm/src/storage/data_handler.rs
@@ -223,7 +223,8 @@ impl FlushableStorage for BlockchainDataHandler {
             .write()
             .unwrap()
             .save_to_disk(TRANSACTION_DATA_PATH)?;
-        self.code_map.write().unwrap().save_to_disk(CODE_MAP_PATH)
+        self.code_map.write().unwrap().save_to_disk(CODE_MAP_PATH)?;
+        self.base_fee_map.write().unwrap().save_to_disk(BASE_FEE_MAP_PATH)
     }
 }
 

--- a/lib/ain-evm/src/storage/data_handler.rs
+++ b/lib/ain-evm/src/storage/data_handler.rs
@@ -71,7 +71,9 @@ impl BlockchainDataHandler {
                 TransactionHashToReceipt::load_from_disk(RECEIPT_MAP_PATH)
                     .expect("Error loading receipts data"),
             ),
-            base_fee_map: RwLock::new(BlockHashtoBaseFee::load_from_disk(BASE_FEE_MAP_PATH).unwrap_or_default()),
+            base_fee_map: RwLock::new(
+                BlockHashtoBaseFee::load_from_disk(BASE_FEE_MAP_PATH).unwrap_or_default(),
+            ),
             code_map: RwLock::new(CodeHistory::load_from_disk(CODE_MAP_PATH).unwrap_or_default()),
         }
     }
@@ -175,7 +177,11 @@ impl BlockStorage for BlockchainDataHandler {
     }
 
     fn get_base_fee(&self, block_hash: &H256) -> Option<U256> {
-        self.base_fee_map.read().unwrap().get(block_hash).map(ToOwned::to_owned)
+        self.base_fee_map
+            .read()
+            .unwrap()
+            .get(block_hash)
+            .map(ToOwned::to_owned)
     }
 
     fn set_base_fee(&self, block_hash: H256, base_fee: U256) {
@@ -256,7 +262,10 @@ impl Rollback for BlockchainDataHandler {
             }
 
             self.block_map.write().unwrap().remove(&block.header.hash());
-            self.base_fee_map.write().unwrap().remove(&block.header.hash());
+            self.base_fee_map
+                .write()
+                .unwrap()
+                .remove(&block.header.hash());
             self.blocks.write().unwrap().remove(&block.header.number);
             self.code_map.write().unwrap().rollback(block.header.number);
 

--- a/lib/ain-evm/src/storage/data_handler.rs
+++ b/lib/ain-evm/src/storage/data_handler.rs
@@ -20,12 +20,14 @@ pub static LATEST_BLOCK_DATA_PATH: &str = "latest_block_data.bin";
 pub static RECEIPT_MAP_PATH: &str = "receipt_map.bin";
 pub static CODE_MAP_PATH: &str = "code_map.bin";
 pub static TRANSACTION_DATA_PATH: &str = "transaction_data.bin";
+pub static BASE_FEE_MAP_PATH: &str = "base_fee_map.bin";
 
 type BlockHashtoBlock = HashMap<H256, U256>;
 type Blocks = HashMap<U256, BlockAny>;
 type TxHashToTx = HashMap<H256, TransactionV2>;
 type LatestBlockNumber = U256;
 type TransactionHashToReceipt = HashMap<H256, Receipt>;
+type BlockHashtoBaseFee = HashMap<H256, U256>;
 
 impl PersistentState for BlockHashtoBlock {}
 impl PersistentState for Blocks {}
@@ -43,6 +45,7 @@ pub struct BlockchainDataHandler {
     block_map: RwLock<BlockHashtoBlock>,
     blocks: RwLock<Blocks>,
     latest_block_number: RwLock<Option<LatestBlockNumber>>,
+    base_fee_map: RwLock<BlockHashtoBaseFee>,
 
     code_map: RwLock<CodeHistory>,
 }
@@ -68,6 +71,7 @@ impl BlockchainDataHandler {
                 TransactionHashToReceipt::load_from_disk(RECEIPT_MAP_PATH)
                     .expect("Error loading receipts data"),
             ),
+            base_fee_map: RwLock::new(BlockHashtoBaseFee::load_from_disk(BASE_FEE_MAP_PATH).unwrap_or_default()),
             code_map: RwLock::new(CodeHistory::load_from_disk(CODE_MAP_PATH).unwrap_or_default()),
         }
     }
@@ -169,6 +173,15 @@ impl BlockStorage for BlockchainDataHandler {
         let mut latest_block_number = self.latest_block_number.write().unwrap();
         *latest_block_number = block.map(|b| b.header.number);
     }
+
+    fn get_base_fee(&self, block_hash: &H256) -> Option<U256> {
+        self.base_fee_map.read().unwrap().get(block_hash).map(ToOwned::to_owned)
+    }
+
+    fn set_base_fee(&self, block_hash: H256, base_fee: U256) {
+        let mut base_fee_map = self.base_fee_map.write().unwrap();
+        base_fee_map.insert(block_hash, base_fee);
+    }
 }
 
 impl ReceiptStorage for BlockchainDataHandler {
@@ -243,6 +256,7 @@ impl Rollback for BlockchainDataHandler {
             }
 
             self.block_map.write().unwrap().remove(&block.header.hash());
+            self.base_fee_map.write().unwrap().remove(&block.header.hash());
             self.blocks.write().unwrap().remove(&block.header.number);
             self.code_map.write().unwrap().rollback(block.header.number);
 

--- a/lib/ain-evm/src/storage/mod.rs
+++ b/lib/ain-evm/src/storage/mod.rs
@@ -91,7 +91,8 @@ impl BlockStorage for Storage {
 
     fn set_base_fee(&self, block_hash: H256, base_fee: U256) {
         self.cache.set_base_fee(block_hash, base_fee);
-        self.blockchain_data_handler.set_base_fee(block_hash, base_fee);
+        self.blockchain_data_handler
+            .set_base_fee(block_hash, base_fee);
     }
 }
 

--- a/lib/ain-evm/src/storage/mod.rs
+++ b/lib/ain-evm/src/storage/mod.rs
@@ -78,6 +78,21 @@ impl BlockStorage for Storage {
         self.cache.put_latest_block(block);
         self.blockchain_data_handler.put_latest_block(block);
     }
+
+    fn get_base_fee(&self, block_hash: &H256) -> Option<U256> {
+        self.cache.get_base_fee(block_hash).or_else(|| {
+            let base_fee = self.blockchain_data_handler.get_base_fee(block_hash);
+            if let Some(base_fee) = base_fee {
+                self.cache.set_base_fee(*block_hash, base_fee);
+            }
+            base_fee
+        })
+    }
+
+    fn set_base_fee(&self, block_hash: H256, base_fee: U256) {
+        self.cache.set_base_fee(block_hash, base_fee);
+        self.blockchain_data_handler.set_base_fee(block_hash, base_fee);
+    }
 }
 
 impl TransactionStorage for Storage {

--- a/lib/ain-evm/src/storage/traits.rs
+++ b/lib/ain-evm/src/storage/traits.rs
@@ -18,6 +18,9 @@ pub trait BlockStorage {
     fn put_block(&self, block: &BlockAny);
     fn get_latest_block(&self) -> Option<BlockAny>;
     fn put_latest_block(&self, block: Option<&BlockAny>);
+
+    fn get_base_fee(&self, block_hash: &H256) -> Option<U256>;
+    fn set_base_fee(&self, block_hash: H256, base_fee: U256);
 }
 
 pub trait TransactionStorage {

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -252,6 +252,7 @@ impl<'a> Visitor<'a> for BlockNumberVisitor {
 }
 
 use std::str::FromStr;
+use ain_evm::block::FeeHistoryData;
 
 use crate::codegen::types::EthTransactionInfo;
 
@@ -322,6 +323,26 @@ impl Serialize for BlockTransactions {
         match *self {
             BlockTransactions::Hashes(ref hashes) => hashes.serialize(serializer),
             BlockTransactions::Full(ref ts) => ts.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcFeeHistory {
+    pub oldest_block: H256,
+    pub base_fee_per_gas: Vec<U256>,
+    pub gas_used_ratio: Vec<f64>,
+    pub reward: Option<Vec<Vec<U256>>>,
+}
+
+impl From<FeeHistoryData> for RpcFeeHistory {
+    fn from(value: FeeHistoryData) -> Self {
+        Self {
+            oldest_block: value.oldest_block,
+            base_fee_per_gas: value.base_fee_per_gas,
+            gas_used_ratio: value.gas_used_ratio,
+            reward: value.reward,
         }
     }
 }

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -78,7 +78,7 @@ impl RpcBlock {
             sha3_uncles: H256::default(),
             logs_bloom: format!("{:#x}", block.header.logs_bloom),
             size: format!("{header_size:#x}"),
-            base_fee_per_gas: base_fee
+            base_fee_per_gas: base_fee,
         }
     }
 }

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -31,10 +31,11 @@ pub struct RpcBlock {
     pub sha3_uncles: H256,
     pub logs_bloom: String,
     pub size: String,
+    pub base_fee_per_gas: U256,
 }
 
 impl RpcBlock {
-    pub fn from_block_with_tx(block: BlockAny, full_transactions: bool) -> Self {
+    pub fn from_block_with_tx(block: BlockAny, full_transactions: bool, base_fee: U256) -> Self {
         let header_size = block.header.rlp_bytes().len();
         RpcBlock {
             hash: block.header.hash(),
@@ -77,6 +78,7 @@ impl RpcBlock {
             sha3_uncles: H256::default(),
             logs_bloom: format!("{:#x}", block.header.logs_bloom),
             size: format!("{header_size:#x}"),
+            base_fee_per_gas: base_fee
         }
     }
 }

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -251,8 +251,8 @@ impl<'a> Visitor<'a> for BlockNumberVisitor {
     }
 }
 
-use std::str::FromStr;
 use ain_evm::block::FeeHistoryData;
+use std::str::FromStr;
 
 use crate::codegen::types::EthTransactionInfo;
 

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -35,7 +35,11 @@ pub struct RpcBlock {
 }
 
 impl RpcBlock {
-    pub fn from_block_with_tx(block: BlockAny, full_transactions: bool, base_fee: U256) -> Self {
+    pub fn from_block_with_tx_and_base_fee(
+        block: BlockAny,
+        full_transactions: bool,
+        base_fee: U256,
+    ) -> Self {
         let header_size = block.header.rlp_bytes().len();
         RpcBlock {
             hash: block.header.hash(),

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -685,15 +685,13 @@ impl MetachainRPCServer for MetachainRPCModule {
 
     fn fee_history(
         &self,
-        block_count: usize,
+        block_count: U256,
         first_block: U256,
-        descending: bool,
         priority_fee_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory> {
         Ok(RpcFeeHistory::from(self.handler.block.fee_history(
-            block_count,
+            block_count.as_usize(),
             first_block,
-            true,
             priority_fee_percentile,
         )))
     }

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockNumber, RpcBlock};
+use crate::block::{BlockNumber, RpcBlock, RpcFeeHistory};
 use crate::bytes::Bytes;
 use crate::call_request::CallRequest;
 use crate::codegen::types::EthTransactionInfo;
@@ -8,6 +8,7 @@ use crate::transaction_request::{TransactionMessage, TransactionRequest};
 use ain_cpp_imports::get_eth_priv_key;
 use ain_evm::executor::TxResponse;
 use ain_evm::handler::Handlers;
+use ain_evm::block::FeeHistoryData;
 
 use ain_evm::storage::traits::{BlockStorage, ReceiptStorage, TransactionStorage};
 use ain_evm::transaction::{SignedTx, TransactionError};
@@ -192,6 +193,9 @@ pub trait MetachainRPC {
     /// Returns current gas_price.
     #[method(name = "gasPrice")]
     fn gas_price(&self) -> RpcResult<U256>;
+
+    #[method(name = "feeHistory")]
+    fn fee_history(&self, block_count: usize, first_block: U256, descending: bool, priority_fee_percentile: Vec<usize>) -> RpcResult<RpcFeeHistory>;
 }
 
 pub struct MetachainRPCModule {
@@ -671,6 +675,10 @@ impl MetachainRPCServer for MetachainRPCModule {
 
     fn eth_submithashrate(&self, _hashrate: String, _id: String) -> RpcResult<bool> {
         Ok(false)
+    }
+
+    fn fee_history(&self, block_count: usize, first_block: U256, descending: bool, priority_fee_percentile: Vec<usize>) -> RpcResult<RpcFeeHistory> {
+        Ok(RpcFeeHistory::from(self.handler.block.fee_history(block_count, first_block, true, priority_fee_percentile)))
     }
 }
 

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -6,9 +6,9 @@ use crate::codegen::types::EthTransactionInfo;
 use crate::receipt::ReceiptResult;
 use crate::transaction_request::{TransactionMessage, TransactionRequest};
 use ain_cpp_imports::get_eth_priv_key;
+use ain_evm::block::FeeHistoryData;
 use ain_evm::executor::TxResponse;
 use ain_evm::handler::Handlers;
-use ain_evm::block::FeeHistoryData;
 
 use ain_evm::storage::traits::{BlockStorage, ReceiptStorage, TransactionStorage};
 use ain_evm::transaction::{SignedTx, TransactionError};
@@ -195,7 +195,13 @@ pub trait MetachainRPC {
     fn gas_price(&self) -> RpcResult<U256>;
 
     #[method(name = "feeHistory")]
-    fn fee_history(&self, block_count: usize, first_block: U256, descending: bool, priority_fee_percentile: Vec<usize>) -> RpcResult<RpcFeeHistory>;
+    fn fee_history(
+        &self,
+        block_count: usize,
+        first_block: U256,
+        descending: bool,
+        priority_fee_percentile: Vec<usize>,
+    ) -> RpcResult<RpcFeeHistory>;
 }
 
 pub struct MetachainRPCModule {
@@ -677,8 +683,19 @@ impl MetachainRPCServer for MetachainRPCModule {
         Ok(false)
     }
 
-    fn fee_history(&self, block_count: usize, first_block: U256, descending: bool, priority_fee_percentile: Vec<usize>) -> RpcResult<RpcFeeHistory> {
-        Ok(RpcFeeHistory::from(self.handler.block.fee_history(block_count, first_block, true, priority_fee_percentile)))
+    fn fee_history(
+        &self,
+        block_count: usize,
+        first_block: U256,
+        descending: bool,
+        priority_fee_percentile: Vec<usize>,
+    ) -> RpcResult<RpcFeeHistory> {
+        Ok(RpcFeeHistory::from(self.handler.block.fee_history(
+            block_count,
+            first_block,
+            true,
+            priority_fee_percentile,
+        )))
     }
 }
 

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -341,8 +341,9 @@ impl MetachainRPCServer for MetachainRPCModule {
             .get_block_by_hash(&hash)
             .map_or(Ok(None), |block| {
                 Ok(Some(RpcBlock::from_block_with_tx(
-                    block,
+                    block.clone(),
                     full_transactions.unwrap_or_default(),
+                    self.handler.storage.get_base_fee(&hash).unwrap_or_default()
                 )))
             })
     }
@@ -382,8 +383,9 @@ impl MetachainRPCServer for MetachainRPCModule {
             .get_block_by_number(&block_number)
             .map_or(Ok(None), |block| {
                 Ok(Some(RpcBlock::from_block_with_tx(
-                    block,
+                    block.clone(),
                     full_transactions.unwrap_or_default(),
+                    self.handler.storage.get_base_fee(&block.header.hash()).unwrap_or_default()
                 )))
             })
     }

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -343,7 +343,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 Ok(Some(RpcBlock::from_block_with_tx(
                     block.clone(),
                     full_transactions.unwrap_or_default(),
-                    self.handler.storage.get_base_fee(&hash).unwrap_or_default()
+                    self.handler.storage.get_base_fee(&hash).unwrap_or_default(),
                 )))
             })
     }
@@ -385,7 +385,10 @@ impl MetachainRPCServer for MetachainRPCModule {
                 Ok(Some(RpcBlock::from_block_with_tx(
                     block.clone(),
                     full_transactions.unwrap_or_default(),
-                    self.handler.storage.get_base_fee(&block.header.hash()).unwrap_or_default()
+                    self.handler
+                        .storage
+                        .get_base_fee(&block.header.hash())
+                        .unwrap_or_default(),
                 )))
             })
     }

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -351,8 +351,8 @@ impl MetachainRPCServer for MetachainRPCModule {
             .storage
             .get_block_by_hash(&hash)
             .map_or(Ok(None), |block| {
-                Ok(Some(RpcBlock::from_block_with_tx(
-                    block.clone(),
+                Ok(Some(RpcBlock::from_block_with_tx_and_base_fee(
+                    block,
                     full_transactions.unwrap_or_default(),
                     self.handler.storage.get_base_fee(&hash).unwrap_or_default(),
                 )))
@@ -393,12 +393,13 @@ impl MetachainRPCServer for MetachainRPCModule {
             .storage
             .get_block_by_number(&block_number)
             .map_or(Ok(None), |block| {
-                Ok(Some(RpcBlock::from_block_with_tx(
-                    block.clone(),
+                let tx_hash = &block.header.hash();
+                Ok(Some(RpcBlock::from_block_with_tx_and_base_fee(
+                    block,
                     full_transactions.unwrap_or_default(),
                     self.handler
                         .storage
-                        .get_base_fee(&block.header.hash())
+                        .get_base_fee(tx_hash)
                         .unwrap_or_default(),
                 )))
             })

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -657,9 +657,9 @@ impl MetachainRPCServer for MetachainRPCModule {
     }
 
     fn gas_price(&self) -> RpcResult<U256> {
-        let gas_price = ain_cpp_imports::get_min_relay_tx_fee().unwrap_or(10);
+        let gas_price = self.handler.block.get_legacy_fee();
         debug!(target:"rpc","gasPrice: {:#?}", gas_price);
-        Ok(U256::from(gas_price))
+        Ok(gas_price)
     }
 
     fn get_receipt(&self, hash: H256) -> RpcResult<Option<ReceiptResult>> {

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -200,6 +200,9 @@ pub trait MetachainRPC {
         first_block: U256,
         priority_fee_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory>;
+
+    #[method(name = "maxPriorityFeePerGas")]
+    fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 }
 
 pub struct MetachainRPCModule {
@@ -692,6 +695,10 @@ impl MetachainRPCServer for MetachainRPCModule {
             first_block,
             priority_fee_percentile,
         )))
+    }
+
+    fn max_priority_fee_per_gas(&self) -> RpcResult<U256> {
+        Ok(self.handler.block.suggested_priority_fee())
     }
 }
 

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -6,7 +6,6 @@ use crate::codegen::types::EthTransactionInfo;
 use crate::receipt::ReceiptResult;
 use crate::transaction_request::{TransactionMessage, TransactionRequest};
 use ain_cpp_imports::get_eth_priv_key;
-use ain_evm::block::FeeHistoryData;
 use ain_evm::executor::TxResponse;
 use ain_evm::handler::Handlers;
 
@@ -197,9 +196,8 @@ pub trait MetachainRPC {
     #[method(name = "feeHistory")]
     fn fee_history(
         &self,
-        block_count: usize,
+        block_count: U256,
         first_block: U256,
-        descending: bool,
         priority_fee_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory>;
 }


### PR DESCRIPTION
- Adds `baseFeePerGas` to block
- Base fee variation by gas usage
- `eth_maxPriorityFeePerGas` and `eth_feeHistory` RPCs

## Notes

- ~Base fee currently increases very fast very quickly due to low number of transactions and high number of transfer transactions which leads to a high `block gas usage / block gas limit` ratio~ Solved by fixing block gas limit and introducing minimum base fee.
- ~Does not include `eth_gasPrice`~
- Currently does not account for native fees