### PR TITLE
EVM: Fix block gas limit validation

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2692,13 +2692,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             const auto applyCustomTxTime = GetTimeMicros();
             uint64_t gasUsed{};
             const auto res = ApplyCustomTx(accountsView, view, tx, consensus, pindex->nHeight, gasUsed, pindex->GetBlockTime(), nullptr, i, evmQueueId, isEvmEnabledForBlock);
-
             totalGas += gasUsed;
-            if (totalGas > MAX_BLOCK_GAS_LIMIT) {
-                return state.Invalid(ValidationInvalidReason::CONSENSUS,
-                                     error("%s: ApplyCustomTx failed. Gas limit: %d Gas used: %d", __func__, MAX_BLOCK_GAS_LIMIT, totalGas),
-                                     REJECT_CUSTOMTX, "over-gas-limit");
-            }
 
             LogApplyCustomTx(tx, applyCustomTxTime);
             if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -127,7 +127,7 @@ class EVMTest(DefiTestFramework):
         assert_equal(len(history["baseFeePerGas"]), count + 1)
         for x in history["reward"]:
             assert_equal(len(x), len(reward_percentiles))
-            assert_equal(x, ['0x2', '0x3', '0x5', '0x7', '0x9', '0xa'])
+            assert_equal(x, ["0x2", "0x3", "0x5", "0x7", "0x9", "0xa"])
 
     def run_test(self):
         self.setup()


### PR DESCRIPTION
## Summary

- Remove validation check in connect block that checks for the EVM block's total gas used with the MAX_BLOCK_GAS_LIMIT, since currently the block gas used is allowed to exceed the total max gas limit.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
