### PR TITLE
EVM: Default CallRequest gas_limit to MAX_GAS_PER_BLOCK

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -24,6 +24,8 @@ use vsdb_core::vsdb_set_base_dir;
 
 pub type NativeTxHash = [u8; 32];
 
+pub const MAX_GAS_PER_BLOCK: U256 = U256([30_000_000, 0, 0, 0]);
+
 pub struct EVMHandler {
     pub tx_queues: Arc<TransactionQueueMap>,
     pub trie_store: Arc<TrieDBStore>,
@@ -196,8 +198,6 @@ impl EVMHandler {
 
         let gas_limit = signed_tx.gas_limit();
 
-        // TODO lift MAX_GAS_PER_BLOCK
-        const MAX_GAS_PER_BLOCK: U256 = U256([30_000_000, 0, 0, 0]);
         debug!(
             "[validate_raw_tx] MAX_GAS_PER_BLOCK: {:#x}",
             MAX_GAS_PER_BLOCK

--- a/lib/ain-evm/src/handler.rs
+++ b/lib/ain-evm/src/handler.rs
@@ -1,6 +1,6 @@
 use crate::backend::{EVMBackend, Vicinity};
 use crate::block::BlockHandler;
-use crate::evm::EVMHandler;
+use crate::evm::{EVMHandler, MAX_GAS_PER_BLOCK};
 use crate::executor::{AinExecutor, TxResponse};
 use crate::receipt::ReceiptHandler;
 use crate::storage::traits::BlockStorage;
@@ -191,7 +191,7 @@ impl Handlers {
                 logs_bloom,
                 difficulty: U256::from(difficulty),
                 number: current_block_number,
-                gas_limit: U256::from(30_000_000),
+                gas_limit: U256::from(MAX_GAS_PER_BLOCK),
                 gas_used: U256::from(gas_used),
                 timestamp,
                 extra_data: Vec::default(),

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -277,7 +277,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 &input
                     .map(|d| d.0)
                     .unwrap_or(data.map(|d| d.0).unwrap_or_default()),
-                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(), // Default to MAX_BLOCK_GAS_LIMIT
+                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(),
                 vec![],
                 self.block_number_to_u256(block_number),
             )
@@ -667,7 +667,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 to,
                 value.unwrap_or_default(),
                 &data.map(|d| d.0).unwrap_or_default(),
-                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(), // Default to MAX_BLOCK_GAS_LIMIT
+                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(),
                 vec![],
                 block_number,
             )

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -7,6 +7,7 @@ use crate::receipt::ReceiptResult;
 use crate::transaction_request::{TransactionMessage, TransactionRequest};
 use crate::utils::{format_h256, format_u256};
 use ain_cpp_imports::get_eth_priv_key;
+use ain_evm::evm::MAX_GAS_PER_BLOCK;
 use ain_evm::executor::TxResponse;
 use ain_evm::handler::Handlers;
 
@@ -276,7 +277,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 &input
                     .map(|d| d.0)
                     .unwrap_or(data.map(|d| d.0).unwrap_or_default()),
-                gas.unwrap_or(U256::from(u64::MAX)).as_u64(),
+                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(), // Default to MAX_BLOCK_GAS_LIMIT
                 vec![],
                 self.block_number_to_u256(block_number),
             )
@@ -666,7 +667,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 to,
                 value.unwrap_or_default(),
                 &data.map(|d| d.0).unwrap_or_default(),
-                gas.unwrap_or(U256::from(u64::MAX)).as_u64(),
+                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(), // Default to MAX_BLOCK_GAS_LIMIT
                 vec![],
                 block_number,
             )


### PR DESCRIPTION

## Summary

- Default CallRequest gas_limit to MAX_GAS_PER_BLOCK
