### PR TITLE
Fix rust lint

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,3 +1,4 @@
+SHELL:=/bin/bash
 CARGO := $(if $(CARGO),$(CARGO),cargo)
 
 # ENABLE_DEBUG is set from configure. We respect DEBUG too if set

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,4 @@
-SHELL:=/bin/bash
+SHELL := /bin/bash
 CARGO := $(if $(CARGO),$(CARGO),cargo)
 
 # ENABLE_DEBUG is set from configure. We respect DEBUG too if set


### PR DESCRIPTION
## Summary

- Fix failing rust lint on MacOS.
- Switch to explicitly set bash shell during rust compilation, since macOS sources sh automatically which causes the process substitution syntax to be invalid.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
