### PR TITLE
feat: Re-enable vmmap blocknumber

### DIFF
--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -174,8 +174,8 @@ UniValue vmmap(const JSONRPCRequest &request) {
           RPCArg::Optional::NO,
           "Map types: \n\
                             0 - Auto \n\
-                            1 - Block Number: DFI -> EVM (Unsupported yet) \n\
-                            2 - Block Number: EVM -> DFI (Unsupported yet) \n\
+                            1 - Block Number: DFI -> EVM \n\
+                            2 - Block Number: EVM -> DFI \n\
                             3 - Block Hash: DFI -> EVM \n\
                             4 - Block Hash: EVM -> DFI \n\
                             5 - Tx Hash: DFI -> EVM \n\

--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -234,7 +234,7 @@ UniValue vmmap(const JSONRPCRequest &request) {
 
         return VMDomainRPCMapType::Unknown;
     };
-/*
+
     auto crossBoundaryOkOrThrow = [&throwInvalidParam](CrossBoundaryResult &result) {
         if (!result.ok) {
             throwInvalidParam(result.reason.c_str());
@@ -264,7 +264,7 @@ UniValue vmmap(const JSONRPCRequest &request) {
                 return VMDomainRPCMapType::Unknown;
             }
         };
-*/
+
     auto type  = static_cast<VMDomainRPCMapType>(typeInt);
     ResVal res = ResVal<std::string>(std::string{}, Res::Ok());
 
@@ -296,7 +296,7 @@ UniValue vmmap(const JSONRPCRequest &request) {
             return ret;
         }
     };
-/*
+
     auto finalizeBlockNumberResult = [&](uint64_t &number, const VMDomainRPCMapType type, const uint64_t input) {
         UniValue ret(UniValue::VOBJ);
         ret.pushKV("input", input);
@@ -346,7 +346,7 @@ UniValue vmmap(const JSONRPCRequest &request) {
         crossBoundaryOkOrThrow(result);
         return finalizeBlockNumberResult(blockNumber, VMDomainRPCMapType::BlockNumberDVMToEVM, height);
     };
-*/
+
     LOCK(cs_main);
 
     if (type == VMDomainRPCMapType::Auto) {
@@ -374,13 +374,12 @@ UniValue vmmap(const JSONRPCRequest &request) {
             res = pcustomcsview->GetVMDomainBlockEdge(VMDomainEdge::EVMToDVM, input);
             break;
         }
-        // TODO(canonbrother): disable for release, more investigation needed
-        // case VMDomainRPCMapType::BlockNumberDVMToEVM: {
-        //     return handleMapBlockNumberDVMToEVMRequest(input);
-        // }
-        // case VMDomainRPCMapType::BlockNumberEVMToDVM: {
-        //     return handleMapBlockNumberEVMToDVMRequest(input);
-        // }
+        case VMDomainRPCMapType::BlockNumberDVMToEVM: {
+            return handleMapBlockNumberDVMToEVMRequest(input);
+        }
+        case VMDomainRPCMapType::BlockNumberEVMToDVM: {
+            return handleMapBlockNumberEVMToDVMRequest(input);
+        }
         default: {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown map type");
         }

--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -242,7 +242,7 @@ UniValue vmmap(const JSONRPCRequest &request) {
     };
 
     auto tryResolveBlockNumberType =
-        [](const std::string input) {
+        [&throwUnsupportedAuto](const std::string input) {
             uint64_t height;
             if (!ParseUInt64(input, &height)) {
                 return VMDomainRPCMapType::Unknown;
@@ -254,7 +254,13 @@ UniValue vmmap(const JSONRPCRequest &request) {
                 return VMDomainRPCMapType::BlockNumberEVMToDVM;
             }
 
-            return VMDomainRPCMapType::BlockNumberDVMToEVM;
+            CBlockIndex* dvmBlock = ::ChainActive()[height];
+            if (dvmBlock != nullptr) {
+                return VMDomainRPCMapType::BlockNumberDVMToEVM;
+            }
+
+            throwUnsupportedAuto();
+            return VMDomainRPCMapType::Unknown;
         };
 
     auto type  = static_cast<VMDomainRPCMapType>(typeInt);

--- a/test/functional/feature_dst20.py
+++ b/test/functional/feature_dst20.py
@@ -15,6 +15,7 @@ from test_framework.evm_key_pair import EvmKeyPair
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
+
 class DST20(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -807,7 +808,6 @@ class DST20(DefiTestFramework):
                 encoding="utf8",
             ).read()
         )["object"]
-
 
         # Generate chain
         self.node.generate(150)

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -244,10 +244,10 @@ class VMMapTests(DefiTestFramework):
             assert_equal(res["type"], "BlockNumberEVMToDVM")
             assert_equal(res["output"], item[0])
 
-            res = self.nodes[0].vmmap(str(item[0]), VMMapType.Auto)
-            assert_equal(res["input"], item[0])
-            assert_equal(res["type"], "BlockNumberDVMToEVM")
-            assert_equal(res["output"], item[1])
+            # res = self.nodes[0].vmmap(str(item[0]), VMMapType.Auto)
+            # assert_equal(res["input"], item[0])
+            # assert_equal(res["type"], "BlockNumberDVMToEVM")
+            # assert_equal(res["output"], item[1])
 
             # res = self.nodes[0].vmmap(str(item[1]), VMMapType.Auto)
             # assert_equal(res['input'], item[1])
@@ -368,8 +368,8 @@ class VMMapTests(DefiTestFramework):
         self.vmmap_valid_tx_should_succeed()
         self.vmmap_valid_block_should_succeed()
         self.vmmap_invalid_should_fail()
-        # self.vmmap_valid_block_number_should_succeed()
-        # self.vmmap_invalid_block_number_should_fail()
+        self.vmmap_valid_block_number_should_succeed()
+        self.vmmap_invalid_block_number_should_fail()
         self.vmmap_rollback_should_succeed()
         self.vmmap_auto_invalid_input_should_fail()
         # logvmmap tests

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -244,15 +244,15 @@ class VMMapTests(DefiTestFramework):
             assert_equal(res["type"], "BlockNumberEVMToDVM")
             assert_equal(res["output"], item[0])
 
-            # res = self.nodes[0].vmmap(str(item[0]), VMMapType.Auto)
-            # assert_equal(res["input"], item[0])
-            # assert_equal(res["type"], "BlockNumberDVMToEVM")
-            # assert_equal(res["output"], item[1])
+            res = self.nodes[0].vmmap(str(item[0]), VMMapType.Auto)
+            assert_equal(res["input"], item[0])
+            assert_equal(res["type"], "BlockNumberDVMToEVM")
+            assert_equal(res["output"], item[1])
 
-            # res = self.nodes[0].vmmap(str(item[1]), VMMapType.Auto)
-            # assert_equal(res['input'], item[1])
-            # assert_equal(res['type'], 'BlockNumberEVMToDVM')
-            # assert_equal(res['output'], item[0])
+            res = self.nodes[0].vmmap(str(item[1]), VMMapType.Auto)
+            assert_equal(res['input'], item[1])
+            assert_equal(res['type'], 'BlockNumberEVMToDVM')
+            assert_equal(res['output'], item[0])
 
     def vmmap_invalid_block_number_should_fail(self):
         assert_invalid = lambda *args: assert_raises_rpc_error(

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -250,9 +250,9 @@ class VMMapTests(DefiTestFramework):
             assert_equal(res["output"], item[1])
 
             res = self.nodes[0].vmmap(str(item[1]), VMMapType.Auto)
-            assert_equal(res['input'], item[1])
-            assert_equal(res['type'], 'BlockNumberEVMToDVM')
-            assert_equal(res['output'], item[0])
+            assert_equal(res["input"], item[1])
+            assert_equal(res["type"], "BlockNumberEVMToDVM")
+            assert_equal(res["output"], item[0])
 
     def vmmap_invalid_block_number_should_fail(self):
         assert_invalid = lambda *args: assert_raises_rpc_error(


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- re-enable vmmap blocknumber
- mild fixes on *rm prefix 0x* and *type* on evm->dvm 
- hash lookup on auto infer path

## RPCs

<!-- Please remove section if deemed to be empty -->
- vmmap

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
