### PR TITLE
Refactor signing provider get key from destination

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2404,9 +2404,9 @@ bool AppInitMain(InitInterfaces& interfaces)
             if (optMasternodeID) {
                 auto nodePtr = pcustomcsview->GetMasternode(*optMasternodeID);
                 assert(nodePtr); // this should not happen if MN was found by operator's id
-                ownerDest = FromOrDefaultKeyIDToDestination(nodePtr->ownerType, nodePtr->ownerAuthAddress, KeyType::MNOwnerKeyType);
+                ownerDest = FromOrDefaultKeyIDToDestination(nodePtr->ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(nodePtr->ownerType), KeyType::MNOwnerKeyType);
                 if (nodePtr->rewardAddressType != 0) {
-                    rewardDest = FromOrDefaultKeyIDToDestination(nodePtr->rewardAddressType, nodePtr->rewardAddress, KeyType::MNRewardKeyType);
+                    rewardDest = FromOrDefaultKeyIDToDestination(nodePtr->rewardAddress, FromOrDefaultDestinationTypeToKeyType(nodePtr->rewardAddressType), KeyType::MNRewardKeyType);
                 }
             }
 

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -1343,13 +1343,13 @@ CAmount CCustomCSView::GetFeeBurnPctFromAttributes() const {
 void CalcMissingRewardTempFix(CCustomCSView &mnview, const uint32_t targetHeight, const CWallet &wallet) {
     mnview.ForEachMasternode([&](const uint256 &id, const CMasternode &node) {
         if (node.rewardAddressType) {
-            const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(node.rewardAddressType, node.rewardAddress, KeyType::MNRewardKeyType));
+            const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(node.rewardAddress, FromOrDefaultDestinationTypeToKeyType(node.rewardAddressType), KeyType::MNRewardKeyType));
             if (IsMineCached(wallet, rewardAddress) == ISMINE_SPENDABLE) {
                 mnview.CalculateOwnerRewards(rewardAddress, targetHeight);
             }
         }
 
-        const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(node.ownerType, node.ownerAuthAddress, KeyType::MNOwnerKeyType));
+        const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(node.ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(node.ownerType), KeyType::MNOwnerKeyType));
         if (IsMineCached(wallet, rewardAddress) == ISMINE_SPENDABLE) {
             mnview.CalculateOwnerRewards(rewardAddress, targetHeight);
         }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -1013,7 +1013,7 @@ public:
                 // next hard fork as this is a workaround for the issue fixed in the following PR:
                 // https://github.com/DeFiCh/ain/pull/1766
                 if (auto addresses = mnview.SettingsGetRewardAddresses()) {
-                    const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(addressType, keyID, KeyType::MNRewardKeyType));
+                    const CScript rewardAddress = GetScriptForDestination(FromOrDefaultKeyIDToDestination(keyID, FromOrDefaultDestinationTypeToKeyType(addressType), KeyType::MNRewardKeyType));
                     addresses->insert(rewardAddress);
                     mnview.SettingsSetRewardAddresses(*addresses);
                 }
@@ -3855,7 +3855,7 @@ public:
         if (!node)
             return Res::Err("masternode <%s> does not exist", obj.masternodeId.GetHex());
 
-        auto ownerDest = FromOrDefaultKeyIDToDestination(node->ownerType, node->ownerAuthAddress, KeyType::MNOwnerKeyType);
+        auto ownerDest = FromOrDefaultKeyIDToDestination(node->ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(node->ownerType), KeyType::MNOwnerKeyType);
         if (!IsValidDestination(ownerDest))
             return Res::Err("masternode <%s> owner address is not invalid", obj.masternodeId.GetHex());
 
@@ -4528,7 +4528,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
         }
     }
 
-    CTxDestination destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyType, finMsg.rewardKeyID, KeyType::MNOwnerKeyType);
+    CTxDestination destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, FromOrDefaultDestinationTypeToKeyType(finMsg.rewardKeyType), KeyType::MNOwnerKeyType);
     if (!IsValidDestination(destination) || tx.vout[1].scriptPubKey != GetScriptForDestination(destination)) {
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");
     }
@@ -4613,9 +4613,9 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView &mnview,
 
     CTxDestination destination;
     if (height < consensusParams.NextNetworkUpgradeHeight) {
-        destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyType, finMsg.rewardKeyID, KeyType::MNOwnerKeyType);
+        destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, FromOrDefaultDestinationTypeToKeyType(finMsg.rewardKeyType), KeyType::MNOwnerKeyType);
     } else {
-        destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyType, finMsg.rewardKeyID, KeyType::MNRewardKeyType);
+        destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, FromOrDefaultDestinationTypeToKeyType(finMsg.rewardKeyType), KeyType::MNRewardKeyType);
     }
     if (!IsValidDestination(destination) || tx.vout[1].scriptPubKey != GetScriptForDestination(destination)) {
         return Res::ErrDbg("bad-ar-dest", "anchor pay destination is incorrect");

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -74,7 +74,7 @@ public:
 
     void operator()(const CCreateMasterNodeMessage &obj) const {
         rpcInfo.pushKV("collateralamount", ValueFromAmount(GetMnCollateralAmount(height)));
-        rpcInfo.pushKV("masternodeoperator", EncodeDestination(FromOrDefaultKeyIDToDestination(obj.operatorType, obj.operatorAuthAddress, KeyType::MNOperatorKeyType)));
+        rpcInfo.pushKV("masternodeoperator", EncodeDestination(FromOrDefaultKeyIDToDestination(obj.operatorAuthAddress, FromOrDefaultDestinationTypeToKeyType(obj.operatorType), KeyType::MNOperatorKeyType)));
         rpcInfo.pushKV("timelock", CMasternode::GetTimelockToString(static_cast<CMasternode::TimeLock>(obj.timelock)));
     }
 
@@ -85,7 +85,7 @@ public:
         for (const auto &[updateType, addressPair] : obj.updates) {
             const auto &[addressType, rawAddress] = addressPair;
             if (updateType == static_cast<uint8_t>(UpdateMasternodeType::OperatorAddress)) {
-                rpcInfo.pushKV("operatorAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(addressType, CKeyID(uint160(rawAddress)), KeyType::MNOperatorKeyType)));
+                rpcInfo.pushKV("operatorAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(CKeyID(uint160(rawAddress)), FromOrDefaultDestinationTypeToKeyType(addressType), KeyType::MNOperatorKeyType)));
             } else if (updateType == static_cast<uint8_t>(UpdateMasternodeType::OwnerAddress)) {
                 CTxDestination dest;
                 if (tx.vout.size() >= 2 && ExtractDestination(tx.vout[1].scriptPubKey, dest)) {
@@ -93,7 +93,7 @@ public:
                 }
             }
             if (updateType == static_cast<uint8_t>(UpdateMasternodeType::SetRewardAddress)) {
-                rpcInfo.pushKV("rewardAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(addressType, CKeyID(uint160(rawAddress)), KeyType::MNRewardKeyType)));
+                rpcInfo.pushKV("rewardAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(CKeyID(uint160(rawAddress)), FromOrDefaultDestinationTypeToKeyType(addressType), KeyType::MNRewardKeyType)));
             } else if (updateType == static_cast<uint8_t>(UpdateMasternodeType::RemRewardAddress)) {
                 rpcInfo.pushKV("rewardAddress", "");
             }

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -12,12 +12,12 @@ UniValue mnToJSON(CCustomCSView& view, uint256 const & nodeId, CMasternode const
     }
     else {
         UniValue obj(UniValue::VOBJ);
-        CTxDestination ownerDest = FromOrDefaultKeyIDToDestination(node.ownerType, node.ownerAuthAddress, KeyType::MNOwnerKeyType);
+        CTxDestination ownerDest = FromOrDefaultKeyIDToDestination(node.ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(node.ownerType), KeyType::MNOwnerKeyType);
         obj.pushKV("ownerAuthAddress", EncodeDestination(ownerDest));
-        CTxDestination operatorDest = FromOrDefaultKeyIDToDestination(node.operatorType, node.operatorAuthAddress, KeyType::MNOperatorKeyType);
+        CTxDestination operatorDest = FromOrDefaultKeyIDToDestination(node.operatorAuthAddress, FromOrDefaultDestinationTypeToKeyType(node.operatorType), KeyType::MNOperatorKeyType);
         obj.pushKV("operatorAuthAddress", EncodeDestination(operatorDest));
         if (node.rewardAddressType != 0) {
-            obj.pushKV("rewardAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(node.rewardAddressType, node.rewardAddress, KeyType::MNRewardKeyType)));
+            obj.pushKV("rewardAddress", EncodeDestination(FromOrDefaultKeyIDToDestination(node.rewardAddress, FromOrDefaultDestinationTypeToKeyType(node.rewardAddressType), KeyType::MNRewardKeyType)));
         }
         else {
             obj.pushKV("rewardAddress", EncodeDestination(CTxDestination()));
@@ -251,7 +251,7 @@ UniValue resignmasternode(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("The masternode %s does not exist", nodeIdStr));
         }
 
-        ownerDest = FromOrDefaultKeyIDToDestination(nodePtr->ownerType, nodePtr->ownerAuthAddress, KeyType::MNOwnerKeyType);
+        ownerDest = FromOrDefaultKeyIDToDestination(nodePtr->ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(nodePtr->ownerType), KeyType::MNOwnerKeyType);
         if (!nodePtr->collateralTx.IsNull()) {
             const auto& coin = ::ChainstateActive().CoinsTip().AccessCoin({nodePtr->collateralTx, 1});
             if (coin.IsSpent() || !ExtractDestination(coin.out.scriptPubKey, collateralDest)) {

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2231,9 +2231,9 @@ static void ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView& cach
 
                 CScript scriptPubKey;
                 if (mn->rewardAddressType != 0) {
-                    scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(mn->rewardAddressType, mn->rewardAddress, KeyType::MNRewardKeyType));
+                    scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(mn->rewardAddress, FromOrDefaultDestinationTypeToKeyType(mn->rewardAddressType), KeyType::MNRewardKeyType));
                 } else {
-                    scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(mn->ownerType, mn->ownerAuthAddress, KeyType::MNOwnerKeyType));
+                    scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(mn->ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(mn->ownerType), KeyType::MNOwnerKeyType));
                 }
 
                 CAccountsHistoryWriter subView(cache, pindex->nHeight, GetNextAccPosition(), pindex->GetBlockHash(), uint8_t(CustomTxType::ProposalFeeRedistribution));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -253,9 +253,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
             CTxDestination destination;
             if (nHeight < consensus.NextNetworkUpgradeHeight) {
-                destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyType, finMsg.rewardKeyID, KeyType::MNOwnerKeyType);
+                destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, FromOrDefaultDestinationTypeToKeyType(finMsg.rewardKeyType), KeyType::MNOwnerKeyType);
             } else {
-                destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyType, finMsg.rewardKeyID, KeyType::MNRewardKeyType);
+                destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, FromOrDefaultDestinationTypeToKeyType(finMsg.rewardKeyType), KeyType::MNRewardKeyType);
             }
 
             if (IsValidDestination(destination)) {
@@ -1057,9 +1057,9 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
         if (args.coinbaseScript.empty()) {
             // this is safe because MN was found
             if (tip->nHeight >= chainparams.GetConsensus().FortCanningHeight && nodePtr->rewardAddressType != 0) {
-                scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(nodePtr->rewardAddressType, nodePtr->rewardAddress, KeyType::MNRewardKeyType));
+                scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(nodePtr->rewardAddress, FromOrDefaultDestinationTypeToKeyType(nodePtr->rewardAddressType), KeyType::MNRewardKeyType));
             } else {
-                scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(nodePtr->ownerType, nodePtr->ownerAuthAddress, KeyType::MNOwnerKeyType));
+                scriptPubKey = GetScriptForDestination(FromOrDefaultKeyIDToDestination(nodePtr->ownerAuthAddress, FromOrDefaultDestinationTypeToKeyType(nodePtr->ownerType), KeyType::MNOwnerKeyType));
             }
         } else {
             scriptPubKey = args.coinbaseScript;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -36,21 +36,18 @@ public:
     static std::optional<CKeyID> TryFromDestination(const CTxDestination &dest, KeyType filter=KeyType::UnknownKeyType) {
         // Explore switching TxDestType to a flag type. Then, we can easily take an allowed
         // flags here and use bit flag logic to decode only specific destinations
-        KeyType destType = FromOrDefaultDestinationTypeToKeyType(dest.index());
-        if ((destType & filter) == KeyType::PKHashKeyType) {
-            return CKeyID(std::get<PKHash>(dest));
-        }
-        else if ((destType & filter) == KeyType::WPKHashKeyType) {
-            return CKeyID(std::get<WitnessV0KeyHash>(dest));
-        }
-        else if ((destType & filter) == KeyType::ScriptHashKeyType) {
-            return CKeyID(std::get<ScriptHash>(dest));
-        }
-        else if ((destType & filter) == KeyType::EthHashKeyType) {
-            return CKeyID(std::get<WitnessV16EthHash>(dest));
-        }
-        else {
-            return {};
+        auto destType = FromOrDefaultDestinationTypeToKeyType(dest.index()) & filter;
+        switch (destType) {
+            case KeyType::PKHashKeyType:
+                return CKeyID(std::get<PKHash>(dest));
+            case KeyType::WPKHashKeyType:
+                return CKeyID(std::get<WitnessV0KeyHash>(dest));
+            case KeyType::ScriptHashKeyType:
+                return CKeyID(std::get<ScriptHash>(dest));
+            case KeyType::EthHashKeyType:
+                return CKeyID(std::get<WitnessV16EthHash>(dest));
+            default:
+                return {};
         }
     }
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -53,7 +53,7 @@ public:
                 }
                 break;
             case WitV16KeyEthHashType:
-                if ((filter & KeyType::EthHashKey) == KeyType::EthHashKey) {
+                if ((filter & KeyType::EthHashKeyType) == KeyType::EthHashKeyType) {
                     return CKeyID(std::get<WitnessV16EthHash>(dest));
                 }
                 break;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -36,31 +36,22 @@ public:
     static std::optional<CKeyID> TryFromDestination(const CTxDestination &dest, KeyType filter=KeyType::UnknownKeyType) {
         // Explore switching TxDestType to a flag type. Then, we can easily take an allowed
         // flags here and use bit flag logic to decode only specific destinations
-        switch (dest.index()) {
-            case PKHashType:
-                if ((filter & KeyType::PKHashKeyType) == KeyType::PKHashKeyType) {
-                    return CKeyID(std::get<PKHash>(dest));
-                }
-                break;
-            case WitV0KeyHashType:
-                if ((filter & KeyType::WPKHashKeyType) == KeyType::WPKHashKeyType) {
-                    return CKeyID(std::get<WitnessV0KeyHash>(dest));
-                }
-                break;
-            case ScriptHashType:
-                if ((filter & KeyType::ScriptHashKeyType) == KeyType::ScriptHashKeyType) {
-                    return CKeyID(std::get<ScriptHash>(dest));
-                }
-                break;
-            case WitV16KeyEthHashType:
-                if ((filter & KeyType::EthHashKeyType) == KeyType::EthHashKeyType) {
-                    return CKeyID(std::get<WitnessV16EthHash>(dest));
-                }
-                break;
-            default: 
-                return {};
+        KeyType destType = FromOrDefaultDestinationTypeToKeyType(dest.index());
+        if ((destType & filter) == KeyType::PKHashKeyType) {
+            return CKeyID(std::get<PKHash>(dest));
         }
-        return {};
+        else if ((destType & filter) == KeyType::WPKHashKeyType) {
+            return CKeyID(std::get<WitnessV0KeyHash>(dest));
+        }
+        else if ((destType & filter) == KeyType::ScriptHashKeyType) {
+            return CKeyID(std::get<ScriptHash>(dest));
+        }
+        else if ((destType & filter) == KeyType::EthHashKeyType) {
+            return CKeyID(std::get<WitnessV16EthHash>(dest));
+        }
+        else {
+            return {};
+        }
     }
 
     static CKeyID FromOrDefaultDestination(const CTxDestination &dest, KeyType filter=KeyType::UnknownKeyType) {

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -34,8 +34,6 @@ public:
     KeyAddressType type{KeyAddressType::DEFAULT};
 
     static std::optional<CKeyID> TryFromDestination(const CTxDestination &dest, KeyType filter=KeyType::UnknownKeyType) {
-        // Explore switching TxDestType to a flag type. Then, we can easily take an allowed
-        // flags here and use bit flag logic to decode only specific destinations
         auto destType = FromOrDefaultDestinationTypeToKeyType(dest.index()) & filter;
         switch (destType) {
             case KeyType::PKHashKeyType:

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -150,7 +150,7 @@ CPubKey AddrToPubKey(FillableSigningProvider* const keystore, const std::string&
     if (!IsValidDestination(dest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address: " + addr_in);
     }
-    CKeyID key = GetKeyForDestination(*keystore, dest);
+    CKeyID key = TryGetKeyForDestination(*keystore, dest);
     if (key.IsNull()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("%s does not refer to a key", addr_in));
     }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -150,7 +150,7 @@ CPubKey AddrToPubKey(FillableSigningProvider* const keystore, const std::string&
     if (!IsValidDestination(dest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address: " + addr_in);
     }
-    CKeyID key = TryGetKeyForDestination(*keystore, dest);
+    CKeyID key = GetKeyOrDefaultFromDestination(*keystore, dest);
     if (key.IsNull()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("%s does not refer to a key", addr_in));
     }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -186,7 +186,7 @@ bool FillableSigningProvider::GetCScript(const CScriptID &hash, CScript& redeemS
     return false;
 }
 
-CKeyID TryGetKeyForDestination(const SigningProvider& store, const CTxDestination& dest)
+CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDestination& dest)
 {
     // Only supports destinations which map to single public keys, i.e. P2PKH,
     // P2WPKH, and P2SH-P2WPKH.

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -205,6 +205,9 @@ CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDes
         if (store.GetCScript(script_id, script) && ExtractDestination(script, inner_dest)) {
             id = CKeyID::FromOrDefaultDestination(inner_dest, KeyType::WPKHashKeyType);
         }
+        else {
+            return {};
+        }
     }
     return id;
 }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -203,7 +203,7 @@ CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDes
             CScriptID script_id(id);
             CTxDestination inner_dest;
             if (store.GetCScript(script_id, script) && ExtractDestination(script, inner_dest)) {
-                id = CKeyID::FromOrDefaultDestination(inner_dest,KeyType::EthHashKeyType);
+                id = CKeyID::FromOrDefaultDestination(inner_dest, KeyType::WPKHashKeyType);
             }
             break;
         }

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -191,23 +191,28 @@ CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDes
     // Only supports destinations which map to single public keys, i.e. P2PKH,
     // P2WPKH, and P2SH-P2WPKH.
     auto id = CKeyID::FromOrDefaultDestination(dest, KeyType::SigningProviderType);
-    KeyType dest_type = FromOrDefaultDestinationTypeToKeyType(dest.index());
-    if ((dest_type & KeyType::SigningProviderType) == KeyType::WPKHashKeyType) {
-        id.type = KeyAddressType::COMPRESSED;
-    }
-    else if ((dest_type & KeyType::SigningProviderType) == KeyType::EthHashKeyType) {
-        id.type = KeyAddressType::UNCOMPRESSED;
-    }
-    else if ((dest_type & KeyType::SigningProviderType) == KeyType::ScriptHashKeyType) {
-        CScript script;
-        CScriptID script_id(id);
-        CTxDestination inner_dest;
-        if (store.GetCScript(script_id, script) && ExtractDestination(script, inner_dest)) {
+    auto dest_type = FromOrDefaultDestinationTypeToKeyType(dest.index()) & KeyType::SigningProviderType;
+    switch (dest_type) {
+        case KeyType::WPKHashKeyType: {
+            id.type = KeyAddressType::COMPRESSED;
+            break;
+        }
+        case KeyType::EthHashKeyType: {
+            id.type = KeyAddressType::UNCOMPRESSED;
+            break;
+        }
+        case KeyType::ScriptHashKeyType: {
+            CScript script;
+            CScriptID script_id(id);
+            CTxDestination inner_dest;
+            if (!store.GetCScript(script_id, script) || !ExtractDestination(script, inner_dest)) {
+                return {};
+            }
             id = CKeyID::FromOrDefaultDestination(inner_dest, KeyType::WPKHashKeyType);
+            break;
         }
-        else {
-            return {};
-        }
+        default:
+            break;
     }
     return id;
 }

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -87,6 +87,6 @@ public:
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
-CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& dest);
+CKeyID TryGetKeyForDestination(const SigningProvider& store, const CTxDestination& dest);
 
 #endif // DEFI_SCRIPT_SIGNINGPROVIDER_H

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -87,6 +87,6 @@ public:
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
-CKeyID TryGetKeyForDestination(const SigningProvider& store, const CTxDestination& dest);
+CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDestination& dest);
 
 #endif // DEFI_SCRIPT_SIGNINGPROVIDER_H

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -253,20 +253,18 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
 }
 
 std::optional<CTxDestination> TryFromKeyIDToDestination(const CKeyID &keyId, KeyType keyIdType, KeyType filter) {
-    if ((keyIdType & filter) == KeyType::PKHashKeyType) {
-        return CTxDestination(PKHash(keyId));
-    }
-    else if ((keyIdType & filter) == KeyType::WPKHashKeyType) {
-        return CTxDestination(WitnessV0KeyHash(keyId));
-    }
-    else if ((keyIdType & filter) == KeyType::ScriptHashKeyType) {
-        return CTxDestination(ScriptHash(keyId));
-    }
-    else if ((keyIdType & filter) == KeyType::EthHashKeyType) {
-        return CTxDestination(WitnessV16EthHash(keyId));
-    }
-    else {
-        return {};
+    auto type = keyIdType & filter;
+    switch (type) {
+        case KeyType::PKHashKeyType:
+            return CTxDestination(PKHash(keyId));
+        case KeyType::WPKHashKeyType:
+            return CTxDestination(WitnessV0KeyHash(keyId));
+        case KeyType::ScriptHashKeyType:
+            return CTxDestination(ScriptHash(keyId));
+        case KeyType::EthHashKeyType:
+            return CTxDestination(WitnessV16EthHash(keyId));
+        default:
+            return {};
     }
 }
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -252,36 +252,26 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
     return true;
 }
 
-std::optional<CTxDestination> TryFromKeyIDToDestination(const char keyIdType, const CKeyID &keyId, KeyType filter) {
-    switch (keyIdType) {
-        case PKHashType:
-            if ((filter & KeyType::PKHashKeyType) == KeyType::PKHashKeyType) {
-                return CTxDestination(PKHash(keyId));
-            }
-            break;
-        case WitV0KeyHashType:
-            if ((filter & KeyType::WPKHashKeyType) == KeyType::WPKHashKeyType) {
-                return CTxDestination(WitnessV0KeyHash(keyId));
-            }
-            break;
-        case ScriptHashType:
-            if ((filter & KeyType::ScriptHashKeyType) == KeyType::ScriptHashKeyType) {
-                return CTxDestination(ScriptHash(keyId));
-            }
-            break;
-        case WitV16KeyEthHashType:
-            if ((filter & KeyType::EthHashKeyType) == KeyType::EthHashKeyType) {
-                return CTxDestination(WitnessV16EthHash(keyId));
-            }
-            break;
-        default:
-            return {};
+std::optional<CTxDestination> TryFromKeyIDToDestination(const CKeyID &keyId, KeyType keyIdType, KeyType filter) {
+    if ((keyIdType & filter) == KeyType::PKHashKeyType) {
+        return CTxDestination(PKHash(keyId));
     }
-    return {};
+    else if ((keyIdType & filter) == KeyType::WPKHashKeyType) {
+        return CTxDestination(WitnessV0KeyHash(keyId));
+    }
+    else if ((keyIdType & filter) == KeyType::ScriptHashKeyType) {
+        return CTxDestination(ScriptHash(keyId));
+    }
+    else if ((keyIdType & filter) == KeyType::EthHashKeyType) {
+        return CTxDestination(WitnessV16EthHash(keyId));
+    }
+    else {
+        return {};
+    }
 }
 
-CTxDestination FromOrDefaultKeyIDToDestination(const char keyIdType, const CKeyID &keyId, KeyType filter) {
-    auto dest = TryFromKeyIDToDestination(keyIdType, keyId, filter);
+CTxDestination FromOrDefaultKeyIDToDestination(const CKeyID &keyId, KeyType keyIdType, KeyType filter) {
+    auto dest = TryFromKeyIDToDestination(keyId, keyIdType, filter);
     if (dest) {
         return *dest;
     }

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -270,7 +270,7 @@ std::optional<CTxDestination> TryFromKeyIDToDestination(const char keyIdType, co
             }
             break;
         case WitV16KeyEthHashType:
-            if ((filter & KeyType::EthHashKey) == KeyType::EthHashKey) {
+            if ((filter & KeyType::EthHashKeyType) == KeyType::EthHashKeyType) {
                 return CTxDestination(WitnessV16EthHash(keyId));
             }
             break;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -164,12 +164,27 @@ enum KeyType {
     ScriptHashKeyType = 1 << 1,
     WPKHashKeyType = 1 << 2,
     EthHashKeyType = 1 << 3,
-    MNOperatorKeyType = (1 << 4) | PKHashKeyType | WPKHashKeyType,
-    MNOwnerKeyType = (1 << 5) | PKHashKeyType | WPKHashKeyType,
-    MNRewardKeyType = (1 << 6) | PKHashKeyType | ScriptHashKeyType | WPKHashKeyType,
-    SigningProviderType = (1 << 7) | PKHashKeyType | ScriptHashKeyType | WPKHashKeyType | EthHashKeyType,
+    MNOperatorKeyType = PKHashKeyType | WPKHashKeyType,
+    MNOwnerKeyType = PKHashKeyType | WPKHashKeyType,
+    MNRewardKeyType = PKHashKeyType | ScriptHashKeyType | WPKHashKeyType,
+    SigningProviderType = PKHashKeyType | ScriptHashKeyType | WPKHashKeyType | EthHashKeyType,
     AllKeyType = ~0,
 };
+
+inline KeyType FromOrDefaultDestinationTypeToKeyType(const size_t index) {
+    switch (index) {
+        case PKHashType:
+            return KeyType::PKHashKeyType;
+        case ScriptHashType:
+            return KeyType::ScriptHashKeyType;
+        case WitV0KeyHashType:
+            return KeyType::WPKHashKeyType;
+        case WitV16KeyEthHashType:
+            return KeyType::EthHashKeyType;
+        default:
+            return KeyType::UnknownKeyType;
+    }
+}
 
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);
@@ -190,10 +205,10 @@ const char* GetTxnOutputType(txnouttype t);
 txnouttype Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned char>>& vSolutionsRet);
 
 /** Try to get the destination address from the keyID type. */
-std::optional<CTxDestination> TryFromKeyIDToDestination(const char keyIdType, const CKeyID &keyId, KeyType filter=KeyType::UnknownKeyType);
+std::optional<CTxDestination> TryFromKeyIDToDestination(const CKeyID &keyId, KeyType keyIdType, KeyType filter=KeyType::UnknownKeyType);
 
 /** Get the destination address (or default) from the keyID type. */
-CTxDestination FromOrDefaultKeyIDToDestination(const char keyIdType, const CKeyID &keyId, KeyType filter=KeyType::UnknownKeyType);
+CTxDestination FromOrDefaultKeyIDToDestination(const CKeyID &keyId, KeyType keyIdType, KeyType filter=KeyType::UnknownKeyType);
 
 /**
  * Parse a standard scriptPubKey for the destination address. Assigns result to

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -163,10 +163,11 @@ enum KeyType {
     PKHashKeyType = 1 << 0,
     ScriptHashKeyType = 1 << 1,
     WPKHashKeyType = 1 << 2,
-    EthHashKey = 1 << 3,
+    EthHashKeyType = 1 << 3,
     MNOperatorKeyType = (1 << 4) | PKHashKeyType | WPKHashKeyType,
     MNOwnerKeyType = (1 << 5) | PKHashKeyType | WPKHashKeyType,
     MNRewardKeyType = (1 << 6) | PKHashKeyType | ScriptHashKeyType | WPKHashKeyType,
+    SigningProviderType = (1 << 7) | PKHashKeyType | ScriptHashKeyType | WPKHashKeyType | EthHashKeyType,
     AllKeyType = ~0,
 };
 

--- a/src/spv/spv_wrapper.cpp
+++ b/src/spv/spv_wrapper.cpp
@@ -703,7 +703,7 @@ UniValue CSpvWrapper::SendBitcoins(CWallet* const pwallet, std::string address, 
 
         }
 
-        auto keyid = GetKeyForDestination(*pwallet, dest);
+        auto keyid = TryGetKeyForDestination(*pwallet, dest);
         if (keyid.IsNull()) {
             BRTransactionFree(tx);
             throw JSONRPCError(RPC_WALLET_ERROR, "Failed to get address hash.");
@@ -1598,7 +1598,7 @@ UniValue CFakeSpvWrapper::SendBitcoins(CWallet* const pwallet, std::string addre
     }
 
     CTxDestination dest = GetDestinationForKey(new_key, OutputType::BECH32);
-    CKeyID keyid = GetKeyForDestination(*pwallet, dest);
+    CKeyID keyid = TryGetKeyForDestination(*pwallet, dest);
     if (keyid.IsNull()) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Failed to get address hash.");
     }

--- a/src/spv/spv_wrapper.cpp
+++ b/src/spv/spv_wrapper.cpp
@@ -703,7 +703,7 @@ UniValue CSpvWrapper::SendBitcoins(CWallet* const pwallet, std::string address, 
 
         }
 
-        auto keyid = TryGetKeyForDestination(*pwallet, dest);
+        auto keyid = GetKeyOrDefaultFromDestination(*pwallet, dest);
         if (keyid.IsNull()) {
             BRTransactionFree(tx);
             throw JSONRPCError(RPC_WALLET_ERROR, "Failed to get address hash.");
@@ -1598,7 +1598,7 @@ UniValue CFakeSpvWrapper::SendBitcoins(CWallet* const pwallet, std::string addre
     }
 
     CTxDestination dest = GetDestinationForKey(new_key, OutputType::BECH32);
-    CKeyID keyid = TryGetKeyForDestination(*pwallet, dest);
+    CKeyID keyid = GetKeyOrDefaultFromDestination(*pwallet, dest);
     if (keyid.IsNull()) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Failed to get address hash.");
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4195,9 +4195,9 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         if (node->rewardAddressType != 0) {
             CTxDestination destination;
             if (height < consensusParams.NextNetworkUpgradeHeight) {
-                destination = FromOrDefaultKeyIDToDestination(node->rewardAddressType, node->rewardAddress, KeyType::MNOwnerKeyType);
+                destination = FromOrDefaultKeyIDToDestination(node->rewardAddress, FromOrDefaultDestinationTypeToKeyType(node->rewardAddressType), KeyType::MNOwnerKeyType);
             } else {
-                destination = FromOrDefaultKeyIDToDestination(node->rewardAddressType, node->rewardAddress, KeyType::MNRewardKeyType);
+                destination = FromOrDefaultKeyIDToDestination(node->rewardAddress, FromOrDefaultDestinationTypeToKeyType(node->rewardAddressType), KeyType::MNRewardKeyType);
             }
 
             if (block.vtx[0]->vout[0].scriptPubKey != GetScriptForDestination(destination)) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -743,7 +743,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!IsValidDestination(dest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Defi address");
     }
-    auto keyid = TryGetKeyForDestination(*pwallet, dest);
+    auto keyid = GetKeyOrDefaultFromDestination(*pwallet, dest);
     if (keyid.IsNull()) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -743,7 +743,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!IsValidDestination(dest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Defi address");
     }
-    auto keyid = GetKeyForDestination(*pwallet, dest);
+    auto keyid = TryGetKeyForDestination(*pwallet, dest);
     if (keyid.IsNull()) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3827,7 +3827,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     }
     ret.pushKV("ischange", pwallet->IsChange(scriptPubKey));
     const CKeyMetadata* meta = nullptr;
-    CKeyID key_id = GetKeyForDestination(*pwallet, dest);
+    CKeyID key_id = TryGetKeyForDestination(*pwallet, dest);
     if (!key_id.IsNull()) {
         auto it = pwallet->mapKeyMetadata.find(key_id);
         if (it != pwallet->mapKeyMetadata.end()) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3827,7 +3827,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     }
     ret.pushKV("ischange", pwallet->IsChange(scriptPubKey));
     const CKeyMetadata* meta = nullptr;
-    CKeyID key_id = TryGetKeyForDestination(*pwallet, dest);
+    CKeyID key_id = GetKeyOrDefaultFromDestination(*pwallet, dest);
     if (!key_id.IsNull()) {
         auto it = pwallet->mapKeyMetadata.find(key_id);
         if (it != pwallet->mapKeyMetadata.end()) {

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -396,7 +396,7 @@ class EVMTest(DefiTestFramework):
         for i in range(63):
             self.nodes[0].evmtx(eth_address, i, 21, 21001, to_address, 1)
 
-        # Test error at the 64th EVM TX
+        # Test error at the 65th EVM TX
         assert_raises_rpc_error(-26, "too-many-eth-txs-by-sender", self.nodes[0].evmtx, eth_address, 64, 21, 21001, to_address, 1)
 
         # Mint a block

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -396,7 +396,7 @@ class EVMTest(DefiTestFramework):
         for i in range(63):
             self.nodes[0].evmtx(eth_address, i, 21, 21001, to_address, 1)
 
-        # Test error at the 65th EVM TX
+        # Test error at the 64th EVM TX
         assert_raises_rpc_error(-26, "too-many-eth-txs-by-sender", self.nodes[0].evmtx, eth_address, 64, 21, 21001, to_address, 1)
 
         # Mint a block


### PR DESCRIPTION
## Summary

- Rename GetKeyForDestination to GetKeyOrDefaultFromDestination
- Refactor GetKeyOrDefaultFromDestination to use FromOrDefaultDestionation with new signing provider key type


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
