### PR TITLE
Fixes to get rollback log before downloading ref logs from gc

### DIFF
--- a/ci/sync/main.sh
+++ b/ci/sync/main.sh
@@ -184,13 +184,13 @@ main() {
     # Create temporary log file
     get_full_log >> "$TMP_LOG"
 
-    # Download reference log file
-    echo "Downloading reference log file : ${REF_LOG_PATH}"
-    $FETCH "$REF_LOG_PATH"
-
     # Create rollback log after sync
     rollback_and_log > "$POST_ROLLBACK_LOG"
     stop_node
+
+    # Download reference log file
+    echo "Downloading reference log file : ${REF_LOG_PATH}"
+    $FETCH "$REF_LOG_PATH"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Fixes to switch order in sync pipeline to get rollback log in the scenario where defid node shutdowns unexpectedly while downloading reference logs.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
