### PR TITLE
EVM: Shift transferdomain transparent tx into the correct attribute

### DIFF
--- a/src/masternodes/errors.h
+++ b/src/masternodes/errors.h
@@ -518,6 +518,14 @@ public:
         return Res::Err("TransferDomain currently only supports a single transfer per transaction");
     }
 
+    static Res TransferDomainSmartContractSourceAddress() {
+        return Res::Err("TransferDomain EVM source is a smart contract");
+    }
+
+    static Res TransferDomainSmartContractDestAddress() {
+        return Res::Err("TransferDomain EVM destination is a smart contract");
+    }
+
     static Res SettingEVMAttributeFailure() {
         return Res::Err("Failed to set EVM attribute");
     }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -2153,7 +2153,11 @@ UniValue transferdomain(const JSONRPCRequest& request) {
 
             std::vector<uint8_t> evmTx(signedTx.size());
             std::copy(signedTx.begin(), signedTx.end(), evmTx.begin());
-            dst.data = evmTx;
+            if (isEVMIn) {
+                dst.data = evmTx;
+            } else {
+                src.data = evmTx;
+            }
 
             msg.transfers.push_back({src, dst});
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -630,7 +630,15 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
         if (obj.transfers.size() != 1) {
             return false;
         }
-        auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, HexStr(obj.transfers[0].second.data));
+
+        std::string evmTx = "";
+        if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
+            evmTx = HexStr(obj.transfers[0].second.data);
+        }
+        else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
+            evmTx = HexStr(obj.transfers[0].first.data);
+        }
+        auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, evmTx);
         if (!result.ok) {
             return false;
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1304,7 +1304,15 @@ Res CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCach
                     }
                     continue;
                 }
-                auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, HexStr(obj.transfers[0].second.data));
+
+                std::string evmTx = "";
+                if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
+                    evmTx = HexStr(obj.transfers[0].second.data);
+                }
+                else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
+                    evmTx = HexStr(obj.transfers[0].first.data);
+                }
+                auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, evmTx);
                 if (!result.ok) {
                     if (newTxLoop) {
                         newEntryRes = Res::Err(result.reason.c_str());

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -736,7 +736,6 @@ class EVMTest(DefiTestFramework):
             tx, self.evm_key_pair.privkey
         )
         hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
-
         self.nodes[0].generate(1)
 
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -775,7 +775,9 @@ class EVMTest(DefiTestFramework):
                 "gas": 1_000_000,
             }
         )
-        signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
+        signed = self.nodes[0].w3.eth.account.sign_transaction(
+            tx, self.evm_key_pair.privkey
+        )
         self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
 
         contract_address = web3.utils.get_create_address(


### PR DESCRIPTION
## Summary

- Shift the transferdomain transparent raw evm tx into the TransferDomainItem source data attribute for DVM-to-EVM edge, and inside the TransferDomainItem destination data attribute for the EVM-to-DVM edge.
- Better refactor TransferDomainMessage consensus pipeline, add more checks to safeguard transferdomain validation checks


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
