### PR TITLE
Validate XVM coinbase OP_RETURN output

### DIFF
--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -21,6 +21,39 @@ class CCoinsViewCache;
 
 class CCustomCSView;
 
+struct EVM {
+    uint32_t version;
+    uint256 blockHash;
+    uint64_t burntFee;
+    uint64_t priorityFee;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(version);
+        READWRITE(blockHash);
+        READWRITE(burntFee);
+        READWRITE(priorityFee);
+    }
+};
+
+struct XVM {
+    uint32_t version;
+    EVM evm;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(version);
+        READWRITE(evm);
+    }
+};
+
+
 struct OPReturnValidationCtx {
     bool checkOPReturn{};
     uint32_t coreOPReturnSize{};

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2476,7 +2476,6 @@ static Res ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCust
         }
 
         auto res = ValidateCoinbaseXVMOutput(block.vtx[0]->vout[1].scriptPubKey, blockResult);
-        LogPrintf("XXX err %s\n", res.msg);
         if (!res) return res;
     }
 

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -2419,7 +2419,7 @@ static Res ValidateCoinbaseXVMOutput(const CScript &scriptPubKey, const Finalize
     return Res::Ok();
 }
 
-static Res ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &cache, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabled) {
+static Res ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &cache, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabledOnBlockHead) {
     if (!IsEVMEnabled(pindex->nHeight, cache, chainparams.GetConsensus())) return Res::Ok();
 
     CKeyID minter;
@@ -2470,7 +2470,7 @@ static Res ProcessEVMQueue(const CBlock &block, const CBlockIndex *pindex, CCust
     auto evmBlockHashData = std::vector<uint8_t>(blockResult.block_hash.rbegin(), blockResult.block_hash.rend());
     auto evmBlockHash = uint256(evmBlockHashData);
 
-    if (evmEnabled) {
+    if (evmEnabledOnBlockHead) {
         if (block.vtx[0]->vout.size() < 2) {
             return Res::Err("Not enough outputs in coinbase TX");
         }
@@ -2514,11 +2514,11 @@ static void FlushCacheCreateUndo(const CBlockIndex *pindex, CCustomCSView &mnvie
     }
 }
 
-Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabled) {
+Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabledOnBlockHead) {
     CCustomCSView cache(mnview);
 
     // Process EVM block
-    auto res = ProcessEVMQueue(block, pindex, cache, chainparams, evmQueueId, beneficiary, evmEnabled);
+    auto res = ProcessEVMQueue(block, pindex, cache, chainparams, evmQueueId, beneficiary, evmEnabledOnBlockHead);
     if (!res) return res;
 
     // Construct undo

--- a/src/masternodes/validation.h
+++ b/src/masternodes/validation.h
@@ -18,7 +18,7 @@ class CCustomCSView;
 using CreationTxs = std::map<uint32_t, std::pair<uint256, std::vector<std::pair<DCT_ID, uint256>>>>;
 
 void ProcessDeFiEvent(const CBlock &block, const CBlockIndex* pindex, CCustomCSView& mnview, const CCoinsViewCache& view, const CChainParams& chainparams, const CreationTxs &creationTxs, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary);
-Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabled);
+Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabledOnBlockHead);
 
 std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets& vaultAssets, const TAmounts& collBalances, const TAmounts& loanBalances);
 

--- a/src/masternodes/validation.h
+++ b/src/masternodes/validation.h
@@ -18,7 +18,7 @@ class CCustomCSView;
 using CreationTxs = std::map<uint32_t, std::pair<uint256, std::vector<std::pair<DCT_ID, uint256>>>>;
 
 void ProcessDeFiEvent(const CBlock &block, const CBlockIndex* pindex, CCustomCSView& mnview, const CCoinsViewCache& view, const CChainParams& chainparams, const CreationTxs &creationTxs, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary);
-Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary);
+Res ProcessFallibleEvent(const CBlock &block, const CBlockIndex *pindex, CCustomCSView &mnview, const CChainParams& chainparams, const uint64_t evmQueueId, std::array<uint8_t, 20>& beneficiary, const bool evmEnabled);
 
 std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets& vaultAssets, const TAmounts& collBalances, const TAmounts& loanBalances);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -38,38 +38,6 @@
 #include <random>
 #include <utility>
 
-struct EVM {
-    uint32_t version;
-    uint256 blockHash;
-    uint64_t burntFee;
-    uint64_t priorityFee;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(version);
-        READWRITE(blockHash);
-        READWRITE(burntFee);
-        READWRITE(priorityFee);
-    }
-};
-
-struct XVM {
-    uint32_t version;
-    EVM evm;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(version);
-        READWRITE(evm);
-    }
-};
-
 typedef std::array<std::uint8_t, 20> EvmAddress;
 
 struct EvmAddressWithNonce {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2613,6 +2613,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
 
+    // Get EVM enabled. Used to check whether the miner will have added a coinbase output with EVM blockhash and fees in.
+    const auto evmEnabled = IsEVMEnabled(pindex->nHeight, mnview, chainparams.GetConsensus());
+
     // Execute TXs
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
@@ -2851,7 +2854,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     accountsView.Flush();
 
     // Execute EVM Queue
-    res = ProcessFallibleEvent(block, pindex, mnview, chainparams, evmQueueId, beneficiary);
+    res = ProcessFallibleEvent(block, pindex, mnview, chainparams, evmQueueId, beneficiary, evmEnabled);
     if (!res.ok) {
         return state.Invalid(ValidationInvalidReason::CONSENSUS, error("%s: %s", __func__, res.msg), REJECT_INVALID, res.dbgMsg);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2614,7 +2614,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
 
     // Get EVM enabled. Used to check whether the miner will have added a coinbase output with EVM blockhash and fees in.
-    const auto evmEnabled = IsEVMEnabled(pindex->nHeight, mnview, chainparams.GetConsensus());
+    const auto evmEnabledOnBlockHead = IsEVMEnabled(pindex->nHeight, mnview, chainparams.GetConsensus());
 
     // Execute TXs
     for (unsigned int i = 0; i < block.vtx.size(); i++)
@@ -2854,7 +2854,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     accountsView.Flush();
 
     // Execute EVM Queue
-    res = ProcessFallibleEvent(block, pindex, mnview, chainparams, evmQueueId, beneficiary, evmEnabled);
+    res = ProcessFallibleEvent(block, pindex, mnview, chainparams, evmQueueId, beneficiary, evmEnabledOnBlockHead);
     if (!res.ok) {
         return state.Invalid(ValidationInvalidReason::CONSENSUS, error("%s: %s", __func__, res.msg), REJECT_INVALID, res.dbgMsg);
     }

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -231,8 +231,6 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].setgov({"ATTRIBUTES": {'v0/transferdomain/evm-dvm/src-formats': ['erc55']}})
         self.nodes[0].generate(1)
 
-        print(self.nodes[0].getgov('ATTRIBUTES'))
-
         # Dectivate transferdomain ERC55 address
         self.nodes[0].setgov({"ATTRIBUTES": {'v0/transferdomain/evm-dvm/dest-formats': ['bech32']}})
         self.nodes[0].generate(1)


### PR DESCRIPTION
Checks that the EVM block hash and fees added to a coinbase output as OP_RETURN data matches on the same data found in consensus when the block is created. If not then the entire block is rejected.