### PR TITLE
Fix evm tx hash and add test case

### DIFF
--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3878,7 +3878,7 @@ public:
         std::vector<unsigned char> evmTxHashBytes;
         sha3(obj.evmTx, evmTxHashBytes);
         auto txHash = tx.GetHash();
-        auto evmTxHash = uint256(evmTxHashBytes);
+        auto evmTxHash = uint256S(HexStr(evmTxHashBytes));
         mnview.SetVMDomainMapTxHash(VMDomainMapType::DVMToEVM, txHash, evmTxHash);
         mnview.SetVMDomainMapTxHash(VMDomainMapType::EVMToDVM, evmTxHash, txHash);
         return Res::Ok();

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -167,11 +167,12 @@ class EVMTest(DefiTestFramework):
         assert_raises_rpc_error(-5, "0x0000000000000000000000000000000000000000 does not refer to a key", self.nodes[0].vmmap, eth_address, 2)
         assert_raises_rpc_error(-5, "Invalid address: test", self.nodes[0].vmmap, 'test', 1)
 
-        #Check if xvmmap is working for Txs
+        # Check if xvmmap is working for Txs
         list_tx = self.nodes[0].logvmmaps(1)
         dvm_tx = list(list_tx['indexes'].keys())[0]
         evm_tx = self.nodes[0].vmmap(dvm_tx, 3)
         assert_equal(dvm_tx, self.nodes[0].vmmap(evm_tx, 4))
+        assert_equal("0x" + evm_tx, self.nodes[0].eth_getBlockByNumber("latest", False)['transactions'][0])
 
         # Check vmmap fail on wrong tx
         evm_tx = '0x0000000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
## Summary

- Fix for the vmmap function. The SHA3 function was giving a reverse hash of the transaction. also added a test to check that it's working.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
