### PR TITLE
getblock RPC

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -207,8 +207,8 @@ public:
         consensus.props.emergencyPeriod = 8640;
         consensus.props.feeBurnPct = COIN / 2;
 
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI of 200 per block (rate normalized to (COIN == 100%))
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::AnchorReward, COIN /10 / 200);       // 0.1 DFI of 200 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI of 200 per block (rate normalized to (COIN == 100%))
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::AnchorReward, COIN /10 / 200);       // 0.1 DFI of 200 per block
 
         // New coinbase reward distribution
         consensus.dist.masternode = 3333; // 33.33%
@@ -219,12 +219,12 @@ public:
         consensus.dist.options = 988; // 9.88%
         consensus.dist.unallocated = 173; // 1.73%
 
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Loan, consensus.dist.loan);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Options, consensus.dist.options);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Loan, consensus.dist.loan);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Options, consensus.dist.options);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
         // EVM chain id
         consensus.evmChainId = 1130; // ETH main chain ID
@@ -483,8 +483,8 @@ public:
         consensus.props.feeBurnPct = COIN / 2;
 
 
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
 
         // New coinbase reward distribution
         consensus.dist.masternode = 3333; // 33.33%
@@ -495,12 +495,12 @@ public:
         consensus.dist.options = 988; // 9.88%
         consensus.dist.unallocated = 173; // 1.73%
 
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Loan, consensus.dist.loan);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Options, consensus.dist.options);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Loan, consensus.dist.loan);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Options, consensus.dist.options);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
         // EVM chain id
         consensus.evmChainId = 1131; // test chain ID
@@ -698,8 +698,8 @@ public:
         consensus.props.emergencyPeriod = 8640;
         consensus.props.feeBurnPct = COIN / 2;
 
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
 
         // New coinbase reward distribution
         consensus.dist.masternode = 3333; // 33.33%
@@ -710,12 +710,12 @@ public:
         consensus.dist.options = 988; // 9.88%
         consensus.dist.unallocated = 173; // 1.73%
 
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Loan, consensus.dist.loan);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Options, consensus.dist.options);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Loan, consensus.dist.loan);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Options, consensus.dist.options);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
         // EVM chain id
         consensus.evmChainId = 1133; // changi chain ID
@@ -914,8 +914,8 @@ public:
         consensus.props.emergencyPeriod = 8640;
         consensus.props.feeBurnPct = COIN / 2;
 
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::IncentiveFunding, 45 * COIN / 200); // 45 DFI @ 200 per block (rate normalized to (COIN == 100%))
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::AnchorReward, COIN/10 / 200);       // 0.1 DFI @ 200 per block
 
         // New coinbase reward distribution
         consensus.dist.masternode = 3333; // 33.33%
@@ -926,12 +926,12 @@ public:
         consensus.dist.options = 988; // 9.88%
         consensus.dist.unallocated = 173; // 1.73%
 
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Loan, consensus.dist.loan);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Options, consensus.dist.options);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Loan, consensus.dist.loan);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Options, consensus.dist.options);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
         // EVM chain id
         consensus.evmChainId = 1132; // dev chain ID
@@ -1133,8 +1133,8 @@ public:
 
         consensus.vaultCreationFee = 1 * COIN;
 
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::IncentiveFunding, 10 * COIN / 50); // normalized to (COIN == 100%) // 10 per block
-        consensus.nonUtxoBlockSubsidies.emplace(CommunityAccountType::AnchorReward, COIN/10 / 50);       // 0.1 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::IncentiveFunding, 10 * COIN / 50); // normalized to (COIN == 100%) // 10 per block
+        consensus.blockTokenRewardsLegacy.emplace(CommunityAccountType::AnchorReward, COIN/10 / 50);       // 0.1 per block
 
         // New coinbase reward distribution
         consensus.dist.masternode = 3333; // 33.33%
@@ -1145,12 +1145,12 @@ public:
         consensus.dist.options = 988; // 9.88%
         consensus.dist.unallocated = 173; // 1.73%
 
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Loan, consensus.dist.loan);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Options, consensus.dist.options);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
-        consensus.newNonUTXOSubsidies.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::AnchorReward, consensus.dist.anchor);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::IncentiveFunding, consensus.dist.liquidity);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Loan, consensus.dist.loan);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Options, consensus.dist.options);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::Unallocated, consensus.dist.unallocated);
+        consensus.blockTokenRewards.emplace(CommunityAccountType::CommunityDevFunds, consensus.dist.community);
 
         // EVM chain id
         consensus.evmChainId = 1133; // regtest chain ID

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -221,8 +221,8 @@ struct Params {
     };
     CProposalParams props;
 
-    std::map<CommunityAccountType, CAmount> nonUtxoBlockSubsidies;
-    std::map<CommunityAccountType, uint32_t> newNonUTXOSubsidies;
+    std::map<CommunityAccountType, CAmount> blockTokenRewardsLegacy;
+    std::map<CommunityAccountType, uint32_t> blockTokenRewards;
 
     uint64_t evmChainId;
 };

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -46,6 +46,6 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0, int verbosity = 0);
 
 #endif // DEFI_CORE_IO_H

--- a/src/masternodes/incentivefunding.h
+++ b/src/masternodes/incentivefunding.h
@@ -18,7 +18,7 @@ inline CommunityAccountType CommunityAccountCodeToType(unsigned char ch) {
         return CommunityAccountType::None;
 }
 
-inline const char *GetCommunityAccountName(CommunityAccountType t) {
+inline const std::string GetCommunityAccountName(const CommunityAccountType t) {
     switch (t) {
         case CommunityAccountType::IncentiveFunding:
             return "IncentiveFunding";

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -51,6 +51,8 @@ struct XVM {
         READWRITE(version);
         READWRITE(evm);
     }
+
+    static ResVal<XVM> TryFrom(const CScript &scriptPubKey);
 };
 
 class CCustomTxVisitor {

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -37,6 +37,8 @@ struct EVM {
         READWRITE(burntFee);
         READWRITE(priorityFee);
     }
+
+    UniValue ToUniValue() const;
 };
 
 struct XVM {
@@ -53,6 +55,8 @@ struct XVM {
     }
 
     static ResVal<XVM> TryFrom(const CScript &scriptPubKey);
+    UniValue ToUniValue() const;
+
 };
 
 class CCustomTxVisitor {

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -1830,7 +1830,7 @@ UniValue listcommunitybalances(const JSONRPCRequest& request) {
 
     LOCK(cs_main);
     CAmount burnt{0};
-    for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies)
+    for (const auto& kv : Params().GetConsensus().blockTokenRewards)
     {
         // Skip these as any unused balance will be burnt.
         if (kv.first == CommunityAccountType::Options) {
@@ -2218,7 +2218,7 @@ UniValue getburninfo(const JSONRPCRequest& request) {
         dfiToDUSDTokens = attributes->GetValue(liveKey, CBalances{});
     }
 
-    for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies) {
+    for (const auto& kv : Params().GetConsensus().blockTokenRewards) {
         if (kv.first == CommunityAccountType::Unallocated ||
             kv.first == CommunityAccountType::IncentiveFunding ||
             (height >= fortCanningHeight  && kv.first == CommunityAccountType::Loan)) {

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -25,7 +25,7 @@
 
 template<typename GovVar>
 static void UpdateDailyGovVariables(const std::map<CommunityAccountType, uint32_t>::const_iterator& incentivePair, CCustomCSView& cache, int nHeight) {
-    if (incentivePair != Params().GetConsensus().newNonUTXOSubsidies.end())
+    if (incentivePair != Params().GetConsensus().blockTokenRewards.end())
     {
         CAmount subsidy = CalculateCoinbaseReward(GetBlockSubsidy(nHeight, Params().GetConsensus()), incentivePair->second);
         subsidy *= Params().GetConsensus().blocksPerDay();
@@ -48,14 +48,14 @@ static void ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& cache,
     // Hard coded LP_DAILY_DFI_REWARD change
     if (pindex->nHeight >= chainparams.GetConsensus().EunosHeight)
     {
-        const auto& incentivePair = chainparams.GetConsensus().newNonUTXOSubsidies.find(CommunityAccountType::IncentiveFunding);
+        const auto& incentivePair = chainparams.GetConsensus().blockTokenRewards.find(CommunityAccountType::IncentiveFunding);
         UpdateDailyGovVariables<LP_DAILY_DFI_REWARD>(incentivePair, cache, pindex->nHeight);
     }
 
     // Hard coded LP_DAILY_LOAN_TOKEN_REWARD change
     if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight)
     {
-        const auto& incentivePair = chainparams.GetConsensus().newNonUTXOSubsidies.find(CommunityAccountType::Loan);
+        const auto& incentivePair = chainparams.GetConsensus().blockTokenRewards.find(CommunityAccountType::Loan);
         UpdateDailyGovVariables<LP_DAILY_LOAN_TOKEN_REWARD>(incentivePair, cache, pindex->nHeight);
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -407,7 +407,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             __func__, blockReward, coinbaseTx.vout[0].nValue, foundationValue);
     } else if (nHeight >= consensus.AMKHeight) {
         // assume community non-utxo funding:
-        for (const auto& kv : consensus.nonUtxoBlockSubsidies) {
+        for (const auto& kv : consensus.blockTokenRewardsLegacy) {
             coinbaseTx.vout[0].nValue -= blockReward * kv.second / COIN;
         }
         // Pinch off foundation share

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -190,11 +190,11 @@ struct RewardInfo {
         result.BlockReward = blockReward;
 
         if (blockindex->nHeight < consensus.EunosHeight) {
-            for (const auto& [accountType, accountVal] : consensus.nonUtxoBlockSubsidies)
+            for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy)
             {
                 CAmount subsidy = blockReward * accountVal / COIN;
                 switch (accountType) {
-                    // CommunityDevFunds, Loan, Options don't exist in nonUtxoBlockSubsidies here
+                    // CommunityDevFunds, Loan, Options don't exist in blockTokenRewardsLegacy here
                     case CommunityAccountType::AnchorReward:{ tokenRewards.AnchorReward = subsidy; break; }
                     case CommunityAccountType::IncentiveFunding: { tokenRewards.IncentiveFunding = subsidy; break; }
                     default: { tokenRewards.Burnt += subsidy; }
@@ -203,7 +203,7 @@ struct RewardInfo {
             return result;
         }
 
-        for (const auto& [accountType, accountVal] : consensus.newNonUTXOSubsidies)
+        for (const auto& [accountType, accountVal] : consensus.blockTokenRewards)
         {
             if (blockindex->nHeight < consensus.GrandCentralHeight 
             && accountType == CommunityAccountType::CommunityDevFunds) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -142,7 +142,7 @@ struct MinterInfo {
         return result;
     }
 
-    void ToUniValueLegacy(UniValue& result) {
+    void ToUniValueLegacy(UniValue& result) const {
         // Note: This follows legacy way of empty checks and prints to preserve
         // compatibility. Don't change it. Use the new method ToUniValue method
         // for new version.
@@ -153,7 +153,7 @@ struct MinterInfo {
         result.pushKV("stakeModifier", StakeModifier.ToString());
     }
 
-    UniValue ToUniValue() {
+    UniValue ToUniValue() const {
         // Note that this breaks compatibility with the legacy version. 
         // Do not use this with existing RPCs
         UniValue result(UniValue::VOBJ);
@@ -222,7 +222,7 @@ struct RewardInfo {
         return result;
     }
 
-    void ToUniValueLegacy(UniValue& result) {
+    void ToUniValueLegacy(UniValue& result) const {
         // Note: This follows legacy way of empty checks and prints to preserve
         // compatibility. Don't change it. Use the new method ToUniValue method
         // for new version.
@@ -243,7 +243,7 @@ struct RewardInfo {
         result.pushKV("nonutxo", rewards);
     }
 
-    UniValue ToUniValue() {
+    UniValue ToUniValue() const {
         // Note that this breaks compatibility with the legacy version. 
         // Do not use this with existing RPCs
         UniValue obj(UniValue::VOBJ);
@@ -271,19 +271,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     AssertLockNotHeld(cs_main); // For performance reasons
     const auto consensus = Params().GetConsensus();
 
-    auto coinbaseXVMToUniValue = [](XVM &obj) {
-        UniValue result(UniValue::VOBJ);
-        result.pushKV("version", static_cast<uint64_t>(obj.version));
-        UniValue evm(UniValue::VOBJ);
-        evm.pushKV("version", static_cast<uint64_t>(obj.evm.version));
-        evm.pushKV("blockHash", "0x" + obj.evm.blockHash.GetHex());
-        evm.pushKV("priorityFee", obj.evm.priorityFee);
-        evm.pushKV("burntFee", obj.evm.burntFee);
-        result.pushKV("evm", evm);
-        return result;
-    };
-
-    auto txVmInfo = [&coinbaseXVMToUniValue](const CTransaction& tx) -> std::optional<UniValue> {
+    auto txVmInfo = [](const CTransaction& tx) -> std::optional<UniValue> {
         CustomTxType guess;
         UniValue txResults(UniValue::VOBJ);
         if (tx.IsCoinBase()) {
@@ -298,7 +286,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
             UniValue result(UniValue::VOBJ);
             result.pushKV("vmtype", "coinbase");
             result.pushKV("txtype", "coinbase");
-            result.pushKV("msg", coinbaseXVMToUniValue(*res));
+            result.pushKV("msg", res->ToUniValue());
             return result;
         }
         auto res = RpcInfo(tx, std::numeric_limits<int>::max(), guess, txResults);

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -32,7 +32,7 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 /** Block description to JSON */
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, bool xVmDetails = false) LOCKS_EXCLUDED(cs_main);
 
 /** Mempool information to JSON */
 UniValue MempoolInfoToJSON(const CTxMemPool& pool);

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -32,7 +32,7 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 /** Block description to JSON */
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, bool v2 = false) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, int verbosity = 0) LOCKS_EXCLUDED(cs_main);
 
 /** Mempool information to JSON */
 UniValue MempoolInfoToJSON(const CTxMemPool& pool);

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -32,7 +32,7 @@ double GetDifficulty(const CBlockIndex* blockindex);
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 /** Block description to JSON */
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, bool xVmDetails = false) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, bool v2 = false) LOCKS_EXCLUDED(cs_main);
 
 /** Mempool information to JSON */
 UniValue MempoolInfoToJSON(const CTxMemPool& pool);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -29,9 +29,9 @@ public:
 // While the relay options are free for interpretation to
 // each node, the accept values are enforced on validation
 
-static const uint64_t MAX_OP_RETURN_CORE_ACCEPT = 1024;
-static const uint64_t MAX_OP_RETURN_DVM_ACCEPT = 4096;
-static const uint64_t MAX_OP_RETURN_EVM_ACCEPT = 65536;
+static const uint32_t MAX_OP_RETURN_CORE_ACCEPT = 2000;
+static const uint32_t MAX_OP_RETURN_DVM_ACCEPT = 4000;
+static const uint32_t MAX_OP_RETURN_EVM_ACCEPT = 20000;
 
 /**
  * This is the check used for IsStandardChecks to allow all of the 3 above
@@ -39,7 +39,7 @@ static const uint64_t MAX_OP_RETURN_EVM_ACCEPT = 65536;
  * Also used as default for nMaxDatacarrierBytes. 
  * Actual data size = N - 3 // 1 for OP_RETURN, 2 for pushdata opcodes.
  */
-static constexpr uint64_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
+static constexpr uint32_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
 
 /**
  * A data carrying output is an unspendable output containing data. The script

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -29,9 +29,9 @@ public:
 // While the relay options are free for interpretation to
 // each node, the accept values are enforced on validation
 
-static const uint32_t MAX_OP_RETURN_CORE_ACCEPT = 2000;
-static const uint32_t MAX_OP_RETURN_DVM_ACCEPT = 4000;
-static const uint32_t MAX_OP_RETURN_EVM_ACCEPT = 20000;
+static const uint64_t MAX_OP_RETURN_CORE_ACCEPT = 1024;
+static const uint64_t MAX_OP_RETURN_DVM_ACCEPT = 4096;
+static const uint64_t MAX_OP_RETURN_EVM_ACCEPT = 65536;
 
 /**
  * This is the check used for IsStandardChecks to allow all of the 3 above
@@ -39,7 +39,7 @@ static const uint32_t MAX_OP_RETURN_EVM_ACCEPT = 20000;
  * Also used as default for nMaxDatacarrierBytes. 
  * Actual data size = N - 3 // 1 for OP_RETURN, 2 for pushdata opcodes.
  */
-static constexpr uint32_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
+static constexpr uint64_t MAX_OP_RETURN_RELAY = std::max({MAX_OP_RETURN_CORE_ACCEPT, MAX_OP_RETURN_DVM_ACCEPT, MAX_OP_RETURN_EVM_ACCEPT});
 
 /**
  * A data carrying output is an unspendable output containing data. The script

--- a/src/test/dip1fork_tests.cpp
+++ b/src/test/dip1fork_tests.cpp
@@ -70,8 +70,8 @@ BOOST_AUTO_TEST_CASE(blockreward_dfip1)
         CAmount const baseSubsidy = GetBlockSubsidy(height, consensus);
         tx.vout[1].nValue = baseSubsidy * consensus.foundationShareDFIP1 / COIN;
         tx.vout[0].nValue -= tx.vout[1].nValue;
-        tx.vout[0].nValue -= baseSubsidy * consensus.nonUtxoBlockSubsidies.at(CommunityAccountType::IncentiveFunding) / COIN;
-        tx.vout[0].nValue -= baseSubsidy * consensus.nonUtxoBlockSubsidies.at(CommunityAccountType::AnchorReward) / COIN;
+        tx.vout[0].nValue -= baseSubsidy * consensus.blockTokenRewardsLegacy.at(CommunityAccountType::IncentiveFunding) / COIN;
+        tx.vout[0].nValue -= baseSubsidy * consensus.blockTokenRewardsLegacy.at(CommunityAccountType::AnchorReward) / COIN;
 
         Res res = ApplyGeneralCoinbaseTx(mnview, CTransaction(tx), height, 0, consensus);
         BOOST_CHECK(res.ok);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2114,7 +2114,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
     CAmount nonUtxoTotal = 0;
 
     if (height < consensus.EunosHeight) {
-        for (const auto& [accountType, accountVal] : consensus.nonUtxoBlockSubsidies) {
+        for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
             CAmount subsidy = blockReward * accountVal / COIN;
             Res res = mnview.AddCommunityBalance(accountType, subsidy);
             if (!res.ok) {
@@ -2129,7 +2129,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
     }
 
     CAmount subsidy;
-    for (const auto& [accountType, accountVal] : consensus.newNonUTXOSubsidies) {
+    for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
         if (accountType == CommunityAccountType::CommunityDevFunds) {
             if (height < consensus.GrandCentralHeight) {
                 continue;
@@ -2213,14 +2213,14 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensu
     // TODO(legacy-cleanup): Use proper structures
 
     if (height < consensus.EunosHeight) {
-        for (const auto& [accountType, accountVal] : consensus.nonUtxoBlockSubsidies) {
+        for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
             CAmount subsidy = blockReward * accountVal / COIN;
             mnview.SubCommunityBalance(accountType, subsidy);
         }
         return;
     }
 
-    for (const auto& [accountType, accountVal] : consensus.newNonUTXOSubsidies) {
+    for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
         if (accountType == CommunityAccountType::CommunityDevFunds) {
             if (height < consensus.GrandCentralHeight) {
                 continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2096,7 +2096,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         if (height >= consensus.EunosHeight)
         {
             CAmount subsidy;
-            for (const auto& kv : consensus.newNonUTXOSubsidies)
+            for (const auto& kv : consensus.blockTokenRewards)
             {
                 if (kv.first == CommunityAccountType::CommunityDevFunds) {
                     if (height < consensus.GrandCentralHeight) {
@@ -2174,7 +2174,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         }
         else
         {
-            for (const auto& kv : consensus.nonUtxoBlockSubsidies) {
+            for (const auto& kv : consensus.blockTokenRewardsLegacy) {
                 CAmount subsidy = blockReward * kv.second / COIN;
                 Res res = mnview.AddCommunityBalance(kv.first, subsidy);
                 if (!res.ok) {
@@ -2205,7 +2205,7 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensu
     {
         if (height >= Params().GetConsensus().EunosHeight)
         {
-            for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies)
+            for (const auto& kv : Params().GetConsensus().blockTokenRewards)
             {
                 if (kv.first == CommunityAccountType::CommunityDevFunds) {
                     if (height < Params().GetConsensus().GrandCentralHeight) {
@@ -2256,7 +2256,7 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensu
         }
         else
         {
-            for (const auto& kv : Params().GetConsensus().nonUtxoBlockSubsidies)
+            for (const auto& kv : Params().GetConsensus().blockTokenRewardsLegacy)
             {
                 CAmount subsidy = blockReward * kv.second / COIN;
                 mnview.SubCommunityBalance(kv.first, subsidy);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2046,6 +2046,9 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
 
 Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int height, CAmount nFees, const Consensus::Params& consensus)
 {
+    // TODO(legacy-cleanup): Clean up the rest of the method with proper structures
+    // and a more comprehensible flow
+    
     TAmounts const cbValues = tx.GetValuesOut();
     CAmount blockReward = GetBlockSubsidy(height, consensus);
     if (cbValues.size() != 1 || cbValues.begin()->first != DCT_ID{0})
@@ -2074,49 +2077,43 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return attrs.GetValue(k, false);
     };
 
-    if (height < consensus.AMKHeight) {
-        return finalCheckAndReturn();
-    }
+    auto tryVerifyUtxoRewards = [](CTransaction const & tx, const CAmount blockReward, int height, const Consensus::Params& consensus) {
+        CAmount foundationReward{0};
+        if (height >= consensus.GrandCentralHeight) {
+            // no foundation utxo reward check anymore
+        }
+        else if (height >= consensus.EunosHeight) {
+            foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
+        }
+        else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
+            foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
+        }
 
-    // TODO(legacy-cleanup): Clean up the rest of the method with proper structures
-    // and a more comprehensible flow
-
-    CAmount foundationReward{0};
-    if (height >= consensus.GrandCentralHeight) {
-        // no foundation utxo reward check anymore
-    }
-    else if (height >= consensus.EunosHeight) {
-        foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
-    }
-    else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
-        foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
-    }
-
-    if (foundationReward) {
-        bool foundationsRewardfound = false;
-        for (auto& txout : tx.vout) {
-            if (txout.scriptPubKey == consensus.foundationShareScript) {
-                if (txout.nValue < foundationReward) {
-                    return Res::ErrDbg("bad-cb-foundation-reward", 
-                        "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
+        if (foundationReward) {
+            bool foundationsRewardfound = false;
+            for (auto& txout : tx.vout) {
+                if (txout.scriptPubKey == consensus.foundationShareScript) {
+                    if (txout.nValue < foundationReward) {
+                        return Res::ErrDbg("bad-cb-foundation-reward", 
+                            "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
+                    }
+                    foundationsRewardfound = true;
+                    break;
                 }
-                foundationsRewardfound = true;
-                break;
+            }
+
+            if (!foundationsRewardfound) {
+                return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay foundation reward!");
             }
         }
+        return Res::Ok();
+    };
 
-        if (!foundationsRewardfound) {
-            return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay foundation reward!");
-        }
-    }
-
-    // count and subtract for non-UTXO community rewards
-    CAmount nonUtxoTotal = 0;
-
-    if (height < consensus.EunosHeight) {
+    auto handleLegacyTokenRewards = [&finalCheckAndReturn, &logAccountChange](CTransaction const & tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus) {
+        CAmount nonUtxoTotal = 0;
         for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
             CAmount subsidy = blockReward * accountVal / COIN;
-            Res res = mnview.AddCommunityBalance(accountType, subsidy);
+            Res res = view.AddCommunityBalance(accountType, subsidy);
             if (!res.ok) {
                 return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
             } else {
@@ -2126,69 +2123,89 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         }
         blockReward -= nonUtxoTotal;
         return finalCheckAndReturn();
-    }
+    };
 
-    CAmount subsidy;
-    for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
-        if (accountType == CommunityAccountType::CommunityDevFunds) {
-            if (height < consensus.GrandCentralHeight) {
-                continue;
-            }
-        }
+    auto handleCurrentTokenRewards = [&finalCheckAndReturn, &logAccountChange, &isGovernanceEnabled, &isUnusedEmissionFundEnabled](CTransaction const & tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus, int height) {
+        CAmount nonUtxoTotal = 0;
+        CAmount subsidy;
 
-        subsidy = CalculateCoinbaseReward(blockReward, accountVal);
-        Res res = Res::Ok();
-
-        // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
-        if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
-            (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
-            res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-            if (res) {
-                logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated));
-            }
-        } else {
-            if (height >= consensus.GrandCentralHeight) {
-                const auto attributes = mnview.GetAttributes();
-                assert(attributes);
-                if (accountType == CommunityAccountType::CommunityDevFunds) {
-                    if (!isGovernanceEnabled(*attributes)) {
-                        continue;
-                    } else {
-                        res = mnview.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
-                        // TODO: Result check missed; check full sync and add checks
-                        logAccountChange(tx, subsidy, ScriptToString(consensus.foundationShareScript));
-                        nonUtxoTotal += subsidy;
-                        continue;
-                    }
-                } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
-                    if (isUnusedEmissionFundEnabled(*attributes)) {
-                        res = mnview.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
-                        if (res) { logAccountChange(tx, subsidy, ScriptToString(consensus.unusedEmission)); }
-                    } else {
-                        // Previous behaviour was for Options and Unallocated to go to Unallocated
-                        res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                        if (res) { logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated)); }
-                    }
-                    nonUtxoTotal += subsidy;
+        for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
+            if (accountType == CommunityAccountType::CommunityDevFunds) {
+                if (height < consensus.GrandCentralHeight) {
                     continue;
                 }
             }
 
-            res = mnview.AddCommunityBalance(accountType, subsidy);
-            if (res) {
-                logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
+            subsidy = CalculateCoinbaseReward(blockReward, accountVal);
+            Res res = Res::Ok();
+
+            // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
+            if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
+                (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
+                res = view.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                if (res) {
+                    logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated));
+                }
+            } else {
+                if (height >= consensus.GrandCentralHeight) {
+                    const auto attributes = view.GetAttributes();
+                    assert(attributes);
+                    if (accountType == CommunityAccountType::CommunityDevFunds) {
+                        if (!isGovernanceEnabled(*attributes)) {
+                            continue;
+                        } else {
+                            res = view.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+                            // TODO: Result check missed; check full sync and add checks
+                            logAccountChange(tx, subsidy, ScriptToString(consensus.foundationShareScript));
+                            nonUtxoTotal += subsidy;
+                            continue;
+                        }
+                    } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
+                        if (isUnusedEmissionFundEnabled(*attributes)) {
+                            res = view.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
+                            if (res) { logAccountChange(tx, subsidy, ScriptToString(consensus.unusedEmission)); }
+                        } else {
+                            // Previous behaviour was for Options and Unallocated to go to Unallocated
+                            res = view.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                            if (res) { logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated)); }
+                        }
+                        nonUtxoTotal += subsidy;
+                        continue;
+                    }
+                }
+
+                res = view.AddCommunityBalance(accountType, subsidy);
+                if (res) {
+                    logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
+                }
             }
+
+            if (!res.ok) {
+                return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
+            }
+
+            nonUtxoTotal += subsidy;
         }
 
-        if (!res.ok) {
-            return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
-        }
+        blockReward -= nonUtxoTotal;
+        return finalCheckAndReturn();
+    };
 
-        nonUtxoTotal += subsidy;
+    // Actual logic starts here
+
+    if (height < consensus.AMKHeight) {
+        return finalCheckAndReturn();
     }
 
-    blockReward -= nonUtxoTotal;
-    return finalCheckAndReturn();
+    if (auto r = tryVerifyUtxoRewards(tx, blockReward, height, consensus); !r) {
+        return r;
+    }
+
+    if (height < consensus.EunosHeight) {
+        return handleLegacyTokenRewards(tx, blockReward, mnview, consensus);
+    }
+
+    return handleCurrentTokenRewards(tx, blockReward, mnview, consensus, height);
 }
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2051,216 +2051,203 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
     if (cbValues.size() != 1 || cbValues.begin()->first != DCT_ID{0})
         return Res::ErrDbg("bad-cb-wrong-tokens", "coinbase should pay only Defi coins");
 
+    auto finalCheckAndReturn = [&]() {
+        if (cbValues.at(DCT_ID{0}) > blockReward + nFees)
+            return Res::ErrDbg("bad-cb-amount", "coinbase pays too much (actual=%d vs limit=%d)", cbValues.at(DCT_ID{0}), blockReward + nFees);
+        return Res::Ok();
+    };
 
-    if (height >= consensus.AMKHeight)
-    {
-        CAmount foundationReward{0};
-        if (height >= consensus.GrandCentralHeight)
-        {
-            // no foundation utxo reward check anymore
-        }
-        else if (height >= consensus.EunosHeight)
-        {
-            foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
-        }
-        else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1)
-        {
-            foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
-        }
+    auto logAccountChange = [](const CTransaction& tx, const CAmount subsidy, const std::string account) {
+        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", 
+            tx.GetHash().ToString(), 
+            account, 
+            (CBalances{{{{0}, subsidy}}}.ToString()));
+    };
 
-        if (foundationReward)
-        {
-            bool foundationsRewardfound = false;
-            for (auto& txout : tx.vout)
-            {
-                if (txout.scriptPubKey == consensus.foundationShareScript)
-                {
-                    if (txout.nValue < foundationReward)
-                    {
-                        return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
-                    }
+    auto isUnusedEmissionFundEnabled = [](const ATTRIBUTES& attrs) {
+        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
+        return attrs.GetValue(k, false);
+    };
 
-                    foundationsRewardfound = true;
-                    break;
-                }
-            }
+    auto isGovernanceEnabled = [](const ATTRIBUTES& attrs) {
+        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
+        return attrs.GetValue(k, false);
+    };
 
-            if (!foundationsRewardfound)
-            {
-                return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay foundation reward!");
-            }
-        }
-
-        // count and subtract for non-UTXO community rewards
-        CAmount nonUtxoTotal = 0;
-        if (height >= consensus.EunosHeight)
-        {
-            CAmount subsidy;
-            for (const auto& kv : consensus.newNonUTXOSubsidies)
-            {
-                if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                    if (height < consensus.GrandCentralHeight) {
-                        continue;
-                    }
-                }
-
-                subsidy = CalculateCoinbaseReward(blockReward, kv.second);
-
-                Res res = Res::Ok();
-
-                // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
-                if ((height < consensus.FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
-                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
-                {
-                    res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                    if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
-                }
-                else
-                {
-                    if (height >= consensus.GrandCentralHeight)
-                    {
-                        const auto attributes = mnview.GetAttributes();
-                        assert(attributes);
-
-                        if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
-
-                            if (!attributes->GetValue(enabledKey, false))
-                            {
-                                res = mnview.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
-                                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n",
-                                         tx.GetHash().ToString(), ScriptToString(consensus.foundationShareScript),
-                                         (CBalances{{{{0}, subsidy}}}.ToString()));
-                                nonUtxoTotal += subsidy;
-
-                                continue;
-                            }
-                        } else if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::Options) {
-                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
-
-                            if (attributes->GetValue(enabledKey, false)) {
-                                res = mnview.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
-                                if (res) {
-                                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n",
-                                             tx.GetHash().ToString(), ScriptToString(consensus.unusedEmission),
-                                             (CBalances{{{{0}, subsidy}}}.ToString()));
-                                }
-                            } else {
-                                // Previous behaviour was for Options and Unallocated to go to Unallocated
-                                res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                                if (res)
-                                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
-                            }
-
-                            nonUtxoTotal += subsidy;
-
-                            continue;
-                        }
-                    }
-
-                    res = mnview.AddCommunityBalance(kv.first, subsidy);
-                    if (res)
-                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
-                }
-
-                if (!res.ok)
-                {
-                    return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
-                }
-
-                nonUtxoTotal += subsidy;
-            }
-        }
-        else
-        {
-            for (const auto& kv : consensus.nonUtxoBlockSubsidies) {
-                CAmount subsidy = blockReward * kv.second / COIN;
-                Res res = mnview.AddCommunityBalance(kv.first, subsidy);
-                if (!res.ok) {
-                    return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
-                } else {
-                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
-                }
-                nonUtxoTotal += subsidy;
-            }
-        }
-
-        blockReward -= nonUtxoTotal;
+    if (height < consensus.AMKHeight) {
+        return finalCheckAndReturn();
     }
 
-    // pre-AMK logic, compatible after prev blockReward mod:
-    if (cbValues.at(DCT_ID{0}) > blockReward + nFees)
-        return Res::ErrDbg("bad-cb-amount", "coinbase pays too much (actual=%d vs limit=%d)", cbValues.at(DCT_ID{0}), blockReward + nFees);
+    // TODO(legacy-cleanup): Clean up the rest of the method with proper structures
+    // and a more comprehensible flow
 
-    return Res::Ok();
+    CAmount foundationReward{0};
+    if (height >= consensus.GrandCentralHeight) {
+        // no foundation utxo reward check anymore
+    }
+    else if (height >= consensus.EunosHeight) {
+        foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
+    }
+    else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
+        foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
+    }
+
+    if (foundationReward) {
+        bool foundationsRewardfound = false;
+        for (auto& txout : tx.vout) {
+            if (txout.scriptPubKey == consensus.foundationShareScript) {
+                if (txout.nValue < foundationReward) {
+                    return Res::ErrDbg("bad-cb-foundation-reward", 
+                        "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
+                }
+                foundationsRewardfound = true;
+                break;
+            }
+        }
+
+        if (!foundationsRewardfound) {
+            return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay foundation reward!");
+        }
+    }
+
+    // count and subtract for non-UTXO community rewards
+    CAmount nonUtxoTotal = 0;
+
+    if (height < consensus.EunosHeight) {
+        for (const auto& [accountType, accountVal] : consensus.nonUtxoBlockSubsidies) {
+            CAmount subsidy = blockReward * accountVal / COIN;
+            Res res = mnview.AddCommunityBalance(accountType, subsidy);
+            if (!res.ok) {
+                return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
+            } else {
+                logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
+            }
+            nonUtxoTotal += subsidy;
+        }
+        blockReward -= nonUtxoTotal;
+        return finalCheckAndReturn();
+    }
+
+    CAmount subsidy;
+    for (const auto& [accountType, accountVal] : consensus.newNonUTXOSubsidies) {
+        if (accountType == CommunityAccountType::CommunityDevFunds) {
+            if (height < consensus.GrandCentralHeight) {
+                continue;
+            }
+        }
+
+        subsidy = CalculateCoinbaseReward(blockReward, accountVal);
+        Res res = Res::Ok();
+
+        // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
+        if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
+            (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
+            res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+            if (res) {
+                logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated));
+            }
+        } else {
+            if (height >= consensus.GrandCentralHeight) {
+                const auto attributes = mnview.GetAttributes();
+                assert(attributes);
+                if (accountType == CommunityAccountType::CommunityDevFunds) {
+                    if (!isGovernanceEnabled(*attributes)) {
+                        continue;
+                    } else {
+                        res = mnview.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+                        // TODO: Result check missed; check full sync and add checks
+                        logAccountChange(tx, subsidy, ScriptToString(consensus.foundationShareScript));
+                        nonUtxoTotal += subsidy;
+                        continue;
+                    }
+                } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
+                    if (isUnusedEmissionFundEnabled(*attributes)) {
+                        res = mnview.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
+                        if (res) { logAccountChange(tx, subsidy, ScriptToString(consensus.unusedEmission)); }
+                    } else {
+                        // Previous behaviour was for Options and Unallocated to go to Unallocated
+                        res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                        if (res) { logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated)); }
+                    }
+                    nonUtxoTotal += subsidy;
+                    continue;
+                }
+            }
+
+            res = mnview.AddCommunityBalance(accountType, subsidy);
+            if (res) {
+                logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
+            }
+        }
+
+        if (!res.ok) {
+            return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
+        }
+
+        nonUtxoTotal += subsidy;
+    }
+
+    blockReward -= nonUtxoTotal;
+    return finalCheckAndReturn();
 }
 
 
 void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensus::Params& consensus)
 {
-    CAmount blockReward = GetBlockSubsidy(height, Params().GetConsensus());
+    CAmount blockReward = GetBlockSubsidy(height, consensus);
+    
+    if (height < consensus.AMKHeight) {
+        return;
+    }
 
-    if (height >= Params().GetConsensus().AMKHeight)
-    {
-        if (height >= Params().GetConsensus().EunosHeight)
-        {
-            for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies)
-            {
-                if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                    if (height < Params().GetConsensus().GrandCentralHeight) {
-                        continue;
-                    }
-                }
+    // TODO(legacy-cleanup): Use proper structures
 
-                CAmount subsidy = CalculateCoinbaseReward(blockReward, kv.second);
+    if (height < consensus.EunosHeight) {
+        for (const auto& [accountType, accountVal] : consensus.nonUtxoBlockSubsidies) {
+            CAmount subsidy = blockReward * accountVal / COIN;
+            mnview.SubCommunityBalance(accountType, subsidy);
+        }
+        return;
+    }
 
-                // Remove Loan and Options balances from Unallocated
-                if ((height < Params().GetConsensus().FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
-                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
-                {
-                    mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                }
-                else
-                {
-                    if (height >= consensus.GrandCentralHeight)
-                    {
-                        const auto attributes = mnview.GetAttributes();
-                        assert(attributes);
-
-                        if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
-
-                            if (!attributes->GetValue(enabledKey, false))
-                            {
-                                mnview.SubBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
-
-                                continue;
-                            }
-                        } else if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::Options) {
-                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
-
-                            if (attributes->GetValue(enabledKey, false)) {
-                                mnview.SubBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
-                            } else {
-                                mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                            }
-
-                            continue;
-                        }
-                    }
-
-                    mnview.SubCommunityBalance(kv.first, subsidy);
-                }
+    for (const auto& [accountType, accountVal] : consensus.newNonUTXOSubsidies) {
+        if (accountType == CommunityAccountType::CommunityDevFunds) {
+            if (height < consensus.GrandCentralHeight) {
+                continue;
             }
         }
-        else
-        {
-            for (const auto& kv : Params().GetConsensus().nonUtxoBlockSubsidies)
-            {
-                CAmount subsidy = blockReward * kv.second / COIN;
-                mnview.SubCommunityBalance(kv.first, subsidy);
+
+        CAmount subsidy = CalculateCoinbaseReward(blockReward, accountVal);
+
+        // Remove Loan and Options balances from Unallocated
+        if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
+            (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
+            mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+        } else {
+            if (height >= consensus.GrandCentralHeight) {
+                const auto attributes = mnview.GetAttributes();
+                assert(attributes);
+
+                if (accountType == CommunityAccountType::CommunityDevFunds) {
+                    CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
+
+                    if (!attributes->GetValue(enabledKey, false))
+                    {
+                        mnview.SubBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+                        continue;
+                    }
+                } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
+                    CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
+
+                    if (attributes->GetValue(enabledKey, false)) {
+                        mnview.SubBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
+                    } else {
+                        mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                    }
+                    continue;
+                }
             }
+            mnview.SubCommunityBalance(accountType, subsidy);
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2046,228 +2046,221 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
 
 Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int height, CAmount nFees, const Consensus::Params& consensus)
 {
-    // TODO(legacy-cleanup): Clean up the rest of the method with proper structures
-    // and a more comprehensible flow
-    
     TAmounts const cbValues = tx.GetValuesOut();
     CAmount blockReward = GetBlockSubsidy(height, consensus);
     if (cbValues.size() != 1 || cbValues.begin()->first != DCT_ID{0})
         return Res::ErrDbg("bad-cb-wrong-tokens", "coinbase should pay only Defi coins");
 
-    auto finalCheckAndReturn = [&](const CAmount reward) {
-        if (cbValues.at(DCT_ID{0}) > reward + nFees)
-            return Res::ErrDbg("bad-cb-amount", "coinbase pays too much (actual=%d vs limit=%d)", cbValues.at(DCT_ID{0}), blockReward + nFees);
-        return Res::Ok();
-    };
 
-    auto logAccountChange = [](const CTransaction& tx, const CAmount subsidy, const std::string account) {
-        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", 
-            tx.GetHash().ToString(), 
-            account, 
-            (CBalances{{{{0}, subsidy}}}.ToString()));
-    };
-
-    auto isUnusedEmissionFundEnabled = [](const ATTRIBUTES& attrs) {
-        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
-        return attrs.GetValue(k, false);
-    };
-
-    auto isGovernanceEnabled = [](const ATTRIBUTES& attrs) {
-        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
-        return attrs.GetValue(k, false);
-    };
-
-    auto tryVerifyUtxoRewards = [](const CTransaction& tx, const CAmount blockReward, int height, const Consensus::Params& consensus) {
+    if (height >= consensus.AMKHeight)
+    {
         CAmount foundationReward{0};
-        if (height >= consensus.GrandCentralHeight) {
+        if (height >= consensus.GrandCentralHeight)
+        {
             // no foundation utxo reward check anymore
-        } else if (height >= consensus.EunosHeight) {
+        }
+        else if (height >= consensus.EunosHeight)
+        {
             foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
-        } else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
+        }
+        else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1)
+        {
             foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
         }
 
-        if (foundationReward) {
+        if (foundationReward)
+        {
             bool foundationsRewardfound = false;
-            for (auto& txout : tx.vout) {
-                if (txout.scriptPubKey == consensus.foundationShareScript) {
-                    if (txout.nValue < foundationReward) {
-                        return Res::ErrDbg("bad-cb-foundation-reward", 
-                            "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
+            for (auto& txout : tx.vout)
+            {
+                if (txout.scriptPubKey == consensus.foundationShareScript)
+                {
+                    if (txout.nValue < foundationReward)
+                    {
+                        return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay proper foundation reward! (actual=%d vs expected=%d", txout.nValue, foundationReward);
                     }
+
                     foundationsRewardfound = true;
                     break;
                 }
             }
 
-            if (!foundationsRewardfound) {
+            if (!foundationsRewardfound)
+            {
                 return Res::ErrDbg("bad-cb-foundation-reward", "coinbase doesn't pay foundation reward!");
             }
         }
-        return Res::Ok();
-    };
 
-    auto handleLegacyTokenRewards = [&finalCheckAndReturn, &logAccountChange](const CTransaction& tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus) {
+        // count and subtract for non-UTXO community rewards
         CAmount nonUtxoTotal = 0;
-        for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
-            CAmount subsidy = blockReward * accountVal / COIN;
-            Res res = view.AddCommunityBalance(accountType, subsidy);
-            if (!res.ok) {
-                return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
-            } else {
-                logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
-            }
-            nonUtxoTotal += subsidy;
-        }
-        blockReward -= nonUtxoTotal;
-        return finalCheckAndReturn(blockReward);
-    };
-
-    auto handleCurrentTokenRewards = [&finalCheckAndReturn, &logAccountChange, &isGovernanceEnabled, &isUnusedEmissionFundEnabled](const CTransaction& tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus, int height) {
-        CAmount nonUtxoTotal = 0;
-        CAmount subsidy;
-
-        for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
-            if (accountType == CommunityAccountType::CommunityDevFunds) {
-                if (height < consensus.GrandCentralHeight) {
-                    continue;
-                }
-            }
-
-            subsidy = CalculateCoinbaseReward(blockReward, accountVal);
-            Res res = Res::Ok();
-
-            // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
-            if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
-                (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
-                res = view.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                if (res) {
-                    logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated));
-                }
-            } else {
-                if (height >= consensus.GrandCentralHeight) {
-                    const auto attributes = view.GetAttributes();
-                    assert(attributes);
-                    if (accountType == CommunityAccountType::CommunityDevFunds) {
-                        if (!isGovernanceEnabled(*attributes)) {
-                            continue;
-                        } else {
-                            res = view.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
-                            // TODO: Result check missed; check full sync and add checks
-                            logAccountChange(tx, subsidy, ScriptToString(consensus.foundationShareScript));
-                            nonUtxoTotal += subsidy;
-                            continue;
-                        }
-                    } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
-                        if (isUnusedEmissionFundEnabled(*attributes)) {
-                            res = view.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
-                            if (res) { logAccountChange(tx, subsidy, ScriptToString(consensus.unusedEmission)); }
-                        } else {
-                            // Previous behaviour was for Options and Unallocated to go to Unallocated
-                            res = view.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-                            if (res) { logAccountChange(tx, subsidy, GetCommunityAccountName(CommunityAccountType::Unallocated)); }
-                        }
-                        nonUtxoTotal += subsidy;
+        if (height >= consensus.EunosHeight)
+        {
+            CAmount subsidy;
+            for (const auto& kv : consensus.newNonUTXOSubsidies)
+            {
+                if (kv.first == CommunityAccountType::CommunityDevFunds) {
+                    if (height < consensus.GrandCentralHeight) {
                         continue;
                     }
                 }
 
-                res = view.AddCommunityBalance(accountType, subsidy);
-                if (res) {
-                    logAccountChange(tx, subsidy, GetCommunityAccountName(accountType));
+                subsidy = CalculateCoinbaseReward(blockReward, kv.second);
+
+                Res res = Res::Ok();
+
+                // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
+                if ((height < consensus.FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
+                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
+                {
+                    res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                    if (res)
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
                 }
-            }
+                else
+                {
+                    if (height >= consensus.GrandCentralHeight)
+                    {
+                        const auto attributes = mnview.GetAttributes();
+                        assert(attributes);
 
-            if (!res.ok) {
-                return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
-            }
+                        if (kv.first == CommunityAccountType::CommunityDevFunds) {
+                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
 
-            nonUtxoTotal += subsidy;
+                            if (!attributes->GetValue(enabledKey, false))
+                            {
+                                res = mnview.AddBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+                                LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n",
+                                         tx.GetHash().ToString(), ScriptToString(consensus.foundationShareScript),
+                                         (CBalances{{{{0}, subsidy}}}.ToString()));
+                                nonUtxoTotal += subsidy;
+
+                                continue;
+                            }
+                        } else if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::Options) {
+                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
+
+                            if (attributes->GetValue(enabledKey, false)) {
+                                res = mnview.AddBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
+                                if (res) {
+                                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n",
+                                             tx.GetHash().ToString(), ScriptToString(consensus.unusedEmission),
+                                             (CBalances{{{{0}, subsidy}}}.ToString()));
+                                }
+                            } else {
+                                // Previous behaviour was for Options and Unallocated to go to Unallocated
+                                res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                                if (res)
+                                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(CommunityAccountType::Unallocated), (CBalances{{{{0}, subsidy}}}.ToString()));
+                            }
+
+                            nonUtxoTotal += subsidy;
+
+                            continue;
+                        }
+                    }
+
+                    res = mnview.AddCommunityBalance(kv.first, subsidy);
+                    if (res)
+                        LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                }
+
+                if (!res.ok)
+                {
+                    return Res::ErrDbg("bad-cb-community-rewards", "Cannot take non-UTXO community share from coinbase");
+                }
+
+                nonUtxoTotal += subsidy;
+            }
+        }
+        else
+        {
+            for (const auto& kv : consensus.nonUtxoBlockSubsidies) {
+                CAmount subsidy = blockReward * kv.second / COIN;
+                Res res = mnview.AddCommunityBalance(kv.first, subsidy);
+                if (!res.ok) {
+                    return Res::ErrDbg("bad-cb-community-rewards", "can't take non-UTXO community share from coinbase");
+                } else {
+                    LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: hash=%s fund=%s change=%s\n", tx.GetHash().ToString(), GetCommunityAccountName(kv.first), (CBalances{{{{0}, subsidy}}}.ToString()));
+                }
+                nonUtxoTotal += subsidy;
+            }
         }
 
         blockReward -= nonUtxoTotal;
-        return finalCheckAndReturn(blockReward);
-    };
-
-    // Actual logic starts here
-
-    if (height < consensus.AMKHeight) {
-        return finalCheckAndReturn(blockReward);
     }
 
-    if (auto r = tryVerifyUtxoRewards(tx, blockReward, height, consensus); !r) {
-        return r;
-    }
+    // pre-AMK logic, compatible after prev blockReward mod:
+    if (cbValues.at(DCT_ID{0}) > blockReward + nFees)
+        return Res::ErrDbg("bad-cb-amount", "coinbase pays too much (actual=%d vs limit=%d)", cbValues.at(DCT_ID{0}), blockReward + nFees);
 
-    if (height < consensus.EunosHeight) {
-        return handleLegacyTokenRewards(tx, blockReward, mnview, consensus);
-    }
-
-    return handleCurrentTokenRewards(tx, blockReward, mnview, consensus, height);
+    return Res::Ok();
 }
 
 
 void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensus::Params& consensus)
 {
-    CAmount blockReward = GetBlockSubsidy(height, consensus);
-    
-    auto isUnusedEmissionFundEnabled = [](const ATTRIBUTES& attrs) {
-        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
-        return attrs.GetValue(k, false);
-    };
+    CAmount blockReward = GetBlockSubsidy(height, Params().GetConsensus());
 
-    auto isGovernanceEnabled = [](const ATTRIBUTES& attrs) {
-        CDataStructureV0 k{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
-        return attrs.GetValue(k, false);
-    };
-
-    if (height < consensus.AMKHeight) {
-        return;
-    }
-
-    // TODO(legacy-cleanup): Use proper structures
-
-    if (height < consensus.EunosHeight) {
-        for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
-            CAmount subsidy = blockReward * accountVal / COIN;
-            mnview.SubCommunityBalance(accountType, subsidy);
-        }
-        return;
-    }
-
-    for (const auto& [accountType, accountVal] : consensus.blockTokenRewards) {
-        if (accountType == CommunityAccountType::CommunityDevFunds) {
-            if (height < consensus.GrandCentralHeight) {
-                continue;
-            }
-        }
-
-        CAmount subsidy = CalculateCoinbaseReward(blockReward, accountVal);
-
-        // Remove Loan and Options balances from Unallocated
-        if ((height < consensus.FortCanningHeight && accountType == CommunityAccountType::Loan) ||
-            (height < consensus.GrandCentralHeight && accountType == CommunityAccountType::Options)) {
-            mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
-        } else {
-            if (height >= consensus.GrandCentralHeight) {
-                const auto attributes = mnview.GetAttributes();
-                assert(attributes);
-
-                if (accountType == CommunityAccountType::CommunityDevFunds) {
-                    if (!isGovernanceEnabled(*attributes)) {
-                        mnview.SubBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+    if (height >= Params().GetConsensus().AMKHeight)
+    {
+        if (height >= Params().GetConsensus().EunosHeight)
+        {
+            for (const auto& kv : Params().GetConsensus().newNonUTXOSubsidies)
+            {
+                if (kv.first == CommunityAccountType::CommunityDevFunds) {
+                    if (height < Params().GetConsensus().GrandCentralHeight) {
                         continue;
                     }
-                } else if (accountType == CommunityAccountType::Unallocated || accountType == CommunityAccountType::Options) {
-                    if (isUnusedEmissionFundEnabled(*attributes)) {
-                        mnview.SubBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
-                    } else {
-                        mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                }
+
+                CAmount subsidy = CalculateCoinbaseReward(blockReward, kv.second);
+
+                // Remove Loan and Options balances from Unallocated
+                if ((height < Params().GetConsensus().FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
+                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
+                {
+                    mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                }
+                else
+                {
+                    if (height >= consensus.GrandCentralHeight)
+                    {
+                        const auto attributes = mnview.GetAttributes();
+                        assert(attributes);
+
+                        if (kv.first == CommunityAccountType::CommunityDevFunds) {
+                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
+
+                            if (!attributes->GetValue(enabledKey, false))
+                            {
+                                mnview.SubBalance(consensus.foundationShareScript, {DCT_ID{0}, subsidy});
+
+                                continue;
+                            }
+                        } else if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::Options) {
+                            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EmissionUnusedFund};
+
+                            if (attributes->GetValue(enabledKey, false)) {
+                                mnview.SubBalance(consensus.unusedEmission, {DCT_ID{0}, subsidy});
+                            } else {
+                                mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
+                            }
+
+                            continue;
+                        }
                     }
-                    continue;
+
+                    mnview.SubCommunityBalance(kv.first, subsidy);
                 }
             }
-            mnview.SubCommunityBalance(accountType, subsidy);
+        }
+        else
+        {
+            for (const auto& kv : Params().GetConsensus().nonUtxoBlockSubsidies)
+            {
+                CAmount subsidy = blockReward * kv.second / COIN;
+                mnview.SubCommunityBalance(kv.first, subsidy);
+            }
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2077,15 +2077,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return attrs.GetValue(k, false);
     };
 
-    auto tryVerifyUtxoRewards = [](CTransaction const & tx, const CAmount blockReward, int height, const Consensus::Params& consensus) {
+    auto tryVerifyUtxoRewards = [](const CTransaction& tx, const CAmount blockReward, int height, const Consensus::Params& consensus) {
         CAmount foundationReward{0};
         if (height >= consensus.GrandCentralHeight) {
             // no foundation utxo reward check anymore
-        }
-        else if (height >= consensus.EunosHeight) {
+        } else if (height >= consensus.EunosHeight) {
             foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
-        }
-        else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
+        } else if (!consensus.foundationShareScript.empty() && consensus.foundationShareDFIP1) {
             foundationReward = blockReward * consensus.foundationShareDFIP1 / COIN;
         }
 
@@ -2109,7 +2107,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return Res::Ok();
     };
 
-    auto handleLegacyTokenRewards = [&finalCheckAndReturn, &logAccountChange](CTransaction const & tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus) {
+    auto handleLegacyTokenRewards = [&finalCheckAndReturn, &logAccountChange](const CTransaction& tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus) {
         CAmount nonUtxoTotal = 0;
         for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy) {
             CAmount subsidy = blockReward * accountVal / COIN;
@@ -2125,7 +2123,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return finalCheckAndReturn();
     };
 
-    auto handleCurrentTokenRewards = [&finalCheckAndReturn, &logAccountChange, &isGovernanceEnabled, &isUnusedEmissionFundEnabled](CTransaction const & tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus, int height) {
+    auto handleCurrentTokenRewards = [&finalCheckAndReturn, &logAccountChange, &isGovernanceEnabled, &isUnusedEmissionFundEnabled](const CTransaction& tx, CAmount blockReward, CCustomCSView& view, const Consensus::Params& consensus, int height) {
         CAmount nonUtxoTotal = 0;
         CAmount subsidy;
 


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Introudces `MinterInfo` and `RewardsInfo` structs to isolate logic from JSON in getblockRPC
- Accept `verbosity` > 2 mode which is a cleaned up version of the RPC without polluting Bitcoin's output schema. 
- Cleans up coinbase rewards on Connect and Disconnect to be more comprehensible and maintainable. 
  - More work needed to move them into structures similar to RewardsInfo later. 
- Adds coinbase info to getblock as well, including XVM structures

## RPCs

<!-- Please remove section if deemed to be empty -->
- `getblock`: Adds verbosity level 3, 4. 


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
