### PR TITLE
Temp. fix for node shutdown on failed ConnectBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3331,9 +3331,13 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
             CrossBoundaryResult result;
             evm_try_finalize(result, evmQueueId, true, blockConnecting.nBits, beneficiary, blockConnecting.GetBlockTime());
             if (!result.ok) {
+                state.Invalid(ValidationInvalidReason::CONSENSUS,
+                                         error("EVM finalization failed: %s", result.reason.c_str()),
+                                         REJECT_INVALID);
+                InvalidBlockFound(pindexNew, state);
+                mnview.GetHistoryWriters().DiscardDB();
                 return error("%s: ConnectBlock %s failed, %s", __func__, pindexNew->GetBlockHash().ToString(), result.reason.c_str());
             }
-
         }
         bool flushed = view.Flush() && mnview.Flush();
         assert(flushed);


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- This correctly sets the state as Invalid, so the node can continue to look for other valid blocks instead of shutting down. 
- However, proper fix it getting rid of the secondary finalize. 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
