### PR TITLE
EVM: Add validation pipeline for transferdomain transparent tx, fix failing EVM tests

### DIFF
--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -155,12 +155,14 @@ pub mod ffi {
             queue_id: u64,
             raw_tx: &str,
             native_hash: &str,
+            pre_validate: bool,
         );
         fn evm_unsafe_try_sub_balance_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             raw_tx: &str,
             native_hash: &str,
+            pre_validate: bool,
         ) -> bool;
         fn evm_unsafe_try_validate_raw_tx_in_q(
             result: &mut CrossBoundaryResult,
@@ -230,6 +232,7 @@ pub mod ffi {
             native_hash: &str,
             token_id: u64,
             out: bool,
+            pre_validate: bool,
         );
         fn evm_try_is_dst20_deployed_or_queued(
             result: &mut CrossBoundaryResult,

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -228,13 +228,13 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             // Add balance to ERC55 address
             auto tokenId = dst.amount.nTokenId;
             if (tokenId == DCT_ID{0}) {
-                evm_unsafe_try_add_balance_in_q(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex());
+                evm_unsafe_try_add_balance_in_q(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex(), evmPreValidate);
                 if (!result.ok) {
                     return Res::Err("Error bridging DFI: %s", result.reason);
                 }
             }
             else {
-                evm_try_bridge_dst20(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex(), tokenId.v, true);
+                evm_try_bridge_dst20(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex(), tokenId.v, true, evmPreValidate);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }
@@ -270,7 +270,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             // Subtract balance from ERC55 address
             auto tokenId = dst.amount.nTokenId;
             if (tokenId == DCT_ID{0}) {
-                if (!evm_unsafe_try_sub_balance_in_q(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex())) {
+                if (!evm_unsafe_try_sub_balance_in_q(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex(), evmPreValidate)) {
                     return DeFiErrors::TransferDomainNotEnoughBalance(EncodeDestination(dest));
                 }
                 if (!result.ok) {
@@ -278,7 +278,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 }
             }
             else {
-                evm_try_bridge_dst20(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex(), tokenId.v, false);
+                evm_try_bridge_dst20(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex(), tokenId.v, false, evmPreValidate);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }

--- a/test/functional/feature_dst20.py
+++ b/test/functional/feature_dst20.py
@@ -552,7 +552,7 @@ class DST20(DefiTestFramework):
         assert_equal(
             self.btc.functions.totalSupply().call()
             / math.pow(10, self.btc.functions.decimals().call()),
-            Decimal(5.5),
+            Decimal(3.5),
         )
         [afterAmount] = [x for x in self.node.getaccount(self.address) if "BTC" in x]
         assert_equal(beforeAmount, afterAmount)
@@ -595,32 +595,6 @@ class DST20(DefiTestFramework):
                     "dst": {"address": self.address, "amount": "1@XYZ", "domain": 2},
                 }
             ],
-        )
-
-    def test_transfer_to_token_address(self):
-        self.nodes[0].transferdomain(
-            [
-                {
-                    "src": {"address": self.address, "amount": "2@BTC", "domain": 2},
-                    "dst": {
-                        "address": self.contract_address_btc,
-                        "amount": "2@BTC",
-                        "domain": 3,
-                    },
-                }
-            ]
-        )
-        self.node.generate(1)
-
-        assert_equal(
-            self.btc.functions.balanceOf(self.contract_address_btc).call()
-            / math.pow(10, self.btc.functions.decimals().call()),
-            Decimal(2),
-        )
-        assert_equal(
-            self.btc.functions.totalSupply().call()
-            / math.pow(10, self.btc.functions.decimals().call()),
-            Decimal(5.5),
         )
 
     def test_negative_transfer(self):
@@ -869,7 +843,6 @@ class DST20(DefiTestFramework):
         self.test_multiple_dvm_evm_bridge()
         self.test_conflicting_bridge()
         self.test_invalid_token()
-        self.test_transfer_to_token_address()
         self.test_bridge_when_no_balance()
         self.test_negative_transfer()
         self.test_different_tokens()

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -761,49 +761,6 @@ class EVMTest(DefiTestFramework):
             ],
         )
 
-    def invalid_transfer_sc_mempool(self):
-        abi, bytecode, _ = EVMContract.from_file("Reverter.sol", "Reverter").compile()
-        compiled = self.nodes[0].w3.eth.contract(abi=abi, bytecode=bytecode)
-        nonce = self.nodes[0].w3.eth.get_transaction_count(self.evm_key_pair.address)
-
-        tx = compiled.constructor().build_transaction(
-            {
-                "chainId": self.nodes[0].w3.eth.chain_id,
-                "nonce": nonce,
-                "maxFeePerGas": 10_000_000_000,
-                "maxPriorityFeePerGas": 1_500_000_000,
-                "gas": 1_000_000,
-            }
-        )
-        signed = self.nodes[0].w3.eth.account.sign_transaction(
-            tx, self.evm_key_pair.privkey
-        )
-        self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
-
-        contract_address = web3.utils.get_create_address(
-            self.evm_key_pair.address, nonce
-        )
-
-        assert_raises_rpc_error(
-            -32600,
-            "EVM destination is a smart contract",
-            self.nodes[0].transferdomain,
-            [
-                {
-                    "src": {
-                        "address": self.address,
-                        "amount": "1@DFI",
-                        "domain": 2,
-                    },
-                    "dst": {
-                        "address": contract_address,
-                        "amount": "1@DFI",
-                        "domain": 3,
-                    },
-                }
-            ],
-        )
-
     def invalid_transfer_no_auth(self):
         assert_raises_rpc_error(
             -5,
@@ -1052,7 +1009,6 @@ class EVMTest(DefiTestFramework):
 
         # Transfer to smart contract
         self.invalid_transfer_sc()
-        self.invalid_transfer_sc_mempool()
 
         # Invalid authorisation
         self.invalid_transfer_no_auth()


### PR DESCRIPTION
## Summary

- Add pipeline to validate raw evm tx specific for transferdomain txs
- Include pre-validation pipeline for transferdomain txs to validate the transferdomain tx without a context
- Fixes to all failing evm tests.
1. feature_dst20.py - test_transfer_to_token_address is now incorrect and removed in this PR since we block transfer of DFI to smart contract addresses.
2. feature_evm_transferdomain.py - invalid_transfer_sc_mempool test is incorrect and removed since RPC will not be able to invalidate the tx as it is using the state of the current tip, thus the test is removed and invalid_transfer_sc test should be sufficient to test for invalidating transfers to sc addresses.

## RPCs

<!-- Please remove section if deemed to be empty -->
- 

## Flags

<!-- Please remove section if deemed to be empty -->
- 

## Protocol

<!-- Please remove section if deemed to be empty -->
- 

## Storage

<!-- Please remove section if deemed to be empty -->
- 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
