### PR TITLE
Fix for native dep compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1377,14 +1377,21 @@ AC_SUBST(PROTOC_INCLUDE_DIR)
 dnl If the host and build triplets are the same, we keep this empty
 if test x$host = x$build; then
   RUST_TARGET=
+  RUST_HOST=
 else
-  RUST_TARGET=`TARGET="$host" $ac_abs_confdir/make.sh get_rust_target`
+  RUST_HOST=`$ac_abs_confdir/make.sh get_rust_triplet "$build"`
+  if test $? != 0; then
+    AC_MSG_ERROR("unsupported build system")
+  fi
+  RUST_TARGET=`$ac_abs_confdir/make.sh get_rust_triplet "$host"`
   if test $? != 0; then
     AC_MSG_ERROR("unsupported host target")
   fi
 fi
 AC_SUBST(RUST_TARGET)
+AC_SUBST(RUST_HOST)
 AM_CONDITIONAL([HAVE_RUST_TARGET], [test x$RUST_TARGET != x])
+AM_CONDITIONAL([HAVE_RUST_HOST], [test x$RUST_HOST != x])
 
 AC_CONFIG_FILES([Makefile src/Makefile lib/Makefile test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
@@ -1473,6 +1480,7 @@ echo "  CXXFLAGS            = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS 
 echo "  LDFLAGS             = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
 echo "  ARFLAGS             = $ARFLAGS"
 echo "  CARGO               = $CARGO"
+echo "  RUST_HOST           = $RUST_HOST"
 echo "  RUST_TARGET         = $RUST_TARGET"
 echo "  ENABLE_DEBUG        = $ENABLE_DEBUG"
 echo

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -31,6 +31,14 @@ CARGO_EXTRA_ARGS ?= $(if $(subst $(build),,$(host)),,--all-targets)
 
 # Export compiler flags
 export CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS AR NM RANLIB
+# Set the native compilers
+if HAVE_RUST_HOST
+export CC_$(RUST_HOST)=gcc
+export CXX_$(RUST_HOST)=g++
+export CFLAGS_$(RUST_HOST)=
+export CXXFLAGS_$(RUST_HOST)=
+endif
+
 # Export compiler support
 export PKG_CONFIG_PATH PKGCONFIG_LIBDIR PYTHONPATH
 # Export protoc vars
@@ -38,6 +46,8 @@ export PROTOC PROTOC_INCLUDE_DIR
 
 # Ensure nested autotools calls by cargo don't end up in unexpected places 
 unexport DESTDIR
+
+export RUST_BACKTRACE=1
 
 .PHONY:
 all: build

--- a/make.sh
+++ b/make.sh
@@ -601,6 +601,7 @@ clean_pkg_local_py_deps() {
 
 pkg_setup_rust() {
     local rust_target
+    # shellcheck disable=SC2120
     rust_target=$(get_rust_triplet)
     rustup target add "${rust_target}"
 }

--- a/make.sh
+++ b/make.sh
@@ -601,7 +601,7 @@ clean_pkg_local_py_deps() {
 
 pkg_setup_rust() {
     local rust_target
-    rust_target=$(get_rust_target)
+    rust_target=$(get_rust_triplet)
     rustup target add "${rust_target}"
 }
 
@@ -999,24 +999,24 @@ ci_setup_deps_test() {
     pkg_local_install_py_deps
 }
 
-get_rust_target() {
+get_rust_triplet() {
     # Note: https://github.com/llvm/llvm-project/blob/master/llvm/lib/TargetParser/Triple.cpp
     # The function is called in 2 places:
     # 1. When setting up Rust, which TARGET is passed from the environment
     # 2. In configure, which sets TARGET with the additional unknown vendor part in the triplet
     # Thus, we normalize across both to source the correct rust target.
-    local target=${TARGET}
-    local rust_target
-    case $target in
-        x86_64-pc-linux-gnu) rust_target=x86_64-unknown-linux-gnu;;
-        aarch64-linux-gnu|aarch64-unknown-linux-gnu) rust_target=aarch64-unknown-linux-gnu;;
-        arm-linux-gnueabihf|arm-unknown-linux-gnueabihf) rust_target=armv7-unknown-linux-gnueabihf;;
-        x86_64-apple-darwin) rust_target=x86_64-apple-darwin;;
-        aarch64-apple-darwin) rust_target=aarch64-apple-darwin;;
-        x86_64-w64-mingw32) rust_target=x86_64-pc-windows-gnu;;
-        *) echo "error: unsupported target: ${target}"; exit 1;;
+    local triplet=${1:-${TARGET}}
+    local result
+    case $triplet in
+        x86_64-pc-linux-gnu) result=x86_64-unknown-linux-gnu;;
+        aarch64-linux-gnu|aarch64-unknown-linux-gnu) result=aarch64-unknown-linux-gnu;;
+        arm-linux-gnueabihf|arm-unknown-linux-gnueabihf) result=armv7-unknown-linux-gnueabihf;;
+        x86_64-apple-darwin) result=x86_64-apple-darwin;;
+        aarch64-apple-darwin) result=aarch64-apple-darwin;;
+        x86_64-w64-mingw32) result=x86_64-pc-windows-gnu;;
+        *) echo "error: unsupported triplet: ${triplet}"; exit 1;;
     esac
-    echo "$rust_target"
+    echo "$result"
 }
 
 _sign() {

--- a/make.sh
+++ b/make.sh
@@ -601,7 +601,7 @@ clean_pkg_local_py_deps() {
 
 pkg_setup_rust() {
     local rust_target
-    # shellcheck disable=SC2120
+    # shellcheck disable=SC2119
     rust_target=$(get_rust_triplet)
     rustup target add "${rust_target}"
 }
@@ -1000,6 +1000,7 @@ ci_setup_deps_test() {
     pkg_local_install_py_deps
 }
 
+# shellcheck disable=SC2120
 get_rust_triplet() {
     # Note: https://github.com/llvm/llvm-project/blob/master/llvm/lib/TargetParser/Triple.cpp
     # The function is called in 2 places:


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- This enables better support for cross compilation on nested builds (autotools -> cargo -> autotools/cpp/asm build)
- Without this, build-deps in cargo will result in going through the same CC cross compiler flags 
- This doesn't take it account:
  - Compiler: Forcing gcc.
  - Darwin cross compiles works by hijacking the compiler with CC/CXX flags. Side effects of clearing CFLAG/CXXFLAGS.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
