### PR TITLE
Restore RPC side address checks

### DIFF
--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -365,10 +365,17 @@ UniValue updatemasternode(const JSONRPCRequest& request)
     UniValue metaObj = request.params[1].get_obj();
     if (!metaObj["ownerAddress"].isNull()) {
         newOwnerDest = DecodeDestination(metaObj["ownerAddress"].getValStr());
+        if (newOwnerDest.index() != PKHashType && newOwnerDest.index() != WitV0KeyHashType) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "ownerAddress (" + metaObj["ownerAddress"].getValStr() +
+                                                      ") does not refer to a P2PKH or P2WPKH address");
+        }
     }
 
     if (!metaObj["operatorAddress"].isNull()) {
         operatorDest = DecodeDestination(metaObj["operatorAddress"].getValStr());
+        if (operatorDest.index() != PKHashType && operatorDest.index() != WitV0KeyHashType) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorAddress (" + metaObj["operatorAddress"].getValStr() + ") does not refer to a P2PKH or P2WPKH address");
+        }
     }
 
     std::string rewardAddress;
@@ -376,6 +383,9 @@ UniValue updatemasternode(const JSONRPCRequest& request)
         rewardAddress = metaObj["rewardAddress"].getValStr();
         if (!rewardAddress.empty()) {
             rewardDest = DecodeDestination(rewardAddress);
+            if (rewardDest.index() != PKHashType && rewardDest.index() != ScriptHashType && rewardDest.index() != WitV0KeyHashType) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "rewardAddress (" + rewardAddress + ") does not refer to a P2SH, P2PKH or P2WPKH address");
+            }
         }
     }
 

--- a/test/functional/rpc_updatemasternode.py
+++ b/test/functional/rpc_updatemasternode.py
@@ -177,8 +177,8 @@ class TestForcedRewardAddress(DefiTestFramework):
                                 self.nodes[0].updatemasternode, "some_bad_mn_id",
                                 {'rewardAddress': forced_reward_address}
                                 )
-        assert_raises_rpc_error(-32600,
-                                "Reward address must be P2PKH or P2WPKH type",
+        assert_raises_rpc_error(-8,
+                                "rewardAddress (some_bad_address) does not refer to a P2SH, P2PKH or P2WPKH address",
                                 self.nodes[0].updatemasternode, mn_id, {'rewardAddress': 'some_bad_address'}
                                 )
 
@@ -276,8 +276,8 @@ class TestForcedRewardAddress(DefiTestFramework):
         assert_raises_rpc_error(-26, "Unknown update type provided", self.nodes[0].sendrawtransaction, updated_tx)
 
         # Test incorrect owner address
-        assert_raises_rpc_error(-32600,
-                                "Owner address must be P2PKH or P2WPKH type",
+        assert_raises_rpc_error(-8,
+                                "ownerAddress (some_bad_address) does not refer to a P2PKH or P2WPKH address",
                                 self.nodes[0].updatemasternode, mn_id, {'ownerAddress': 'some_bad_address'}
                                 )
 
@@ -477,7 +477,7 @@ class TestForcedRewardAddress(DefiTestFramework):
         assert_equal(result['rewardAddress'], script_address)
 
         # Verify post fork error on invalid address
-        assert_raises_rpc_error(-32600, "Reward address must be P2SH, P2PKH or P2WPKH type",
+        assert_raises_rpc_error(-8, "rewardAddress (invalid_address) does not refer to a P2SH, P2PKH or P2WPKH address",
                                 self.nodes[0].updatemasternode, mn2, {'rewardAddress': 'invalid_address'})
 
 if __name__ == '__main__':


### PR DESCRIPTION
These checks in updatemasternode are actually required to prevent use of std::get on an unexpected index.