### PR TITLE
Add Rust logs for CI full sync

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -90,6 +90,7 @@ impl EVMBackend {
         };
 
         storage.into_iter().for_each(|(k, v)| {
+            debug!("Apply::Modify storage, key: {:x} value: {:x}", k, v);
             let _ = storage_trie.insert(k.as_bytes(), v.as_bytes());
         });
 
@@ -285,7 +286,11 @@ impl ApplyBackend for EVMBackend {
                     storage,
                     reset_storage,
                 } => {
-                    debug!("Apply::Modify, address {:#x}, basic {:#?}", address, basic);
+                    debug!(
+                        "Apply::Modify address {:x}, basic {:?}, code {:?}",
+                        address, basic, code,
+                    );
+
                     let new_account = self
                         .apply(address, basic, code, storage, reset_storage)
                         .expect("Error applying state");


### PR DESCRIPTION
## Summary

- Adds logs to be used by CI full sync.
- Greppable via `grep "Apply::Modify" | cut -d" " -f4-`

Outputs :
```
Apply::Modify, address 6e5d309741f8103bb95695e0b3eb8b61c9299578, basic Basic { balance: 56421325650940207844854, nonce: 1 }, code None
Apply::Modify storage, key: 093899b70d2290215fe170bf738341d7aa5f5ca41dad9eb7d6bac9c6e3b1765c value: 0000000000000000000000000000000000000000000000000000000000000000
Apply::Modify storage, key: 76c64224069769e8cf8ffdc19bc8b477c7a384dcdf05665efc7f739d6915235f value: 0000000000000000000000000000000000000000000006d17bf2baffce58e5c6
Apply::Modify, address cc4bffc84f6b05f82552ebe4a44925b9316f10f7, basic Basic { balance: 0, nonce: 1 }, code None
Apply::Modify, address 38f42cae7c9fbda9fcff6d590eb8c5c50e94d08a, basic Basic { balance: 140000000000000000, nonce: 1 }, code None
Apply::Modify storage, key: 0000000000000000000000000000000000000000000000000000000000000008 value: 000000000000000000000000000000000000000000000000000000000000000e
Apply::Modify storage, key: 0fdfc5cf811e4cd02ad866da7ab74d14f9e6d5959be308a8a0fc15e3c61e1bba value: 000000000000000000000000000000000000000000000000000000000c0eeb05
Apply::Modify storage, key: 720280c57b52870249e77b0e0c2e25d7bf8278f5fb6ce251feb01c5a9104e776 value: 000000000000000000000000000000000000000000000000000000000000000e
Apply::Modify storage, key: a2e8be7f68d4543393e3e8fea2ee08eb42082ca5a4d2cceecb91ee5cab09d320 value: 000000000000000000000000b63dfc08061d959e5c52f8bc7a95403ec0f45f86
```