### PR TITLE
EVM construct block

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -1,7 +1,7 @@
 use crate::backend::{EVMBackend, EVMBackendError, InsufficientBalance, Vicinity};
 use crate::block::INITIAL_BASE_FEE;
 use crate::executor::TxResponse;
-use crate::fee::calculate_prepay_gas_fee;
+use crate::fee::{calculate_prepay_gas_fee, get_tx_max_gas_price};
 use crate::gas::check_tx_intrinsic_gas;
 use crate::receipt::ReceiptService;
 use crate::services::SERVICES;
@@ -21,7 +21,6 @@ use ethereum::{AccessList, Account, Block, Log, PartialHeader, TransactionV2};
 use ethereum_types::{Bloom, BloomInput, H160, U256};
 
 use anyhow::anyhow;
-use hex::FromHex;
 use log::debug;
 use std::error::Error;
 use std::path::PathBuf;
@@ -164,6 +163,24 @@ impl EVMCoreService {
         }))
     }
 
+    /// Validates a raw tx.
+    ///
+    /// The validation checks of the tx before we consider it to be valid are:
+    /// 1. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
+    /// 2. Gas price check: verify that the maximum gas price  is minimally of the block initial base fee.
+    /// 3. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// 4. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
+    /// 5. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The raw tx.
+    /// * `queue_id` - The queue_id queue number.
+    /// * `use_context` - Flag to call tx with stack executor.
+    ///
+    /// # Returns
+    ///
+    /// Returns the signed tx, tx prepay gas fees and the gas used to call the tx.
     pub fn validate_raw_tx(
         &self,
         tx: &str,
@@ -171,24 +188,24 @@ impl EVMCoreService {
         use_context: bool,
     ) -> Result<ValidateTxInfo, Box<dyn Error>> {
         debug!("[validate_raw_tx] raw transaction : {:#?}", tx);
-        let buffer = <Vec<u8>>::from_hex(tx)?;
-        let tx: TransactionV2 = ethereum::EnvelopedDecodable::decode(&buffer)
+        let signed_tx = SignedTx::try_from(tx)
             .map_err(|_| anyhow!("Error: decoding raw tx to TransactionV2"))?;
-        debug!("[validate_raw_tx] TransactionV2 : {:#?}", tx);
+        debug!(
+            "[validate_raw_tx] TransactionV2 : {:#?}",
+            signed_tx.transaction
+        );
 
         let block_number = self
             .storage
             .get_latest_block()
             .map(|block| block.header.number)
             .unwrap_or_default();
-
         debug!("[validate_raw_tx] block_number : {:#?}", block_number);
 
         let signed_tx: SignedTx = tx.try_into()?;
         let nonce = self
             .get_nonce(signed_tx.sender, block_number)
             .map_err(|e| anyhow!("Error getting nonce {e}"))?;
-
         debug!(
             "[validate_raw_tx] signed_tx.sender : {:#?}",
             signed_tx.sender
@@ -209,16 +226,21 @@ impl EVMCoreService {
             .into());
         }
 
+        // Validate tx gas price with initial block base fee
+        let tx_gas_price = get_tx_max_gas_price(&signed_tx);
+        if tx_gas_price < INITIAL_BASE_FEE {
+            debug!("[validate_raw_tx] tx gas price is lower than initial block base fee");
+            return Err(anyhow!("tx gas price is lower than initial block base fee").into());
+        }
+
         let balance = self
             .get_balance(signed_tx.sender, block_number)
             .map_err(|e| anyhow!("Error getting balance {e}"))?;
-
-        debug!("[validate_raw_tx] Account balance : {:x?}", balance);
-
         let prepay_fee = calculate_prepay_gas_fee(&signed_tx)?;
+        debug!("[validate_raw_tx] Account balance : {:x?}", balance);
         debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
 
-        let gas_limit = signed_tx.gas_limit();
+        // Validate tx prepay fees with account balance
         if balance < prepay_fee {
             debug!("[validate_raw_tx] insufficient balance to pay fees");
             return Err(anyhow!("insufficient balance to pay fees").into());
@@ -227,12 +249,13 @@ impl EVMCoreService {
         // Validate tx gas limit with intrinsic gas
         check_tx_intrinsic_gas(&signed_tx)?;
 
+        // Validate gas limit
+        let gas_limit = signed_tx.gas_limit();
         if gas_limit > MAX_GAS_PER_BLOCK {
-            debug!("[validate_raw_tx] Gas limit higher than MAX_GAS_PER_BLOCK");
-            return Err(anyhow!("Gas limit higher than MAX_GAS_PER_BLOCK").into());
+            debug!("[validate_raw_tx] gas limit higher than MAX_GAS_PER_BLOCK");
+            return Err(anyhow!("gas limit higher than MAX_GAS_PER_BLOCK").into());
         }
 
-        // Get tx gas usage
         let used_gas = if use_context {
             let TxResponse { used_gas, .. } = self.call(EthCallArgs {
                 caller: Some(signed_tx.sender),

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -99,7 +99,7 @@ impl EVMServices {
         }
     }
 
-    pub fn create_block(
+    pub fn construct_block(
         &self,
         queue_id: u64,
         difficulty: u32,

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -350,7 +350,7 @@ pub fn evm_try_queue_tx(
 /// # Returns
 ///
 /// Returns a `FinalizeBlockResult` containing the block hash, failed transactions, burnt fees and priority fees (in satoshis) on success.
-pub fn evm_try_create_block(
+pub fn evm_try_construct_block(
     result: &mut ffi::CrossBoundaryResult,
     queue_id: u64,
     difficulty: u32,
@@ -360,7 +360,7 @@ pub fn evm_try_create_block(
     let eth_address = H160::from(miner_address);
     match SERVICES
         .evm
-        .create_block(queue_id, difficulty, eth_address, timestamp)
+        .construct_block(queue_id, difficulty, eth_address, timestamp)
     {
         Ok(FinalizedBlockInfo {
             block_hash,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -107,7 +107,7 @@ pub mod ffi {
             hash: [u8; 32],
             gas_used: u64,
         );
-        fn evm_try_create_block(
+        fn evm_try_construct_block(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             difficulty: u32,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -107,19 +107,18 @@ pub mod ffi {
             hash: [u8; 32],
             gas_used: u64,
         );
-        fn evm_try_finalize(
+        fn evm_try_create_block(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
-            update_state: bool,
             difficulty: u32,
             miner_address: [u8; 20],
             timestamp: u64,
         ) -> FinalizeBlockCompletion;
+        fn evm_try_finalize_block(result: &mut CrossBoundaryResult, queue_id: u64);
         fn evm_try_create_and_sign_tx(
             result: &mut CrossBoundaryResult,
             ctx: CreateTransactionContext,
         ) -> Vec<u8>;
-
         fn evm_try_get_block_hash_by_number(
             result: &mut CrossBoundaryResult,
             height: u64,

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2422,7 +2422,7 @@ static void ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCus
     }
 
     CrossBoundaryResult result;
-    const auto blockResult = evm_try_create_block(result, evmQueueId, block.nBits, beneficiary, block.GetBlockTime());
+    const auto blockResult = evm_try_construct_block(result, evmQueueId, block.nBits, beneficiary, block.GetBlockTime());
     if (!result.ok) {
         LogPrintf("ERROR: EVM try finalize failed: %s\n", result.reason.c_str());
     }

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2422,7 +2422,7 @@ static void ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCus
     }
 
     CrossBoundaryResult result;
-    const auto blockResult = evm_try_finalize(result, evmQueueId, false, block.nBits, beneficiary, block.GetBlockTime());
+    const auto blockResult = evm_try_create_block(result, evmQueueId, block.nBits, beneficiary, block.GetBlockTime());
     if (!result.ok) {
         LogPrintf("ERROR: EVM try finalize failed: %s\n", result.reason.c_str());
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -318,7 +318,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         std::array<uint8_t, 20> beneficiary{};
         std::copy(nodePtr->ownerAuthAddress.begin(), nodePtr->ownerAuthAddress.end(), beneficiary.begin());
         CrossBoundaryResult result;
-        auto blockResult = evm_try_create_block(result, evmQueueId, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), beneficiary, blockTime);
+        auto blockResult = evm_try_construct_block(result, evmQueueId, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), beneficiary, blockTime);
         evm_discard_context(evmQueueId);
 
         const auto blockHash = std::vector<uint8_t>(blockResult.block_hash.begin(), blockResult.block_hash.end());

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -318,7 +318,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         std::array<uint8_t, 20> beneficiary{};
         std::copy(nodePtr->ownerAuthAddress.begin(), nodePtr->ownerAuthAddress.end(), beneficiary.begin());
         CrossBoundaryResult result;
-        auto blockResult = evm_try_finalize(result, evmQueueId, false, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), beneficiary, blockTime);
+        auto blockResult = evm_try_create_block(result, evmQueueId, pos::GetNextWorkRequired(pindexPrev, pblock->nTime, consensus), beneficiary, blockTime);
         evm_discard_context(evmQueueId);
 
         const auto blockHash = std::vector<uint8_t>(blockResult.block_hash.begin(), blockResult.block_hash.end());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3329,7 +3329,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
         LogPrint(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime3 - nTime2) * MILLI, nTimeConnectTotal * MICRO, nTimeConnectTotal * MILLI / nBlocksTotal);
         if (IsEVMEnabled(pindexNew->nHeight, mnview, chainparams.GetConsensus())) {
             CrossBoundaryResult result;
-            evm_try_finalize(result, evmQueueId, true, blockConnecting.nBits, beneficiary, blockConnecting.GetBlockTime());
+            evm_try_finalize_block(result, evmQueueId);
             if (!result.ok) {
                 state.Invalid(ValidationInvalidReason::CONSENSUS,
                                          error("EVM finalization failed: %s", result.reason.c_str()),

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -77,7 +77,7 @@ class EVMFeeTest(DefiTestFramework):
         balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
         assert_equal(int(balance[2:], 16), 100000000000000000000)
 
-        assert_raises_rpc_error(-32001, "tx gas price is lower than block base fee", self.nodes[0].eth_sendTransaction, {
+        assert_raises_rpc_error(-32001, "tx gas price is lower than initial block base fee", self.nodes[0].eth_sendTransaction, {
             'from': self.ethAddress,
             'to': self.toAddress,
             'value': '0x7148', # 29_000
@@ -156,7 +156,7 @@ class EVMFeeTest(DefiTestFramework):
         balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
         assert_equal(int(balance[2:], 16), 100000000000000000000)
 
-        assert_raises_rpc_error(-32001, "evm tx failed to validate Gas limit higher than MAX_GAS_PER_BLOCK", self.nodes[0].eth_sendTransaction, {
+        assert_raises_rpc_error(-32001, "evm tx failed to validate gas limit higher than MAX_GAS_PER_BLOCK", self.nodes[0].eth_sendTransaction, {
             'from': self.ethAddress,
             'to': self.toAddress,
             'value': '0x7148', # 29_000


### PR DESCRIPTION
## Summary

- Pipeline to validate and execute transactions and update the new state into the block in finalize_block is shifted out into construct_block.
- Once the construction is done in a particular txqueue, the queue now holds the newly minted block in the queue.
- finalize_block will be called to commit the state and connect the block into storage. The old pipeline runs finalize_block twice (in ConnectBlock and subsequently in ConnectTip). This prevents redoing and running the block creation again.

## Bug fixes

- Fix txqueue clear and drain_all methods bug to clear account nonce index.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
