### PR TITLE
Add bool flag to validation for EVM context

### DIFF
--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -457,8 +457,7 @@ void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuth
         if (optAuthTx)
             AddCoins(coins, *optAuthTx, height);
         CCustomCSView view(*pcustomcsview);
-        uint64_t gasUsed{};
-        res = CustomTxVisit(view, coins, tx, height, Params().GetConsensus(), txMessage, ::ChainActive().Tip()->nTime, gasUsed);
+        res = CustomTxVisit(view, coins, tx, height, Params().GetConsensus(), txMessage, ::ChainActive().Tip()->nTime);
     }
     if (!res) {
         if (res.code == CustomTxErrCodes::NotEnoughBalance) {


### PR DESCRIPTION
## Summary

- execTestTx implementation uses the validation pipeline, which creates undesirable behavior when testing evm tx execution. Specifically, the function is called in eth RPC and dvm RPC.
- Fix to pass a boolean flag to the visitor pattern in validation (mn_checks) where we will pass that flag on to evm_try_prevalidate_raw_tx to validate the raw evm tx with or without evm context.
- Note that evmContext = 0 is safe as it is double guarded in txqueue to be an invalid context key.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
