### PR TITLE
bug: minter info should be allowed in block 0

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -120,7 +120,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
 
 struct MinterInfo {
     std::string Id{};
-    std::string OwnerAddress{}; 
+    std::string OwnerAddress{};
     std::string OperatorAddress{};
     std::string RewardAddress{};
     uint64_t MintedBlocks{};
@@ -131,7 +131,7 @@ struct MinterInfo {
         CKeyID minter;
         block.ExtractMinterKey(minter);
         auto id = view.GetMasternodeIdByOperator(minter);
-        if (!id) return {};
+        if (!id && block.deprecatedHeight != 0) return {};
         result.Id = id->ToString();
         auto mn = view.GetMasternode(*id);
         if (mn) {
@@ -155,7 +155,7 @@ struct MinterInfo {
     }
 
     UniValue ToUniValue() const {
-        // Note that this breaks compatibility with the legacy version. 
+        // Note that this breaks compatibility with the legacy version.
         // Do not use this with existing RPCs
         UniValue result(UniValue::VOBJ);
         result.pushKV("id", Id);
@@ -206,7 +206,7 @@ struct RewardInfo {
 
         for (const auto& [accountType, accountVal] : consensus.blockTokenRewards)
         {
-            if (blockindex->nHeight < consensus.GrandCentralHeight 
+            if (blockindex->nHeight < consensus.GrandCentralHeight
             && accountType == CommunityAccountType::CommunityDevFunds) {
                 continue;
             }
@@ -214,7 +214,7 @@ struct RewardInfo {
             CAmount subsidy = CalculateCoinbaseReward(blockReward, accountVal);
             switch (accountType) {
                 // Everything else is burnt. Should update post fort canning. Retaining
-                // compatibility for old logic for now. 
+                // compatibility for old logic for now.
                 case CommunityAccountType::AnchorReward:{ tokenRewards.AnchorReward = subsidy; break; }
                 case CommunityAccountType::CommunityDevFunds: { tokenRewards.CommunityDevFunds = subsidy; break; }
                 default: { tokenRewards.Burnt += subsidy; }
@@ -231,7 +231,7 @@ struct RewardInfo {
         UniValue obj(UniValue::VOBJ);
 
         auto& r = TokenRewards;
-        auto items = std::vector<std::pair<CommunityAccountType, CAmount>>{ 
+        auto items = std::vector<std::pair<CommunityAccountType, CAmount>>{
                     { CommunityAccountType::AnchorReward, r.AnchorReward },
                     { CommunityAccountType::CommunityDevFunds, r.CommunityDevFunds },
                     { CommunityAccountType::Unallocated, r.Burnt }};
@@ -245,12 +245,12 @@ struct RewardInfo {
     }
 
     UniValue ToUniValue() const {
-        // Note that this breaks compatibility with the legacy version. 
+        // Note that this breaks compatibility with the legacy version.
         // Do not use this with existing RPCs
         UniValue obj(UniValue::VOBJ);
 
         auto& r = TokenRewards;
-        auto items = std::vector<std::pair<CommunityAccountType, CAmount>>{ 
+        auto items = std::vector<std::pair<CommunityAccountType, CAmount>>{
                     { CommunityAccountType::AnchorReward, r.AnchorReward },
                     { CommunityAccountType::CommunityDevFunds, r.CommunityDevFunds },
                     { CommunityAccountType::IncentiveFunding, r.IncentiveFunding },
@@ -323,7 +323,7 @@ UniValue ExtendedTxToUniv(const CTransaction& tx, bool include_hex, int serializ
     if (txDetails) {
         UniValue objTx(UniValue::VOBJ);
         TxToUniv(tx, uint256(), objTx, version != 3, RPCSerializationFlags(), version);
-        if (version > 2) { 
+        if (version > 2) {
             if (auto r = VmInfoUniv(tx, isEvmEnabledForBlock); r) {
                 objTx.pushKV("vm", *r);
             }
@@ -367,7 +367,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         auto minterInfo = MinterInfo::TryFrom(block, blockindex, *pcustomcsview);
         if (minterInfo) { minterInfo->ToUniValueLegacy(result); }
     }
-    
+
     result.pushKV("version", block.nVersion);
     result.pushKV("versionHex", strprintf("%08x", block.nVersion));
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
@@ -391,7 +391,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
 
     if (v3plus) {
         auto minterInfo = MinterInfo::TryFrom(block, blockindex, *pcustomcsview);
-        if (minterInfo) { 
+        if (minterInfo) {
             result.pushKV("minter", minterInfo->ToUniValue());
         }
         auto rewardInfo = RewardInfo::TryFrom(block, blockindex, consensus);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -131,7 +131,7 @@ struct MinterInfo {
         CKeyID minter;
         block.ExtractMinterKey(minter);
         auto id = view.GetMasternodeIdByOperator(minter);
-        if (!id && block.deprecatedHeight != 0) return {};
+        if (!id && blockindex->deprecatedHeight != 0) return {};
         result.Id = id->ToString();
         auto mn = view.GetMasternode(*id);
         if (mn) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -132,6 +132,7 @@ struct MinterInfo {
         block.ExtractMinterKey(minter);
         auto id = view.GetMasternodeIdByOperator(minter);
         if (!id && blockindex->nHeight != 0) return {};
+        // note: understand block0(!id) will cause panic here but since block0 never have minter
         result.Id = id->ToString();
         auto mn = view.GetMasternode(*id);
         if (mn) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -131,7 +131,7 @@ struct MinterInfo {
         CKeyID minter;
         block.ExtractMinterKey(minter);
         auto id = view.GetMasternodeIdByOperator(minter);
-        if (!id && blockindex->deprecatedHeight != 0) return {};
+        if (!id && blockindex->nHeight != 0) return {};
         result.Id = id->ToString();
         auto mn = view.GetMasternode(*id);
         if (mn) {

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -55,8 +55,29 @@ class BlockchainTest(DefiTestFramework):
         self.restart_node(
             0, extra_args=["-stopatheight=207", "-prune=1"]
         )  # Set extra args with pruning after rescan is complete
+        self.extra_args = [
+            [
+                "-dummypos=0",
+                "-txnotokens=0",
+                "-amkheight=50",
+                "-bayfrontheight=51",
+                "-eunosheight=80",
+                "-fortcanningheight=82",
+                "-fortcanninghillheight=84",
+                "-fortcanningroadheight=86",
+                "-fortcanningcrunchheight=88",
+                "-fortcanningspringheight=90",
+                "-fortcanninggreatworldheight=94",
+                "-fortcanningepilogueheight=96",
+                "-grandcentralheight=101",
+                "-nextnetworkupgradeheight=105",
+                "-subsidytest=1",
+                "-txindex=1",
+            ],
+        ]
 
         self._test_getblockchaininfo()
+        self._test_getgenesisblock()
         self._test_getchaintxstats()
         self._test_gettxoutsetinfo()
         self._test_getblockheader()
@@ -400,6 +421,29 @@ class BlockchainTest(DefiTestFramework):
         assert isinstance(header["version"], int)
         assert isinstance(int(header["versionHex"], 16), int)
         assert isinstance(header["difficulty"], Decimal)
+
+    def _test_getgenesisblock(self):
+        node = self.nodes[0]
+        genesis = node.getblock(node.getblockhash(0))
+        assert genesis["hash"]
+        assert_equal(genesis["confirmations"], 201)
+        assert_equal(genesis["strippedsize"], 1288)
+        assert_equal(genesis["weight"], 5152)
+        assert_equal(genesis["height"], 0)
+        assert genesis["masternode"]
+        assert_equal(genesis["mintedBlocks"], 0)
+        assert_equal(genesis["stakeModifier"], "0000000000000000000000000000000000000000000000000000000000000000")
+        assert_equal(genesis["version"], 1)
+        assert_equal(genesis["versionHex"], "00000001")
+        assert genesis["merkleroot"]
+        assert genesis["tx"]
+        assert genesis["time"]
+        assert genesis["mediantime"]
+        assert genesis["bits"]
+        assert genesis["difficulty"]
+        assert genesis["chainwork"]
+        assert genesis["nTx"]
+        assert genesis["nextblockhash"]
 
     def _test_getdifficulty(self):
         difficulty = self.nodes[0].getdifficulty()


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- regression fix by allowing default minter value in genesis block


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
