### PR TITLE
Fix failing in evm functional test

### DIFF
--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -166,7 +166,7 @@ class EVMTest(DefiTestFramework):
         self.test_accounts()
 
         self.nodes[0].transferdomain([{"src": {"address":self.address, "amount":"100@DFI", "domain": 2}, "dst":{"address":self.ethAddress, "amount":"100@DFI", "domain": 3}}])
-        self.nodes[0].generate(2)
+        self.nodes[0].generate(1)
 
         self.test_address_state(self.ethAddress) # TODO test smart contract
 


### PR DESCRIPTION
## Summary

- Fix merge error from PR #2067 for the failing feature_evm_rpc.py test.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
