### PR TITLE
Reject sending UTXO to Eth addresses

### DIFF
--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -262,6 +262,8 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
             }
             CScript scriptPubKey = GetScriptForDestination(destination);
 
+            RejectEthAddress(scriptPubKey);
+
             auto amounts = DecodeAmounts(chain, outputs[name_], name_);
             for (auto const & kv : amounts.balances) {
                 CTxOut out(kv.second, scriptPubKey, kv.first);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -421,6 +421,8 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
+    RejectEthAddress(GetScriptForDestination(dest));
+
     // Amount
     CTokenAmount const tokenAmount = DecodeAmount(pwallet->chain(), request.params[1], request.params[0].get_str()); // don't support multiple tokens due to "SendMoney()" compatibility
 
@@ -921,6 +923,8 @@ static UniValue sendmany(const JSONRPCRequest& request)
     std::vector<CRecipient> vecSend;
 
     for (auto const & scriptBalances : recip) {
+
+        RejectEthAddress(scriptBalances.first);
 
         bool fSubtractFeeFromAmount = false;
         for (unsigned int idx = 0; idx < subtractFeeFromAmount.size(); idx++) {

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -93,7 +93,7 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].getbalance()
 
         # Fund DFI address
-        self.nodes[0].utxostoaccount({address: "101@DFI"})
+        txid = self.nodes[0].utxostoaccount({address: "101@DFI"})
         self.nodes[0].generate(1)
         self.sync_blocks()
 
@@ -107,6 +107,10 @@ class EVMTest(DefiTestFramework):
         assert_equal(len(self.nodes[0].getaccount(ethAddress, {}, True)), 0)
 
         # Check for invalid parameters in transferdomain rpc
+        assert_raises_rpc_error(-5, "Eth type addresses are not valid", self.nodes[0].createrawtransaction, [{'txid': txid, 'vout': 1}], [{ethAddress: 1}])
+        assert_raises_rpc_error(-5, "Eth type addresses are not valid", self.nodes[0].sendmany, "", {ethAddress: 1})
+        assert_raises_rpc_error(-5, "Eth type addresses are not valid", self.nodes[0].sendmany, "", {ethAddress: 1})
+        assert_raises_rpc_error(-5, "Eth type addresses are not valid", self.nodes[0].sendtoaddress, ethAddress, 1)
         assert_raises_rpc_error(-5, "Eth type addresses are not valid", self.nodes[0].accounttoaccount, address, {ethAddress: "1@DFI"})
         assert_raises_rpc_error(-8, "Invalid parameters, src argument \"address\" must not be null", self.nodes[0].transferdomain, [{"src": {"amount":"100@DFI", "domain": 2}, "dst":{"address":ethAddress, "amount":"100@DFI", "domain": 3}}])
         assert_raises_rpc_error(-8, "Invalid parameters, src argument \"amount\" must not be null", self.nodes[0].transferdomain, [{"src": {"address":address, "domain": 2}, "dst":{"address":ethAddress, "amount":"100@DFI", "domain": 3}}])


### PR DESCRIPTION
Reject sending UTXO to Eth addresses in the following RPC calls.

createpsbt
createrawtransaction
sendmany
sendtoaddress
walletcreatefundedpsbt