### PR TITLE
EVM: Fixes for transfer domain edges

### DIFF
--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -434,6 +434,10 @@ public:
         return Res::Err("Cannot transfer inside same domain");
     }
 
+    static Res TransferDomainInvalidDomain() {
+        return Res::Err("Cannot transfer inside invalid domain specified");
+    }
+
     static Res TransferDomainUnequalAmount() {
         return Res::Err("Source amount must be equal to destination amount");
     }


### PR DESCRIPTION
## Summary

- Switch to stricter VMDomain conditional edges in transfer domain validation pipeline in mn_checks.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
