### PR TITLE
Add pre-validation check for max money

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -21,6 +21,7 @@ use crate::storage::Storage;
 use crate::transaction::system::{BalanceUpdate, SystemTx};
 use crate::trie::TrieDBStore;
 use crate::txqueue::{QueueError, QueueTx, TransactionQueueMap};
+use crate::weiamount::WeiAmount;
 use crate::{
     executor::AinExecutor,
     traits::{Executor, ExecutorContext},
@@ -167,10 +168,11 @@ impl EVMCoreService {
     ///
     /// The validation checks of the tx before we consider it to be valid are:
     /// 1. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
-    /// 2. Gas price check: verify that the maximum gas price  is minimally of the block initial base fee.
-    /// 3. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
-    /// 4. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
-    /// 5. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
+    /// 2. Gas price check: verify that the maximum gas price is minimally of the block initial base fee.
+    /// 3. Gas price and tx value check: verify that amount is within money range.
+    /// 4. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// 5. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
+    /// 6. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
     ///
     /// # Arguments
     ///
@@ -231,6 +233,12 @@ impl EVMCoreService {
         if tx_gas_price < INITIAL_BASE_FEE {
             debug!("[validate_raw_tx] tx gas price is lower than initial block base fee");
             return Err(format_err!("tx gas price is lower than initial block base fee").into());
+        }
+
+        // Validate tx gas price and tx value within money range
+        if !WeiAmount(tx_gas_price).wei_range() || !WeiAmount(signed_tx.value()).wei_range() {
+            debug!("[validate_raw_tx] value more than money range");
+            return Err(format_err!("value more than money range").into());
         }
 
         let balance = self

--- a/lib/ain-evm/src/weiamount.rs
+++ b/lib/ain-evm/src/weiamount.rs
@@ -22,7 +22,7 @@ impl WeiAmount {
     pub fn wei_range(&self) -> bool {
         let max_money_sats = MAX_MONEY_SATS;
         let max_money_wei = max_money_sats.saturating_mul(WEI_TO_SATS);
-        self.0 >= U256::zero() && self.0 <= max_money_wei
+        self.0 <= max_money_wei
     }
 }
 

--- a/lib/ain-evm/src/weiamount.rs
+++ b/lib/ain-evm/src/weiamount.rs
@@ -8,6 +8,7 @@ pub struct WeiAmount(pub U256);
 pub const WEI_TO_GWEI: U256 = U256([1_000_000_000, 0, 0, 0]);
 pub const WEI_TO_SATS: U256 = U256([10_000_000_000, 0, 0, 0]);
 pub const GWEI_TO_SATS: U256 = U256([10, 0, 0, 0]);
+pub const MAX_MONEY_SATS: U256 = U256([120_000_000_000_000_000, 0, 0, 0]);
 
 impl WeiAmount {
     pub fn to_gwei(&self) -> U256 {
@@ -16,6 +17,12 @@ impl WeiAmount {
 
     pub fn to_satoshi(&self) -> U256 {
         self.0 / WEI_TO_SATS
+    }
+
+    pub fn wei_range(&self) -> bool {
+        let max_money_sats = MAX_MONEY_SATS;
+        let max_money_wei = max_money_sats.saturating_mul(WEI_TO_SATS);
+        self.0 >= U256::zero() && self.0 <= max_money_wei
     }
 }
 

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -114,13 +114,13 @@ class EVMFeeTest(DefiTestFramework):
         balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
         assert_equal(int(balance[2:], 16), 100000000000000000000)
 
-        # Test fee overflow error
-        assert_raises_rpc_error(-32001, "evm tx failed to validate calculate prepay gas failed from overflow", self.nodes[0].eth_sendTransaction, {
+        # Test gas price exceed money range error
+        assert_raises_rpc_error(-32001, "value more than money range", self.nodes[0].eth_sendTransaction, {
             'from': self.ethAddress,
             'to': self.toAddress,
             'value': '0x7148', # 29_000
             'gas': '0x7a120',
-            'gasPrice': '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            'gasPrice': '3E09DE2596099E2B0000001', # 1_200_000_000_000_000_000_000_000_001
         })
 
         # Test insufficient balance due to high gas fees
@@ -129,7 +129,7 @@ class EVMFeeTest(DefiTestFramework):
             'to': self.toAddress,
             'value': '0x7148', # 29_000
             'gas': '0x7a120',
-            'gasPrice': '0xfffffffffffffffffffffffffffffffffffff',
+            'gasPrice': '0xfffffffffffffff',
         })
 
         self.rollback_to(height)


### PR DESCRIPTION
## Summary

- Add additional safety layer check in pre-validation evm tx to ensure gas price and tx value do not exceed max money value in wei.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
