### PR TITLE
Fix test-sync CI

### DIFF
--- a/.github/workflows/tests-sync.yml
+++ b/.github/workflows/tests-sync.yml
@@ -36,7 +36,7 @@ jobs:
       run: ./make.sh ci-setup-deps-target
 
     - name: Install dependencies for test
-      run: ./make.sh ci-setup-deps-test
+      run: sudo ./make.sh ci-setup-deps-test
 
       # TODO: Switch this to a docker build later and this builds on the native
       # VM toolchain and loses disparity with the CI release builds


### PR DESCRIPTION
## Summary

- Rsolved CI failing from installing deps_test due to python3 interpreter used on the self hosted runner is the system python.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
