### PR TITLE
Extend logvmmaps

### DIFF
--- a/src/masternodes/evm.cpp
+++ b/src/masternodes/evm.cpp
@@ -31,18 +31,18 @@ ResVal<uint256> CVMDomainGraphView::GetVMDomainTxEdge(VMDomainEdge type, uint256
     return DeFiErrors::DatabaseKeyNotFound(txHashKey.GetHex());
 }
 
-void CVMDomainGraphView::ForEachVMDomainBlockEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback) {
+void CVMDomainGraphView::ForEachVMDomainBlockEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback, const std::pair<VMDomainEdge, uint256> &start) {
     ForEach<VMDomainBlockEdge, std::pair<uint8_t, uint256>, uint256>(
             [&callback](const std::pair<uint8_t, uint256> &key, uint256 val) {
                 auto k = std::make_pair(static_cast<VMDomainEdge>(key.first), key.second);
                 return callback(k, val);
-            });
+            }, std::make_pair(static_cast<uint8_t>(start.first), start.second));
 }
 
-void CVMDomainGraphView::ForEachVMDomainTxEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback) {
+void CVMDomainGraphView::ForEachVMDomainTxEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback, const std::pair<VMDomainEdge, uint256> &start) {
     ForEach<VMDomainTxEdge, std::pair<uint8_t, uint256>, uint256>(
             [&callback](const std::pair<uint8_t, uint256> &key, uint256 val) {
                 auto k = std::make_pair(static_cast<VMDomainEdge>(key.first), key.second);
                 return callback(k, val);
-            });
+            }, std::make_pair(static_cast<uint8_t>(start.first), start.second));
 }

--- a/src/masternodes/evm.h
+++ b/src/masternodes/evm.h
@@ -30,11 +30,11 @@ class CVMDomainGraphView : public virtual CStorageView {
 public:
     Res SetVMDomainBlockEdge(VMDomainEdge type, uint256 blockHashKey, uint256 blockHash);
     ResVal<uint256> GetVMDomainBlockEdge(VMDomainEdge type, uint256 blockHashKey) const;
-    void ForEachVMDomainBlockEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback);
+    void ForEachVMDomainBlockEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback, const std::pair<VMDomainEdge, uint256> &start = {});
 
     Res SetVMDomainTxEdge(VMDomainEdge type, uint256 txHashKey, uint256 txHash);
     ResVal<uint256> GetVMDomainTxEdge(VMDomainEdge type, uint256 txHashKey) const;
-    void ForEachVMDomainTxEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback);
+    void ForEachVMDomainTxEdges(std::function<bool(const std::pair<VMDomainEdge, uint256> &, const uint256 &)> callback, const std::pair<VMDomainEdge, uint256> &start = {});
 
     struct VMDomainBlockEdge {
         static constexpr uint8_t prefix() { return 'N'; }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -3993,8 +3993,14 @@ public:
         sha3(obj.evmTx, evmTxHashBytes);
         auto txHash = tx.GetHash();
         auto evmTxHash = uint256S(HexStr(evmTxHashBytes));
-        mnview.SetVMDomainTxEdge(VMDomainEdge::DVMToEVM, txHash, evmTxHash);
-        mnview.SetVMDomainTxEdge(VMDomainEdge::EVMToDVM, evmTxHash, txHash);
+        auto res = mnview.SetVMDomainTxEdge(VMDomainEdge::DVMToEVM, txHash, evmTxHash);
+        if (!res) {
+            LogPrintf("Failed to store DVMtoEVM TX hash for DFI TX %s\n", txHash.ToString());
+        }
+        res = mnview.SetVMDomainTxEdge(VMDomainEdge::EVMToDVM, evmTxHash, txHash);
+        if (!res) {
+            LogPrintf("Failed to store EVMToDVM TX hash for DFI TX %s\n", txHash.ToString());
+        }
         return Res::Ok();
     }
 

--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -267,7 +267,11 @@ UniValue logvmmaps(const JSONRPCRequest &request) {
     RPCHelpMan{
         "logvmmaps",
         "\nLogs all block or tx indexes for debugging.\n",
-        {{"type", RPCArg::Type::NUM, RPCArg::Optional::NO, "Type of log: 0 - Blocks, 1 - Txs"}},
+        {{"type", RPCArg::Type::NUM, RPCArg::Optional::NO, "Type of log:\n"
+                                                           "    0 - DVMToEVM Blocks\n"
+                                                           "    1 - EVMToDVM Blocks\n"
+                                                           "    2 - DVMToEVM TXs\n"
+                                                           "    3 - EVMToDVM TXs"}},
         RPCResult{"{...} (array) Json object with account balances if rpcresult is enabled."
                   "This is for debugging purposes only.\n"},
         RPCExamples{HelpExampleCli("logvmmaps", R"('"<hex>"' 1)")},

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2429,8 +2429,14 @@ static void ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCus
     auto evmBlockHashData = std::vector<uint8_t>(blockResult.block_hash.rbegin(), blockResult.block_hash.rend());
     auto evmBlockHash = uint256(evmBlockHashData);
 
-    cache.SetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, block.GetHash(), evmBlockHash);
-    cache.SetVMDomainBlockEdge(VMDomainEdge::EVMToDVM, evmBlockHash, block.GetHash());
+    auto res = cache.SetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, block.GetHash(), evmBlockHash);
+    if (!res) {
+        LogPrintf("Failed to store DVMtoEVM block hash for DFI TX %s\n", block.GetHash().ToString());
+    }
+    res = cache.SetVMDomainBlockEdge(VMDomainEdge::EVMToDVM, evmBlockHash, block.GetHash());
+    if (!res) {
+        LogPrintf("Failed to store EVMToDVM block hash for DFI TX %s\n", block.GetHash().ToString());
+    }
 
     if (!blockResult.failed_transactions.empty()) {
         std::vector<std::string> failedTransactions;

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -140,7 +140,7 @@ class VMMapTests(DefiTestFramework):
         new_block = self.nodes[0].eth_getBlockByNumber("latest", False)['hash']
         list_blocks = self.nodes[0].logvmmaps(0)
         list_blocks = list(list_blocks['indexes'].values())
-        list_tx = self.nodes[0].logvmmaps(1)
+        list_tx = self.nodes[0].logvmmaps(2)
         list_tx = list(list_tx['indexes'].keys())
         assert_equal(base_block[2:] in list_blocks, True)
         assert_equal(new_block[2:] in list_blocks, True)
@@ -148,7 +148,7 @@ class VMMapTests(DefiTestFramework):
         self.nodes[0].invalidateblock(base_block_dvm)
         list_blocks = self.nodes[0].logvmmaps(0)
         list_blocks = list(list_blocks['indexes'].values())
-        list_tx = self.nodes[0].logvmmaps(1)
+        list_tx = self.nodes[0].logvmmaps(2)
         list_tx = list(list_tx['indexes'].keys())
         assert_equal(base_block[2:] in list_blocks, True)
         assert_equal(new_block[2:] in list_blocks, False)
@@ -160,13 +160,13 @@ class VMMapTests(DefiTestFramework):
         self.nodes[0].generate(1)
         tx = self.nodes[0].evmtx(self.ethAddress, 0, 21, 21000, self.toAddress, 1)
         self.nodes[0].generate(1)
-        list_tx = self.nodes[0].logvmmaps(1)
+        list_tx = self.nodes[0].logvmmaps(2)
         eth_tx = self.nodes[0].eth_getBlockByNumber("latest", False)['transactions'][0]
         assert_equal(eth_tx[2:] in list(list_tx['indexes'].values()), True)
         assert_equal(tx in list(list_tx['indexes'].keys()), True)
 
     def logvmmaps_invalid_tx_should_fail(self):
-        list_tx = self.nodes[0].logvmmaps(1)
+        list_tx = self.nodes[0].logvmmaps(2)
         assert_equal("invalid tx" not in list(list_tx['indexes'].values()), True)
         assert_equal("0x0000000000000000000000000000000000000000000000000000000000000000" not in list(list_tx['indexes'].values()), True)
         assert_equal("garbage" not in list(list_tx['indexes'].values()), True)
@@ -180,7 +180,7 @@ class VMMapTests(DefiTestFramework):
         assert_equal(dfi_block in list(list_blocks['indexes'].keys()), True)
 
     def logvmmaps_invalid_block_should_fail(self):
-        list_block = self.nodes[0].logvmmaps(1)
+        list_block = self.nodes[0].logvmmaps(2)
         assert_equal("invalid tx" not in list(list_block['indexes'].values()), True)
         assert_equal("0x0000000000000000000000000000000000000000000000000000000000000000" not in list(list_block['indexes'].values()), True)
         assert_equal("garbage" not in list(list_block['indexes'].values()), True)


### PR DESCRIPTION
Log DB write failures.
Add logging for DVMToEVM and EVMToDVM for blocks and TXs.
Throw error if type out of range.
Update help text.