### PR TITLE
Refine Cargo / C++ build integration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 # We set this so that Makefile based
 # builds and ad-hoc cargo invocations all
 # result in the consistent compilation
-target-dir = "../build/lib/target"
+target-dir = "./build/lib/target"
 
 # We temporarily ignore linkages until
 # we fix cpp links 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,22 +3,3 @@
 # builds and ad-hoc cargo invocations all
 # result in the consistent compilation
 target-dir = "./build/lib/target"
-
-# We temporarily ignore linkages until
-# we fix cpp links 
-rustflags = [
-  "-C", "link-arg=-z",
-  "-C", "link-arg=undefs",
-]
-
-[target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 
 # Editors.
 *.sw*
-.vscode
+.vscode/settings.json
 .clangd
 
 # Misc

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,8 @@
 
 # Editors.
 *.sw*
-.vscode/settings.json
+.vscode
+!.vscode/settings.default.json
 .clangd
 
 # Misc

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # Editors.
 *.sw*
-.vscode
+.vscode/settings.json
 .clangd
 
 # Misc

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 
 # Editors.
 *.sw*
-.vscode/settings.json
+.vscode
+!.vscode/settings.default.json
 .clangd
 
 # Misc

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.assist.expressionFillDefault": "default",
+    "rust-analyzer.cargo.buildScripts.overrideCommand": ["../make.sh", "rust-analyzer-check" ],
+    "rust-analyzer.check.overrideCommand":  ["../make.sh", "rust-analyzer-check" ],
+    "rust-analyzer.workspace.symbol.search.kind": "all_symbols"
+}

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,4 +1,6 @@
 {
+    // Recommended default config. Place into settings.json
+    // or copy over as `.vscode/settings.json` to take effect.
     "rust-analyzer.assist.expressionFillDefault": "default",
     "rust-analyzer.cargo.buildScripts.overrideCommand": ["../make.sh", "rust-analyzer-check" ],
     "rust-analyzer.check.overrideCommand":  ["../make.sh", "rust-analyzer-check" ],

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,11 +52,6 @@ DIST_SHARE = \
 BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
            $(top_srcdir)/contrib/devtools/security-check.py
 
-COVERAGE_INFO = baseline.info \
-  test_defi_filtered.info total_coverage.info \
-  baseline_filtered.info functional_test.info functional_test_filtered.info \
-  test_defi_coverage.info test_defi.info
-
 dist-hook:
 	-$(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
 
@@ -69,51 +64,6 @@ $(DEFI_CLI_BIN): FORCE
 $(DEFI_TX_BIN): FORCE
 	$(MAKE) -C src $(@F)
 
-if USE_LCOV
-LCOV_FILTER_PATTERN=-p "/usr/include/" -p "/usr/lib/" -p "src/leveldb/" -p "src/bench/" -p "src/univalue" -p "src/crypto/ctaes" -p "src/secp256k1"
-
-baseline.info:
-	$(LCOV) -c -i -d $(abs_builddir)/src -o $@
-
-baseline_filtered.info: baseline.info
-	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@
-	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
-
-test_defi.info: baseline_filtered.info
-	$(MAKE) -C src/ check
-	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src -t test_defi -o $@
-	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
-
-test_defi_filtered.info: test_defi.info
-	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@
-	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
-
-functional_test.info: test_defi_filtered.info
-	@TIMEOUT=15 test/functional/test_runner.py $(EXTENDED_FUNCTIONAL_TESTS)
-	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t functional-tests -o $@
-	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
-
-functional_test_filtered.info: functional_test.info
-	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@
-	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
-
-test_defi_coverage.info: baseline_filtered.info test_defi_filtered.info
-	$(LCOV) -a $(LCOV_OPTS) baseline_filtered.info -a test_defi_filtered.info -o $@
-
-total_coverage.info: test_defi_filtered.info functional_test_filtered.info
-	$(LCOV) -a $(LCOV_OPTS) baseline_filtered.info -a test_defi_filtered.info -a functional_test_filtered.info -o $@ | $(GREP) "\%" | $(AWK) '{ print substr($$3,2,50) "/" $$5 }' > coverage_percent.txt
-
-test_defi.coverage/.dirstamp:  test_defi_coverage.info
-	$(GENHTML) -s $(LCOV_OPTS) $< -o $(@D)
-	@touch $@
-
-total.coverage/.dirstamp: total_coverage.info
-	$(GENHTML) -s $(LCOV_OPTS) $< -o $(@D)
-	@touch $@
-
-cov: test_defi.coverage/.dirstamp total.coverage/.dirstamp
-
-endif
 
 dist_noinst_SCRIPTS = autogen.sh
 
@@ -125,61 +75,12 @@ EXTRA_DIST += \
 
 EXTRA_DIST += \
     test/util/defi-util-test.py \
-    test/util/data/defi-util-test.json \
-    test/util/data/blanktxv1.hex \
-    test/util/data/blanktxv1.json \
-    test/util/data/blanktxv2.hex \
-    test/util/data/blanktxv2.json \
-    test/util/data/tt-delin1-out.hex \
-    test/util/data/tt-delin1-out.json \
-    test/util/data/tt-delout1-out.hex \
-    test/util/data/tt-delout1-out.json \
-    test/util/data/tt-locktime317000-out.hex \
-    test/util/data/tt-locktime317000-out.json \
-    test/util/data/tx394b54bb.hex \
-    test/util/data/txcreate1.hex \
-    test/util/data/txcreate1.json \
-    test/util/data/txcreate2.hex \
-    test/util/data/txcreate2.json \
-    test/util/data/txcreatedata1.hex \
-    test/util/data/txcreatedata1.json \
-    test/util/data/txcreatedata2.hex \
-    test/util/data/txcreatedata2.json \
-    test/util/data/txcreatedata_seq0.hex \
-    test/util/data/txcreatedata_seq0.json \
-    test/util/data/txcreatedata_seq1.hex \
-    test/util/data/txcreatedata_seq1.json \
-    test/util/data/txcreatemultisig1.hex \
-    test/util/data/txcreatemultisig1.json \
-    test/util/data/txcreatemultisig2.hex \
-    test/util/data/txcreatemultisig2.json \
-    test/util/data/txcreatemultisig3.hex \
-    test/util/data/txcreatemultisig3.json \
-    test/util/data/txcreatemultisig4.hex \
-    test/util/data/txcreatemultisig4.json \
-    test/util/data/txcreatemultisig5.json \
-    test/util/data/txcreateoutpubkey1.hex \
-    test/util/data/txcreateoutpubkey1.json \
-    test/util/data/txcreateoutpubkey2.hex \
-    test/util/data/txcreateoutpubkey2.json \
-    test/util/data/txcreateoutpubkey3.hex \
-    test/util/data/txcreateoutpubkey3.json \
-    test/util/data/txcreatescript1.hex \
-    test/util/data/txcreatescript1.json \
-    test/util/data/txcreatescript2.hex \
-    test/util/data/txcreatescript2.json \
-    test/util/data/txcreatescript3.hex \
-    test/util/data/txcreatescript3.json \
-    test/util/data/txcreatescript4.hex \
-    test/util/data/txcreatescript4.json \
-    test/util/data/txcreatesignv1.hex \
-    test/util/data/txcreatesignv1.json \
-    test/util/data/txcreatesignv2.hex \
-    test/util/rpcauth-test.py
+    test/util/rpcauth-test.py \
+    $(wildcard test/util/data/*)
 
 CLEANFILES = 
 
-.INTERMEDIATE: $(COVERAGE_INFO)
+.INTERMEDIATE: 
 
 DISTCHECK_CONFIGURE_FLAGS = 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1371,15 +1371,15 @@ AC_SUBST(PROTOC_INCLUDE_DIR)
 
 dnl If the host and build triplets are the same, we keep this empty
 if test x$host = x$build; then
-  CARGO_BUILD_TARGET=
+  RUST_TARGET=
 else
-  CARGO_BUILD_TARGET=`TARGET="$host" $ac_abs_confdir/make.sh get_rust_target`
+  RUST_TARGET=`TARGET="$host" $ac_abs_confdir/make.sh get_rust_target`
   if test $? != 0; then
     AC_MSG_ERROR("unsupported host target")
   fi
 fi
-AC_SUBST(CARGO_BUILD_TARGET)
-AM_CONDITIONAL([HAVE_CARGO_BUILD_TARGET], [test x$CARGO_BUILD_TARGET != x])
+AC_SUBST(RUST_TARGET)
+AM_CONDITIONAL([HAVE_RUST_TARGET], [test x$RUST_TARGET != x])
 
 AC_CONFIG_FILES([Makefile src/Makefile lib/Makefile test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
@@ -1468,6 +1468,6 @@ echo "  CXXFLAGS            = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS 
 echo "  LDFLAGS             = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
 echo "  ARFLAGS             = $ARFLAGS"
 echo "  CARGO               = $CARGO"
-echo "  CARGO_BUILD_TARGET  = $CARGO_BUILD_TARGET"
+echo "  RUST_TARGET         = $RUST_TARGET"
 echo "  ENABLE_DEBUG        = $ENABLE_DEBUG"
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -83,15 +83,11 @@ dnl Check/return PATH for base programs.
 AC_PATH_TOOL(AR, ar)
 AC_PATH_TOOL(RANLIB, ranlib)
 AC_PATH_TOOL(STRIP, strip)
-AC_PATH_TOOL(GCOV, gcov)
-AC_PATH_PROG(LCOV, lcov)
 dnl Python 3.5 is specified in .python-version and should be used if available, see doc/dependencies.md
 AC_PATH_PROGS([PYTHON], [python3.5 python3.6 python3.7 python3.8 python3 python])
-AC_PATH_PROG(GENHTML, genhtml)
 AC_PATH_PROG([GIT], [git])
 AC_PATH_PROG(CCACHE,ccache)
-AC_PATH_PROG(XGETTEXT,xgettext)
-AC_PATH_PROG(HEXDUMP,hexdump)
+AC_PATH_PROG(HEXDUMP, hexdump)
 AC_PATH_TOOL(READELF, readelf)
 AC_PATH_TOOL(CPPFILT, c++filt)
 AC_PATH_TOOL(OBJCOPY, objcopy)
@@ -144,7 +140,7 @@ AC_ARG_ENABLE(bench,
     [use_bench=yes])
 
 AC_ARG_ENABLE([extended-functional-tests],
-    AS_HELP_STRING([--enable-extended-functional-tests],[enable expensive functional tests when using lcov (default no)]),
+    AS_HELP_STRING([--enable-extended-functional-tests],[enable expensive functional tests]),
     [use_extended_functional_tests=$enableval],
     [use_extended_functional_tests=no])
 
@@ -171,18 +167,6 @@ AC_ARG_ENABLE([ccache],
   [do not use ccache for building (default is to use if found)])],
   [use_ccache=$enableval],
   [use_ccache=auto])
-
-AC_ARG_ENABLE([lcov],
-  [AS_HELP_STRING([--enable-lcov],
-  [enable lcov testing (default is no)])],
-  [use_lcov=$enableval],
-  [use_lcov=no])
-
-AC_ARG_ENABLE([lcov-branch-coverage],
-  [AS_HELP_STRING([--enable-lcov-branch-coverage],
-  [enable lcov testing branch coverage (default is no)])],
-  [use_lcov_branch=yes],
-  [use_lcov_branch=no])
 
 AC_ARG_ENABLE([glibc-back-compat],
   [AS_HELP_STRING([--enable-glibc-back-compat],
@@ -608,32 +592,6 @@ fi
 
 if test x$use_extended_functional_tests != xno; then
   AC_SUBST(EXTENDED_FUNCTIONAL_TESTS, --extended)
-fi
-
-if test x$use_lcov = xyes; then
-  if test x$LCOV = x; then
-    AC_MSG_ERROR("lcov testing requested but lcov not found")
-  fi
-  if test x$GCOV = x; then
-    AC_MSG_ERROR("lcov testing requested but gcov not found")
-  fi
-  if test x$PYTHON = x; then
-    AC_MSG_ERROR("lcov testing requested but python not found")
-  fi
-  if test x$GENHTML = x; then
-    AC_MSG_ERROR("lcov testing requested but genhtml not found")
-  fi
-  LCOV="$LCOV --gcov-tool=$GCOV"
-  AX_CHECK_LINK_FLAG([[--coverage]], [LDFLAGS="$LDFLAGS --coverage"],
-    [AC_MSG_ERROR("lcov testing requested but --coverage linker flag does not work")])
-  AX_CHECK_COMPILE_FLAG([--coverage],[CXXFLAGS="$CXXFLAGS --coverage"],
-    [AC_MSG_ERROR("lcov testing requested but --coverage flag does not work")])
-  AC_DEFINE(USE_COVERAGE, 1, [Define this symbol if coverage is enabled])
-  CXXFLAGS="$CXXFLAGS -Og"
-fi
-
-if test x$use_lcov_branch != xno; then
-  AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
 dnl Check for endianness
@@ -1335,7 +1293,6 @@ AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_FUZZ],[test x$enable_fuzz = xyes])
 AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xno])
-AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 AM_CONDITIONAL([ENABLE_SSE42],[test x$enable_sse42 = xyes])
@@ -1412,17 +1369,17 @@ AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(PROTOC)
 AC_SUBST(PROTOC_INCLUDE_DIR)
 
-dnl If the host and build triplets are the same, we don't 
-dnl keep this empty
+dnl If the host and build triplets are the same, we keep this empty
 if test x$host = x$build; then
-  RUST_TARGET=
+  CARGO_BUILD_TARGET=
 else
-  RUST_TARGET=`TARGET="$host" $ac_abs_confdir/make.sh get_rust_target`
+  CARGO_BUILD_TARGET=`TARGET="$host" $ac_abs_confdir/make.sh get_rust_target`
   if test $? != 0; then
     AC_MSG_ERROR("unsupported host target")
   fi
 fi
-AC_SUBST(RUST_TARGET)
+AC_SUBST(CARGO_BUILD_TARGET)
+AM_CONDITIONAL([HAVE_CARGO_BUILD_TARGET], [test x$CARGO_BUILD_TARGET != x])
 
 AC_CONFIG_FILES([Makefile src/Makefile lib/Makefile test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
@@ -1485,32 +1442,32 @@ esac
 
 echo
 echo "Options used to compile and link:"
-echo "  with wallet   = $enable_wallet"
-echo "  with zmq      = $use_zmq"
-echo "  with test     = $use_tests"
+echo "  with wallet         = $enable_wallet"
+echo "  with zmq            = $use_zmq"
+echo "  with test           = $use_tests"
 if test x$use_tests != xno; then
-    echo "    with prop   = $enable_property_tests"
-    echo "    with fuzz   = $enable_fuzz"
+    echo "    with prop         = $enable_property_tests"
+    echo "    with fuzz         = $enable_fuzz"
 fi
-echo "  with bench    = $use_bench"
-echo "  with upnp     = $use_upnp"
-echo "  use asm       = $use_asm"
-echo "  sanitizers    = $use_sanitizers"
-echo "  debug enabled = $enable_debug"
-echo "  gprof enabled = $enable_gprof"
-echo "  werror        = $enable_werror"
+echo "  with bench          = $use_bench"
+echo "  with upnp           = $use_upnp"
+echo "  use asm             = $use_asm"
+echo "  sanitizers          = $use_sanitizers"
+echo "  debug enabled       = $enable_debug"
+echo "  gprof enabled       = $enable_gprof"
+echo "  werror              = $enable_werror"
 echo
-echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  target os           = $TARGET_OS"
+echo "  build os            = $BUILD_OS"
 echo
-echo "  CC            = $CC"
-echo "  CFLAGS        = $CFLAGS"
-echo "  CPPFLAGS      = $DEBUG_CPPFLAGS $HARDENED_CPPFLAGS $CPPFLAGS"
-echo "  CXX           = $CXX"
-echo "  CXXFLAGS      = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS $NOWARN_CXXFLAGS $ERROR_CXXFLAGS $GPROF_CXXFLAGS $CXXFLAGS"
-echo "  LDFLAGS       = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
-echo "  ARFLAGS       = $ARFLAGS"
-echo "  CARGO         = $CARGO"
-echo "  ENABLE_DEBUG  = $ENABLE_DEBUG"
-echo "  RUST_TARGET   = $RUST_TARGET"
+echo "  CC                  = $CC"
+echo "  CFLAGS              = $CFLAGS"
+echo "  CPPFLAGS            = $DEBUG_CPPFLAGS $HARDENED_CPPFLAGS $CPPFLAGS"
+echo "  CXX                 = $CXX"
+echo "  CXXFLAGS            = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS $NOWARN_CXXFLAGS $ERROR_CXXFLAGS $GPROF_CXXFLAGS $CXXFLAGS"
+echo "  LDFLAGS             = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
+echo "  ARFLAGS             = $ARFLAGS"
+echo "  CARGO               = $CARGO"
+echo "  CARGO_BUILD_TARGET  = $CARGO_BUILD_TARGET"
+echo "  ENABLE_DEBUG        = $ENABLE_DEBUG"
 echo

--- a/depends/packages/protobuf.mk
+++ b/depends/packages/protobuf.mk
@@ -1,28 +1,23 @@
 package=protobuf
-$(package)_version=22.2
-$(package)_download_path=https://github.com/protocolbuffers/protobuf/releases/download/v22.2/
+$(package)_version=23.3
+$(package)_download_path=https://github.com/protocolbuffers/protobuf/releases/download/v$($(package)_version)/
 
 # NOTE: protoc gets invoked on the BUILD OS during compile. So, we don't
 # care about HOST OS, unlike all other dependencies. 
 # That is: protoc is run on the BUILD OS, not targeted to run on the 
 # HOST OS.
 
-# TODO: Fill up hashes later
 ifeq ($(build_os)-$(build_arch),linux-x86_64)
   $(package)_file_name=protoc-$($(package)_version)-linux-x86_64.zip
-  $(package)_sha256_hash=15f281b36897e0ffbbe3a02f687ff9108c7a0f98bb653fb433e4bd62e698abe7
+  $(package)_sha256_hash=8f5abeb19c0403a7bf6e48f4fa1bb8b97724d8701f6823a327922df8cc1da4f5
 endif
 ifeq ($(build_os)-$(build_arch),linux-aarch64)
   $(package)_file_name=protoc-$($(package)_version)-linux-aarch_64.zip
-  $(package)_sha256_hash=aa2efbb2d481b7ad3c2428e0aa4dd6d813e4538e6c0a1cd4d921ac998187e07e
+  $(package)_sha256_hash=4e5154e51744c288ca1362f9cca942188003fc7b860431a984a30cb1e73aed9e
 endif
-ifeq ($(build_os)-$(build_arch),darwin-x86_64)
-  $(package)_file_name=protoc-$($(package)_version)-osx-x86_64.zip
-  $(package)_sha256_hash=8bb75680c376190d960ef1d073618c1103960f70dc4fafa7bde872029562aec1
-endif
-ifeq ($(build_os)-$(build_arch),darwin-arm)
-  $(package)_file_name=protoc-$($(package)_version)-osx-aarch_64.zip
-  $(package)_sha256_hash=a196fd39acd312688b58e81266fd88e9f7799967c5439738c10345a29049261d
+ifeq ($(build_os),darwin)
+  $(package)_file_name=protoc-$($(package)_version)-osx-universal_binary.zip
+  $(package)_sha256_hash=2783d50e35cbb546c0d75fbc2a46f76e2c620fb66c9f6bfc5ff70f5dda234100
 endif
 
 ifeq ($($(package)_file_name),)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,82 +1,60 @@
 CARGO := $(if $(CARGO),$(CARGO),cargo)
 
-# RUST_TARGET is set from configure. Can be empty. If it is we skip
-# setting target. This is done to emulate cargo's default behavior where
-# it puts things into `target/` directly where no `--target <triplet>`
-# is set. If set, it uses `target/<triplet>` and there's no way to force
-# cargo to always just stick to one.
-# 
-# If it's empty, this collapses dir for SPECIFIC_TARGET_DIR to retain
-# cargo's behavior
-TARGET = $(if $(RUST_TARGET),$(RUST_TARGET),)
-
-# This is set from configure
-ENABLE_DEBUG ?= 
-# We use DEBUG as well, since that's the more conventional
-# setup. Either of them set will result in debug builds
+# ENABLE_DEBUG is set from configure. We respect DEBUG too if set
 DEBUG ?= $(ENABLE_DEBUG)
 
-TARGET_DIR ?= $(abs_builddir)/target
-SPECIFIC_TARGET_DIR = $(TARGET_DIR)/$(TARGET)/$(if $(DEBUG),debug,release)
-CARGO_MANIFEST_PATH = $(abs_srcdir)/Cargo.toml
+# CARGO_BUILD_TARGET and HAVE_CARGO_BUILD_TARGET is set from configure. 
+# Can be empty. If empty, we skip export it. Otherwise we do. 
+#  
+# We do this to emulate cargo's default behavior (--target=<triplet>) where
+# it puts things into `target/` directly when not given or `target/<triplet>`.
+# There's no way to force cargo to a stick to one behavior at the moment.
+# 
+# Note: We use HAVE checks due to automake ifeq/ifneq not working outside rules
+if HAVE_CARGO_BUILD_TARGET
+export CARGO_BUILD_TARGET := $(CARGO_BUILD_TARGET)
+endif
 
-# We're resetting DESTDIR so that nested autotools based builds
-# don't end up in unexpected places (Currently protobuf-src is affected)
+export CARGO_TARGET_DIR ?= $(abs_builddir)/target
+CARGO_MANIFEST_PATH = $(abs_srcdir)/Cargo.toml
+SPECIFIC_TARGET_DIR = $(CARGO_TARGET_DIR)/$(CARGO_BUILD_TARGET)/$(if $(DEBUG),debug,release)
+
+CARGO_MANIFEST_ARG = --manifest-path "$(CARGO_MANIFEST_PATH)"
+CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
+
+# Export compiler flags
+export CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS AR NM RANLIB
+# Export protoc vars
+export PROTOC PROTOC_INCLUDE_DIR
+
+# Ensure nested autotools calls by cargo don't end up in unexpected places 
+unexport DESTDIR
 
 .PHONY:
 all: build
 
 .PHONY:
 build: 
-	DESTDIR= TARGET_DIR="$(TARGET_DIR)" \
-	CC="$(CC)" CXX="$(CXX)" \
-	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" \
-	LDFLAGS="$(LDFLAGS)" AR="$(AR)" NM="$(NM)" RANLIB="$(RANLIB)" \
-	PROTOC="$(PROTOC)" PROTOC_INCLUDE_DIR="$(PROTOC_INCLUDE_DIR)" \
-	$(CARGO) build \
-		--manifest-path "$(CARGO_MANIFEST_PATH)" \
-		--target-dir "$(TARGET_DIR)" \
-		$(if $(DEBUG),,--release) \
-		$(if $(TARGET),--target $(TARGET),) && \
-	cp $(SPECIFIC_TARGET_DIR)/libain_rs_exports.a $(TARGET_DIR)/lib/
+	$(CARGO) build $(CARGO_MANIFEST_ARG) $(CARGO_BUILD_TYPE_ARG) && \
+	cp $(SPECIFIC_TARGET_DIR)/libain_rs_exports.a $(CARGO_TARGET_DIR)/lib/
 
 .PHONY:
 check:
-	DESTDIR= TARGET_DIR="$(TARGET_DIR)" \
-	CC="$(CC)" CXX="$(CXX)" \
-	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" \
-	LDFLAGS="$(LDFLAGS)" AR="$(AR)" NM="$(NM)" RANLIB="$(RANLIB)" \
-	PROTOC="$(PROTOC)" PROTOC_INCLUDE_DIR="$(PROTOC_INCLUDE_DIR)" \
-	$(CARGO) test \
-		--manifest-path "$(CARGO_MANIFEST_PATH)" \
-		--target-dir "$(TARGET_DIR)" \
-		$(if $(TARGET),--target $(TARGET),)
+	$(CARGO) test $(CARGO_MANIFEST_ARG)
 
 .PHONY:
 clippy:
-	DESTDIR= TARGET_DIR="$(TARGET_DIR)" \
-	CC="$(CC)" CXX="$(CXX)" \
-	CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" \
-	LDFLAGS="$(LDFLAGS)" AR="$(AR)" NM="$(NM)" RANLIB="$(RANLIB)" \
-	PROTOC="$(PROTOC)" PROTOC_INCLUDE_DIR="$(PROTOC_INCLUDE_DIR)" \
-	$(CARGO) clippy \
-		--manifest-path "$(CARGO_MANIFEST_PATH)" \
-		--target-dir "$(TARGET_DIR)" \
-		$(if $(TARGET),--target $(TARGET),)
+	$(CARGO) clippy $(CARGO_MANIFEST_ARG)
 
 .PHONY:
 fmt-check:
-	$(CARGO) fmt --all --check \
-		--manifest-path "$(CARGO_MANIFEST_PATH)"
+	$(CARGO) fmt $(CARGO_MANIFEST_ARG) --all --check
 
 .PHONY:
 fmt:
-	$(CARGO) fmt --all \
-		--manifest-path "$(CARGO_MANIFEST_PATH)"
+	$(CARGO) fmt $(CARGO_MANIFEST_ARG) --all
 
 .PHONY:
 clean-local:
-	$(CARGO) clean \
-		--manifest-path "$(CARGO_MANIFEST_PATH)" \
-		--target-dir "$(TARGET_DIR)" && \
-	rm -rf $(TARGET_DIR)/{include,lib,src}
+	$(CARGO) clean $(CARGO_MANIFEST_ARG) && \
+	rm -rf $(CARGO_TARGET_DIR)/{include,lib,src}

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,6 +27,8 @@ CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
 
 # Export compiler flags
 export CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS AR NM RANLIB
+# Export compiler support
+export PKG_CONFIG_PATH PKGCONFIG_LIBDIR PYTHONPATH
 # Export protoc vars
 export PROTOC PROTOC_INCLUDE_DIR
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,7 +20,7 @@ export CARGO_TARGET_DIR ?= $(abs_builddir)/target
 export CARGO_BUILD_JOBS ?= $(if $(JOBS),$(JOBS),-1)
 
 CARGO_MANIFEST_PATH = $(abs_srcdir)/Cargo.toml
-SPECIFIC_TARGET_DIR = $(CARGO_TARGET_DIR)/$(TARGET)/$(if $(DEBUG),debug,release)
+BUILD_ARTIFACTS_DIR = $(CARGO_TARGET_DIR)/$(TARGET)/$(if $(DEBUG),debug,release)
 
 CARGO_MANIFEST_ARG = --manifest-path "$(CARGO_MANIFEST_PATH)"
 CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
@@ -45,7 +45,7 @@ all: build
 .PHONY: build
 build:
 	$(CARGO) build $(CARGO_MANIFEST_ARG) $(CARGO_BUILD_TYPE_ARG) $(CARGO_EXTRA_ARGS) && \
-	cp $(SPECIFIC_TARGET_DIR)/libain_rs_exports.a $(CARGO_TARGET_DIR)/lib/
+	cp $(BUILD_ARTIFACTS_DIR)/libain_rs_exports.a $(CARGO_TARGET_DIR)/lib/
 
 .PHONY: check
 check:

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,12 +1,9 @@
 CARGO := $(if $(CARGO),$(CARGO),cargo)
-CARGO_EXTRA_ARGS ?= --all-targets
-
-export CARGO_BUILD_JOBS := $(if $(CARGO_BUILD_JOBS),$(CARGO_BUILD_JOBS),-1)
 
 # ENABLE_DEBUG is set from configure. We respect DEBUG too if set
 DEBUG ?= $(ENABLE_DEBUG)
 
-# CARGO_BUILD_TARGET and HAVE_CARGO_BUILD_TARGET is set from configure. 
+# RUST_TARGET and HAVE_RUST_TARGET is set from configure. 
 # Can be empty. If empty, we skip export it. Otherwise we do. 
 #  
 # We do this to emulate cargo's default behavior (--target=<triplet>) where
@@ -14,16 +11,23 @@ DEBUG ?= $(ENABLE_DEBUG)
 # There's no way to force cargo to a stick to one behavior at the moment.
 # 
 # Note: We use HAVE checks due to automake ifeq/ifneq not working outside rules
-if HAVE_CARGO_BUILD_TARGET
-export CARGO_BUILD_TARGET := $(CARGO_BUILD_TARGET)
+if HAVE_RUST_TARGET
+export CARGO_BUILD_TARGET = $(RUST_TARGET)
 endif
+TARGET = $(RUST_TARGET)
 
 export CARGO_TARGET_DIR ?= $(abs_builddir)/target
+export CARGO_BUILD_JOBS ?= $(if $(JOBS),$(JOBS),-1)
+
 CARGO_MANIFEST_PATH = $(abs_srcdir)/Cargo.toml
-SPECIFIC_TARGET_DIR = $(CARGO_TARGET_DIR)/$(CARGO_BUILD_TARGET)/$(if $(DEBUG),debug,release)
+SPECIFIC_TARGET_DIR = $(CARGO_TARGET_DIR)/$(TARGET)/$(if $(DEBUG),debug,release)
 
 CARGO_MANIFEST_ARG = --manifest-path "$(CARGO_MANIFEST_PATH)"
 CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
+
+# If $build == $host, we add --all-targets otherwise we skip
+# since compiling with `--test` fails on cross compilation
+CARGO_EXTRA_ARGS ?= $(if $(subst $(build),,$(host)),,--all-targets)
 
 # Export compiler flags
 export CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS AR NM RANLIB

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,7 @@
 CARGO := $(if $(CARGO),$(CARGO),cargo)
+CARGO_EXTRA_ARGS ?= --all-targets
+
+export CARGO_BUILD_JOBS := $(if $(CARGO_BUILD_JOBS),$(CARGO_BUILD_JOBS),-1)
 
 # ENABLE_DEBUG is set from configure. We respect DEBUG too if set
 DEBUG ?= $(ENABLE_DEBUG)
@@ -33,28 +36,31 @@ unexport DESTDIR
 .PHONY:
 all: build
 
-.PHONY:
-build: 
-	$(CARGO) build $(CARGO_MANIFEST_ARG) $(CARGO_BUILD_TYPE_ARG) && \
+.PHONY: build
+build:
+	$(CARGO) build $(CARGO_MANIFEST_ARG) $(CARGO_BUILD_TYPE_ARG) $(CARGO_EXTRA_ARGS) && \
 	cp $(SPECIFIC_TARGET_DIR)/libain_rs_exports.a $(CARGO_TARGET_DIR)/lib/
 
-.PHONY:
+.PHONY: check
 check:
-	$(CARGO) test $(CARGO_MANIFEST_ARG)
+	$(CARGO) check $(CARGO_MANIFEST_ARG) $(CARGO_EXTRA_ARGS)
 
-.PHONY:
+.PHONY: test
+test:
+	$(CARGO) test $(CARGO_MANIFEST_ARG) $(CARGO_EXTRA_ARGS)
+
+.PHONY: clippy
 clippy:
-	$(CARGO) clippy $(CARGO_MANIFEST_ARG)
+	$(CARGO) clippy $(CARGO_MANIFEST_ARG) $(CARGO_EXTRA_ARGS)
 
-.PHONY:
+.PHONY: fmt-check
 fmt-check:
 	$(CARGO) fmt $(CARGO_MANIFEST_ARG) --all --check
 
-.PHONY:
+.PHONY: fmt
 fmt:
 	$(CARGO) fmt $(CARGO_MANIFEST_ARG) --all
 
-.PHONY:
 clean-local:
 	$(CARGO) clean $(CARGO_MANIFEST_ARG) && \
 	rm -rf $(CARGO_TARGET_DIR)/{include,lib,src}

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -1,12 +1,12 @@
 use std::error::Error;
 
-#[cfg(not(any(test, bench, example, doc)))]
+#[cfg(not(test))]
 mod bridge;
 
-#[cfg(not(any(test, bench, example, doc)))]
+#[cfg(not(test))]
 use bridge::ffi;
 
-#[cfg(any(test, bench, example, doc))]
+#[cfg(test)]
 #[allow(non_snake_case)]
 mod ffi {
     const UNIMPL_MSG: &str = "This cannot be used on a test path";

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -297,7 +297,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 &input
                     .map(|d| d.0)
                     .unwrap_or(data.map(|d| d.0).unwrap_or_default()),
-                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(),
+                gas.unwrap_or(MAX_GAS_PER_BLOCK).as_u64(),
                 vec![],
                 self.block_number_to_u256(block_number),
             )
@@ -687,7 +687,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 to,
                 value.unwrap_or_default(),
                 &data.map(|d| d.0).unwrap_or_default(),
-                gas.unwrap_or(U256::from(MAX_GAS_PER_BLOCK)).as_u64(),
+                gas.unwrap_or(MAX_GAS_PER_BLOCK).as_u64(),
                 vec![],
                 block_number,
             )

--- a/lib/ain-grpc/src/transaction_request.rs
+++ b/lib/ain-grpc/src/transaction_request.rs
@@ -58,7 +58,7 @@ impl From<TransactionRequest> for Option<TransactionMessage> {
                 value: req.value.unwrap_or_default(),
                 input: req
                     .input
-                    .or_else(|| req.data)
+                    .or(req.data)
                     .map(Bytes::into_vec)
                     .unwrap_or_default(),
                 action: match req.to {
@@ -75,7 +75,7 @@ impl From<TransactionRequest> for Option<TransactionMessage> {
                 value: req.value.unwrap_or_default(),
                 input: req
                     .input
-                    .or_else(|| req.data)
+                    .or(req.data)
                     .map(Bytes::into_vec)
                     .unwrap_or_default(),
                 action: match req.to {
@@ -96,7 +96,7 @@ impl From<TransactionRequest> for Option<TransactionMessage> {
                     value: req.value.unwrap_or_default(),
                     input: req
                         .input
-                        .or_else(|| req.data)
+                        .or(req.data)
                         .map(Bytes::into_vec)
                         .unwrap_or_default(),
                     action: match req.to {

--- a/lib/ain-rs-exports/build.rs
+++ b/lib/ain-rs-exports/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Otherwise, use the path for OUT_DIR that cargo sets, as usual.
     // Reason: Currently setting --out-dir is nightly only, so there's no way to get OUT_DIR
     // out of cargo reliably for pointing the C++ link targets to this determinisitcally.
-    let target_dir: PathBuf = PathBuf::from(env::var("TARGET_DIR").or(env::var("OUT_DIR"))?);
+    let target_dir: PathBuf = PathBuf::from(env::var("CARGO_TARGET_DIR").or(env::var("OUT_DIR"))?);
     let res = ["src", "include", "lib"].map(|x| target_dir.join(x));
     for x in &res {
         std::fs::create_dir_all(x)?;

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -12,7 +12,7 @@ use ethereum::{EnvelopedEncodable, TransactionAction, TransactionSignature};
 use primitive_types::{H160, H256, U256};
 use transaction::{LegacyUnsignedTransaction, TransactionError, LOWER_H256};
 
-use crate::ffi::RustRes;
+use crate::ffi::CrossBoundaryResult;
 
 pub const WEI_TO_GWEI: u64 = 1_000_000_000;
 pub const GWEI_TO_SATS: u64 = 10;
@@ -43,9 +43,9 @@ pub mod ffi {
         used_gas: u64,
     }
 
-    pub struct RustRes {
-        ok: bool,
-        reason: String,
+    pub struct CrossBoundaryResult {
+        pub ok: bool,
+        pub reason: String,
     }
 
     extern "Rust" {
@@ -67,7 +67,7 @@ pub mod ffi {
         ) -> Result<bool>;
 
         fn evm_try_prevalidate_raw_tx(
-            result: &mut RustRes,
+            result: &mut CrossBoundaryResult,
             tx: &str,
             with_gas_usage: bool,
         ) -> Result<ValidateTxResult>;
@@ -75,7 +75,7 @@ pub mod ffi {
         fn evm_get_context() -> u64;
         fn evm_discard_context(context: u64);
         fn evm_try_queue_tx(
-            result: &mut RustRes,
+            result: &mut CrossBoundaryResult,
             context: u64,
             raw_tx: &str,
             native_tx_hash: [u8; 32],
@@ -311,7 +311,7 @@ pub fn evm_sub_balance(
 /// Returns the transaction nonce, sender address and gas used if the transaction is valid.
 /// logs and set the error reason to result object otherwise.
 pub fn evm_try_prevalidate_raw_tx(
-    result: &mut RustRes,
+    result: &mut CrossBoundaryResult,
     tx: &str,
     with_gas_usage: bool,
 ) -> Result<ffi::ValidateTxResult, Box<dyn Error>> {
@@ -325,10 +325,9 @@ pub fn evm_try_prevalidate_raw_tx(
             })
         }
         Err(e) => {
-            debug!("evm_try_prevalidate_raw_tx fails with error: {e}");
+            debug!("evm_try_prevalidate_raw_tx failed with error: {e}");
             result.ok = false;
             result.reason = e.to_string();
-
             Ok(ffi::ValidateTxResult::default())
         }
     }
@@ -372,7 +371,7 @@ fn evm_discard_context(context: u64) {
 ///
 /// Returns `true` if the transaction is successfully queued, `false` otherwise.
 fn evm_try_queue_tx(
-    result: &mut RustRes,
+    result: &mut CrossBoundaryResult,
     context: u64,
     raw_tx: &str,
     hash: [u8; 32],

--- a/lib/labs-grpc2/build.rs
+++ b/lib/labs-grpc2/build.rs
@@ -2,8 +2,9 @@ use anyhow::{format_err, Result};
 use std::path::PathBuf;
 
 fn main() -> Result<()> {
-    std::env::set_var("PROTOC", protobuf_src::protoc());
-    let proto_include = protobuf_src::include();
+    let proto_include = std::env::var("PROTOC_INCLUDE_DIR")
+        .map(PathBuf::from)
+        .map(|f| String::from(f.to_str().unwrap()));
 
     // let manifest_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
     // let gen_path = manifest_path.join("gen");
@@ -27,12 +28,7 @@ fn main() -> Result<()> {
         .type_attribute(".", default_attrs)
         .compile(
             &["proto/services.proto"],
-            &[
-                "proto",
-                proto_include
-                    .to_str()
-                    .ok_or(format_err!("proto include path err"))?,
-            ],
+            &["proto", proto_include.unwrap_or(".".to_string()).as_str()],
         )?;
     Ok(())
 }

--- a/make.sh
+++ b/make.sh
@@ -174,7 +174,7 @@ build_make() {
     _fold_start "build_make"
 
     # shellcheck disable=SC2086
-    make DESTDIR="${build_target_dir}" -j${make_jobs} CARGO_BUILD_JOBS=${make_jobs} ${make_args}
+    make DESTDIR="${build_target_dir}" -j${make_jobs} JOBS=${make_jobs} ${make_args}
 
     _fold_end
     _exit_dir
@@ -381,7 +381,7 @@ exec() {
     _fold_start "exec:: ${*-(default)}"
 
     # shellcheck disable=SC2086,SC2068
-    make -j$make_jobs CARGO_BUILD_JOBS=${make_jobs} $make_args $@
+    make -j$make_jobs JOBS=${make_jobs} $make_args $@
 
     _fold_end
     _exit_dir
@@ -793,7 +793,7 @@ lib() {
     
     check_enter_build_rs_dir
     # shellcheck disable=SC2086
-    make CARGO_BUILD_JOBS=${jobs} ${cmd} || { if [[ "${exit_on_err}" == "1" ]]; then  
+    make JOBS=${jobs} ${cmd} || { if [[ "${exit_on_err}" == "1" ]]; then  
         echo "Error: Please resolve all checks"; 
         exit 1;
         fi; }

--- a/make.sh
+++ b/make.sh
@@ -725,7 +725,8 @@ _get_default_conf_args() {
 }
 
 _get_default_jobs() {
-    local total=$(_nproc)
+    local total
+    total=$(_nproc)
     # Use a num closer to 80% of the cores by default
     local jobs=$(( total * 4/5 ))
     if (( jobs > 1 )); then

--- a/make.sh
+++ b/make.sh
@@ -446,7 +446,6 @@ pkg_install_deps() {
 
     # gcc-multilib: for cross compilations
     # locales: for using en-US.UTF-8 (see head of this file).
-
     apt-get install -y \
         software-properties-common build-essential git libtool autotools-dev automake \
         pkg-config bsdmainutils python3 python3-pip libssl-dev libevent-dev libboost-system-dev \
@@ -454,6 +453,7 @@ pkg_install_deps() {
         libminiupnpc-dev libzmq3-dev libqrencode-dev wget \
         libdb-dev libdb++-dev libdb5.3 libdb5.3-dev libdb5.3++ libdb5.3++-dev \
         curl cmake unzip libc6-dev gcc-multilib locales locales-all
+    locale-gen "en_US.UTF-8"
 
     _fold_end
 }

--- a/make.sh
+++ b/make.sh
@@ -453,9 +453,14 @@ pkg_install_deps() {
         libminiupnpc-dev libzmq3-dev libqrencode-dev wget \
         libdb-dev libdb++-dev libdb5.3 libdb5.3-dev libdb5.3++ libdb5.3++-dev \
         curl cmake unzip libc6-dev gcc-multilib locales locales-all
-    locale-gen "en_US.UTF-8"
 
     _fold_end
+}
+
+pkg_setup_locale() {
+    # Not a hard requirement. We use en_US.UTF-8 to maintain coherence across
+    # different platforms. C.UTF-8 is not available on all platforms.
+    locale-gen "en_US.UTF-8"
 }
 
 pkg_install_deps_mingw_x86_64() {
@@ -899,6 +904,7 @@ ci_export_vars() {
 ci_setup_deps() {
     DEBIAN_FRONTEND=noninteractive pkg_update_base
     DEBIAN_FRONTEND=noninteractive pkg_install_deps
+    DEBIAN_FRONTEND=noninteractive pkg_setup_locale
     DEBIAN_FRONTEND=noninteractive pkg_install_llvm
     DEBIAN_FRONTEND=noninteractive pkg_install_rust
 }

--- a/make.sh
+++ b/make.sh
@@ -792,6 +792,7 @@ lib() {
     local jobs="$MAKE_JOBS"
     
     check_enter_build_rs_dir
+    # shellcheck disable=SC2086
     make CARGO_BUILD_JOBS=${jobs} ${cmd} || { if [[ "${exit_on_err}" == "1" ]]; then  
         echo "Error: Please resolve all checks"; 
         exit 1;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,15 +27,17 @@ LIBDEFI_SPV_INCLUDES = \
 	-I$(srcdir)/spv/bcash
 
 LIBAIN_DIR = $(abs_top_builddir)/lib/target
-LIBAIN_RS_INCLUDES = -I$(LIBAIN_DIR)/include
-LIBAIN_RS_LIB = -L$(LIBAIN_DIR)/lib -lain_rs_exports
 LIBAIN_RS_SRC = $(LIBAIN_DIR)/src/ain_rs_exports.cpp
 LIBAIN_RS_H = $(LIBAIN_DIR)/include/ain_rs_exports.h
+LIBAIN_RS_LIB = -L$(LIBAIN_DIR)/lib -lain_rs_exports
+LIBAIN_RS_LIB_PATH = $(LIBAIN_DIR)/lib/libain_rs_exports.a
+LIBAIN_RS_INCLUDES = -I$(LIBAIN_DIR)/include
 
 $(LIBAIN_RS_SRC):
 $(LIBAIN_RS_H):
-$(LIBAIN_RS_LIB): FORCE
+$(LIBAIN_RS_LIB_PATH): FORCE
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(abs_top_builddir)/lib
+
 
 DEFI_INCLUDES = -I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS)
 DEFI_INCLUDES += -I$(srcdir)/secp256k1/include
@@ -695,7 +697,7 @@ nodist_libdefi_util_a_SOURCES = $(srcdir)/obj/build.h
 #
 
 # defid binary
-defid_SOURCES = $(LIBAIN_RS_SRC) $(LIBAIN_RS_H) defid.cpp
+defid_SOURCES = defid.cpp
 defid_CPPFLAGS = $(AM_CPPFLAGS) $(DEFI_INCLUDES)
 defid_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 defid_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
@@ -732,6 +734,8 @@ endif
 if TARGET_WINDOWS
 defid_LDADD += -luserenv -lbcrypt
 endif
+
+EXTRA_defid_DEPENDENCIES: $(LIBAIN_RS_LIB_PATH)
 
 # defi-cli binary #
 defi_cli_SOURCES = defi-cli.cpp
@@ -810,7 +814,6 @@ $(top_srcdir)/$(subdir)/config/defi-config.h.in:  $(am__configure_deps)
 clean-local:
 	-$(MAKE) -C secp256k1 clean
 	-$(MAKE) -C univalue clean
-	-$(MAKE) -C rust clean
 	-rm -f leveldb/*/*.gcda leveldb/*/*.gcno leveldb/helpers/memenv/*.gcda leveldb/helpers/memenv/*.gcno
 	-rm -f config.h
 	-rm -rf test/__pycache__

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3859,7 +3859,7 @@ public:
         if (obj.evmTx.size() > static_cast<size_t>(EVM_TX_SIZE))
             return Res::Err("evm tx size too large");
 
-        RustRes result;
+        CrossBoundaryResult result;
         const auto hashAndGas = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx), true);
 
         if (!result.ok) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -800,7 +800,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
                     const auto obj = std::get<CEvmTxMessage>(txMessage);
 
-                    RustRes result;
+                    CrossBoundaryResult result;
                     const auto txResult = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx), false);
                     if (!result.ok) {
                         customTxPassed = false;


### PR DESCRIPTION
## Summary

- Refine cargo build integration, and fix stale build due to updated Rust libs being untracked on C++ dep tree 
  - This PR injects the final librs_exports.a into sources as proxy so that it a part of the dep graph whenever rebuilt naturally
  - Workaround to touch defid.cpp is no longer needed. 
- Cleans up the build process removing things that's not practically used and adds noise.
- Refactor cargo Makefile
  - Use `RUST_TARGET` to set `CARGO_BUILD_TARGET` which is tracked by cargo (https://doc.rust-lang.org/cargo/reference/environment-variables.html)
  - Uses `CARGO_TARGET_DIR` env instead of having to pass `--target-dir` in each step.
  - Use `--all-targets` when not cross compiling to catch more failures early 
  - Uses `JOBS` var to set `CARGO_BUILD_JOBS` to maintain coherency across jobs  
  - Remove further noise by exporting CC related envs 
- Fixes incoherent `.cargo/config.toml` apply. 
  - Moves `.cargo/config.toml` to the root dir so that it works across all tooling since cargo searches up.  
  - Remove workaround no longer needed
  
### make.sh
  
- `MAKE_JOBS` is now respected throughout the build and carried coherently across C++ and Rust. 
- `./make.sh lib` is now available that forwards to the Makefile in `/lib` for easier execution. 
  - `./make.sh lib check / lib fmt / lib fmt-check` etc are now used through this.
- `compiledb` now available with `./make.sh` for convenience
- `rust-analyzer-check` for better consistency across build configs
- `_get_default_jobs` is now used by default during make to ensure that there's a max cap of `80%` of the cores on compiles to now use up all cores. 20% offers minimal difference to compile times, but provides for better dev experience without overloading machines.

### Misc

- Move protobuf up to v23.3.
- Use osx universal binaries to simplify. 
- Adds `.vscode/settings.default.json` for recommended coherent settings that avoiding excessive recompilation during dev 

### Further pending Rust Issues

- Enable cargo test for full code graphs that call C++ libs
- [Fixed] ~~Rust-analyzer and cargo build ends up in different configs due to RUSTFLAGS. What's applied in `.cargo/config.toml` doesn't seem to be applied to rust-analyzer workflow resulting in multiple compilations and invalidating compile caches all the time.~~
  - ~~Not sure why, since the target dir is picked up as expected, just RUSTFLAGS aren't applied. Can be verified by looking into the fingerprints json files.~~
  - ~~Related (May be): https://github.com/rust-lang/rust-analyzer/issues/13529~~

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
