### PR TITLE
Add miner test for different gas used

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -622,6 +622,7 @@ void CTxMemPool::_clear()
     mapTx.clear();
     vTxHashes.clear();
     mapNextTx.clear();
+    ethTxsBySender.clear();
     totalTxSize = 0;
     cachedInnerUsage = 0;
     lastRollingFeeUpdate = GetTime();

--- a/test/functional/contracts/StateChange.sol
+++ b/test/functional/contracts/StateChange.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.7.0 <0.9.0;
+
+contract StateChange {
+    mapping(address => bool) public state;
+    function changeState(bool a) public {
+        state[msg.sender] = a;
+    }
+
+    function loop(uint256 num) public {
+        uint number = 0;
+        require(state[msg.sender]);
+        while (number < num) {
+            number++;
+        }
+    }
+}

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1008,7 +1008,7 @@ class EVMTest(DefiTestFramework):
 
     def mempool_tx_limit(self):
         # Test max limit of TX from a specific sender
-        for i in range(63):
+        for i in range(64):
             self.nodes[0].evmtx(self.eth_address, i, 21, 21001, self.to_address, 1)
 
         # Test error at the 64th EVM TX
@@ -1017,7 +1017,7 @@ class EVMTest(DefiTestFramework):
             "too-many-eth-txs-by-sender",
             self.nodes[0].evmtx,
             self.eth_address,
-            63,
+            64,
             21,
             21001,
             self.to_address,
@@ -1030,31 +1030,31 @@ class EVMTest(DefiTestFramework):
         block_txs = self.nodes[0].getblock(
             self.nodes[0].getblockhash(self.nodes[0].getblockcount())
         )["tx"]
-        assert_equal(len(block_txs), 64)
+        assert_equal(len(block_txs), 65)
 
         # Check accounting of EVM fees
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 64
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 63
+            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min_hash"],
@@ -1062,7 +1062,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],
@@ -1072,22 +1072,22 @@ class EVMTest(DefiTestFramework):
         # Check Eth balances after transfer
         assert_equal(
             int(self.nodes[0].eth_getBalance(self.eth_address)[2:], 16),
-            136972217000000000000,
+            135971776000000000000,
         )
         assert_equal(
             int(self.nodes[0].eth_getBalance(self.to_address)[2:], 16),
-            63000000000000000000,
+            64000000000000000000,
         )
 
-        # Try and send another TX to make sure mempool has removed entires
-        tx = self.nodes[0].evmtx(self.eth_address, 63, 21, 21001, self.to_address, 1)
+        # Try and send another TX to make sure mempool has removed entries
+        tx = self.nodes[0].evmtx(self.eth_address, 64, 21, 21001, self.to_address, 1)
         self.nodes[0].generate(1)
         self.blockHash1 = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
 
         # Check accounting of EVM fees
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 64
+            attributes["v0/live/economy/evm/block/fee_burnt"], self.burnt_fee * 65
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee
@@ -1096,13 +1096,13 @@ class EVMTest(DefiTestFramework):
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash1
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 64
+            attributes["v0/live/economy/evm/block/fee_priority"], self.priority_fee * 65
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"], self.priority_fee
@@ -1113,7 +1113,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],
@@ -1128,11 +1128,11 @@ class EVMTest(DefiTestFramework):
 
     def multiple_eth_rbf(self):
         # Test multiple replacement TXs with differing fees
-        self.nodes[0].evmtx(self.eth_address, 64, 22, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 23, 21001, self.to_address, 1)
-        tx0 = self.nodes[0].evmtx(self.eth_address, 64, 25, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 21, 21001, self.to_address, 1)
-        self.nodes[0].evmtx(self.eth_address, 64, 24, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 22, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 23, 21001, self.to_address, 1)
+        tx0 = self.nodes[0].evmtx(self.eth_address, 65, 25, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 21, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 24, 21001, self.to_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 22, 21001, self.eth_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 23, 21001, self.eth_address, 1)
         tx1 = self.nodes[0].evmtx(self.to_address, 0, 25, 21001, self.eth_address, 1)
@@ -1141,29 +1141,29 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check accounting of EVM fees
-        txLegacy64 = {
+        txLegacy65 = {
             "nonce": "0x1",
             "from": self.eth_address,
             "value": "0x1",
             "gas": "0x5208",  # 21000
             "gasPrice": "0x5D21DBA00",  # 25_000_000_000,
         }
-        fees64 = self.nodes[0].debug_feeEstimate(txLegacy64)
-        self.burnt_fee64 = hex_to_decimal(fees64["burnt_fee"])
-        self.priority_fee64 = hex_to_decimal(fees64["priority_fee"])
+        fees65 = self.nodes[0].debug_feeEstimate(txLegacy65)
+        self.burnt_fee65 = hex_to_decimal(fees65["burnt_fee"])
+        self.priority_fee65 = hex_to_decimal(fees65["priority_fee"])
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt"],
-            self.burnt_fee * 64 + 2 * self.burnt_fee64,
+            self.burnt_fee * 65 + 2 * self.burnt_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority"],
-            self.priority_fee * 64 + 2 * self.priority_fee64,
+            self.priority_fee * 65 + 2 * self.priority_fee65,
         )
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt"],
-            self.burnt_fee * 64 + 2 * self.burnt_fee64,
+            self.burnt_fee * 65 + 2 * self.burnt_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_min"], self.burnt_fee
@@ -1172,14 +1172,14 @@ class EVMTest(DefiTestFramework):
             attributes["v0/live/economy/evm/block/fee_burnt_min_hash"], self.blockHash1
         )
         assert_equal(
-            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 63
+            attributes["v0/live/economy/evm/block/fee_burnt_max"], self.burnt_fee * 64
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_burnt_max_hash"], self.blockHash
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority"],
-            self.priority_fee * 64 + 2 * self.priority_fee64,
+            self.priority_fee * 65 + 2 * self.priority_fee65,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_min"], self.priority_fee
@@ -1190,7 +1190,7 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max"],
-            self.priority_fee * 63,
+            self.priority_fee * 64,
         )
         assert_equal(
             attributes["v0/live/economy/evm/block/fee_priority_max_hash"],

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -9,7 +9,7 @@ from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    int_to_eth_u256,
+    # int_to_eth_u256,
 )
 from decimal import Decimal
 

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -459,16 +459,21 @@ class EVMTest(DefiTestFramework):
             assert_equal(block["transactions"][11 + idx], hashes[11 + idx])
             assert_equal(gas_used, gas_used_when_false)
 
-        correct_gas_used = gas_used_when_true * 10 + gas_used_when_false * 8 + gas_used_when_change_state
-        block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)
-        assert_equal(block_info["tx"][0]["vm"]["xvmHeader"]["gasUsed"], correct_gas_used)
-
-        # Check that the remaining 7 evm txs are still in mempool
-        assert_equal(Decimal(self.nodes[0].getmempoolinfo()["size"]), Decimal("7"))
-
         # TODO: Thereotical block size calculated in txqueue would be:
         # gas_used_when_true * 18 + gas_used_when_change_state = 28639540
         # But the minted block is only of size 16111252.
+        correct_gas_used = (
+            gas_used_when_true * 10
+            + gas_used_when_false * 8
+            + gas_used_when_change_state
+        )
+        block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)
+        assert_equal(
+            block_info["tx"][0]["vm"]["xvmHeader"]["gasUsed"], correct_gas_used
+        )
+
+        # Check that the remaining 7 evm txs are still in mempool
+        assert_equal(Decimal(self.nodes[0].getmempoolinfo()["size"]), Decimal("7"))
 
     def run_test(self):
         self.setup()

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -9,7 +9,7 @@ from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    # int_to_eth_u256,
+    int_to_eth_u256,
 )
 from decimal import Decimal
 
@@ -459,10 +459,9 @@ class EVMTest(DefiTestFramework):
             assert_equal(block["transactions"][11 + idx], hashes[11 + idx])
             assert_equal(gas_used, gas_used_when_false)
 
-        # TODO: Verified with debug logs that this assertion is correct, but eth_getBlockByNumber RPC is
-        # returning incorrect gas used. Disabling this check for now.
-        # correct_gas_used = gas_used_when_true * 10 + gas_used_when_false * 8 + gas_used_when_change_state
-        # assert_equal(block["gasUsed"], int_to_eth_u256(int(correct_gas_used)))
+        correct_gas_used = gas_used_when_true * 10 + gas_used_when_false * 8 + gas_used_when_change_state
+        block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)
+        assert_equal(block_info["tx"][0]["vm"]["xvmHeader"]["gasUsed"], correct_gas_used)
 
         # Check that the remaining 7 evm txs are still in mempool
         assert_equal(Decimal(self.nodes[0].getmempoolinfo()["size"]), Decimal("7"))

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -282,7 +282,9 @@ class EVMTest(DefiTestFramework):
         )
         assert_equal(before_balance, Decimal("100"))
 
-        abi, bytecode = EVMContract.from_file("StateChange.sol", "StateChange").compile()
+        abi, bytecode = EVMContract.from_file(
+            "StateChange.sol", "StateChange"
+        ).compile()
         compiled = self.nodes[0].w3.eth.contract(abi=abi, bytecode=bytecode)
         tx = compiled.constructor().build_transaction(
             {
@@ -296,10 +298,10 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
         self.nodes[0].generate(1)
-        contract_address = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["contractAddress"]
-        contract = self.nodes[0].w3.eth.contract(
-            address=contract_address, abi=abi
-        )
+        contract_address = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)[
+            "contractAddress"
+        ]
+        contract = self.nodes[0].w3.eth.contract(address=contract_address, abi=abi)
 
         # gas used values
         gas_used_when_true = Decimal("1589866")
@@ -330,7 +332,9 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
         self.nodes[0].generate(1)
-        gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"])
+        gas_used = Decimal(
+            self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
+        )
         assert_equal(gas_used, gas_used_when_true)
 
         # Set state to false
@@ -345,9 +349,11 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
         self.nodes[0].generate(1)
-        gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"])
+        gas_used = Decimal(
+            self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
+        )
         assert_equal(gas_used, gas_used_when_change_state)
-        
+
         tx = contract.functions.loop(9_000).build_transaction(
             {
                 "chainId": self.nodes[0].w3.eth.chain_id,
@@ -359,7 +365,9 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
         self.nodes[0].generate(1)
-        gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"])
+        gas_used = Decimal(
+            self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
+        )
         assert_equal(gas_used, gas_used_when_false)
 
         # Set state back to true
@@ -390,7 +398,7 @@ class EVMTest(DefiTestFramework):
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
             hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
             hashes.append((signed.hash.hex()))
-        
+
         # Send change of state
         tx = contract.functions.changeState(False).build_transaction(
             {
@@ -428,16 +436,26 @@ class EVMTest(DefiTestFramework):
 
         # Check first 10 txs should have gas used when true
         for idx in range(10):
-            gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[idx])["gasUsed"])
+            gas_used = Decimal(
+                self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[idx])[
+                    "gasUsed"
+                ]
+            )
             assert_equal(block["transactions"][idx], hashes[idx])
             assert_equal(gas_used, gas_used_when_true)
-        
-        gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[10])["gasUsed"])
+
+        gas_used = Decimal(
+            self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[10])["gasUsed"]
+        )
         assert_equal(gas_used, gas_used_when_change_state)
 
         # Check last 5 txs should have gas used when false
         for idx in range(8):
-            gas_used = Decimal(self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[11 + idx])["gasUsed"])
+            gas_used = Decimal(
+                self.nodes[0].w3.eth.wait_for_transaction_receipt(hashes[11 + idx])[
+                    "gasUsed"
+                ]
+            )
             assert_equal(block["transactions"][11 + idx], hashes[11 + idx])
             assert_equal(gas_used, gas_used_when_false)
 

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -9,7 +9,6 @@ from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    int_to_eth_u256,
 )
 from decimal import Decimal
 


### PR DESCRIPTION
## Summary

- Add miner test to test for different gas used in pipeline when validating txs on the current tip's state root and during construct block.
- Verifies that the behaviour is correct, and that the gas used calcuations during construct block is correct.
- The test changes the state of the contract call, which results in a different gas used calcuation when adding into the txqueue vs during construct block.
- This PR is dependent on PR #2398 

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
