### PR TITLE
Fixes to failing rust lint

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -108,9 +108,10 @@ impl EVMServices {
         beneficiary: H160,
         timestamp: u64,
     ) -> Result<FinalizedBlockInfo, Box<dyn Error>> {
-        let mut all_transactions = Vec::with_capacity(self.core.tx_queues.len(queue_id));
-        let mut failed_transactions = Vec::with_capacity(self.core.tx_queues.len(queue_id));
-        let mut receipts_v3: Vec<ReceiptV3> = Vec::with_capacity(self.core.tx_queues.len(queue_id));
+        let mut all_transactions = Vec::with_capacity(self.core.tx_queues.count(queue_id));
+        let mut failed_transactions = Vec::with_capacity(self.core.tx_queues.count(queue_id));
+        let mut receipts_v3: Vec<ReceiptV3> =
+            Vec::with_capacity(self.core.tx_queues.count(queue_id));
         let mut total_gas_used = 0u64;
         let mut total_gas_fees = U256::zero();
         let mut logs_bloom: Bloom = Bloom::default();

--- a/lib/ain-evm/src/txqueue.rs
+++ b/lib/ain-evm/src/txqueue.rs
@@ -113,7 +113,7 @@ impl TransactionQueueMap {
             .map_or(Vec::new(), TransactionQueue::get_cloned_vec)
     }
 
-    pub fn len(&self, queue_id: u64) -> usize {
+    pub fn count(&self, queue_id: u64) -> usize {
         self.queues
             .read()
             .unwrap()


### PR DESCRIPTION
## Summary

- Rename len to count to fix failing rust clippy check

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
