### PR TITLE
Fix block creation validation pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -355,7 +355,7 @@ impl EVMCoreService {
     ) -> Result<()> {
         let queue_tx = QueueTx::SystemTx(SystemTx::EvmIn(BalanceUpdate { address, amount }));
         self.tx_queues
-            .push_in(queue_id, queue_tx, hash, U256::zero(), U256::zero())?;
+            .push_in(queue_id, queue_tx, hash, U256::zero())?;
         Ok(())
     }
 
@@ -387,7 +387,7 @@ impl EVMCoreService {
         } else {
             let queue_tx = QueueTx::SystemTx(SystemTx::EvmOut(BalanceUpdate { address, amount }));
             self.tx_queues
-                .push_in(queue_id, queue_tx, hash, U256::zero(), U256::zero())?;
+                .push_in(queue_id, queue_tx, hash, U256::zero())?;
             Ok(())
         }
     }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -438,16 +438,9 @@ impl EVMServices {
         hash: XHash,
         gas_used: U256,
     ) -> Result<()> {
-        let parent_data = self.block.get_latest_block_hash_and_number()?;
-        let parent_hash = match parent_data {
-            Some((hash, _)) => hash,
-            None => H256::zero(),
-        };
-        let base_fee = self.block.calculate_base_fee(parent_hash)?;
-
         self.core
             .tx_queues
-            .push_in(queue_id, tx.clone(), hash, gas_used, base_fee)?;
+            .push_in(queue_id, tx.clone(), hash, gas_used)?;
 
         if let QueueTx::SignedTx(signed_tx) = tx {
             self.filters.add_tx_to_filters(signed_tx.transaction.hash());
@@ -680,7 +673,6 @@ fn get_dst20_migration_txs(mnview_ptr: usize) -> Result<Vec<QueueTxItem>> {
         txs.push(QueueTxItem {
             tx,
             tx_hash: Default::default(),
-            tx_fee: U256::zero(),
             gas_used: U256::zero(),
         });
     }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -333,10 +333,6 @@ impl EVMServices {
             total_priority_fees
         );
 
-        if (total_burnt_fees + total_priority_fees) != queue.total_fees {
-            return Err(format_err!("EVM block rejected because block total fees != (burnt fees + priority fees). Burnt fees: {}, priority fees: {}, total fees: {}", total_burnt_fees, total_priority_fees, queue.total_fees).into());
-        }
-
         let extra_data = format!("DFI: {}", dvm_block_number).into_bytes();
         let gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
         let block = Block::new(

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -432,7 +432,10 @@ class BlockchainTest(DefiTestFramework):
         assert_equal(genesis["height"], 0)
         assert genesis["masternode"]
         assert_equal(genesis["mintedBlocks"], 0)
-        assert_equal(genesis["stakeModifier"], "0000000000000000000000000000000000000000000000000000000000000000")
+        assert_equal(
+            genesis["stakeModifier"],
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
         assert_equal(genesis["version"], 1)
         assert_equal(genesis["versionHex"], "00000001")
         assert genesis["merkleroot"]


### PR DESCRIPTION
## Summary

- Remove incorrect validation check in EVM block construction to compare actual total burnt and total priority fees with fees calculated in the queue
- When signed transactions are validated and queued into the unique queue, validation and calculating the gas used from the transaction call is with respect to the state of the chain at the current tip
- During block creation, gas used will differ since the transaction call is based on the actual state of the chain while minting transactions into the EVM block
- Fixes #2273 and #2385 


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
