### PR TITLE
Prevent setting EVM or TD Gov var below height

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -1972,21 +1972,24 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                 break;
 
             case AttributeTypes::Param:
-                if (attrV0->typeId == ParamIDs::Feature && attrV0->key == DFIPKeys::MintTokens) {
-                    if (view.GetLastHeight() < Params().GetConsensus().GrandCentralEpilogueHeight) {
-                        return Res::Err("Cannot be set before GrandCentralEpilogueHeight");
-                    }
-                } else if (attrV0->typeId == ParamIDs::Feature || attrV0->typeId == ParamIDs::Foundation ||
-                    attrV0->key == DFIPKeys::Members) {
+                if (attrV0->typeId == ParamIDs::Feature) {
                     if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }
-                } else if (attrV0->typeId == ParamIDs::Foundation || attrV0->key == DFIPKeys::Members) {
+                    if (attrV0->key == DFIPKeys::MintTokens) {
+                        if (view.GetLastHeight() < Params().GetConsensus().GrandCentralEpilogueHeight) {
+                            return Res::Err("Cannot be set before GrandCentralEpilogueHeight");
+                        }
+                    } else if (attrV0->key == DFIPKeys::EVMEnabled || attrV0->key == DFIPKeys::TransferDomain) {
+                        if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                            return Res::Err("Cannot be set before NextNetworkUpgradeHeight");
+                        }
+                    }
+                } else if (attrV0->typeId == ParamIDs::Foundation) {
                     if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }
-                } else if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->key == DFIPKeys::StartBlock ||
-                           attrV0->typeId == ParamIDs::DFIP2206A) {
+                } else if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->typeId == ParamIDs::DFIP2206A) {
                     if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
                         return Res::Err("Cannot be set before FortCanningSpringHeight");
                     }

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -253,6 +253,18 @@ class EVMTest(DefiTestFramework):
         # Check setting vars before height
         assert_raises_rpc_error(
             -32600,
+            "Cannot be set before NextNetworkUpgradeHeight",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/params/feature/evm": "true"}}
+        )
+        assert_raises_rpc_error(
+            -32600,
+            "Cannot be set before NextNetworkUpgradeHeight",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/params/feature/transferdomain": "true"}}
+        )
+        assert_raises_rpc_error(
+            -32600,
             "called before NextNetworkUpgrade height",
             self.nodes[0].evmtx,
             self.eth_address,

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -255,13 +255,13 @@ class EVMTest(DefiTestFramework):
             -32600,
             "Cannot be set before NextNetworkUpgradeHeight",
             self.nodes[0].setgov,
-            {"ATTRIBUTES": {"v0/params/feature/evm": "true"}}
+            {"ATTRIBUTES": {"v0/params/feature/evm": "true"}},
         )
         assert_raises_rpc_error(
             -32600,
             "Cannot be set before NextNetworkUpgradeHeight",
             self.nodes[0].setgov,
-            {"ATTRIBUTES": {"v0/params/feature/transferdomain": "true"}}
+            {"ATTRIBUTES": {"v0/params/feature/transferdomain": "true"}},
         )
         assert_raises_rpc_error(
             -32600,

--- a/test/functional/feature_evm_logs.py
+++ b/test/functional/feature_evm_logs.py
@@ -11,6 +11,7 @@ from test_framework.evm_contract import EVMContract
 from test_framework.evm_key_pair import EvmKeyPair
 from web3._utils.events import get_event_data
 
+
 class EVMTestLogs(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -189,7 +189,6 @@ class EVMRolllbackTest(DefiTestFramework):
     def run_test(self):
         self.setup()
 
-
         self.nodes[0].transferdomain(
             [
                 {

--- a/test/functional/feature_evm_transaction_replacement.py
+++ b/test/functional/feature_evm_transaction_replacement.py
@@ -138,7 +138,8 @@ class EVMTest(DefiTestFramework):
             -32001,
             "lower fee as existing mempool entry",
             self.send_transaction,
-            gasPrices[0], count
+            gasPrices[0],
+            count,
         )
 
         self.nodes[0].generate(1)

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -908,10 +908,12 @@ class EVMTest(DefiTestFramework):
         self.valid_transfer_dvm_evm()
 
         balance = self.nodes[0].eth_getBalance(self.eth_address)
-        assert_equal(balance, "0x56bc75e2d63100000") # 100 DFI
-        erc55_address = self.nodes[0].getnewaddress('', 'erc55')
+        assert_equal(balance, "0x56bc75e2d63100000")  # 100 DFI
+        erc55_address = self.nodes[0].getnewaddress("", "erc55")
 
-        tx1 = self.nodes[0].evmtx(self.eth_address, 0, 21, 21001, erc55_address, 50) # Spend half balance
+        tx1 = self.nodes[0].evmtx(
+            self.eth_address, 0, 21, 21001, erc55_address, 50
+        )  # Spend half balance
 
         # Transfer 100 DFI from EVM to DVM
         tx2 = transfer_domain(
@@ -947,7 +949,8 @@ class EVMTest(DefiTestFramework):
 
         self.valid_transfer_to_evm_then_move_then_back_to_dvm()
 
-        self.invalid_transfer_evm_dvm_after_evm_tx() # TODO assert behaviour here. transferdomain shouldn't be kept in mempool since its nonce will never be valid
+        self.invalid_transfer_evm_dvm_after_evm_tx()  # TODO assert behaviour here. transferdomain shouldn't be kept in mempool since its nonce will never be valid
+
 
 if __name__ == "__main__":
     EVMTest().main()

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -395,7 +395,11 @@ class VMMapTests(DefiTestFramework):
         tx = self.nodes[0].transferdomain(
             [
                 {
-                    "src": {"address": self.ethAddress, "amount": "100@DFI", "domain": 3},
+                    "src": {
+                        "address": self.ethAddress,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
                     "dst": {
                         "address": self.address,
                         "amount": "100@DFI",


### PR DESCRIPTION
- Prevents setting of EVM or transfer domain Governance variables before the fork height.
- Also removes conditional OR checks on attrV0->key which could pick up unrelated keys, these should have been conditional AND checks but are all redundant as it was enough to check against the attrV0->typeId being the only type these keys were used with anyway.
- Also runs fmt-py on all Python tests.