### PR TITLE
EVM gas fee bug fixes

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -217,15 +217,23 @@ impl EVMCoreService {
         let prepay_gas = calculate_prepay_gas(&signed_tx);
         debug!("[validate_raw_tx] prepay_gas : {:x?}", prepay_gas);
 
-        if balance < prepay_gas {
-            debug!("[validate_raw_tx] insufficient balance to pay fees");
-            return Err(anyhow!("insufficient balance to pay fees").into());
-        }
-
         let gas_limit = signed_tx.gas_limit();
-        if gas_limit < MIN_GAS_PER_TX {
-            debug!("[validate_raw_tx] gas limit is below the minimum gas per tx");
-            return Err(anyhow!("gas limit is below the minimum gas per tx").into());
+        if ain_cpp_imports::past_changi_intermediate_height_4_height() {
+            if balance < prepay_gas {
+                debug!("[validate_raw_tx] insufficient balance to pay fees");
+                return Err(anyhow!("insufficient balance to pay fees").into());
+            }
+
+            if gas_limit < MIN_GAS_PER_TX {
+                debug!("[validate_raw_tx] gas limit is below the minimum gas per tx");
+                return Err(anyhow!("gas limit is below the minimum gas per tx").into());
+            }
+        }
+        else {
+            if balance < MIN_GAS_PER_TX || balance < prepay_gas {
+                debug!("[validate_raw_tx] insufficient balance to pay fees");
+                return Err(anyhow!("insufficient balance to pay fees").into());
+            }
         }
 
         if gas_limit > MAX_GAS_PER_BLOCK {

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -228,12 +228,9 @@ impl EVMCoreService {
                 debug!("[validate_raw_tx] gas limit is below the minimum gas per tx");
                 return Err(anyhow!("gas limit is below the minimum gas per tx").into());
             }
-        }
-        else {
-            if balance < MIN_GAS_PER_TX || balance < prepay_gas {
-                debug!("[validate_raw_tx] insufficient balance to pay fees");
-                return Err(anyhow!("insufficient balance to pay fees").into());
-            }
+        } else if balance < MIN_GAS_PER_TX || balance < prepay_gas {
+            debug!("[validate_raw_tx] insufficient balance to pay fees");
+            return Err(anyhow!("insufficient balance to pay fees").into());
         }
 
         if gas_limit > MAX_GAS_PER_BLOCK {

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -27,6 +27,7 @@ use vsdb_core::vsdb_set_base_dir;
 
 pub type NativeTxHash = [u8; 32];
 
+pub const MIN_GAS_PER_TX: U256 = U256([21_000, 0, 0, 0]);
 pub const MAX_GAS_PER_BLOCK: U256 = U256([30_000_000, 0, 0, 0]);
 
 pub struct EVMCoreService {
@@ -207,7 +208,6 @@ impl EVMCoreService {
             .into());
         }
 
-        const MIN_GAS_PER_TX: U256 = U256([21_000, 0, 0, 0]);
         let balance = self
             .get_balance(signed_tx.sender, block_number)
             .map_err(|e| anyhow!("Error getting balance {e}"))?;
@@ -217,18 +217,19 @@ impl EVMCoreService {
         let prepay_gas = calculate_prepay_gas(&signed_tx);
         debug!("[validate_raw_tx] prepay_gas : {:x?}", prepay_gas);
 
-        if balance < MIN_GAS_PER_TX || balance < prepay_gas {
+        if balance < prepay_gas {
             debug!("[validate_raw_tx] insufficient balance to pay fees");
             return Err(anyhow!("insufficient balance to pay fees").into());
         }
 
         let gas_limit = signed_tx.gas_limit();
+        if gas_limit < MIN_GAS_PER_TX {
+            debug!("[validate_raw_tx] gas limit is below the minimum gas per tx");
+            return Err(anyhow!("gas limit is below the minimum gas per tx").into());
+        }
 
-        debug!(
-            "[validate_raw_tx] MAX_GAS_PER_BLOCK: {:#x}",
-            MAX_GAS_PER_BLOCK
-        );
         if gas_limit > MAX_GAS_PER_BLOCK {
+            debug!("[validate_raw_tx] Gas limit higher than MAX_GAS_PER_BLOCK");
             return Err(anyhow!("Gas limit higher than MAX_GAS_PER_BLOCK").into());
         }
 

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -132,6 +132,8 @@ impl EVMServices {
             ),
         };
 
+        let base_fee = self.block.calculate_base_fee(parent_hash);
+
         let mut backend = EVMBackend::from_root(
             state_root,
             Arc::clone(&self.core.trie_store),
@@ -170,7 +172,7 @@ impl EVMServices {
                         failed_transactions.push(hex::encode(hash));
                     }
 
-                    let gas_fee = calculate_gas_fee(&signed_tx, U256::from(used_gas));
+                    let gas_fee = calculate_gas_fee(&signed_tx, U256::from(used_gas), base_fee);
                     total_gas_used += used_gas;
                     total_gas_fees += gas_fee;
 
@@ -241,9 +243,6 @@ impl EVMServices {
             block.header.hash(),
             block.header.number,
         );
-
-        // calculate base fee
-        let base_fee = self.block.calculate_base_fee(parent_hash);
 
         if update_state {
             debug!(

--- a/lib/ain-evm/src/fee.rs
+++ b/lib/ain-evm/src/fee.rs
@@ -1,6 +1,6 @@
-use ethereum_types::U256;
-
 use crate::transaction::SignedTx;
+use ethereum_types::U256;
+use std::cmp;
 
 // Gas prices are denoted in wei
 pub fn calculate_prepay_gas(signed_tx: &SignedTx) -> U256 {
@@ -12,11 +12,15 @@ pub fn calculate_prepay_gas(signed_tx: &SignedTx) -> U256 {
 }
 
 // Gas prices are denoted in wei
-pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: U256) -> U256 {
+pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: U256, base_fee: U256) -> U256 {
     match &signed_tx.transaction {
         ethereum::TransactionV2::Legacy(tx) => used_gas.saturating_mul(tx.gas_price),
         ethereum::TransactionV2::EIP2930(tx) => used_gas.saturating_mul(tx.gas_price),
-        ethereum::TransactionV2::EIP1559(tx) => used_gas.saturating_mul(tx.max_fee_per_gas),
+        ethereum::TransactionV2::EIP1559(tx) => {
+            let max_gas_fee = used_gas.saturating_mul(tx.max_fee_per_gas);
+            let gas_fee_with_tip = used_gas.saturating_mul(tx.max_priority_fee_per_gas + base_fee);
+            cmp::min(max_gas_fee, gas_fee_with_tip)
+        }
     }
 }
 

--- a/lib/ain-evm/src/fee.rs
+++ b/lib/ain-evm/src/fee.rs
@@ -17,9 +17,8 @@ pub fn calculate_gas_fee(signed_tx: &SignedTx, used_gas: U256, base_fee: U256) -
         ethereum::TransactionV2::Legacy(tx) => used_gas.saturating_mul(tx.gas_price),
         ethereum::TransactionV2::EIP2930(tx) => used_gas.saturating_mul(tx.gas_price),
         ethereum::TransactionV2::EIP1559(tx) => {
-            let max_gas_fee = used_gas.saturating_mul(tx.max_fee_per_gas);
-            let gas_fee_with_tip = used_gas.saturating_mul(tx.max_priority_fee_per_gas + base_fee);
-            cmp::min(max_gas_fee, gas_fee_with_tip)
+            let gas_fee = cmp::min(tx.max_fee_per_gas, tx.max_priority_fee_per_gas + base_fee);
+            used_gas.saturating_mul(gas_fee)
         }
     }
 }

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -113,6 +113,22 @@ class EVMFeeTest(DefiTestFramework):
 
         self.rollback_to(height)
 
+    def test_low_gas_limit(self):
+        height = self.nodes[0].getblockcount()
+
+        balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
+        assert_equal(int(balance[2:], 16), 100000000000000000000)
+
+        assert_raises_rpc_error(-32001, "evm tx failed to validate gas limit is below the minimum gas per tx", self.nodes[0].eth_sendTransaction, {
+            'from': self.ethAddress,
+            'to': self.toAddress,
+            'value': '0x7148', # 29_000
+            'gas': '0x5207', # 20_999
+            'gasPrice': '0x2540BE400', # 10_000_000_000
+        })
+
+        self.rollback_to(height)
+
     def test_gas_limit_higher_than_block_limit(self):
         height = self.nodes[0].getblockcount()
 
@@ -182,6 +198,8 @@ class EVMFeeTest(DefiTestFramework):
         self.test_high_gas_price()
 
         self.test_max_gas_price()
+
+        self.test_low_gas_limit()
 
         self.test_gas_limit_higher_than_block_limit()
 


### PR DESCRIPTION
## Summary

- Fixes to EIP1559 transactions to align with ethereum. Gas fee calculations uses the max priority fee specified + the base fee, or the maximum gas price if that exceeds the sender's maximum gas fee specified.
- Bug fixes to evm validation tx pipeline check for minimum gas per transaction, aligning with ethereum minimum gas limits per tx (https://ethereum.org/en/developers/docs/gas/)

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
