### PR TITLE
Guard DUSD loops with Changi Intermediate 2

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -142,6 +142,8 @@ public:
         consensus.GrandCentralEpilogueHeight = 2574000; // Jan 10th, 2023.
         consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -418,6 +420,8 @@ public:
         consensus.GrandCentralEpilogueHeight = 1438200;
         consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -638,6 +642,7 @@ public:
         consensus.NextNetworkUpgradeHeight = 1586750;
         consensus.ChangiIntermediateHeight = 1717800;
         consensus.ChangiIntermediateHeight2 = 1717493;
+        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -855,6 +860,8 @@ public:
         consensus.GrandCentralEpilogueHeight = 1438200;
         consensus.NextNetworkUpgradeHeight = 1586750;
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
+        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -1075,6 +1082,8 @@ public:
         consensus.GrandCentralEpilogueHeight = 10000000;
         consensus.NextNetworkUpgradeHeight = 10000000;
         consensus.ChangiIntermediateHeight = 10000000;
+        consensus.ChangiIntermediateHeight2 = 10000000;
+        consensus.ChangiIntermediateHeight3 = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -1322,6 +1331,7 @@ void SetupCommonArgActivationParams(Consensus::Params &consensus) {
     UpdateHeightValidation("Grand Central Epilogue", "-grandcentralepilogueheight", consensus.GrandCentralEpilogueHeight);
     UpdateHeightValidation("Next Network Upgrade", "-nextnetworkupgradeheight", consensus.NextNetworkUpgradeHeight);
     UpdateHeightValidation("Changi Intermediate", "-changiintermediateheight", consensus.ChangiIntermediateHeight);
+    UpdateHeightValidation("Changi Intermediate3", "-changiintermediate3height", consensus.ChangiIntermediateHeight3);
 
     if (gArgs.GetBoolArg("-simulatemainnet", false)) {
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,7 +143,6 @@ public:
         consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
-        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -421,7 +420,6 @@ public:
         consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
-        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -642,7 +640,6 @@ public:
         consensus.NextNetworkUpgradeHeight = 1586750;
         consensus.ChangiIntermediateHeight = 1717800;
         consensus.ChangiIntermediateHeight2 = 1717493;
-        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -861,7 +858,6 @@ public:
         consensus.NextNetworkUpgradeHeight = 1586750;
         consensus.ChangiIntermediateHeight = std::numeric_limits<int>::max();
         consensus.ChangiIntermediateHeight2 = std::numeric_limits<int>::max();
-        consensus.ChangiIntermediateHeight3 = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -1083,7 +1079,6 @@ public:
         consensus.NextNetworkUpgradeHeight = 10000000;
         consensus.ChangiIntermediateHeight = 10000000;
         consensus.ChangiIntermediateHeight2 = 10000000;
-        consensus.ChangiIntermediateHeight3 = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -1331,7 +1326,7 @@ void SetupCommonArgActivationParams(Consensus::Params &consensus) {
     UpdateHeightValidation("Grand Central Epilogue", "-grandcentralepilogueheight", consensus.GrandCentralEpilogueHeight);
     UpdateHeightValidation("Next Network Upgrade", "-nextnetworkupgradeheight", consensus.NextNetworkUpgradeHeight);
     UpdateHeightValidation("Changi Intermediate", "-changiintermediateheight", consensus.ChangiIntermediateHeight);
-    UpdateHeightValidation("Changi Intermediate3", "-changiintermediate3height", consensus.ChangiIntermediateHeight3);
+    UpdateHeightValidation("Changi Intermediate2", "-changiintermediate2height", consensus.ChangiIntermediateHeight2);
 
     if (gArgs.GetBoolArg("-simulatemainnet", false)) {
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -104,7 +104,6 @@ struct Params {
     int NextNetworkUpgradeHeight;
     int ChangiIntermediateHeight; // To be changed to NextNetworkUpgradeHeight on mainnet release
     int ChangiIntermediateHeight2; // To be changed to NextNetworkUpgradeHeight on mainnet release
-    int ChangiIntermediateHeight3; // To be changed to NextNetworkUpgradeHeight on mainnet release
 
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -104,6 +104,7 @@ struct Params {
     int NextNetworkUpgradeHeight;
     int ChangiIntermediateHeight; // To be changed to NextNetworkUpgradeHeight on mainnet release
     int ChangiIntermediateHeight2; // To be changed to NextNetworkUpgradeHeight on mainnet release
+    int ChangiIntermediateHeight3; // To be changed to NextNetworkUpgradeHeight on mainnet release
 
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -513,7 +513,7 @@ void SetupServerArgs()
     gArgs.AddArg("-grandcentralepilogueheight", "Grand Central Epilogue fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-nextnetworkupgradeheight", "Next Network Upgrade fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-changiintermediateheight", "Changi Intermediate fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
-    gArgs.AddArg("-changiintermediate3height", "Changi Intermediate3 fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-changiintermediate2height", "Changi Intermediate2 fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-jellyfish_regtest", "Configure the regtest network for jellyfish testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-regtest-skip-loan-collateral-validation", "Skip loan collateral check for jellyfish testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-regtest-minttoken-simulate-mainnet", "Simulate mainnet for minttokens on regtest -  default behavior on regtest is to allow anyone to mint mintable tokens for ease of testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -513,6 +513,7 @@ void SetupServerArgs()
     gArgs.AddArg("-grandcentralepilogueheight", "Grand Central Epilogue fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-nextnetworkupgradeheight", "Next Network Upgrade fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-changiintermediateheight", "Changi Intermediate fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-changiintermediate3height", "Changi Intermediate3 fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-jellyfish_regtest", "Configure the regtest network for jellyfish testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-regtest-skip-loan-collateral-validation", "Skip loan collateral check for jellyfish testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-regtest-minttoken-simulate-mainnet", "Simulate mainnet for minttokens on regtest -  default behavior on regtest is to allow anyone to mint mintable tokens for ease of testing", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3036,7 +3036,7 @@ public:
         auto isPostFCE = static_cast<int>(height) >= consensus.FortCanningEpilogueHeight;
         auto isPostFCR = static_cast<int>(height) >= consensus.FortCanningRoadHeight;
         auto isPostGC  = static_cast<int>(height) >= consensus.GrandCentralHeight;
-        auto isPostNext =  static_cast<int>(height) >= consensus.NextNetworkUpgradeHeight;
+        auto isPostNext =  static_cast<int>(height) >= consensus.ChangiIntermediateHeight3; // Change to NextNetworkUpgradeHeight on mainnet release
 
         if(isPostNext) {
             const CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AllowDUSDLoops};

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3036,7 +3036,7 @@ public:
         auto isPostFCE = static_cast<int>(height) >= consensus.FortCanningEpilogueHeight;
         auto isPostFCR = static_cast<int>(height) >= consensus.FortCanningRoadHeight;
         auto isPostGC  = static_cast<int>(height) >= consensus.GrandCentralHeight;
-        auto isPostNext =  static_cast<int>(height) >= consensus.ChangiIntermediateHeight3; // Change to NextNetworkUpgradeHeight on mainnet release
+        auto isPostNext =  static_cast<int>(height) >= consensus.ChangiIntermediateHeight2; // Change to NextNetworkUpgradeHeight on mainnet release
 
         if(isPostNext) {
             const CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AllowDUSDLoops};

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1354,7 +1354,6 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "grandcentral", consensusParams.GrandCentralHeight);
     BuriedForkDescPushBack(softforks, "grandcentralepilogue", consensusParams.GrandCentralEpilogueHeight);
     BuriedForkDescPushBack(softforks, "nextnetworkupgrade", consensusParams.NextNetworkUpgradeHeight);
-    BuriedForkDescPushBack(softforks, "changiintermediate", consensusParams.ChangiIntermediateHeight);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 

--- a/test/functional/feature_dusd_loans.py
+++ b/test/functional/feature_dusd_loans.py
@@ -27,13 +27,13 @@ class DUSDLoanTests(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.fortcanninghillheight = 1000
-        self.fortcanningroadheight = 2000
-        self.fortcanninggreatworldheight = 3000
-        self.fortcanningepilogueheight = 4000
-        self.grandcentralheight = 4500
-        self.grandcentralepilogueheight = 5000
-        self.nextnetworkupgradeheight = 6000
+        self.fortcanninghillheight = 200
+        self.fortcanningroadheight = 300
+        self.fortcanninggreatworldheight = 400
+        self.fortcanningepilogueheight = 500
+        self.grandcentralheight = 600
+        self.grandcentralepilogueheight = 700
+        self.nextnetworkupgradeheight = 800
 
         self.extra_args = [
             ['-txnotokens=0',
@@ -50,6 +50,7 @@ class DUSDLoanTests(DefiTestFramework):
              f'-grandcentralheight={self.grandcentralheight}',
              f'-grandcentralepilogueheight={self.grandcentralepilogueheight}',
              f'-nextnetworkupgradeheight={self.nextnetworkupgradeheight}',
+             f'-changiintermediate3height={self.nextnetworkupgradeheight}', # Remove this line on mainnet release
 
              '-jellyfish_regtest=1', '-txindex=1', '-simulatemainnet=1']
         ]
@@ -152,13 +153,13 @@ class DUSDLoanTests(DefiTestFramework):
             'token': self.idDFI,
             'factor': 1,
             'fixedIntervalPriceId': "DFI/USD"})
-        self.nodes[0].generate(120)
+        self.nodes[0].generate(1)
 
         self.nodes[0].setcollateraltoken({
             'token': self.symbolBTC,
             'factor': 1,
             'fixedIntervalPriceId': "BTC/USD"})
-        self.nodes[0].generate(120)
+        self.nodes[0].generate(1)
         self.idBTC = list(self.nodes[0].gettoken(self.symbolBTC).keys())[0]
 
         self.nodes[0].setloantoken({
@@ -167,14 +168,14 @@ class DUSDLoanTests(DefiTestFramework):
             'fixedIntervalPriceId': "DUSD/USD",
             'mintable': True,
             'interest': 0})
-        self.nodes[0].generate(120)
+        self.nodes[0].generate(1)
         self.iddUSD = list(self.nodes[0].gettoken(self.symboldUSD).keys())[0]
 
         self.nodes[0].setcollateraltoken({
             'token': self.iddUSD,
             'factor': 0.99,
             'fixedIntervalPriceId': "DUSD/USD"})
-        self.nodes[0].generate(120)
+        self.nodes[0].generate(1)
 
         self.nodes[0].setloantoken({
             'symbol': self.symbolTSLA,
@@ -221,18 +222,16 @@ class DUSDLoanTests(DefiTestFramework):
         # feed oracle
         timestamp = calendar.timegm(time.gmtime())
         self.nodes[0].setoracledata(self.oracle_id2, timestamp, oracle_prices)
-        self.nodes[0].generate(120)
+        self.nodes[0].generate(11)
 
-    def update_oracle_price(self, add_time=3000):
+    def update_oracle_price(self):
         oracle_prices = [{"currency": "USD", "tokenAmount": "10@TSLA"},
                          {"currency": "USD", "tokenAmount": "1@DUSD"},
                          {"currency": "USD", "tokenAmount": "1@BTC"},
                          {"currency": "USD", "tokenAmount": "10@DFI"}]
 
-        mock_time = int(time.time() + add_time)
-        self.nodes[0].setmocktime(mock_time)
-        self.nodes[0].setoracledata(self.oracle_id1, mock_time, oracle_prices)
-        self.nodes[0].generate(120)
+        self.nodes[0].setoracledata(self.oracle_id1, int(time.time()), oracle_prices)
+        self.nodes[0].generate(10)
 
     def create_pool_pairs(self):
         self.nodes[0].createpoolpair({
@@ -558,7 +557,7 @@ class DUSDLoanTests(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # not sure why this is needed like this. but it works
-        self.update_oracle_price(13000)
+        self.update_oracle_price()
         #also fails with other crypto in
         self.nodes[0].deposittovault(vault_id, self.account0, "100.00000000@BTC")
         self.nodes[0].generate(1)

--- a/test/functional/feature_dusd_loans.py
+++ b/test/functional/feature_dusd_loans.py
@@ -50,7 +50,7 @@ class DUSDLoanTests(DefiTestFramework):
              f'-grandcentralheight={self.grandcentralheight}',
              f'-grandcentralepilogueheight={self.grandcentralepilogueheight}',
              f'-nextnetworkupgradeheight={self.nextnetworkupgradeheight}',
-             f'-changiintermediate3height={self.nextnetworkupgradeheight}', # Remove this line on mainnet release
+             f'-changiintermediate2height={self.nextnetworkupgradeheight}', # Remove this line on mainnet release
 
              '-jellyfish_regtest=1', '-txindex=1', '-simulatemainnet=1']
         ]

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -144,7 +144,6 @@ class BlockchainTest(DefiTestFramework):
             'grandcentral': {'type': 'buried', 'active': False, 'height': 10000000},
             'grandcentralepilogue': {'type': 'buried', 'active': False, 'height': 10000000},
             'nextnetworkupgrade': {'type': 'buried', 'active': False, 'height': 10000000},
-            'changiintermediate': {'type': 'buried', 'active': False, 'height': 10000000},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {


### PR DESCRIPTION
Adds the ChangiIntermediate3 fork and puts the DUSD loop changes behind it.