### PR TITLE
Fix lints to enable `eth_` forwarding on defi-cli

### DIFF
--- a/test/lint/check-rpc-mappings.py
+++ b/test/lint/check-rpc-mappings.py
@@ -135,6 +135,9 @@ def main():
     errors = 0
     for (cmdname, argidx, argname) in mapping:
         try:
+            # Ignore eth_ forwarding commands
+            if cmdname.startswith('eth_'):
+                continue
             rargnames = cmds_by_name[cmdname].args[argidx].names
         except IndexError:
             print('ERROR: %s argument %i (named %s in vRPCConvertParams) is not defined in dispatch table' % (


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Relax RPC lints to enable eth forwarding

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
