### PR TITLE
In TransferDomain handle ExtractDestination failure

### DIFF
--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -427,11 +427,11 @@ public:
     }
 
     static Res TransferDomainETHSourceAddress() {
-        return Res::Err("Src address must be a legacy or Bech32 address in case of \"DVM\" domain");
+        return Res::Err("Src address must be an ETH address in case of \"EVM\" domain");
     }
 
     static Res TransferDomainDFISourceAddress() {
-        return Res::Err("Src address must be an ETH address in case of \"EVM\" domain");
+        return Res::Err("Src address must be a legacy or Bech32 address in case of \"DVM\" domain");
     }
 
     static Res TransferDomainInvalidSourceDomain() {
@@ -439,11 +439,11 @@ public:
     }
 
     static Res TransferDomainETHDestinationAddress() {
-        return Res::Err("Dst address must be a legacy or Bech32 address in case of \"DVM\" domain");
+        return Res::Err("Dst address must be an ETH address in case of \"EVM\" domain");
     }
 
     static Res TransferDomainDVMDestinationAddress() {
-        return Res::Err("Dst address must be a legacy or Bech32 address in case of \"EVM\" domain");
+        return Res::Err("Dst address must be a legacy or Bech32 address in case of \"DVM\" domain");
     }
 
     static Res TransferDomainInvalidDestinationDomain() {

--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -427,7 +427,7 @@ public:
     }
 
     static Res TransferDomainETHSourceAddress() {
-        return Res::Err("Src address must not be an ETH address in case of \"DVM\" domain");
+        return Res::Err("Src address must be a legacy or Bech32 address in case of \"DVM\" domain");
     }
 
     static Res TransferDomainDFISourceAddress() {
@@ -439,11 +439,11 @@ public:
     }
 
     static Res TransferDomainETHDestinationAddress() {
-        return Res::Err("Dst address must not be an ETH address in case of \"DVM\" domain");
+        return Res::Err("Dst address must be a legacy or Bech32 address in case of \"DVM\" domain");
     }
 
     static Res TransferDomainDVMDestinationAddress() {
-        return Res::Err("Dst address must be an ETH address in case of \"EVM\" domain");
+        return Res::Err("Dst address must be a legacy or Bech32 address in case of \"EVM\" domain");
     }
 
     static Res TransferDomainInvalidDestinationDomain() {

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -4013,6 +4013,8 @@ Res ValidateTransferDomain(const CTransaction &tx,
                 if (dest.index() == WitV16KeyEthHashType) {
                     return DeFiErrors::TransferDomainETHSourceAddress();
                 }
+            } else {
+                return DeFiErrors::TransferDomainETHSourceAddress();
             }
             // Check for authorization on source address
             res = HasAuth(tx, coins, src.address);
@@ -4024,6 +4026,8 @@ Res ValidateTransferDomain(const CTransaction &tx,
                 if (dest.index() != WitV16KeyEthHashType) {
                     return DeFiErrors::TransferDomainDFISourceAddress();
                 }
+            } else {
+                return DeFiErrors::TransferDomainDFISourceAddress();
             }
             // Check for authorization on source address
             res = HasAuth(tx, coins, src.address, AuthStrategy::EthKeyMatch);
@@ -4040,6 +4044,8 @@ Res ValidateTransferDomain(const CTransaction &tx,
                 if (dest.index() == WitV16KeyEthHashType) {
                     return DeFiErrors::TransferDomainETHDestinationAddress();
                 }
+            } else {
+                return DeFiErrors::TransferDomainETHDestinationAddress();
             }
         } else if (dst.domain == static_cast<uint8_t>(VMDomain::EVM)) {
             // Reject if source address is DFI address
@@ -4047,6 +4053,8 @@ Res ValidateTransferDomain(const CTransaction &tx,
                 if (dest.index() != WitV16KeyEthHashType) {
                     return DeFiErrors::TransferDomainDVMDestinationAddress();
                 }
+            } else {
+                return DeFiErrors::TransferDomainDVMDestinationAddress();
             }
         } else
             return DeFiErrors::TransferDomainInvalidDestinationDomain();

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -4034,12 +4034,12 @@ Res ValidateTransferDomain(const CTransaction &tx,
             if (height < static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
                 if (ExtractDestination(src.address, dest)) {
                     if (dest.index() == WitV16KeyEthHashType) {
-                        return DeFiErrors::TransferDomainETHSourceAddress();
+                        return DeFiErrors::TransferDomainDFISourceAddress();
                     }
                 }
             } else {
                 if (!DomainTransferAllowedAddress(src.address, DomainTransferType::DVM)) {
-                    return DeFiErrors::TransferDomainETHSourceAddress();
+                    return DeFiErrors::TransferDomainDFISourceAddress();
                 }
             }
             // Check for authorization on source address
@@ -4051,12 +4051,12 @@ Res ValidateTransferDomain(const CTransaction &tx,
             if (height < static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
                 if (ExtractDestination(src.address, dest)) {
                     if (dest.index() != WitV16KeyEthHashType) {
-                        return DeFiErrors::TransferDomainDFISourceAddress();
+                        return DeFiErrors::TransferDomainETHSourceAddress();
                     }
                 }
             } else {
                 if (!DomainTransferAllowedAddress(src.address, DomainTransferType::EVM)) {
-                    return DeFiErrors::TransferDomainDFISourceAddress();
+                    return DeFiErrors::TransferDomainETHSourceAddress();
                 }
             }
             // Check for authorization on source address
@@ -4073,12 +4073,12 @@ Res ValidateTransferDomain(const CTransaction &tx,
             if (height < static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
                 if (ExtractDestination(dst.address, dest)) {
                     if (dest.index() == WitV16KeyEthHashType) {
-                        return DeFiErrors::TransferDomainETHDestinationAddress();
+                        return DeFiErrors::TransferDomainDVMDestinationAddress();
                     }
                 }
             } else {
                 if (!DomainTransferAllowedAddress(dst.address, DomainTransferType::DVM)) {
-                    return DeFiErrors::TransferDomainETHDestinationAddress();
+                    return DeFiErrors::TransferDomainDVMDestinationAddress();
                 }
             }
         } else if (dst.domain == static_cast<uint8_t>(VMDomain::EVM)) {
@@ -4086,12 +4086,12 @@ Res ValidateTransferDomain(const CTransaction &tx,
             if (height < static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
                 if (ExtractDestination(dst.address, dest)) {
                     if (dest.index() != WitV16KeyEthHashType) {
-                        return DeFiErrors::TransferDomainDVMDestinationAddress();
+                        return DeFiErrors::TransferDomainETHDestinationAddress();
                     }
                 }
             } else {
                 if (!DomainTransferAllowedAddress(dst.address, DomainTransferType::EVM)) {
-                    return DeFiErrors::TransferDomainDVMDestinationAddress();
+                    return DeFiErrors::TransferDomainETHDestinationAddress();
                 }
             }
         } else

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -4014,7 +4014,10 @@ Res ValidateTransferDomain(const CTransaction &tx,
                     return DeFiErrors::TransferDomainETHSourceAddress();
                 }
             } else {
-                return DeFiErrors::TransferDomainETHSourceAddress();
+                // Remove guard on mainnet release
+                if (height > static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
+                    return DeFiErrors::TransferDomainETHSourceAddress();
+                }
             }
             // Check for authorization on source address
             res = HasAuth(tx, coins, src.address);
@@ -4027,7 +4030,10 @@ Res ValidateTransferDomain(const CTransaction &tx,
                     return DeFiErrors::TransferDomainDFISourceAddress();
                 }
             } else {
-                return DeFiErrors::TransferDomainDFISourceAddress();
+                // Remove guard on mainnet release
+                if (height > static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
+                    return DeFiErrors::TransferDomainDFISourceAddress();
+                }
             }
             // Check for authorization on source address
             res = HasAuth(tx, coins, src.address, AuthStrategy::EthKeyMatch);
@@ -4045,7 +4051,10 @@ Res ValidateTransferDomain(const CTransaction &tx,
                     return DeFiErrors::TransferDomainETHDestinationAddress();
                 }
             } else {
-                return DeFiErrors::TransferDomainETHDestinationAddress();
+                // Remove guard on mainnet release
+                if (height > static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
+                    return DeFiErrors::TransferDomainETHDestinationAddress();
+                }
             }
         } else if (dst.domain == static_cast<uint8_t>(VMDomain::EVM)) {
             // Reject if source address is DFI address
@@ -4054,7 +4063,10 @@ Res ValidateTransferDomain(const CTransaction &tx,
                     return DeFiErrors::TransferDomainDVMDestinationAddress();
                 }
             } else {
-                return DeFiErrors::TransferDomainDVMDestinationAddress();
+                // Remove guard on mainnet release
+                if (height > static_cast<uint32_t>(consensus.ChangiIntermediateHeight3)) {
+                    return DeFiErrors::TransferDomainDVMDestinationAddress();
+                }
             }
         } else
             return DeFiErrors::TransferDomainInvalidDestinationDomain();

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -20,8 +20,8 @@ class EVMTest(DefiTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-fortcanningepilogueheight=96', '-grandcentralheight=101', '-nextnetworkupgradeheight=105', '-changiintermediateheight=105', '-subsidytest=1', '-txindex=1'],
-            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-fortcanningepilogueheight=96', '-grandcentralheight=101', '-nextnetworkupgradeheight=105', '-changiintermediateheight=105', '-subsidytest=1', '-txindex=1']
+            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-fortcanningepilogueheight=96', '-grandcentralheight=101', '-nextnetworkupgradeheight=105', '-changiintermediateheight=105', '-changiintermediate3height=105', '-subsidytest=1', '-txindex=1'],
+            ['-dummypos=0', '-txnotokens=0', '-amkheight=50', '-bayfrontheight=51', '-eunosheight=80', '-fortcanningheight=82', '-fortcanninghillheight=84', '-fortcanningroadheight=86', '-fortcanningcrunchheight=88', '-fortcanningspringheight=90', '-fortcanninggreatworldheight=94', '-fortcanningepilogueheight=96', '-grandcentralheight=101', '-nextnetworkupgradeheight=105', '-changiintermediateheight=105', '-changiintermediate3height=105', '-subsidytest=1', '-txindex=1']
         ]
 
     def test_tx_without_chainid(self, node, keypair):
@@ -120,8 +120,8 @@ class EVMTest(DefiTestFramework):
         assert_raises_rpc_error(-5, "recipient (blablabla) does not refer to any valid address", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":"blablabla", "amount":"100@DFI", "domain": 3}}])
 
         # Check for valid values DVM->EVM in transferdomain rpc
-        assert_raises_rpc_error(-32600, "Src address must not be an ETH address in case of \"DVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 3}}])
-        assert_raises_rpc_error(-32600, "Dst address must be an ETH address in case of \"EVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":address, "amount":"100@DFI", "domain": 3}}])
+        assert_raises_rpc_error(-32600, "Src address must be a legacy or Bech32 address in case of \"DVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 3}}])
+        assert_raises_rpc_error(-32600, "Dst address must be a legacy or Bech32 address in case of \"EVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":address, "amount":"100@DFI", "domain": 3}}])
         assert_raises_rpc_error(-32600, "Cannot transfer inside same domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 2}}])
         assert_raises_rpc_error(-32600, "Source amount must be equal to destination amount", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"101@DFI", "domain": 3}}])
         assert_raises_rpc_error(-32600, "For transferdomain, only DFI token is currently supported", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@BTC", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 3}}])
@@ -156,7 +156,7 @@ class EVMTest(DefiTestFramework):
 
         # Check for valid values EVM->DVM in transferdomain rpc
         assert_raises_rpc_error(-32600, "Src address must be an ETH address in case of \"EVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 3}, "dst":{"address":address, "amount":"100@DFI", "domain": 2}}])
-        assert_raises_rpc_error(-32600, "Dst address must not be an ETH address in case of \"DVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 3}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 2}}])
+        assert_raises_rpc_error(-32600, "Dst address must be a legacy or Bech32 address in case of \"DVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 3}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 2}}])
         assert_raises_rpc_error(-32600, "Cannot transfer inside same domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 3}, "dst":{"address":address, "amount":"100@DFI", "domain": 3}}])
         assert_raises_rpc_error(-32600, "Source amount must be equal to destination amount", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 3}, "dst":{"address":address, "amount":"101@DFI", "domain": 2}}])
         assert_raises_rpc_error(-32600, "For transferdomain, only DFI token is currently supported", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@BTC", "domain": 3}, "dst":{"address":address, "amount":"100@DFI", "domain": 2}}])

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -121,7 +121,7 @@ class EVMTest(DefiTestFramework):
 
         # Check for valid values DVM->EVM in transferdomain rpc
         assert_raises_rpc_error(-32600, "Src address must be a legacy or Bech32 address in case of \"DVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":eth_address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 3}}])
-        assert_raises_rpc_error(-32600, "Dst address must be a legacy or Bech32 address in case of \"EVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":address, "amount":"100@DFI", "domain": 3}}])
+        assert_raises_rpc_error(-32600, "Dst address must be an ETH address in case of \"EVM\" domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":address, "amount":"100@DFI", "domain": 3}}])
         assert_raises_rpc_error(-32600, "Cannot transfer inside same domain", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 2}}])
         assert_raises_rpc_error(-32600, "Source amount must be equal to destination amount", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@DFI", "domain": 2}, "dst":{"address":eth_address, "amount":"101@DFI", "domain": 3}}])
         assert_raises_rpc_error(-32600, "For transferdomain, only DFI token is currently supported", self.nodes[0].transferdomain, [{"src": {"address":address, "amount":"100@BTC", "domain": 2}, "dst":{"address":eth_address, "amount":"100@DFI", "domain": 3}}])


### PR DESCRIPTION
If TransferDomain fails to extract the destination from the source or destination address return with a failure message.