### PR TITLE
fix(ain-evm): remove `maxFeePerGas` at Legacy and EIP2930

### DIFF
--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -270,8 +270,8 @@ impl SignedTx {
 
     pub fn max_fee_per_gas(&self) -> Option<U256> {
         match &self.transaction {
-            TransactionV2::Legacy(tx) => Some(tx.gas_price),
-            TransactionV2::EIP2930(tx) => Some(tx.gas_price),
+            TransactionV2::Legacy(_) => None,
+            TransactionV2::EIP2930(_) => None,
             TransactionV2::EIP1559(tx) => Some(tx.max_fee_per_gas),
         }
     }


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

Proper struct transaction maxFeePerGas field on correct tx type

To fix:
https://github.com/DeFiCh/metachain-ts-tests/blob/5c8a6511e416c7f6ea4d4ee98ffc683f6b78badc/tests/test-transaction-version.ts#L43-L44

https://github.com/DeFiCh/metachain-ts-tests/blob/5c8a6511e416c7f6ea4d4ee98ffc683f6b78badc/tests/test-transaction-version.ts#L70-L71

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
