### PR TITLE
Cap data in transferdomain

### DIFF
--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -11,15 +11,15 @@
 
 class DeFiErrors {
 public:
-    static Res MNInvalid(const std::string &nodeRefString) { 
+    static Res MNInvalid(const std::string &nodeRefString) {
         return Res::Err("node %s does not exists", nodeRefString);
     }
 
-    static Res MNInvalidAltMsg(const std::string &nodeRefString) { 
+    static Res MNInvalidAltMsg(const std::string &nodeRefString) {
         return Res::Err("masternode %s does not exist", nodeRefString);
     }
 
-    static Res MNStateNotEnabled(const std::string &nodeRefString) { 
+    static Res MNStateNotEnabled(const std::string &nodeRefString) {
         return Res::Err("Masternode %s is not in 'ENABLED' state", nodeRefString);
     }
 
@@ -178,8 +178,8 @@ public:
         return Res::Err("Negative price (%s/%s)", tokenSymbol, currency);
     }
 
-    static Res AmountOverflowAsValuePrice(const CAmount amount, const CAmount price) { 
-        return Res::Err("Value/price too high (%s/%s)", GetDecimalString(amount), GetDecimalString(price)); 
+    static Res AmountOverflowAsValuePrice(const CAmount amount, const CAmount price) {
+        return Res::Err("Value/price too high (%s/%s)", GetDecimalString(amount), GetDecimalString(price));
     }
 
     static Res GovVarVerifyInt() {
@@ -396,6 +396,10 @@ public:
 
     static Res TransferDomainNotEnoughBalance(const std::string address) {
         return Res::Err("Not enough balance in %s to cover \"EVM\" domain transfer", address);
+    }
+
+    static Res TransferDomainInvalidDataSize(const uint32_t max_data) {
+        return Res::Err("Excess data set, maximum allow is %d", max_data);
     }
 
     static Res InvalidAuth() {

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3846,6 +3846,10 @@ public:
                 balanceIn *= CAMOUNT_TO_GWEI * WEI_IN_GWEI;
                 evm_add_balance(evmContext, HexStr(toAddress.begin(), toAddress.end()), ArithToUint256(balanceIn).ToArrayReversed(), tx.GetHash().ToArrayReversed());
             }
+
+            if (src.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN || dst.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN) {
+                return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
+            }
         }
 
         return res;

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -68,6 +68,8 @@ enum AuthStrategy: uint32_t {
 
 constexpr uint8_t MAX_POOL_SWAPS = 3;
 
+constexpr uint32_t MAX_TRANSFERDOMAIN_EVM_DATA_LEN = 0;
+
 enum CustomTxErrCodes : uint32_t {
     NotSpecified = 0,
     //    NotCustomTx  = 1,


### PR DESCRIPTION
Currently the only limit on the data in CTransferDomainItem is the cap set by the OP_RETURN limit, however this limit is only a policy and not consensus. This PR sets a well defined limit for the EVM domain which is 0.