### PR TITLE
evm: Fix genesis block number

### DIFF
--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -17,9 +17,7 @@ impl BlockHandler {
     pub fn get_latest_block_hash_and_number(&self) -> Option<(H256, U256)> {
         self.storage
             .get_latest_block()
-            .map(|latest_block| {
-                (latest_block.header.hash(), latest_block.header.number)
-            })
+            .map(|latest_block| (latest_block.header.hash(), latest_block.header.number))
     }
 
     pub fn get_latest_state_root(&self) -> H256 {

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -14,10 +14,10 @@ impl BlockHandler {
         Self { storage }
     }
 
-    pub fn get_latest_block_hash_and_number(&self) -> (H256, U256) {
+    pub fn get_latest_block_hash_and_number(&self) -> Option<(H256, U256)> {
         self.storage
             .get_latest_block()
-            .map_or((H256::default(), U256::zero()), |latest_block| {
+            .map(|latest_block| {
                 (latest_block.header.hash(), latest_block.header.number)
             })
     }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction::SignedTx,
 };
 use anyhow::anyhow;
-use ethereum::{AccessList, Account, Block, BlockV2, Header, Log, TransactionV2};
+use ethereum::{AccessList, Account, Log, TransactionV2};
 use ethereum_types::{Bloom, BloomInput};
 
 use hex::FromHex;

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction::SignedTx,
 };
 use anyhow::anyhow;
-use ethereum::{AccessList, Account, Log, TransactionV2};
+use ethereum::{AccessList, Account, Block, BlockV2, Header, Log, TransactionV2};
 use ethereum_types::{Bloom, BloomInput};
 
 use hex::FromHex;

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -57,7 +57,7 @@ impl Handlers {
         let mut gas_used = 0u64;
         let mut logs_bloom: Bloom = Bloom::default();
 
-        let (parent_hash, parent_number) = self.block.get_latest_block_hash_and_number();
+        let parent_data = self.block.get_latest_block_hash_and_number();
         let state_root = self
             .storage
             .get_latest_block()
@@ -65,11 +65,27 @@ impl Handlers {
                 block.header.state_root
             });
 
-        let vicinity = Vicinity {
-            beneficiary,
-            timestamp: U256::from(timestamp),
-            block_number: parent_number + 1,
-            ..Default::default()
+        let (vicinity, parent_hash, current_block_number) = match parent_data {
+            None => (
+                Vicinity {
+                    beneficiary,
+                    timestamp: U256::from(timestamp),
+                    block_number: U256::from(0),
+                    ..Default::default()
+                },
+                H256::zero(),
+                U256::from(0),
+            ),
+            Some((hash, number)) => (
+                Vicinity {
+                    beneficiary,
+                    timestamp: U256::from(timestamp),
+                    block_number: number + 1,
+                    ..Default::default()
+                },
+                hash,
+                number + 1,
+            ),
         };
 
         let mut backend = EVMBackend::from_root(
@@ -149,7 +165,7 @@ impl Handlers {
                 receipts_root: ReceiptHandler::get_receipts_root(&receipts_v3),
                 logs_bloom,
                 difficulty: U256::from(difficulty),
-                number: parent_number + 1,
+                number: current_block_number,
                 gas_limit: U256::from(30_000_000),
                 gas_used: U256::from(gas_used),
                 timestamp,


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Initial block was being assigned block `0x1`. This PR fixes it such that the blocks now start at `0x0`.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
