### PR TITLE
Clear eth txs index by sender when clearing mempool

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -622,6 +622,7 @@ void CTxMemPool::_clear()
     mapTx.clear();
     vTxHashes.clear();
     mapNextTx.clear();
+    ethTxsBySender.clear();
     totalTxSize = 0;
     cachedInnerUsage = 0;
     lastRollingFeeUpdate = GetTime();

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1008,7 +1008,7 @@ class EVMTest(DefiTestFramework):
 
     def mempool_tx_limit(self):
         # Test max limit of TX from a specific sender
-        for i in range(63):
+        for i in range(64):
             self.nodes[0].evmtx(self.eth_address, i, 21, 21001, self.to_address, 1)
 
         # Test error at the 64th EVM TX
@@ -1017,7 +1017,7 @@ class EVMTest(DefiTestFramework):
             "too-many-eth-txs-by-sender",
             self.nodes[0].evmtx,
             self.eth_address,
-            63,
+            64,
             21,
             21001,
             self.to_address,
@@ -1030,31 +1030,31 @@ class EVMTest(DefiTestFramework):
         block_txs = self.nodes[0].getblock(
             self.nodes[0].getblockhash(self.nodes[0].getblockcount())
         )["tx"]
-        assert_equal(len(block_txs), 64)
+        assert_equal(len(block_txs), 65)
 
         # Check accounting of EVM fees
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 64
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 63
+            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min_hash"],
@@ -1062,7 +1062,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],
@@ -1072,22 +1072,22 @@ class EVMTest(DefiTestFramework):
         # Check Eth balances after transfer
         assert_equal(
             int(self.nodes[0].eth_getBalance(self.eth_address)[2:], 16),
-            136972217000000000000,
+            135971776000000000000,
         )
         assert_equal(
             int(self.nodes[0].eth_getBalance(self.to_address)[2:], 16),
-            63000000000000000000,
+            64000000000000000000,
         )
 
-        # Try and send another TX to make sure mempool has removed entires
-        tx = self.nodes[0].evmtx(self.eth_address, 63, 21, 21001, self.to_address, 1)
+        # Try and send another TX to make sure mempool has removed entries
+        tx = self.nodes[0].evmtx(self.eth_address, 64, 21, 21001, self.to_address, 1)
         self.nodes[0].generate(1)
         self.blockHash1 = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
 
         # Check accounting of EVM fees
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 64
+            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 65
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee
@@ -1096,13 +1096,13 @@ class EVMTest(DefiTestFramework):
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash1
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 64
+            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 65
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"], self.priority_fee
@@ -1113,7 +1113,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],
@@ -1128,11 +1128,11 @@ class EVMTest(DefiTestFramework):
 
     def multiple_eth_rbf(self):
         # Test multiple replacement TXs with differing fees
-        self.nodes[0].evmtx(self.eth_address, 64, 22, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 23, 21001, self.to_address, 1)
-        tx0 = self.nodes[0].evmtx(self.eth_address, 64, 25, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 21, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 24, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 22, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 23, 21001, self.to_address, 1)
+        tx0 = self.nodes[0].evmtx(self.eth_address, 65, 25, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 21, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 24, 21001, self.to_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 22, 21001, self.eth_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 23, 21001, self.eth_address, 1)
         tx1 = self.nodes[0].evmtx(self.to_address, 0, 25, 21001, self.eth_address, 1)
@@ -1141,29 +1141,29 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check accounting of EVM fees
-        txLegacy64 = {
+        txLegacy65 = {
             "nonce": "0x1",
             "from": self.eth_address,
             "value": "0x1",
             "gas": "0x5208",  # 21000
             "gasPrice": "0x5D21DBA00",  # 25_000_000_000,
         }
-        fees64 = self.nodes[0].debug_feeEstimate(txLegacy64)
-        self.burnt_fee64 = hex_to_decimal(fees64["burnt_fee"])
-        self.priority_fee64 = hex_to_decimal(fees64["priority_fee"])
+        fees65 = self.nodes[0].debug_feeEstimate(txLegacy65)
+        self.burnt_fee65 = hex_to_decimal(fees65["burnt_fee"])
+        self.priority_fee65 = hex_to_decimal(fees65["priority_fee"])
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt"],
-            self.burnt_fee * 64 + 2 * self.burnt_fee64,
+            self.burnt_fee * 65 + 2 * self.burnt_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority"],
-            self.priority_fee * 64 + 2 * self.priority_fee64,
+            self.priority_fee * 65 + 2 * self.priority_fee65,
         )
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt"],
-            self.burnt_fee * 64 + 2 * self.burnt_fee64,
+            self.burnt_fee * 65 + 2 * self.burnt_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee
@@ -1172,14 +1172,14 @@ class EVMTest(DefiTestFramework):
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash1
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority"],
-            self.priority_fee * 64 + 2 * self.priority_fee64,
+            self.priority_fee * 65 + 2 * self.priority_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"], self.priority_fee
@@ -1190,7 +1190,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],


### PR DESCRIPTION
## Summary

- Clear sender to evm tx hashes map when clearing mempool.
- Fixes to feature_evm incorrect mempool limit tx - 65th tx should fail instead of the 64th tx.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
