### PR TITLE
Fix getblock older hex behaviour

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -185,7 +185,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
 
 void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex, int serialize_flags, int version)
 {
-    const auto txInToUniValue = [](const CTransaction& tx, const CTxIn& txin, const unsigned int index, bool include_hex) {
+    const auto txInToUniValue = [](const CTransaction& tx, const CTxIn& txin, const unsigned int index, bool include_hex, int version) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
@@ -194,7 +194,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
-            if (include_hex) {
+            if (include_hex || version <= 2) {
                 o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
             }
             in.pushKV("scriptSig", o);
@@ -215,7 +215,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
         out.pushKV("value", ValueFromAmount(txout.nValue));
         out.pushKV("n", (int64_t)index);
         UniValue o(UniValue::VOBJ);
-        ScriptPubKeyToUniv(txout.scriptPubKey, o, include_hex);
+        ScriptPubKeyToUniv(txout.scriptPubKey, o, include_hex || version <= 2);
         out.pushKV("scriptPubKey", o);
         // We skip this for v3+ as we tokenId field is unused.
         if (version <= 2 && tx.nVersion >= CTransaction::TOKENS_MIN_VERSION) {
@@ -235,7 +235,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
 
     UniValue vin(UniValue::VARR);
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        vin.push_back(txInToUniValue(tx, tx.vin[i], i, include_hex));
+        vin.push_back(txInToUniValue(tx, tx.vin[i], i, include_hex, version));
     }
     entry.pushKV("vin", vin);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -310,7 +310,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         {
             if (txDetails) {
                 UniValue objTx(UniValue::VOBJ);
-                TxToUniv(*tx, uint256(), objTx, version > 3, RPCSerializationFlags(), version);
+                TxToUniv(*tx, uint256(), objTx, version != 3, RPCSerializationFlags(), version);
                 if (version > 2) { 
                     if (auto r = txVmInfo(*tx); r) {
                         objTx.pushKV("vm", *r);


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- #2291 broke older behaviour of include_hex by properly carrying that across the call tree. 
- However this breaks many tests and compatibility. This restores the older behaviour unless version > 2.  


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
