### PR TITLE
EVM: Fix pre-validation evm tx check

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -264,7 +264,6 @@ impl EVMCoreService {
             return Err(format_err!("value more than money range").into());
         }
 
-
         // Validate tx gas limit with intrinsic gas
         check_tx_intrinsic_gas(&signed_tx)?;
 

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -264,18 +264,6 @@ impl EVMCoreService {
             return Err(format_err!("value more than money range").into());
         }
 
-        let balance = self
-            .get_balance(signed_tx.sender, block_number)
-            .map_err(|e| format_err!("Error getting balance {e}"))?;
-        let prepay_fee = calculate_prepay_gas_fee(&signed_tx)?;
-        debug!("[validate_raw_tx] Account balance : {:x?}", balance);
-        debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
-
-        // Validate tx prepay fees with account balance
-        if balance < prepay_fee {
-            debug!("[validate_raw_tx] insufficient balance to pay fees");
-            return Err(format_err!("insufficient balance to pay fees").into());
-        }
 
         // Validate tx gas limit with intrinsic gas
         check_tx_intrinsic_gas(&signed_tx)?;
@@ -307,8 +295,21 @@ impl EVMCoreService {
             u64::default()
         };
 
-        // Validate total gas usage in queued txs exceeds block size
+        let prepay_fee = calculate_prepay_gas_fee(&signed_tx)?;
+        debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
         if use_queue {
+            // Validate tx prepay fees with account balance
+            let balance = self
+                .get_balance(signed_tx.sender, block_number)
+                .map_err(|e| format_err!("Error getting balance {e}"))?;
+            debug!("[validate_raw_tx] Account balance : {:x?}", balance);
+
+            if balance < prepay_fee {
+                debug!("[validate_raw_tx] insufficient balance to pay fees");
+                return Err(format_err!("insufficient balance to pay fees").into());
+            }
+
+            // Validate total gas usage in queued txs exceeds block size
             debug!("[validate_raw_tx] used_gas: {:#?}", used_gas);
             let total_current_gas_used = self
                 .tx_queues


### PR DESCRIPTION
## Summary

- PR fixes pre-validation pipeline of EVM transactions to remove the account balance check.
- Looser check allows EVM tx to be added into the mempool without initial account balance validation check, thus resolving transferdomain tx and evm tx being minted in the same block.
- Depends on PR to add state trie inside txqueue.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
