### PR TITLE
Fix rust str bug

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -32,8 +32,8 @@ double GetDifficulty(const CBlockIndex* blockindex);
 /** Callback for when block tip changed. */
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
-std::optional<UniValue> VmInfoUniv(const CTransaction& tx);
-UniValue ExtendedTxToUniv(const CTransaction& tx, bool include_hex, int serialize_flags, int version, bool txDetails);
+std::optional<UniValue> VmInfoUniv(const CTransaction& tx, bool isEvmEnabledForBlock);
+UniValue ExtendedTxToUniv(const CTransaction& tx, bool include_hex, int serialize_flags, int version, bool txDetails, bool isEvmEnabledForBlock);
 
 /** Block description to JSON */
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false, int verbosity = 0) LOCKS_EXCLUDED(cs_main);

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -297,12 +297,12 @@ static void TxInErrorToJSON(const CTxIn& txin, UniValue& vErrorsRet, const std::
 }
 
 int RPCSerializationFlags();
-UniValue ExtendedTxToUniv(const CTransaction& tx, bool include_hex, int serialize_flags, int version, bool txDetails);
+UniValue ExtendedTxToUniv(const CTransaction& tx, bool include_hex, int serialize_flags, int version, bool txDetails, bool isEvmEnabledForBlock);
 
 UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival, FillableSigningProvider* keystore, std::map<COutPoint, Coin>& coins, bool is_temp_keystore, const UniValue& hashType)
 {
     if (LogAcceptCategory(BCLog::SIGN)) {
-        LogPrintf("SignTransaction::Pre: %s\n", ExtendedTxToUniv(CTransaction(mtx), true, RPCSerializationFlags(), 4, true).write(2));
+        LogPrintf("SignTransaction::Pre: %s\n", ExtendedTxToUniv(CTransaction(mtx), true, RPCSerializationFlags(), 4, true, true).write(2));
     }
     // Add previous txouts given in the RPC call:
     if (!prevTxsUnival.isNull()) {
@@ -432,7 +432,7 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
     bool fComplete = vErrors.empty();
 
     if (LogAcceptCategory(BCLog::SIGN)) {
-        LogPrintf("SignTransaction::Post: %s\n", ExtendedTxToUniv(CTransaction(mtx), true, RPCSerializationFlags(), 4, true).write(2));
+        LogPrintf("SignTransaction::Post: %s\n", ExtendedTxToUniv(CTransaction(mtx), true, RPCSerializationFlags(), 4, true, true).write(2));
     }
 
     UniValue result(UniValue::VOBJ);


### PR DESCRIPTION
## Summary

- Fix rust string not utf-8 encoding bug when logging block in ConnectTip


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
