### PR TITLE
Add EVM block limit test

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -151,6 +151,7 @@ impl EVMServices {
                 block.header.state_root
             });
 
+        debug!("[construct_block] queue_id: {:?}", queue_id);
         debug!("[construct_block] beneficiary: {:?}", beneficiary);
         let (vicinity, parent_hash, current_block_number) = match parent_data {
             None => (
@@ -211,6 +212,7 @@ impl EVMServices {
             executor.update_storage(address, storage)?;
         }
 
+        debug!("[construct_block] Processing {:?} transactions in queue", queue.transactions.len());
         for queue_item in queue.transactions.clone() {
             match queue_item.tx {
                 QueueTx::SignedTx(signed_tx) => {
@@ -461,7 +463,7 @@ impl EVMServices {
             .core
             .get_latest_contract_storage(address, ain_contracts::u256_to_h256(U256::one()))?;
 
-        debug!("Count: {:#x}", count + U256::one());
+        debug!("[counter_contract] count: {:#x}", count + U256::one());
 
         Ok(DeployContractInfo {
             address,

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -212,7 +212,10 @@ impl EVMServices {
             executor.update_storage(address, storage)?;
         }
 
-        debug!("[construct_block] Processing {:?} transactions in queue", queue.transactions.len());
+        debug!(
+            "[construct_block] Processing {:?} transactions in queue",
+            queue.transactions.len()
+        );
         for queue_item in queue.transactions.clone() {
             match queue_item.tx {
                 QueueTx::SignedTx(signed_tx) => {

--- a/test/functional/contracts/Loop.sol
+++ b/test/functional/contracts/Loop.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.7.0 <0.9.0;
+
+contract Loop {
+    function loop(uint256 num) public {
+        uint256 number = 0;
+        while (number < num) {
+            number++;
+        }
+    }
+}

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1298,8 +1298,12 @@ class EVMTest(DefiTestFramework):
             assert_equal(tx_info["vm"]["vmtype"], "evm")
             assert_equal(tx_info["vm"]["txtype"], "EvmTx")
             assert_equal(tx_info["vm"]["msg"]["sender"], self.eth_address)
-            assert_equal(tx_info["vm"]["msg"]["nonce"], start_nonce + first_block_total_txs + idx)
-            assert_equal(tx_info["vm"]["msg"]["hash"], hashes[first_block_total_txs + idx])
+            assert_equal(
+                tx_info["vm"]["msg"]["nonce"], start_nonce + first_block_total_txs + idx
+            )
+            assert_equal(
+                tx_info["vm"]["msg"]["hash"], hashes[first_block_total_txs + idx]
+            )
             assert_equal(tx_info["vm"]["msg"]["to"], receipt["contractAddress"].lower())
 
         # check that the remaining evm txs is minted into this block
@@ -1312,15 +1316,29 @@ class EVMTest(DefiTestFramework):
             assert_equal(tx_infos[idx]["vm"]["vmtype"], "evm")
             assert_equal(tx_infos[idx]["vm"]["txtype"], "EvmTx")
             assert_equal(tx_infos[idx]["vm"]["msg"]["sender"], self.eth_address)
-            assert_equal(tx_infos[idx]["vm"]["msg"]["nonce"], start_nonce + first_block_total_txs + second_block_total_txs + idx)
-            assert_equal(tx_infos[idx]["vm"]["msg"]["hash"], hashes[first_block_total_txs + second_block_total_txs + idx])
-            assert_equal(tx_infos[idx]["vm"]["msg"]["to"], receipt["contractAddress"].lower())
+            assert_equal(
+                tx_infos[idx]["vm"]["msg"]["nonce"],
+                start_nonce + first_block_total_txs + second_block_total_txs + idx,
+            )
+            assert_equal(
+                tx_infos[idx]["vm"]["msg"]["hash"],
+                hashes[first_block_total_txs + second_block_total_txs + idx],
+            )
+            assert_equal(
+                tx_infos[idx]["vm"]["msg"]["to"], receipt["contractAddress"].lower()
+            )
         for idx in range(6, third_block_total_txs):
             assert_equal(tx_infos[idx]["vm"]["vmtype"], "evm")
             assert_equal(tx_infos[idx]["vm"]["txtype"], "EvmTx")
             assert_equal(tx_infos[idx]["vm"]["msg"]["sender"], self.eth_address)
-            assert_equal(tx_infos[idx]["vm"]["msg"]["nonce"], start_nonce + first_block_total_txs + second_block_total_txs + idx)
-            assert_equal(tx_infos[idx]["vm"]["msg"]["hash"], hashes[first_block_total_txs + second_block_total_txs + idx])
+            assert_equal(
+                tx_infos[idx]["vm"]["msg"]["nonce"],
+                start_nonce + first_block_total_txs + second_block_total_txs + idx,
+            )
+            assert_equal(
+                tx_infos[idx]["vm"]["msg"]["hash"],
+                hashes[first_block_total_txs + second_block_total_txs + idx],
+            )
             assert_equal(tx_infos[idx]["vm"]["msg"]["to"], self.to_address)
 
     def toggle_evm_enablement(self):

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1234,7 +1234,7 @@ class EVMTest(DefiTestFramework):
                 {
                     "chainId": self.nodes[0].w3.eth.chain_id,
                     "nonce": count + i,
-                    "gasPrice": 10_000_000_000,
+                    "gasPrice": 20_000_000_000,
                     "gas": 30_000_000,
                 }
             )
@@ -1248,7 +1248,7 @@ class EVMTest(DefiTestFramework):
 
         # check that remaining 13 evm txs will be minted in the next block
         self.nodes[0].generate(1)
-        # assert_equal(len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 13)
+        assert_equal(len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 13)
 
     def toggle_evm_enablement(self):
         # Deactivate EVM

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1220,11 +1220,15 @@ class EVMTest(DefiTestFramework):
                 "gas": 1_000_000,
             }
         )
-        signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.eth_address_privkey)
+        signed = self.nodes[0].w3.eth.account.sign_transaction(
+            tx, self.eth_address_privkey
+        )
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
-        contract = self.nodes[0].w3.eth.contract(address=receipt["contractAddress"], abi=abi)
+        contract = self.nodes[0].w3.eth.contract(
+            address=receipt["contractAddress"], abi=abi
+        )
 
         count = self.nodes[0].w3.eth.get_transaction_count(self.eth_address)
         for i in range(30):
@@ -1238,17 +1242,23 @@ class EVMTest(DefiTestFramework):
                     "gas": 30_000_000,
                 }
             )
-            signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.eth_address_privkey)
+            signed = self.nodes[0].w3.eth.account.sign_transaction(
+                tx, self.eth_address_privkey
+            )
             hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
 
         # check that 17 of the 30 evm txs should have been minted in the current block for
         # block size limit = 30_000_000
         self.nodes[0].generate(1)
-        assert_equal(len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 17)
+        assert_equal(
+            len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 17
+        )
 
         # check that remaining 13 evm txs will be minted in the next block
         self.nodes[0].generate(1)
-        assert_equal(len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 13)
+        assert_equal(
+            len(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["tx"]) - 1, 13
+        )
 
     def toggle_evm_enablement(self):
         # Deactivate EVM


### PR DESCRIPTION
## Summary

- Add multiple evm transactions into mempool that exceeds block size limit to ensure evm txs are minted correctly in the subsequent blocks


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
