### PR TITLE
Add tx type and EIP1559 tx information into get evm tx info RPC

### DIFF
--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -10,11 +10,15 @@ pub mod ffi {
     // ========== Transaction ==========
     #[derive(Default)]
     pub struct EVMTransaction {
+        // EIP-2718 transaction type: legacy - 0x0, EIP2930 - 0x1, EIP1559 - 0x2
+        pub tx_type: u8,
         pub hash: [u8; 32],
         pub sender: [u8; 20],
         pub nonce: u64,
         pub gas_price: u64,
         pub gas_limit: u64,
+        pub max_fee_per_gas: u64,
+        pub max_priority_fee_per_gas: u64,
         pub create_tx: bool,
         pub to: [u8; 20],
         pub value: u64,

--- a/src/masternodes/evm.h
+++ b/src/masternodes/evm.h
@@ -11,6 +11,13 @@
 
 constexpr const uint16_t EVM_TX_SIZE = 32768;
 
+// EIP-2718 transaction type: legacy - 0x0, EIP2930 - 0x1, EIP1559 - 0x2
+enum CEVMTxType {
+    LegacyTransaction = 0,
+    EIP2930Transaction = 1,
+    EIP1559Transaction = 2,
+};
+
 using CRawEvmTx = TBytes;
 
 extern std::string CTransferDomainToString(const VMDomain domain);

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -581,13 +581,34 @@ public:
             CrossBoundaryResult result;
             auto txInfo = evm_try_get_tx_by_hash(result, evmTxHash->GetByteArray());
             if (result.ok) {
+                std::string tx_type;
+                switch (txInfo.tx_type) {
+                    case CEVMTxType::LegacyTransaction: {
+                        tx_type = "legacy-tx";
+                        break;
+                    }
+                    case CEVMTxType::EIP2930Transaction: {
+                        tx_type = "EIP2930-tx";
+                        break;
+                    }
+                    case CEVMTxType::EIP1559Transaction: {
+                        tx_type = "EIP1559-tx";
+                        break;
+                    }
+                    default: {
+                        break;
+                    }
+                }
                 auto senderBytes = std::vector<uint8_t>(txInfo.sender.begin(), txInfo.sender.end());
                 auto sender = CTxDestination(WitnessV16EthHash(uint160(senderBytes)));
+                rpcInfo.pushKV("tx-type", tx_type);
                 rpcInfo.pushKV("hash", evmTxHash->ToString());
-                rpcInfo.pushKV("nonce", txInfo.nonce);
                 rpcInfo.pushKV("sender", EncodeDestination(sender));
+                rpcInfo.pushKV("nonce", txInfo.nonce);
                 rpcInfo.pushKV("gasPrice", txInfo.gas_price);
                 rpcInfo.pushKV("gasLimit", txInfo.gas_limit);
+                rpcInfo.pushKV("maxFeePerGas", txInfo.max_fee_per_gas);
+                rpcInfo.pushKV("maxPriorityFeePerGas", txInfo.max_priority_fee_per_gas);
                 rpcInfo.pushKV("createTx", txInfo.create_tx);
 
                 std::string to = "";

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -584,15 +584,15 @@ public:
                 std::string tx_type;
                 switch (txInfo.tx_type) {
                     case CEVMTxType::LegacyTransaction: {
-                        tx_type = "legacy-tx";
+                        tx_type = "legacy";
                         break;
                     }
                     case CEVMTxType::EIP2930Transaction: {
-                        tx_type = "EIP2930-tx";
+                        tx_type = "eip2930";
                         break;
                     }
                     case CEVMTxType::EIP1559Transaction: {
-                        tx_type = "EIP1559-tx";
+                        tx_type = "eip1559";
                         break;
                     }
                     default: {
@@ -601,7 +601,7 @@ public:
                 }
                 auto senderBytes = std::vector<uint8_t>(txInfo.sender.begin(), txInfo.sender.end());
                 auto sender = CTxDestination(WitnessV16EthHash(uint160(senderBytes)));
-                rpcInfo.pushKV("tx-type", tx_type);
+                rpcInfo.pushKV("type", tx_type);
                 rpcInfo.pushKV("hash", evmTxHash->ToString());
                 rpcInfo.pushKV("sender", EncodeDestination(sender));
                 rpcInfo.pushKV("nonce", txInfo.nonce);


### PR DESCRIPTION
## Summary

- Add tx-type based on EIP-2718 [https://eips.ethereum.org/EIPS/eip-2718](url) into exposed get evm tx info in Rust FFI
- Add EIP1559 tx gas fee information when logging evm txs
## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
