### PR TITLE
tests: fix multiple failing tests based on recent changes

### DIFF
--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -1997,6 +1997,11 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                     if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
                         return DeFiErrors::GovVarValidateFortCanningRoad();
                     }
+                    if (attrV0->key == DFIPKeys::StartBlock) {
+                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
+                            return Res::Err("Cannot be set before FortCanningSpringHeight");
+                        }
+                    }
                 } else if (attrV0->typeId != ParamIDs::DFIP2201) {
                     return Res::Err("Unrecognised param id");
                 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -552,7 +552,14 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     if (pcustomcsview) {
         accountsViewDirty |= forceRebuildForReorg;
         CTransactionRef ptx{};
-        rebuildAccountsView(nMemPoolHeight, &::ChainstateActive().CoinsTip(), ptx);
+
+        CCoinsView dummy;
+        CCoinsViewCache view(&dummy);
+        CCoinsViewCache& coins_cache = ::ChainstateActive().CoinsTip();
+        CCoinsViewMemPool viewMemPool(&coins_cache, *this);
+        view.SetBackend(viewMemPool);
+
+        rebuildAccountsView(nMemPoolHeight, view, ptx);
     }
 }
 
@@ -619,7 +626,14 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     if (pcustomcsview) {
         accountsViewDirty |= forceRebuildForReorg;
         CTransactionRef ptx{};
-        rebuildAccountsView(nBlockHeight, &::ChainstateActive().CoinsTip(), ptx);
+
+        CCoinsView dummy;
+        CCoinsViewCache view(&dummy);
+        CCoinsViewCache& coins_cache = ::ChainstateActive().CoinsTip();
+        CCoinsViewMemPool viewMemPool(&coins_cache, *this);
+        view.SetBackend(viewMemPool);
+
+        rebuildAccountsView(nBlockHeight, view, ptx);
     }
 
     lastRollingFeeUpdate = GetTime();


### PR DESCRIPTION
Fixes the following failing tests:

```
feature_account_mining.py                              | ✖ Failed  | 3 s
feature_auth_return_change.py                          | ✖ Failed  | 2 s
feature_consortium.py                                  | ✖ Failed  | 7 s
feature_prevent_bad_tx_propagation.py                  | ✖ Failed  | 2 s
feature_setgov.py                                      | ✖ Failed  | 15 s
mempool_packages.py                                    | ✖ Failed  | 3 s
mempool_resurrect.py                                   | ✖ Failed  | 2 s
rpc_updatemasternode.py                                | ✖ Failed  | 13 s
wallet_balance.py                                      | ✖ Failed  | 12 s
```