### PR TITLE
Fix tx context in validate tx pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -298,9 +298,9 @@ impl EVMCoreService {
                 gas_limit: signed_tx.gas_limit().as_u64(),
                 access_list: signed_tx.access_list(),
                 block_number,
-                gas_price: None,
-                max_fee_per_gas: None,
-                transaction_type: None,
+                gas_price: Some(tx_gas_price),
+                max_fee_per_gas: signed_tx.max_fee_per_gas(),
+                transaction_type: Some(signed_tx.get_tx_type()),
             })?;
             used_gas
         } else {

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -303,9 +303,9 @@ impl SignedTx {
 
     pub fn get_tx_type(&self) -> U256 {
         match &self.transaction {
-            TransactionV2::Legacy(tx) => U256::from(0),
-            TransactionV2::EIP2930(tx) => U256::from(1),
-            TransactionV2::EIP1559(tx) => U256::from(2),
+            TransactionV2::Legacy(_) => U256::from(0),
+            TransactionV2::EIP2930(_) => U256::from(1),
+            TransactionV2::EIP1559(_) => U256::from(2),
         }
     }
 }

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -300,6 +300,14 @@ impl SignedTx {
             TransactionV2::EIP1559(tx) => tx.hash(),
         }
     }
+
+    pub fn get_tx_type(&self) -> U256 {
+        match &self.transaction {
+            TransactionV2::Legacy(tx) => U256::from(0),
+            TransactionV2::EIP2930(tx) => U256::from(1),
+            TransactionV2::EIP1559(tx) => U256::from(2),
+        }
+    }
 }
 
 use std::convert::{TryFrom, TryInto};

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -432,7 +432,10 @@ class BlockchainTest(DefiTestFramework):
         assert_equal(genesis["height"], 0)
         assert genesis["masternode"]
         assert_equal(genesis["mintedBlocks"], 0)
-        assert_equal(genesis["stakeModifier"], "0000000000000000000000000000000000000000000000000000000000000000")
+        assert_equal(
+            genesis["stakeModifier"],
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
         assert_equal(genesis["version"], 1)
         assert_equal(genesis["versionHex"], "00000001")
         assert genesis["merkleroot"]


### PR DESCRIPTION
## Summary

- Fix incorrect transaction context when setting vicinity before calling the tx on EVM in validate_raw_transaction in a queue context.



## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
