### PR TITLE
Add unit tests support

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -464,7 +464,7 @@ fmt_lib() {
 test() {
     _fold_start "unit-tests"
     # shellcheck disable=SC2086
-    test_units "$@"
+    test_unit
     _fold_end
 
     _fold_start "functional-tests"
@@ -475,9 +475,9 @@ test() {
     _exit_dir
 }
 
-test_units() {
+test_unit() {
     test_cpp
-    test_rust "$@"
+    test_rs
 }
 
 test_cpp() {
@@ -487,11 +487,11 @@ test_cpp() {
 
     _ensure_enter_dir "${build_target_dir}"
     # shellcheck disable=SC2086
-    make -j$make_jobs check
+    make -j$make_jobs check "$@"
     _exit_dir
 }
 
-test_rust() {
+test_rs() {
     lib test "$@"
 }
 

--- a/make.sh
+++ b/make.sh
@@ -464,18 +464,27 @@ fmt_lib() {
 test() {
     _fold_start "unit-tests"
     # shellcheck disable=SC2086
-    test_units
+    unit_tests
     _fold_end
 
     _fold_start "functional-tests"
     # shellcheck disable=SC2119
-    test_py
+    functional_tests
     _fold_end
 
     _exit_dir
 }
 
 unit_tests() {
+    test_cpp
+    test_rust
+}
+
+functional_tests() {
+    test_py
+}
+
+test_cpp() {
     local make_jobs=${MAKE_JOBS}
     local make_args=${MAKE_ARGS:-}
     local build_target_dir=${BUILD_TARGET_DIR}
@@ -484,12 +493,14 @@ unit_tests() {
     # shellcheck disable=SC2086
     make -j$make_jobs check
     _exit_dir
+}
 
+test_rust() {
     lib test
 }
 
 # shellcheck disable=SC2120
-functional_tests() {
+test_py() {
     local build_target_dir=${BUILD_TARGET_DIR}
     local src_dir=${_SCRIPT_DIR}
     local tests_fail_fast=${TESTS_FAILFAST}

--- a/make.sh
+++ b/make.sh
@@ -475,7 +475,7 @@ test() {
     _exit_dir
 }
 
-test_units() {
+unit_tests() {
     local make_jobs=${MAKE_JOBS}
     local make_args=${MAKE_ARGS:-}
     local build_target_dir=${BUILD_TARGET_DIR}
@@ -489,7 +489,7 @@ test_units() {
 }
 
 # shellcheck disable=SC2120
-test_py() {
+functional_tests() {
     local build_target_dir=${BUILD_TARGET_DIR}
     local src_dir=${_SCRIPT_DIR}
     local tests_fail_fast=${TESTS_FAILFAST}

--- a/make.sh
+++ b/make.sh
@@ -464,24 +464,20 @@ fmt_lib() {
 test() {
     _fold_start "unit-tests"
     # shellcheck disable=SC2086
-    unit_tests
+    unit_tests "$@"
     _fold_end
 
     _fold_start "functional-tests"
     # shellcheck disable=SC2119
-    functional_tests
+    test_py
     _fold_end
 
     _exit_dir
 }
 
-unit_tests() {
+test_units() {
     test_cpp
-    test_rust
-}
-
-functional_tests() {
-    test_py
+    test_rust "$@"
 }
 
 test_cpp() {
@@ -496,7 +492,7 @@ test_cpp() {
 }
 
 test_rust() {
-    lib test
+    lib test "$@"
 }
 
 # shellcheck disable=SC2120

--- a/make.sh
+++ b/make.sh
@@ -462,15 +462,9 @@ fmt_lib() {
 # ---
 
 test() {
-    local make_jobs=${MAKE_JOBS}
-    local make_args=${MAKE_ARGS:-}
-    local build_target_dir=${BUILD_TARGET_DIR}
-
-    _ensure_enter_dir "${build_target_dir}"
-
     _fold_start "unit-tests"
     # shellcheck disable=SC2086
-    make -j$make_jobs check
+    test_units
     _fold_end
 
     _fold_start "functional-tests"
@@ -479,6 +473,19 @@ test() {
     _fold_end
 
     _exit_dir
+}
+
+test_units() {
+    local make_jobs=${MAKE_JOBS}
+    local make_args=${MAKE_ARGS:-}
+    local build_target_dir=${BUILD_TARGET_DIR}
+
+    _ensure_enter_dir "${build_target_dir}"
+    # shellcheck disable=SC2086
+    make -j$make_jobs check
+    _exit_dir
+
+    lib test
 }
 
 # shellcheck disable=SC2120

--- a/make.sh
+++ b/make.sh
@@ -464,7 +464,7 @@ fmt_lib() {
 test() {
     _fold_start "unit-tests"
     # shellcheck disable=SC2086
-    unit_tests "$@"
+    test_units "$@"
     _fold_end
 
     _fold_start "functional-tests"


### PR DESCRIPTION
## Summary

- Add make.sh unit-tests helper function to run cpp and rust unit tests
- Rename test-py to functional-tests


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
