### PR TITLE
Evm/fix miner fee

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -204,7 +204,7 @@ impl EVMCoreService {
             .get_balance(signed_tx.sender, block_number)
             .map_err(|e| anyhow!("Error getting balance {e}"))?;
 
-        debug!("[validate_raw_tx] Accout balance : {:x?}", balance);
+        debug!("[validate_raw_tx] Account balance : {:x?}", balance);
 
         let prepay_gas = calculate_prepay_gas(&signed_tx);
         debug!("[validate_raw_tx] prepay_gas : {:x?}", prepay_gas);

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -2,6 +2,7 @@ use crate::backend::{EVMBackend, Vicinity};
 use crate::block::BlockService;
 use crate::core::{EVMCoreService, EVMError, NativeTxHash, MAX_GAS_PER_BLOCK};
 use crate::executor::{AinExecutor, TxResponse};
+use crate::fee::calculate_gas_fee;
 use crate::filters::FilterService;
 use crate::log::LogService;
 use crate::receipt::ReceiptService;
@@ -88,8 +89,8 @@ impl EVMServices {
         let mut all_transactions = Vec::with_capacity(self.core.tx_queues.len(context));
         let mut failed_transactions = Vec::with_capacity(self.core.tx_queues.len(context));
         let mut receipts_v3: Vec<ReceiptV3> = Vec::with_capacity(self.core.tx_queues.len(context));
-        let mut gas_used = 0u64;
-        let mut gas_fees = 0u64;
+        let mut total_gas_used = 0u64;
+        let mut total_gas_fees = U256::zero();
         let mut logs_bloom: Bloom = Bloom::default();
 
         let parent_data = self.block.get_latest_block_hash_and_number();
@@ -161,9 +162,9 @@ impl EVMServices {
                         failed_transactions.push(hex::encode(hash));
                     }
 
-                    let gas_fee = calculate_gas_fee(signed_tx, used_gas);
-                    gas_used += used_gas;
-                    gas_fees += gas_fee;
+                    let gas_fee = calculate_gas_fee(&signed_tx, U256::from(used_gas));
+                    total_gas_used += used_gas;
+                    total_gas_fees += gas_fee;
 
                     all_transactions.push(signed_tx.clone());
                     EVMCoreService::logs_bloom(logs, &mut logs_bloom);
@@ -213,7 +214,7 @@ impl EVMServices {
                 difficulty: U256::from(difficulty),
                 number: current_block_number,
                 gas_limit: MAX_GAS_PER_BLOCK,
-                gas_used: U256::from(gas_used),
+                gas_used: U256::from(total_gas_used),
                 timestamp,
                 extra_data: Vec::default(),
                 mix_hash: H256::default(),
@@ -252,14 +253,14 @@ impl EVMServices {
             Ok((
                 *block.header.hash().as_fixed_bytes(),
                 failed_transactions,
-                gas_fees,
+                total_gas_fees.try_into().unwrap(),
             ))
         }
         else {
             Ok((
                 *block.header.hash().as_fixed_bytes(),
                 failed_transactions,
-                gas_used,
+                total_gas_used,
             ))
         }
     }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -255,8 +255,7 @@ impl EVMServices {
                 failed_transactions,
                 total_gas_fees.try_into().unwrap(),
             ))
-        }
-        else {
+        } else {
             Ok((
                 *block.header.hash().as_fixed_bytes(),
                 failed_transactions,

--- a/lib/ain-evm/src/fee.rs
+++ b/lib/ain-evm/src/fee.rs
@@ -10,7 +10,7 @@ pub fn calculate_prepay_gas(signed_tx: &SignedTx) -> U256 {
     }
 }
 
-pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: &U64) -> U64 {
+pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: U256) -> U256 {
     match &signed_tx.transaction {
         ethereum::TransactionV2::Legacy(tx) => used_gas.saturating_mul(tx.gas_price),
         ethereum::TransactionV2::EIP2930(tx) => used_gas.saturating_mul(tx.gas_price),

--- a/lib/ain-evm/src/fee.rs
+++ b/lib/ain-evm/src/fee.rs
@@ -9,3 +9,11 @@ pub fn calculate_prepay_gas(signed_tx: &SignedTx) -> U256 {
         ethereum::TransactionV2::EIP1559(tx) => tx.gas_limit.saturating_mul(tx.max_fee_per_gas),
     }
 }
+
+pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: &U64) -> U64 {
+    match &signed_tx.transaction {
+        ethereum::TransactionV2::Legacy(tx) => used_gas.saturating_mul(tx.gas_price),
+        ethereum::TransactionV2::EIP2930(tx) => used_gas.saturating_mul(tx.gas_price),
+        ethereum::TransactionV2::EIP1559(tx) => used_gas.saturating_mul(tx.max_fee_per_gas),
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes to current finalize_block pipeline to return the total gas fees instead of the total gas used which will be passed as miner fees to the miner on the accounts layer.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
