### PR TITLE
Remove failfast on CI e2e

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
     container: defi/ain-builder:latest
     env:
       GITHUB_PULL_REQUEST: ${{ github.event.number }}
-      TESTS_FAILFAST: 1
+      TESTS_FAILFAST: 0
       TESTS_COMBINED_LOGS: 500
     steps:
     - name: Checkout base branch and/or merge


### PR DESCRIPTION
## Summary

- Stop failfast behavior on CI e2e tests for better error tracing



## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
