### PR TITLE
Finalize OP_RETURN default rules

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -1492,6 +1492,8 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                 ret.pushKV(key, KeyBuilder(*number));
             } else if (const auto number = std::get_if<uint32_t>(&attribute.second)) {
                 ret.pushKV(key, KeyBuilder(*number));
+            } else if (const auto number = std::get_if<uint64_t>(&attribute.second)) {
+                ret.pushKV(key, KeyBuilder(*number));
             } else if (const auto amount = std::get_if<CAmount>(&attribute.second)) {
                 if (attrV0->type == AttributeTypes::Param &&
                     (attrV0->typeId == DFIP2203 || attrV0->typeId == DFIP2206F) &&

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -4344,8 +4344,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                   uint64_t time,
                   uint256 *canSpend,
                   uint32_t txn,
-                  const uint64_t evmQueueId,
-                  const OpReturnLimits &opReturnLimits) {
+                  const uint64_t evmQueueId) {
     auto res = Res::Ok();
     if (tx.IsCoinBase() && height > 0) {  // genesis contains custom coinbase txs
         return res;
@@ -4354,7 +4353,11 @@ Res ApplyCustomTx(CCustomCSView &mnview,
     const auto metadataValidation = height >= static_cast<uint32_t>(consensus.FortCanningHeight);
     const auto txType = GuessCustomTxType(tx, metadata, metadataValidation);
 
+    auto attributes = mnview.GetAttributes();
+    assert(attributes);
+
     // Check OP_RETURN sizes
+    const auto opReturnLimits = OpReturnLimits::From(height, consensus, *attributes);
     if (opReturnLimits.shouldEnforce) {
         if (auto r = opReturnLimits.Validate(tx, txType); !r) {
             return r;
@@ -5243,10 +5246,10 @@ struct OpReturnLimitsKeys {
     CDataStructureV0 evmKey{AttributeTypes::Rules, RulesIDs::TXRules, RulesKeys::EVMOPReturn};
 };
 
-OpReturnLimits OpReturnLimits::From(const uint64_t height, const CChainParams& chainparams, const ATTRIBUTES& attributes) {
+OpReturnLimits OpReturnLimits::From(const uint64_t height, const Consensus::Params &consensus, const ATTRIBUTES &attributes) {
     OpReturnLimitsKeys k{};
     auto item = OpReturnLimits::Default();
-    item.shouldEnforce = height >= static_cast<uint64_t>(chainparams.GetConsensus().NextNetworkUpgradeHeight);
+    item.shouldEnforce = height >= static_cast<uint64_t>(consensus.NextNetworkUpgradeHeight);
     item.coreSizeBytes = attributes.GetValue(k.coreKey, item.coreSizeBytes);
     item.dvmSizeBytes = attributes.GetValue(k.dvmKey, item.dvmSizeBytes);
     item.evmSizeBytes = attributes.GetValue(k.evmKey, item.evmSizeBytes);

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -5230,7 +5230,7 @@ bool IsTransferDomainEnabled(const int height, const CCustomCSView &view, const 
 
 OpReturnLimits OpReturnLimits::Default() {
     return OpReturnLimits {
-        true,
+        false,
         MAX_OP_RETURN_CORE_ACCEPT,
         MAX_OP_RETURN_DVM_ACCEPT,
         MAX_OP_RETURN_EVM_ACCEPT,

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -295,7 +295,7 @@ struct OpReturnLimits {
     uint64_t evmSizeBytes{};
 
     static OpReturnLimits Default();
-    static OpReturnLimits From(const uint64_t height, const CChainParams& chainparams, const ATTRIBUTES& attributes);
+    static OpReturnLimits From(const uint64_t height, const Consensus::Params &consensus, const ATTRIBUTES &attributes);
 
     void SetToAttributesIfNotExists(ATTRIBUTES& attrs) const;
     Res Validate(const CTransaction& tx, const CustomTxType txType) const;
@@ -551,8 +551,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                   uint64_t time            = 0,
                   uint256 *canSpend        = nullptr,
                   uint32_t txn             = 0,
-                  const uint64_t evmQueueId = 0,
-                  const OpReturnLimits &opReturnLimits = OpReturnLimits::Default());
+                  const uint64_t evmQueueId = 0);
 Res CustomTxVisit(CCustomCSView &mnview,
                   const CCoinsViewCache &coins,
                   const CTransaction &tx,

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -879,7 +879,7 @@ UniValue getgov(const JSONRPCRequest& request) {
 
 static void AddDefaultVars(uint64_t height, CChainParams params, ATTRIBUTES &attrs) {
     // OpReturnLimits
-    const auto opReturnLimits = OpReturnLimits::From(height, params, attrs);
+    const auto opReturnLimits = OpReturnLimits::From(height, params.GetConsensus(), attrs);
     opReturnLimits.SetToAttributesIfNotExists(attrs);
 
     // TransferDomainConfig

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -29,9 +29,9 @@ public:
 // While the relay options are free for interpretation to
 // each node, the accept values are enforced on validation
 
-static const uint32_t MAX_OP_RETURN_CORE_ACCEPT = 2000;
-static const uint32_t MAX_OP_RETURN_DVM_ACCEPT = 4000;
-static const uint32_t MAX_OP_RETURN_EVM_ACCEPT = 20000;
+static const uint64_t MAX_OP_RETURN_CORE_ACCEPT = 1024;
+static const uint64_t MAX_OP_RETURN_DVM_ACCEPT = 4096;
+static const uint64_t MAX_OP_RETURN_EVM_ACCEPT = 65536;
 
 /**
  * This is the check used for IsStandardChecks to allow all of the 3 above
@@ -39,7 +39,7 @@ static const uint32_t MAX_OP_RETURN_EVM_ACCEPT = 20000;
  * Also used as default for nMaxDatacarrierBytes. 
  * Actual data size = N - 3 // 1 for OP_RETURN, 2 for pushdata opcodes.
  */
-static constexpr uint32_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
+static constexpr uint64_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
 
 /**
  * A data carrying output is an unspendable output containing data. The script

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2601,7 +2601,6 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     const auto attributes = accountsView.GetAttributes();
     assert(attributes);
 
-    auto opReturnLimits = OpReturnLimits::From(pindex->nHeight, chainparams, *attributes);
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
 
     // Get EVM enabled. Used to check whether the miner will have added a coinbase output with EVM blockhash and fees in.
@@ -2677,7 +2676,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             }
 
             const auto applyCustomTxTime = GetTimeMicros();
-            const auto res = ApplyCustomTx(accountsView, view, tx, chainparams.GetConsensus(), pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmQueueId, opReturnLimits);
+            const auto res = ApplyCustomTx(accountsView, view, tx, chainparams.GetConsensus(), pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmQueueId);
 
             LogApplyCustomTx(tx, applyCustomTxTime);
             if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Finalizes default rule sets of OP_RETURN sizes
  - Can be considered as proxy for EVM, DVM Tx sizes without the envelopes and signatures on DVM

## Protocol

<!-- Please remove section if deemed to be empty -->
- OP_RETURN sizes on validation:
  - Core: 1k (`v0/rules/tx/core_op_return_max_size_bytes`)
  - DVM: 4k (`v0/rules/tx/dvm_op_return_max_size_bytes`)
  - EVM: 64k  (`v0/rules/tx/evm_op_return_max_size_bytes`)
- Note: The above are part of validation, not just miner policy like the `-datacarriersize`, which still exists and can be used to limit further per node


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
