### PR TITLE
Keep track of state changes in tx queue

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -201,6 +201,12 @@ impl EVMBackend {
             .unwrap_or_default()
     }
 
+    pub fn get_balance(&self, address: &H160) -> U256 {
+        self.get_account(address)
+            .map(|acc| acc.balance)
+            .unwrap_or_default()
+    }
+
     pub fn get_contract_storage(&self, contract: H160, storage_index: &[u8]) -> Result<U256> {
         let Some(account) = self.get_account(&contract) else {
             return Ok(U256::zero());

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -559,10 +559,11 @@ impl EVMServices {
         tx: QueueTx,
         hash: XHash,
         gas_used: U256,
+        state_root: H256,
     ) -> Result<()> {
         self.core
             .tx_queues
-            .push_in(queue_id, tx.clone(), hash, gas_used)?;
+            .push_in(queue_id, tx.clone(), hash, gas_used, state_root)?;
 
         if let QueueTx::SignedTx(signed_tx) = tx {
             self.filters.add_tx_to_filters(signed_tx.transaction.hash());
@@ -702,6 +703,7 @@ fn get_dst20_migration_txs(mnview_ptr: usize) -> Result<Vec<QueueTxItem>> {
             tx,
             tx_hash: Default::default(),
             gas_used: U256::zero(),
+            state_root: H256::default(),
         });
     }
     Ok(txs)

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -102,6 +102,7 @@ pub mod ffi {
         pub tx_hash: String,
         pub prepay_fee: u64,
         pub gas_used: u64,
+        pub state_root: [u8; 32],
     }
 
     extern "Rust" {
@@ -145,8 +146,8 @@ pub mod ffi {
         ) -> ValidateTxCompletion;
         fn evm_unsafe_try_validate_raw_tx_in_q(
             result: &mut CrossBoundaryResult,
-            tx: &str,
             queue_id: u64,
+            tx: &str,
         ) -> ValidateTxCompletion;
         fn evm_unsafe_try_push_tx_in_q(
             result: &mut CrossBoundaryResult,
@@ -154,6 +155,7 @@ pub mod ffi {
             raw_tx: &str,
             native_hash: &str,
             gas_used: u64,
+            state_root: [u8; 32],
         );
         fn evm_unsafe_try_construct_block_in_q(
             result: &mut CrossBoundaryResult,

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -287,7 +287,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Ok();
     }
 
-    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, HexStr(obj.evmTx), evmQueueId);
+    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
     if (!result.ok) {
         LogPrintf("[evm_try_validate_raw_tx] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to validate %s", result.reason);
@@ -295,7 +295,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
 
     gasUsed = validateResults.gas_used;
 
-    evm_unsafe_try_push_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), tx.GetHash().GetHex(), validateResults.gas_used);
+    evm_unsafe_try_push_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), tx.GetHash().GetHex(), validateResults.gas_used, validateResults.state_root);
     if (!result.ok) {
         LogPrintf("[evm_try_push_tx_in_q] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to queue %s\n", result.reason);

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -430,7 +430,7 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         # Check that only 19 txs are minted
-        block = self.nodes[0].eth_getBlockByNumber("latest", False)
+        block = self.nodes[0].eth_getBlockByNumber("latest")
         assert_equal(len(block["transactions"]), 19)
 
         # Check first 10 txs should have gas used when true


### PR DESCRIPTION
## Summary

- Add additional `state_root` to queued tx representing its resulting changes to the state trie 

## Missing
- [ ] Remove all TX down to the removed TX on RBF
- [ ] Remove transferdomain state revert
- [ ] Test for transferdomain out after an EVM TX using the fund (check failure on queue instead of catching it on block creation)

## Implications

- Storage
  - [x] Database reindex required

- Consensus
  - [x] Network upgrade required
