### PR TITLE
Fix the toolchain madness

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1371,8 +1371,16 @@ AC_SUBST(HAVE_O_CLOEXEC)
 AC_SUBST(HAVE_BUILTIN_PREFETCH)
 AC_SUBST(HAVE_MM_PREFETCH)
 AC_SUBST(HAVE_STRONG_GETAUXVAL)
+
+AC_SUBST(BUILD_CC)
+AC_SUBST(BUILD_CXX)
+AC_SUBST(BUILD_AR)
+AC_SUBST(BUILD_NM)
+AC_SUBST(BUILD_RANLIB)
+
 AC_SUBST(PROTOC)
 AC_SUBST(PROTOC_INCLUDE_DIR)
+AC_SUBST(SOLC_PATH)
 
 dnl If the host and build triplets are the same, we keep this empty
 RUST_HOST=`$ac_abs_confdir/make.sh get_rust_triplet "$build"`
@@ -1456,7 +1464,8 @@ case ${OS} in
 esac
 
 echo
-echo "Options used to compile and link:"
+echo " === options === "
+echo 
 echo "  with wallet         = $enable_wallet"
 echo "  with zmq            = $use_zmq"
 echo "  with test           = $use_tests"
@@ -1475,15 +1484,36 @@ echo
 echo "  target os           = $TARGET_OS"
 echo "  build os            = $BUILD_OS"
 echo
+echo "  === target os toolchain ==== "
+echo 
 echo "  CC                  = $CC"
 echo "  CFLAGS              = $CFLAGS"
 echo "  CPPFLAGS            = $DEBUG_CPPFLAGS $HARDENED_CPPFLAGS $CPPFLAGS"
 echo "  CXX                 = $CXX"
 echo "  CXXFLAGS            = $DEBUG_CXXFLAGS $HARDENED_CXXFLAGS $WARN_CXXFLAGS $NOWARN_CXXFLAGS $ERROR_CXXFLAGS $GPROF_CXXFLAGS $CXXFLAGS"
 echo "  LDFLAGS             = $PTHREAD_CFLAGS $HARDENED_LDFLAGS $GPROF_LDFLAGS $LDFLAGS"
+echo "  AR                  = $AR"
 echo "  ARFLAGS             = $ARFLAGS"
+echo "  NM                  = $NM"
+echo "  RANLIB              = $RANLIB"
+echo 
+echo "  === build os toolchain ==== "
+echo 
+echo "  CC                  = $BUILD_CC"
+echo "  CXX                 = $BUILD_CXX"
+echo "  AR                  = $BUILD_AR"
+echo "  NM                  = $BUILD_NM"
+echo "  RANLIB              = $BUILD_RANLIB"
+echo 
+echo "  === mixed toolchain ==="
+echo 
 echo "  CARGO               = $CARGO"
 echo "  RUST_HOST           = $RUST_HOST"
 echo "  RUST_TARGET         = $RUST_TARGET"
 echo "  ENABLE_DEBUG        = $ENABLE_DEBUG"
-echo
+echo "  PROTOC              = $PROTOC"
+echo "  PROTOC_INCLUDE_DIR  = $PROTOC_INCLUDE_DIR"
+echo "  SOLC_PATH           = $SOLC_PATH"
+echo 
+echo "  ==="
+echo 

--- a/configure.ac
+++ b/configure.ac
@@ -1376,16 +1376,17 @@ AC_SUBST(PROTOC_INCLUDE_DIR)
 
 dnl If the host and build triplets are the same, we keep this empty
 RUST_HOST=`$ac_abs_confdir/make.sh get_rust_triplet "$build"`
-if test $? != 0; then
-AC_MSG_ERROR("unsupported build system")
+if test "x$?" != "x0"; then
+  AC_MSG_ERROR("unsupported build system")
 fi
 
+dnl If the host and build triplets are the same, we keep this empty
 RUST_TARGET=`$ac_abs_confdir/make.sh get_rust_triplet "$host"`
-if test $? != 0; then
-AC_MSG_ERROR("unsupported host target")
+if test "x$?" != "x0"; then
+  AC_MSG_ERROR("unsupported target system")
 fi
 
-if test x$RUST_HOST = x$RUST_TARGET; then
+if test "x$RUST_HOST" = "x$RUST_TARGET"; then
   RUST_TARGET=
   RUST_HOST=
 fi

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -131,6 +131,11 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
 	$(AT)@mkdir -p $(@D)
 	$(AT)sed -e 's|@HOST@|$(host)|' \
+            -e 's|@BUILD_CC@|$(build_CC)|' \
+            -e 's|@BUILD_CXX@|$(build_CXX)|' \
+            -e 's|@BUILD_AR@|$(build_AR)|' \
+            -e 's|@BUILD_RANLIB@|$(build_RANLIB)|' \
+            -e 's|@BUILD_NM@|$(build_NM)|' \
             -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
             -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
             -e 's|@AR@|$(toolchain_path)$(host_AR)|' \

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -25,7 +25,7 @@ if test x@host_os@ = xdarwin; then
   PORT=no
 fi
 
-PATH=$depends_prefix/bin/:$depends_prefix/native/bin:$PATH
+PATH=$depends_prefix/native/bin:$PATH
 PKG_CONFIG="`which pkg-config` --static"
 
 # These two need to remain exported because pkg-config does not see them

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -25,7 +25,7 @@ if test x@host_os@ = xdarwin; then
   PORT=no
 fi
 
-PATH=$depends_prefix/native/bin:$PATH
+PATH=$depends_prefix/bin/:$depends_prefix/native/bin:$PATH
 PKG_CONFIG="`which pkg-config` --static"
 
 # These two need to remain exported because pkg-config does not see them
@@ -79,5 +79,6 @@ if test -n "@LDFLAGS@"; then
   LDFLAGS="@LDFLAGS@ $LDFLAGS"
 fi
 
+export SOLC=${depends_prefix}/bin/solc
 export PROTOC=${depends_prefix}/bin/protoc
 export PROTOC_INCLUDE_DIR=${depends_prefix}/include

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -79,6 +79,17 @@ if test -n "@LDFLAGS@"; then
   LDFLAGS="@LDFLAGS@ $LDFLAGS"
 fi
 
-export SOLC=${depends_prefix}/bin/solc
-export PROTOC=${depends_prefix}/bin/protoc
-export PROTOC_INCLUDE_DIR=${depends_prefix}/include
+# Build system compilers
+# Everything that's overwritten above, we make sure to preserve
+# the native items so it can be used for the rest of the workflow
+BUILD_CC="@BUILD_CC@"
+BUILD_CXX="@BUILD_CXX@"
+BUILD_AR="@BUILD_AR@"
+BUILD_RANLIB="@BUILD_RANLIB@"
+BUILD_NM="@BUILD_NM@"
+
+# External deps
+SOLC_PATH=${depends_prefix}/bin/solc
+PROTOC=${depends_prefix}/bin/protoc
+PROTOC_INCLUDE_DIR=${depends_prefix}/include
+

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -11,14 +11,12 @@ DARWIN_SHAREDCC_FLAGS=-target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --
 
 # There are some blockers to cleanly using just the flags and not 
 # overriding the CC/CXX with flags above, due to how depends system
-# has been built on Bitoin. For now, we follow the BTC way
-# until we can resolve the specific blockers, however we also
-# add them to the flags, so downstream nested compilations can 
-# use them properly.
+# has been built on Bitcoin. For now, we follow the BTC way
+# until we can resolve the specific blockers
 darwin_CC=clang $(DARWIN_SHAREDCC_FLAGS)
 darwin_CXX=clang++ -stdlib=libc++ -std=c++17 $(DARWIN_SHAREDCC_FLAGS)
 
-darwin_CFLAGS=-pipe $(DARWIN_SHAREDCC_FLAGS)
+darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS) -stdlib=libc++ -std=c++17
 
 darwin_release_CFLAGS=-O2

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages := boost libevent protobuf
+packages := boost libevent protobuf solc
 
 rapidcheck_packages = rapidcheck
 wallet_packages = bdb

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -32,6 +32,6 @@ endef
 
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
-  chmod +x $($(package)_source) && \
-  cp $($(package)_source) $($(package)_ROOT)/$(package)
+  cp $($(package)_source) $($(package)_ROOT)/$(package) && \
+  chmod +x $($(package)_ROOT)/$(package)
 endef

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -1,0 +1,45 @@
+package=solc
+$(package)_version=0.8.20
+$(package)_download_path=https://github.com/ethereum/solidity/releases/download/v$($(package)_version)/
+$(package)_file_ext=
+
+# NOTE: solc gets invoked on the BUILD OS during compile. So, we don't
+# care about HOST OS, unlike all other dependencies.
+# That is: solc is run on the BUILD OS, not targeted to run on the
+# HOST OS.
+
+ifeq ($(build_os)-$(build_arch),linux-x86_64)
+  $(package)_file_name=solc-static-linux
+  $(package)_sha256_hash=0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782
+endif
+ifeq ($(build_os),darwin)
+  $(package)_file_name=solc-macos
+  $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa
+endif
+ifeq ($(build_os),windows)
+  $(package)_file_name=solc-windows.exe
+  $(package)_sha256_hash=a0fa8eb77805c530cfb6962f400643dbe83991387d27b319efd6b89482061946
+  $(package)_file_ext=.exe
+endif
+
+$(package)_target_name=$(package)$($(package)_file_ext)
+
+
+ifeq ($($(package)_file_name),)
+    $(error Unsupported build platform: $(BUILD))
+endif
+
+define $(package)_extract_cmds
+  mkdir -p $$($(package)_extract_dir) && echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash &&  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash && cp $$($(package)_source) $(package)
+endef
+
+define $(package)_set_vars
+  $(package)_ROOT="$($(package)_staging_dir)/$(host_prefix)/bin"
+endef
+
+define $(package)_build_cmds
+  mkdir -p $($(package)_ROOT) && \
+  chmod +x $($(package)_target_name) && \
+  mv $($(package)_target_name) $($(package)_ROOT)
+endef
+

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -22,15 +22,14 @@ ifeq ($(build_os),windows)
   $(package)_file_ext=.exe
 endif
 
-$(package)_target_name=$(package)$($(package)_file_ext)
-
-
 ifeq ($($(package)_file_name),)
     $(error Unsupported build platform: $(BUILD))
 endif
 
 define $(package)_extract_cmds
-  mkdir -p $$($(package)_extract_dir) && echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash &&  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash && cp $$($(package)_source) $(package)
+  mkdir -p $$($(package)_extract_dir) && \
+  echo "$$($(package)_sha256_hash)  $$($(package)_source)" > $$($(package)_extract_dir)/.$$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $$($(package)_extract_dir)/.$$($(package)_file_name).hash
 endef
 
 define $(package)_set_vars
@@ -39,7 +38,6 @@ endef
 
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
-  chmod +x $($(package)_target_name) && \
-  mv $($(package)_target_name) $($(package)_ROOT)
+  chmod +x $($(package)_source) && \
+  cp $($(package)_source) $($(package)_ROOT)/$(package)$($(package)_file_ext)
 endef
-

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -11,6 +11,9 @@ ifeq ($(build_os)-$(build_arch),linux-x86_64)
   $(package)_file_name=solc-static-linux
   $(package)_sha256_hash=0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782
 endif
+
+# Note: solc only provides binaries for darwin amd64, however since rosetta is
+# expected to be present, this should work through emulation without additional config.
 ifeq ($(build_os),darwin)
   $(package)_file_name=solc-macos
   $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa

--- a/depends/packages/solc.mk
+++ b/depends/packages/solc.mk
@@ -1,7 +1,6 @@
 package=solc
 $(package)_version=0.8.20
 $(package)_download_path=https://github.com/ethereum/solidity/releases/download/v$($(package)_version)/
-$(package)_file_ext=
 
 # NOTE: solc gets invoked on the BUILD OS during compile. So, we don't
 # care about HOST OS, unlike all other dependencies.
@@ -15,11 +14,6 @@ endif
 ifeq ($(build_os),darwin)
   $(package)_file_name=solc-macos
   $(package)_sha256_hash=fc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa
-endif
-ifeq ($(build_os),windows)
-  $(package)_file_name=solc-windows.exe
-  $(package)_sha256_hash=a0fa8eb77805c530cfb6962f400643dbe83991387d27b319efd6b89482061946
-  $(package)_file_ext=.exe
 endif
 
 ifeq ($($(package)_file_name),)
@@ -39,5 +33,5 @@ endef
 define $(package)_build_cmds
   mkdir -p $($(package)_ROOT) && \
   chmod +x $($(package)_source) && \
-  cp $($(package)_source) $($(package)_ROOT)/$(package)$($(package)_file_ext)
+  cp $($(package)_source) $($(package)_ROOT)/$(package)
 endef

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -25,12 +25,16 @@ BUILD_ARTIFACTS_DIR = $(CARGO_TARGET_DIR)/$(TARGET)/$(if $(DEBUG),debug,release)
 CARGO_MANIFEST_ARG = --manifest-path "$(CARGO_MANIFEST_PATH)"
 CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
 
-# If $build == $host, we add --all-targets otherwise we skip
-# since compiling with `--test` fails on cross compilation
+
+#  We add --all-targets only on native build, i.e $build == $host
+#  otherwise things like `--test` cannot run
 CARGO_EXTRA_ARGS ?= $(if $(subst $(build),,$(host)),,--all-targets)
 
 # Export toolchain flags
-export CC CXX AR NM RANLIB
+export CC CXX AR NM RANLIB CFLAGS CXXFLAGS 
+# Not exported as these will break nested assumptions
+# CPPFLAGS LDFLAGS ARFLAGS
+
 # Set the native toolchain flags
 if HAVE_RUST_HOST
 export CC_$(RUST_HOST)=$(BUILD_CC)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -29,20 +29,21 @@ CARGO_BUILD_TYPE_ARG = $(if $(DEBUG),,--release)
 # since compiling with `--test` fails on cross compilation
 CARGO_EXTRA_ARGS ?= $(if $(subst $(build),,$(host)),,--all-targets)
 
-# Export compiler flags
-export CC CXX CFLAGS CXXFLAGS CPPFLAGS LDFLAGS AR NM RANLIB
-# Set the native compilers
+# Export toolchain flags
+export CC CXX AR NM RANLIB
+# Set the native toolchain flags
 if HAVE_RUST_HOST
-export CC_$(RUST_HOST)=gcc
-export CXX_$(RUST_HOST)=g++
-export CFLAGS_$(RUST_HOST)=
-export CXXFLAGS_$(RUST_HOST)=
+export CC_$(RUST_HOST)=$(BUILD_CC)
+export CXX_$(RUST_HOST)=$(BUILD_CXX)
+export AR_$(RUST_HOST)=$(BUILD_AR)
+export NM_$(RUST_HOST)=$(BUILD_NM)
+export RANLIB_$(RUST_HOST)=$(BUILD_RANLIB)
 endif
 
 # Export compiler support
 export PKG_CONFIG_PATH PKGCONFIG_LIBDIR PYTHONPATH
-# Export protoc vars
-export PROTOC PROTOC_INCLUDE_DIR
+# Export other dep vars
+export PROTOC PROTOC_INCLUDE_DIR SOLC_PATH
 
 # Ensure nested autotools calls by cargo don't end up in unexpected places 
 unexport DESTDIR

--- a/make.sh
+++ b/make.sh
@@ -40,16 +40,15 @@ setup_vars() {
     
     MAKE_DEBUG=${MAKE_DEBUG:-"1"}
 
-    local default_compiler_flags=""
     if [[ "${TARGET}" == "x86_64-pc-linux-gnu" ]]; then
         local clang_ver="${CLANG_DEFAULT_VERSION}"
-        default_compiler_flags="CC=clang-${clang_ver} CXX=clang++-${clang_ver}"
+        [[ -z "${CC:-}" ]] && export CC=clang-${clang_ver}
+        [[ -z "${CXX:-}" ]] && export CXX=clang++-${clang_ver}
     fi
 
     MAKE_JOBS=${MAKE_JOBS:-"$(get_default_jobs)"}
 
     MAKE_CONF_ARGS="$(get_default_conf_args) ${MAKE_CONF_ARGS:-}"
-    MAKE_CONF_ARGS="${default_compiler_flags} ${MAKE_CONF_ARGS:-}"
     if [[ "${MAKE_DEBUG}" == "1" ]]; then
       MAKE_CONF_ARGS="${MAKE_CONF_ARGS} --enable-debug";
     fi

--- a/make.sh
+++ b/make.sh
@@ -39,11 +39,12 @@ setup_vars() {
     RUST_DEFAULT_VERSION=${RUST_DEFAULT_VERSION:-"1.70"}
     
     MAKE_DEBUG=${MAKE_DEBUG:-"1"}
+    MAKE_USE_CLANG=${MAKE_USE_CLANG:-"$(get_default_use_clang)"}
 
-    if [[ "${TARGET}" == "x86_64-pc-linux-gnu" ]]; then
+    if [[ "${MAKE_USE_CLANG}" == "1" ]]; then
         local clang_ver="${CLANG_DEFAULT_VERSION}"
-        [[ -z "${CC:-}" ]] && export CC=clang-${clang_ver}
-        [[ -z "${CXX:-}" ]] && export CXX=clang++-${clang_ver}
+        export CC=clang-${clang_ver}
+        export CXX=clang++-${clang_ver}
     fi
 
     MAKE_JOBS=${MAKE_JOBS:-"$(get_default_jobs)"}
@@ -801,6 +802,20 @@ get_default_jobs() {
     else
         echo 1
     fi
+}
+
+get_default_use_clang() {
+    local target=${TARGET}
+    local cc=${CC:-}
+    local cxx=${CXX:-}
+    if [[ -z "${cc}" && -z "${cxx}" ]]; then
+        if [[ "${target}" == "x86_64-pc-linux-gnu" ]]; then
+            echo 1
+            return
+        fi
+    fi
+    echo 0
+    return
 }
 
 # Dev tools


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- The largest headaches in the toolchain is often due to the way depends overrides the toolchains
  - For darwin cross compiles it hijacks the compilers entirely
  - For the others, it reuses the env compilers
- Rust and cargo ecosystem will attempt to compile it's native libraries on it's own which will result in calling C/XX compilers resulting in nested compilation env that are highly inconsistent since depends simply overrides it.
- This is further made challenging since some Rust libs will require host builds (eg: build-deps), while some require target builds.
- This retains the overrides from depends and passes it along cleanly in an attempt to resolve this madness. 

### Additional

- ./make.sh respects CC and CXX vars and will not override them
- `MAKE_USE_CLANG` is auto set based on basic heuristics and can now be easily switched off 
- solc:
  - Adds solc to depends system
  - Exports SOLC_PATH var for solc bin path
  - *References*:
    - https://docs.soliditylang.org/en/latest/installing-solidity.html#static-binaries
    - Repo structure: https://github.com/ethereum/solc-bin/

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
