### PR TITLE
Rename SHA3 to KECCAK

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -881,7 +881,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 //
                 case OP_RIPEMD160:
                 case OP_SHA1:
-                case OP_SHA3:
+                case OP_KECCAK:
                 case OP_SHA256:
                 case OP_HASH160:
                 case OP_HASH256:
@@ -890,12 +890,12 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     if (stack.size() < 1)
                         return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch = stacktop(-1);
-                    valtype vchHash((opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_SHA3 || opcode == OP_HASH160) ? 20 : 32);
+                    valtype vchHash((opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_KECCAK || opcode == OP_HASH160) ? 20 : 32);
                     if (opcode == OP_RIPEMD160)
                         CRIPEMD160().Write(vch.data(), vch.size()).Finalize(vchHash.data());
                     else if (opcode == OP_SHA1)
                         CSHA1().Write(vch.data(), vch.size()).Finalize(vchHash.data());
-                    else if (opcode == OP_SHA3) {
+                    else if (opcode == OP_KECCAK) {
                         const size_t HEADER_OFFSET{1};
                         const auto result = Sha3({vch.begin() + HEADER_OFFSET, vch.end()});
                         memcpy(vchHash.data(), result.begin(), 20);
@@ -1459,7 +1459,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
             if (witness.stack.size() != 2) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH); // 2 items in witness
             }
-            scriptPubKey << OP_DUP << OP_SHA3 << program << OP_EQUALVERIFY << OP_CHECKSIG;
+            scriptPubKey << OP_DUP << OP_KECCAK << program << OP_EQUALVERIFY << OP_CHECKSIG;
             stack = witness.stack;
         } else {
             return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_WRONG_LENGTH);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -117,7 +117,7 @@ const char* GetOpName(opcodetype opcode)
     // crypto
     case OP_RIPEMD160              : return "OP_RIPEMD160";
     case OP_SHA1                   : return "OP_SHA1";
-    case OP_SHA3                   : return "OP_SHA3";
+    case OP_KECCAK                 : return "OP_KECCAK";
     case OP_SHA256                 : return "OP_SHA256";
     case OP_HASH160                : return "OP_HASH160";
     case OP_HASH256                : return "OP_HASH256";

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -56,7 +56,8 @@ enum opcodetype
     // push value
     OP_0 = 0x00,
     OP_FALSE = OP_0,
-    OP_PUSHDATA1 = 0x4c,
+
+    OP_PUSHDATA1 = 0x4c,                    // 76
     OP_PUSHDATA2 = 0x4d,
     OP_PUSHDATA4 = 0x4e,
     OP_1NEGATE = 0x4f,
@@ -80,7 +81,7 @@ enum opcodetype
     OP_16 = 0x60,
 
     // control
-    OP_NOP = 0x61,
+    OP_NOP = 0x61,                          // 97
     OP_VER = 0x62,
     OP_IF = 0x63,
     OP_NOTIF = 0x64,
@@ -92,7 +93,7 @@ enum opcodetype
     OP_RETURN = 0x6a,
 
     // stack ops
-    OP_TOALTSTACK = 0x6b,
+    OP_TOALTSTACK = 0x6b,                   // 107
     OP_FROMALTSTACK = 0x6c,
     OP_2DROP = 0x6d,
     OP_2DUP = 0x6e,
@@ -113,14 +114,14 @@ enum opcodetype
     OP_TUCK = 0x7d,
 
     // splice ops
-    OP_CAT = 0x7e,
+    OP_CAT = 0x7e,                          // 126
     OP_SUBSTR = 0x7f,
     OP_LEFT = 0x80,
     OP_RIGHT = 0x81,
     OP_SIZE = 0x82,
 
     // bit logic
-    OP_INVERT = 0x83,
+    OP_INVERT = 0x83,                       // 131
     OP_AND = 0x84,
     OP_OR = 0x85,
     OP_XOR = 0x86,
@@ -130,7 +131,7 @@ enum opcodetype
     OP_RESERVED2 = 0x8a,
 
     // numeric
-    OP_1ADD = 0x8b,
+    OP_1ADD = 0x8b,                         // 139
     OP_1SUB = 0x8c,
     OP_2MUL = 0x8d,
     OP_2DIV = 0x8e,
@@ -162,9 +163,8 @@ enum opcodetype
     OP_WITHIN = 0xa5,
 
     // crypto
-    OP_RIPEMD160 = 0xa6,
+    OP_RIPEMD160 = 0xa6,                    // 166
     OP_SHA1 = 0xa7,
-    OP_SHA3 = 0xc0,
     OP_SHA256 = 0xa8,
     OP_HASH160 = 0xa9,
     OP_HASH256 = 0xaa,
@@ -175,7 +175,7 @@ enum opcodetype
     OP_CHECKMULTISIGVERIFY = 0xaf,
 
     // expansion
-    OP_NOP1 = 0xb0,
+    OP_NOP1 = 0xb0,                         // 176
     OP_CHECKLOCKTIMEVERIFY = 0xb1,
     OP_NOP2 = OP_CHECKLOCKTIMEVERIFY,
     OP_CHECKSEQUENCEVERIFY = 0xb2,
@@ -188,7 +188,10 @@ enum opcodetype
     OP_NOP9 = 0xb8,
     OP_NOP10 = 0xb9,
 
-    OP_INVALIDOPCODE = 0xff,
+    // DeFiChain expansion
+    OP_KECCAK = 0xc0,                       // 192
+
+    OP_INVALIDOPCODE = 0xff,                // 255
 };
 
 // Maximum value that an opcode can be

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -231,7 +231,7 @@ bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreato
     else if (solved && whichType == TX_WITNESS_V16_ETHHASH)
     {
         CScript witnessscript;
-        witnessscript << OP_DUP << OP_SHA3 << ToByteVector(result[0]) << OP_EQUALVERIFY << OP_CHECKSIG;
+        witnessscript << OP_DUP << OP_KECCAK << ToByteVector(result[0]) << OP_EQUALVERIFY << OP_CHECKSIG;
         txnouttype subType;
         solved = solved && SignStep(provider, creator, witnessscript, result, subType, SigVersion::WITNESS_V16, sigdata);
         sigdata.scriptWitness.stack = result;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -63,7 +63,7 @@ static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
 static bool MatchPayToPubkeyHash(const CScript& script, valtype& pubkeyhash)
 {
     if ((script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) ||
-        (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_SHA3 && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG)) {
+        (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_KECCAK && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG)) {
         pubkeyhash = valtype(script.begin () + 3, script.begin() + 23);
         return true;
     }


### PR DESCRIPTION
## Summary

- Rename OP_SHA3 to OP_KECCAK to be more accurate, since SHA3 impl has been standardised to have different parameters though both are based are based on the same family of Sponge construction.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
