### PR TITLE
Refactor: replace `block_number_to_u256` by `get_block`

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "statrs",
  "substrate-bn",
  "tempdir",
+ "thiserror",
  "tokio",
  "vsdb_core",
  "vsdb_trie_db",

--- a/lib/ain-evm/Cargo.toml
+++ b/lib/ain-evm/Cargo.toml
@@ -25,6 +25,7 @@ ethbloom = "0.13.0"
 ethereum-types = "0.14.1"
 serde_json = "1.0.96"
 statrs = "0.16.0"
+thiserror = "1.0"
 rustc-hex = "2.1.0"
 
 # Trie dependencies

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -8,7 +8,6 @@ use keccak_hash::H256;
 use log::{debug, trace};
 use primitive_types::U256;
 use statrs::statistics::{Data, OrderStatistics};
-
 use thiserror::Error;
 
 use crate::storage::{traits::BlockStorage, Storage};

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -9,7 +9,15 @@ use log::{debug, trace};
 use primitive_types::U256;
 use statrs::statistics::{Data, OrderStatistics};
 
+use thiserror::Error;
+
 use crate::storage::{traits::BlockStorage, Storage};
+
+#[derive(Debug, Error)]
+pub enum BlockError {
+    #[error("block not found")]
+    BlockNotFound,
+}
 
 pub struct BlockService {
     storage: Arc<Storage>,

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use ain_cpp_imports::get_eth_priv_key;
+use ain_evm::block::BlockError;
 use ain_evm::bytes::Bytes;
 use ain_evm::core::EthCallArgs;
-use ain_evm::block::BlockError;
 use ain_evm::evm::EVMServices;
 use ain_evm::executor::TxResponse;
 use ain_evm::filters::Filter;
@@ -294,7 +294,7 @@ impl MetachainRPCModule {
                         .checked_sub(U256::from(finality_count))?;
                     self.handler.storage.get_block_by_number(&safe_block_number)
                 })
-            },
+            }
             // BlockNumber::Pending => todo!(),
             _ => self.handler.storage.get_latest_block(),
         }


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- the intention is to have `get_block` utils for happy dev, the `block number` can be grabbed from `get_block`

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
