### PR TITLE
Add solc to depends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1373,6 +1373,7 @@ AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
 AC_SUBST(PROTOC)
 AC_SUBST(PROTOC_INCLUDE_DIR)
+AC_SUBST(SOLC_PATH)
 
 dnl If the host and build triplets are the same, we keep this empty
 RUST_HOST=`$ac_abs_confdir/make.sh get_rust_triplet "$build"`

--- a/configure.ac
+++ b/configure.ac
@@ -1376,16 +1376,17 @@ AC_SUBST(PROTOC_INCLUDE_DIR)
 
 dnl If the host and build triplets are the same, we keep this empty
 RUST_HOST=`$ac_abs_confdir/make.sh get_rust_triplet "$build"`
-if test $? != 0; then
-AC_MSG_ERROR("unsupported build system")
+if test "x$?" != "x0"; then
+  AC_MSG_ERROR("unsupported build system")
 fi
 
+dnl If the host and build triplets are the same, we keep this empty
 RUST_TARGET=`$ac_abs_confdir/make.sh get_rust_triplet "$host"`
-if test $? != 0; then
-AC_MSG_ERROR("unsupported host target")
+if test "x$?" != "x0"; then
+  AC_MSG_ERROR("unsupported target system")
 fi
 
-if test x$RUST_HOST = x$RUST_TARGET; then
+if test "x$RUST_HOST" = "x$RUST_TARGET"; then
   RUST_TARGET=
   RUST_HOST=
 fi

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -25,7 +25,7 @@ if test x@host_os@ = xdarwin; then
   PORT=no
 fi
 
-PATH=$depends_prefix/bin/:$depends_prefix/native/bin:$PATH
+PATH=$depends_prefix/native/bin:$PATH
 PKG_CONFIG="`which pkg-config` --static"
 
 # These two need to remain exported because pkg-config does not see them

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -25,7 +25,7 @@ if test x@host_os@ = xdarwin; then
   PORT=no
 fi
 
-PATH=$depends_prefix/native/bin:$PATH
+PATH=$depends_prefix/bin/:$depends_prefix/native/bin:$PATH
 PKG_CONFIG="`which pkg-config` --static"
 
 # These two need to remain exported because pkg-config does not see them
@@ -79,5 +79,6 @@ if test -n "@LDFLAGS@"; then
   LDFLAGS="@LDFLAGS@ $LDFLAGS"
 fi
 
+export SOLC=${depends_prefix}/bin/solc
 export PROTOC=${depends_prefix}/bin/protoc
 export PROTOC_INCLUDE_DIR=${depends_prefix}/include

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -79,6 +79,6 @@ if test -n "@LDFLAGS@"; then
   LDFLAGS="@LDFLAGS@ $LDFLAGS"
 fi
 
-export SOLC=${depends_prefix}/bin/solc
+export SOLC_PATH=${depends_prefix}/bin/solc
 export PROTOC=${depends_prefix}/bin/protoc
 export PROTOC_INCLUDE_DIR=${depends_prefix}/include

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages := boost libevent protobuf
+packages := boost libevent protobuf solc
 
 rapidcheck_packages = rapidcheck
 wallet_packages = bdb

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -32,6 +32,6 @@ endef
 
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
-  chmod +x $($(package)_source) && \
-  cp $($(package)_source) $($(package)_ROOT)/$(package)
+  cp $($(package)_source) $($(package)_ROOT)/$(package) && \
+  chmod +x $($(package)_ROOT)/$(package)
 endef

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -1,0 +1,45 @@
+package=solc
+$(package)_version=0.8.20
+$(package)_download_path=https://github.com/ethereum/solidity/releases/download/v$($(package)_version)/
+$(package)_file_ext=
+
+# NOTE: solc gets invoked on the BUILD OS during compile. So, we don't
+# care about HOST OS, unlike all other dependencies.
+# That is: solc is run on the BUILD OS, not targeted to run on the
+# HOST OS.
+
+ifeq ($(build_os)-$(build_arch),linux-x86_64)
+  $(package)_file_name=solc-static-linux
+  $(package)_sha256_hash=0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782
+endif
+ifeq ($(build_os),darwin)
+  $(package)_file_name=solc-macos
+  $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa
+endif
+ifeq ($(build_os),windows)
+  $(package)_file_name=solc-windows.exe
+  $(package)_sha256_hash=a0fa8eb77805c530cfb6962f400643dbe83991387d27b319efd6b89482061946
+  $(package)_file_ext=.exe
+endif
+
+$(package)_target_name=$(package)$($(package)_file_ext)
+
+
+ifeq ($($(package)_file_name),)
+    $(error Unsupported build platform: $(BUILD))
+endif
+
+define $(package)_extract_cmds
+  mkdir -p $$($(package)_extract_dir) && echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash &&  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash && cp $$($(package)_source) $(package)
+endef
+
+define $(package)_set_vars
+  $(package)_ROOT="$($(package)_staging_dir)/$(host_prefix)/bin"
+endef
+
+define $(package)_build_cmds
+  mkdir -p $($(package)_ROOT) && \
+  chmod +x $($(package)_target_name) && \
+  mv $($(package)_target_name) $($(package)_ROOT)
+endef
+

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -22,15 +22,14 @@ ifeq ($(build_os),windows)
   $(package)_file_ext=.exe
 endif
 
-$(package)_target_name=$(package)$($(package)_file_ext)
-
-
 ifeq ($($(package)_file_name),)
     $(error Unsupported build platform: $(BUILD))
 endif
 
 define $(package)_extract_cmds
-  mkdir -p $$($(package)_extract_dir) && echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash &&  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash && cp $$($(package)_source) $(package)
+  mkdir -p $$($(package)_extract_dir) && \
+  echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash
 endef
 
 define $(package)_set_vars
@@ -39,7 +38,6 @@ endef
 
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
-  chmod +x $($(package)_target_name) && \
-  mv $($(package)_target_name) $($(package)_ROOT)
+  chmod +x $($(package)_source) && \
+  cp $($(package)_source) $($(package)_ROOT)/$(package)$($(package)_file_ext)
 endef
-

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -11,6 +11,9 @@ ifeq ($(build_os)-$(build_arch),linux-x86_64)
   $(package)_file_name=solc-static-linux
   $(package)_sha256_hash=0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782
 endif
+
+# Note: solc only provides binaries for darwin amd64, however since rosetta is
+# expected to be present, this should work through emulation without additional config.
 ifeq ($(build_os),darwin)
   $(package)_file_name=solc-macos
   $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -1,7 +1,6 @@
 package=solc
 $(package)_version=0.8.20
 $(package)_download_path=https://github.com/ethereum/solidity/releases/download/v$($(package)_version)/
-$(package)_file_ext=
 
 # NOTE: solc gets invoked on the BUILD OS during compile. So, we don't
 # care about HOST OS, unlike all other dependencies.
@@ -15,11 +14,6 @@ endif
 ifeq ($(build_os),darwin)
   $(package)_file_name=solc-macos
   $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa
-endif
-ifeq ($(build_os),windows)
-  $(package)_file_name=solc-windows.exe
-  $(package)_sha256_hash=a0fa8eb77805c530cfb6962f400643dbe83991387d27b319efd6b89482061946
-  $(package)_file_ext=.exe
 endif
 
 ifeq ($($(package)_file_name),)
@@ -39,5 +33,5 @@ endef
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
   chmod +x $($(package)_source) && \
-  cp $($(package)_source) $($(package)_ROOT)/$(package)$($(package)_file_ext)
+  cp $($(package)_source) $($(package)_ROOT)/$(package)
 endef

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -43,8 +43,10 @@ endif
 export PKG_CONFIG_PATH PKGCONFIG_LIBDIR PYTHONPATH
 # Export protoc vars
 export PROTOC PROTOC_INCLUDE_DIR
+# Export solc path
+export SOLC_PATH
 
-# Ensure nested autotools calls by cargo don't end up in unexpected places 
+# Ensure nested autotools calls by cargo don't end up in unexpected places
 unexport DESTDIR
 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Adds solc to depends system
- Exports SOLC var for solc bin path

*Additional solc references*:
  - https://docs.soliditylang.org/en/latest/installing-solidity.html#static-binaries
  - Repo structure: https://github.com/ethereum/solc-bin/

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
