### PR TITLE
Remove frontier test trigger on master

### DIFF
--- a/.github/workflows/tests-frontier.yml
+++ b/.github/workflows/tests-frontier.yml
@@ -2,9 +2,6 @@ name: Tests - DeFiCh/metachain-ts-suite
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary

- Remove workflow trigger on master for frontier tests
  - Context: The current failures have been validated to be acceptable implementation differences. 
  - Removing these to reduce noise temporarily.  
  - Once consensus tests are completed and release is set, we expect to re-enable as we fill up the missing implementations.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
