### PR TITLE
Fix miner Eth bugs

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -811,7 +811,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
                     if (nonce != txResult.nonce) {
                         // Only add if not already in failed TXs to prevent adding on second attempt.
                         if (!failedTx.count(iter)) {
-                            failedNonces.emplace(nonce, iter);
+                            failedNonces.emplace(txResult.nonce, iter);
                         }
                         customTxPassed = false;
                         break;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -543,6 +543,10 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = *it->second;
+            // Coinbase TX prevout may incorrectly match and remove EVM TX
+            if (IsEVMTx(txConflict)) {
+                continue;
+            }
             if (txConflict != tx)
             {
                 ClearPrioritisation(txConflict.GetHash());

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -283,8 +283,16 @@ class EVMTest(DefiTestFramework):
         assert_equal(result[2]['s'], '0x1876f296657bc56499cc6398617f97b2327fa87189c0a49fb671b4361876142a')
 
         # Check mempools for TXs
-        assert_equal(self.nodes[0].getrawmempool(), [tx3, tx2, tx4, tx])
-        assert_equal(self.nodes[1].getrawmempool(), [tx3, tx2, tx4, tx])
+        mempool = self.nodes[0].getrawmempool()
+        assert(mempool.count(tx))
+        assert(mempool.count(tx2))
+        assert(mempool.count(tx3))
+        assert(mempool.count(tx4))
+        mempool = self.nodes[1].getrawmempool()
+        assert(mempool.count(tx))
+        assert(mempool.count(tx2))
+        assert(mempool.count(tx3))
+        assert(mempool.count(tx4))
         self.nodes[0].generate(1)
 
         # Check TXs in block in correct order

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -284,15 +284,15 @@ class EVMTest(DefiTestFramework):
 
         # Check mempools for TXs
         mempool = self.nodes[0].getrawmempool()
-        assert(mempool.count(tx))
-        assert(mempool.count(tx2))
-        assert(mempool.count(tx3))
-        assert(mempool.count(tx4))
+        assert (mempool.count(tx))
+        assert (mempool.count(tx2))
+        assert (mempool.count(tx3))
+        assert (mempool.count(tx4))
         mempool = self.nodes[1].getrawmempool()
-        assert(mempool.count(tx))
-        assert(mempool.count(tx2))
-        assert(mempool.count(tx3))
-        assert(mempool.count(tx4))
+        assert (mempool.count(tx))
+        assert (mempool.count(tx2))
+        assert (mempool.count(tx3))
+        assert (mempool.count(tx4))
         self.nodes[0].generate(1)
 
         # Check TXs in block in correct order

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -49,8 +49,7 @@ class EVMRolllbackTest(DefiTestFramework):
 
         self.nodes[0].invalidateblock(initialBlockHash)
 
-        block = self.nodes[0].eth_getBlockByNumber(blockNumberPreInvalidation)
-        assert_equal(block, None)
+        assert_raises_rpc_error(-32001, "Custom error: header not found", self.nodes[0].eth_getBlockByNumber, blockNumberPreInvalidation)
         blockByHash = self.nodes[0].eth_getBlockByHash(blockPreInvalidation['hash'])
         assert_equal(blockByHash, None)
         block = self.nodes[0].eth_getBlockByNumber('latest')


### PR DESCRIPTION
Add failed Eth TXs to failed nonce map by nonce in TX, not account nonce.
Do not remove conflicting TXs if they are Eth TXs as they are incorrectly matched on a coinbase TX.