### PR TITLE
Fix getblock RPC for DVM genesis block minter info

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -131,7 +131,7 @@ struct MinterInfo {
         CKeyID minter;
         block.ExtractMinterKey(minter);
         auto id = view.GetMasternodeIdByOperator(minter);
-        if (!id) return {};
+        if (!id && blockindex->nHeight != 0) return {};
         result.Id = id->ToString();
         auto mn = view.GetMasternode(*id);
         if (mn) {


### PR DESCRIPTION
## Summary

- Fixes for DVM genesis block minter info


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
