### PR TITLE
evm: Add next block baseFeePerGas in `eth_feeHistory` output

### DIFF
--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -174,6 +174,7 @@ impl BlockService {
             block_number -= U256::one();
         }
 
+        // TODO(): b.hash -> b.number
         let oldest_block = blocks.last().unwrap().header.hash();
 
         let (mut base_fee_per_gas, mut gas_used_ratio): (Vec<U256>, Vec<f64>) = blocks

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -17,7 +17,7 @@ pub struct BlockService {
 }
 
 pub struct FeeHistoryData {
-    pub oldest_block: H256,
+    pub oldest_block: U256,
     pub base_fee_per_gas: Vec<U256>,
     pub gas_used_ratio: Vec<f64>,
     pub reward: Option<Vec<Vec<U256>>>,
@@ -174,8 +174,7 @@ impl BlockService {
             block_number -= U256::one();
         }
 
-        // TODO(): b.hash -> b.number
-        let oldest_block = blocks.last().unwrap().header.hash();
+        let oldest_block = blocks.last().unwrap().header.number;
 
         let (mut base_fee_per_gas, mut gas_used_ratio): (Vec<U256>, Vec<f64>) = blocks
             .iter()

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -236,7 +236,7 @@ impl BlockService {
                 let mut data = Data::new(priority_fees);
 
                 for pct in &priority_fee_percentile {
-                    block_rewards.push(U256::from(data.percentile(*pct).ceil() as u64));
+                    block_rewards.push(U256::from(data.percentile(*pct).floor() as u64));
                 }
 
                 reward.push(block_rewards);

--- a/lib/ain-grpc/src/block.rs
+++ b/lib/ain-grpc/src/block.rs
@@ -337,7 +337,7 @@ impl Serialize for BlockTransactions {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcFeeHistory {
-    pub oldest_block: H256,
+    pub oldest_block: U256,
     pub base_fee_per_gas: Vec<U256>,
     pub gas_used_ratio: Vec<f64>,
     pub reward: Option<Vec<Vec<U256>>>,

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -116,21 +116,18 @@ class EVMTest(DefiTestFramework):
     def test_fee_history(self):
         node = self.nodes[0]
 
-        self.create_block(2, [2, 3, 5, 6, 7])
+        self.create_block(2, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
         count = 2
-        reward_percentiles = [20, 50, 70]
-        # import pdb; pdb.set_trace()
+        reward_percentiles = [20, 30, 50, 70, 85, 100]
         history = node.eth_feeHistory(hex(count), "latest", reward_percentiles)
-        print("history: ", history)
 
         current = node.eth_blockNumber()
         assert_equal(history["oldestBlock"], hex(int(current, 16) - count + 1))
         assert_equal(len(history["baseFeePerGas"]), count + 1)
-        # assert gas_used ratio
         for x in history["reward"]:
             assert_equal(len(x), len(reward_percentiles))
-            assert_equal(x, ['0x2', '0x5', '0x7'])
+            assert_equal(x, ['0x2', '0x3', '0x5', '0x7', '0x9', '0xa'])
 
     def run_test(self):
         self.setup()

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -21,6 +21,7 @@ from test_framework.util import (
 # }
 CONTRACT_BYTECODE = "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063165c4a1614602d575b600080fd5b603c6038366004605f565b604e565b60405190815260200160405180910390f35b600060588284607f565b9392505050565b600080604083850312156070578182fd5b50508035926020909101359150565b600081600019048311821515161560a457634e487b7160e01b81526011600452602481fd5b50029056fea2646970667358221220223df7833fd08eb1cd3ce363a9c4cb4619c1068a5f5517ea8bb862ed45d994f764736f6c63430008020033"
 
+
 class EVMTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -96,8 +97,8 @@ class EVMTest(DefiTestFramework):
         assert_equal(balance, int_to_eth_u256(50))
 
     def create_block(self, count, priority_fees):
-       node = self.nodes[0]
-       for x in range(count):
+        node = self.nodes[0]
+        for x in range(count):
             for y in priority_fees:
                 tx = {
                     "from": self.ethAddress,
@@ -119,8 +120,8 @@ class EVMTest(DefiTestFramework):
 
         count = 2
         reward_percentiles = [20, 50, 70]
-        history = node.eth_feeHistory(hex(count), 'latest', reward_percentiles)
-        print('history: ', history)
+        history = node.eth_feeHistory(hex(count), "latest", reward_percentiles)
+        print("history: ", history)
 
         # assert oldest_block
         assert_equal(len(history["baseFeePerGas"]), count + 1)
@@ -129,12 +130,10 @@ class EVMTest(DefiTestFramework):
         for x in history["reward"]:
             assert_equal(len(x), len(reward_percentiles))
 
-
     def run_test(self):
         self.setup()
 
         self.test_fee_history()
-
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -8,9 +8,7 @@
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_is_hex_string,
     int_to_eth_u256,
-    hex_to_decimal,
 )
 
 # pragma solidity ^0.8.2;
@@ -110,7 +108,6 @@ class EVMTest(DefiTestFramework):
                     "maxFeePerGas": "0x22ecb25c00",  # 150_000_000_000
                     "type": "0x2",
                 }
-                hash = node.eth_sendTransaction(tx)
             node.generate(1)
 
     def test_fee_history(self):

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test EVM behaviour"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_is_hex_string,
+    int_to_eth_u256,
+    hex_to_decimal,
+)
+
+# pragma solidity ^0.8.2;
+# contract Multiply {
+#     function multiply(uint a, uint b) public pure returns (uint) {
+#         return a * b;
+#     }
+# }
+CONTRACT_BYTECODE = "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063165c4a1614602d575b600080fd5b603c6038366004605f565b604e565b60405190815260200160405180910390f35b600060588284607f565b9392505050565b600080604083850312156070578182fd5b50508035926020909101359150565b600081600019048311821515161560a457634e487b7160e01b81526011600452602481fd5b50029056fea2646970667358221220223df7833fd08eb1cd3ce363a9c4cb4619c1068a5f5517ea8bb862ed45d994f764736f6c63430008020033"
+
+class EVMTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            [
+                "-dummypos=0",
+                "-txnotokens=0",
+                "-amkheight=50",
+                "-bayfrontheight=51",
+                "-eunosheight=80",
+                "-fortcanningheight=82",
+                "-fortcanninghillheight=84",
+                "-fortcanningroadheight=86",
+                "-fortcanningcrunchheight=88",
+                "-fortcanningspringheight=90",
+                "-fortcanninggreatworldheight=94",
+                "-fortcanningepilogueheight=96",
+                "-grandcentralheight=101",
+                "-nextnetworkupgradeheight=105",
+                "-subsidytest=1",
+                "-txindex=1",
+            ],
+        ]
+
+    def setup(self):
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+        self.ethAddress = "0x9b8a4af42140d8a4c153a822f02571a1dd037e89"
+        self.toAddress = "0x6c34cbb9219d8caa428835d2073e8ec88ba0a110"
+        self.nodes[0].importprivkey(
+            "af990cc3ba17e776f7f57fcc59942a82846d75833fa17d2ba59ce6858d886e23"
+        )  # ethAddress
+        self.nodes[0].importprivkey(
+            "17b8cb134958b3d8422b6c43b0732fcdb8c713b524df2d45de12f0c7e214ba35"
+        )  # toAddress
+
+        # Generate chain
+        self.nodes[0].generate(105)
+
+        self.nodes[0].getbalance()
+        self.nodes[0].utxostoaccount({self.address: "201@DFI"})
+        self.nodes[0].setgov(
+            {
+                "ATTRIBUTES": {
+                    "v0/params/feature/evm": "true",
+                    "v0/params/feature/transferdomain": "true",
+                    "v0/transferdomain/dvm-evm/enabled": "true",
+                    "v0/transferdomain/dvm-evm/src-formats": ["p2pkh", "bech32"],
+                    "v0/transferdomain/dvm-evm/dest-formats": ["erc55"],
+                    "v0/transferdomain/evm-dvm/src-formats": ["erc55"],
+                    "v0/transferdomain/evm-dvm/auth-formats": ["bech32-erc55"],
+                    "v0/transferdomain/evm-dvm/dest-formats": ["p2pkh", "bech32"],
+                }
+            }
+        )
+        self.nodes[0].generate(1)
+
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "50@DFI", "domain": 2},
+                    "dst": {
+                        "address": self.ethAddress,
+                        "amount": "50@DFI",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+
+        balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
+        assert_equal(balance, int_to_eth_u256(50))
+
+    def create_block(self, count, priority_fees):
+       node = self.nodes[0]
+       for x in range(count):
+            for y in priority_fees:
+                tx = {
+                    "from": self.ethAddress,
+                    "value": "0x0",
+                    "data": CONTRACT_BYTECODE,
+                    "gas": "0x18e70",  # 102_000
+                    "maxPriorityFeePerGas": hex(16),
+                    # "maxPriorityFeePerGas": hex(y), # <-- too-many-eth-txs-by-sender
+                    "maxFeePerGas": "0x22ecb25c00",  # 150_000_000_000
+                    "type": "0x2",
+                }
+                hash = node.eth_sendTransaction(tx)
+            node.generate(1)
+
+    def test_fee_history(self):
+        node = self.nodes[0]
+
+        self.create_block(11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+        count = 2
+        reward_percentiles = [20, 50, 70]
+        history = node.eth_feeHistory(hex(count), 'latest', reward_percentiles)
+        print('history: ', history)
+
+        # assert oldest_block
+        assert_equal(len(history["baseFeePerGas"]), count + 1)
+        # assert gas_used ratio
+        # assert len(history.reward) == count
+        for x in history["reward"]:
+            assert_equal(len(x), len(reward_percentiles))
+
+
+    def run_test(self):
+        self.setup()
+
+        self.test_fee_history()
+
+
+
+if __name__ == "__main__":
+    EVMTest().main()


### PR DESCRIPTION
Refining rpc `eth_feeHistory` with
  - [x] add next block base fee
  - [x] change oldest block type from hash to number
  - [x] some percentiles to fine tune