### PR TITLE
EVM FFI refactor and hosuekeeping

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -47,7 +47,7 @@ pub struct EthCallArgs<'a> {
 
 pub struct ValidateTxInfo {
     pub signed_tx: SignedTx,
-    pub prepay_gas: U256,
+    pub prepay_fee: U256,
     pub used_gas: u64,
 }
 
@@ -167,8 +167,8 @@ impl EVMCoreService {
     pub fn validate_raw_tx(
         &self,
         tx: &str,
-        use_context: bool,
         context: u64,
+        use_context: bool,
     ) -> Result<ValidateTxInfo, Box<dyn Error>> {
         debug!("[validate_raw_tx] raw transaction : {:#?}", tx);
         let buffer = <Vec<u8>>::from_hex(tx)?;
@@ -214,12 +214,12 @@ impl EVMCoreService {
 
         debug!("[validate_raw_tx] Account balance : {:x?}", balance);
 
-        let prepay_gas = calculate_prepay_gas(&signed_tx)?;
-        debug!("[validate_raw_tx] prepay_gas : {:x?}", prepay_gas);
+        let prepay_fee = calculate_prepay_gas(&signed_tx)?;
+        debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
 
         let gas_limit = signed_tx.gas_limit();
         if ain_cpp_imports::past_changi_intermediate_height_4_height() {
-            if balance < prepay_gas {
+            if balance < prepay_fee {
                 debug!("[validate_raw_tx] insufficient balance to pay fees");
                 return Err(anyhow!("insufficient balance to pay fees").into());
             }
@@ -228,7 +228,7 @@ impl EVMCoreService {
                 debug!("[validate_raw_tx] gas limit is below the minimum gas per tx");
                 return Err(anyhow!("gas limit is below the minimum gas per tx").into());
             }
-        } else if balance < MIN_GAS_PER_TX || balance < prepay_gas {
+        } else if balance < MIN_GAS_PER_TX || balance < prepay_fee {
             debug!("[validate_raw_tx] insufficient balance to pay fees");
             return Err(anyhow!("insufficient balance to pay fees").into());
         }
@@ -267,7 +267,7 @@ impl EVMCoreService {
 
         Ok(ValidateTxInfo {
             signed_tx,
-            prepay_gas,
+            prepay_fee,
             used_gas,
         })
     }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -48,6 +48,13 @@ pub mod ffi {
     }
 
     #[derive(Default)]
+    pub struct PreValidateTxCompletion {
+        pub nonce: u64,
+        pub sender: [u8; 20],
+        pub tx_fees: u64,
+    }
+
+    #[derive(Default)]
     pub struct ValidateTxCompletion {
         pub nonce: u64,
         pub sender: [u8; 20],
@@ -81,7 +88,10 @@ pub mod ffi {
         fn evm_try_prevalidate_raw_tx(
             result: &mut CrossBoundaryResult,
             tx: &str,
-            use_context: bool,
+        ) -> PreValidateTxCompletion;
+        fn evm_try_validate_raw_tx(
+            result: &mut CrossBoundaryResult,
+            tx: &str,
             context: u64,
         ) -> ValidateTxCompletion;
         fn evm_try_queue_tx(

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -769,7 +769,7 @@ class CCustomTxApplyVisitor : public CCustomTxVisitor {
     uint64_t time;
     uint32_t txn;
     uint64_t evmContext;
-    bool useEvmContext;
+    bool prevalidateEvm;
 
 public:
     CCustomTxApplyVisitor(const CTransaction &tx,
@@ -780,13 +780,13 @@ public:
                           uint64_t time,
                           uint32_t txn,
                           const uint64_t evmContext,
-                          const bool useEvmContext)
+                          const bool prevalidateEvm)
 
         : CCustomTxVisitor(tx, height, coins, mnview, consensus),
           time(time),
           txn(txn),
           evmContext(evmContext),
-          useEvmContext(useEvmContext) {}
+          prevalidateEvm(prevalidateEvm) {}
 
     Res operator()(const CCreateMasterNodeMessage &obj) const {
         Require(CheckMasternodeCreationTx());
@@ -3930,20 +3930,31 @@ public:
             return Res::Err("evm tx size too large");
 
         CrossBoundaryResult result;
-        const auto prevalidateResults = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx), useEvmContext, evmContext);
+        if (!prevalidateEvm) {
+            const auto prevalidateResults = evm_try_validate_raw_tx(result, HexStr(obj.evmTx), evmContext);
+            // Completely remove this fork guard on mainnet upgrade to restore nonce check from EVM activation
+            if (height >= static_cast<uint32_t>(consensus.ChangiIntermediateHeight)) {
+                if (!result.ok) {
+                    LogPrintf("[evm_try_validate_raw_tx] failed, reason : %s\n", result.reason);
+                    return Res::Err("evm tx failed to validate %s", result.reason);
+                }
+            }
 
-        // Completely remove this fork guard on mainnet upgrade to restore nonce check from EVM activation
-        if (height >= static_cast<uint32_t>(consensus.ChangiIntermediateHeight)) {
+            evm_try_queue_tx(result, evmContext, HexStr(obj.evmTx), tx.GetHash().GetByteArray(), prevalidateResults.gas_used);
             if (!result.ok) {
-                LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
-                return Res::Err("evm tx failed to validate %s", result.reason);
+                LogPrintf("[evm_try_queue_tx] failed, reason : %s\n", result.reason);
+                return Res::Err("evm tx failed to queue %s\n", result.reason);
             }
         }
-
-        evm_try_queue_tx(result, evmContext, HexStr(obj.evmTx), tx.GetHash().GetByteArray(), prevalidateResults.gas_used);
-        if (!result.ok) {
-            LogPrintf("[evm_try_queue_tx] failed, reason : %s\n", result.reason);
-            return Res::Err("evm tx failed to queue %s\n", result.reason);
+        else {
+            const auto prevalidateResults = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx));
+            // Completely remove this fork guard on mainnet upgrade to restore nonce check from EVM activation
+            if (height >= static_cast<uint32_t>(consensus.ChangiIntermediateHeight)) {
+                if (!result.ok) {
+                    LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
+                    return Res::Err("evm tx failed to validate %s", result.reason);
+                }
+            }
         }
 
         std::vector<unsigned char> evmTxHashBytes;
@@ -4179,14 +4190,14 @@ Res CustomTxVisit(CCustomCSView &mnview,
     }
 
     auto context = evmContext;
-    bool useEvmContext = true;
+    bool prevalidateEvm = false;
     if (context == 0) {
-        useEvmContext = false;
+        prevalidateEvm = true;
         context = evm_get_context();
     }
 
     try {
-        return std::visit(CCustomTxApplyVisitor(tx, height, coins, mnview, consensus, time, txn, context, useEvmContext), txMessage);
+        return std::visit(CCustomTxApplyVisitor(tx, height, coins, mnview, consensus, time, txn, context, prevalidateEvm), txMessage);
     } catch (const std::bad_variant_access &e) {
         return Res::Err(e.what());
     } catch (...) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -864,7 +864,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
                     const auto obj = std::get<CEvmTxMessage>(txMessage);
 
                     CrossBoundaryResult result;
-                    const auto txResult = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx), true, evmContext);
+                    const auto txResult = evm_try_validate_raw_tx(result, HexStr(obj.evmTx), evmContext);
                     if (!result.ok) {
                         customTxPassed = false;
                         break;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -918,7 +918,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
             const auto obj = std::get<CEvmTxMessage>(txMessage);
             CrossBoundaryResult result;
-            const auto txResult = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx), false, 0u);
+            const auto txResult = evm_try_prevalidate_raw_tx(result, HexStr(obj.evmTx));
             if (!result.ok) {
                 return state.Invalid(ValidationInvalidReason::CONSENSUS, error("evm tx failed to validate %s", result.reason.c_str()), REJECT_INVALID, "evm-validate-failed");
             }


### PR DESCRIPTION
## Summary

- Refactor to implement evm_try_prevalidate_tx and evm_try_validate_tx.
- Clearer intent in validation, mining and mempool pipelines.
- Remove passing a bool flag (useEvmContext) to rust FFI, and the flag handling is encapsulated inside the functions.
- Housekeeping - tidy up function descriptions.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
