### PR TITLE
Add branch to get the earliest block in block_number_to_u256

### DIFF
--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -291,13 +291,18 @@ impl MetachainRPCModule {
                     .get_block_by_number(&U256::from(n))
                     .map(|block| block.header.number)
             }
+            BlockNumber::Earliest => {
+                self.handler
+                    .storage
+                    .get_block_by_number(&U256::zero())
+                    .map(|block| block.header.number)
+            }
             _ => {
                 self.handler
                     .storage
                     .get_latest_block()
                     .map(|block| block.header.number)
             }
-            // BlockNumber::Earliest => todo!(),
             // BlockNumber::Pending => todo!(),
             // BlockNumber::Safe => todo!(),
             // BlockNumber::Finalized => todo!(),


### PR DESCRIPTION
## Summary

- This PR is made to fix the test for Log filtering. it just adds a branch to `block_number_to_u256` for the earliest block. other branch will be added later.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
