### PR TITLE
EVM: Add optional nonce parameter for transfer domain RPC

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -216,7 +216,6 @@ impl EVMCoreService {
         tx: &str,
         queue_id: u64,
         pre_validate: bool,
-        test_tx: bool,
     ) -> Result<ValidateTxInfo> {
         debug!("[validate_raw_tx] queue_id {}", queue_id);
         debug!("[validate_raw_tx] raw transaction : {:#?}", tx);
@@ -333,11 +332,9 @@ impl EVMCoreService {
             .get_total_gas_used_in(queue_id)
             .unwrap_or_default();
 
-        if !test_tx {
-            let block_gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
-            if total_current_gas_used + U256::from(used_gas) > U256::from(block_gas_limit) {
-                return Err(format_err!("Tx can't make it in block. Block size limit {}, pending block gas used : {:x?}, tx used gas : {:x?}, total : {:x?}", block_gas_limit, total_current_gas_used, U256::from(used_gas), total_current_gas_used + U256::from(used_gas)).into());
-            }
+        let block_gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
+        if total_current_gas_used + U256::from(used_gas) > U256::from(block_gas_limit) {
+            return Err(format_err!("Tx can't make it in block. Block size limit {}, pending block gas used : {:x?}, tx used gas : {:x?}, total : {:x?}", block_gas_limit, total_current_gas_used, U256::from(used_gas), total_current_gas_used + U256::from(used_gas)).into());
         }
 
         Ok(ValidateTxInfo {

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -503,7 +503,6 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
     queue_id: u64,
     raw_tx: &str,
     pre_validate: bool,
-    test_tx: bool,
 ) -> ffi::ValidateTxMiner {
     debug!("[evm_unsafe_try_validate_raw_tx_in_q]");
     match SERVICES.evm.verify_tx_fees(raw_tx) {
@@ -517,7 +516,7 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
         match SERVICES
             .evm
             .core
-            .validate_raw_tx(raw_tx, queue_id, pre_validate, test_tx)
+            .validate_raw_tx(raw_tx, queue_id, pre_validate)
         {
             Ok(ValidateTxInfo {
                 signed_tx,

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -235,11 +235,16 @@ pub fn evm_try_create_and_sign_transfer_domain_tx(
             }
         }
     };
-    let Ok(nonce) = SERVICES.evm.get_nonce(from_address, state_root) else {
-        return cross_boundary_error_return(
-            result,
-            format!("Could not get nonce for {from_address:x?}"),
-        );
+    let nonce = if ctx.use_nonce {
+        U256::from(ctx.nonce)
+    } else {
+        let Ok(nonce) = SERVICES.evm.get_nonce(from_address, state_root) else {
+            return cross_boundary_error_return(
+                result,
+                format!("Could not get nonce for {from_address:x?}"),
+            );
+        };
+        nonce
     };
 
     let t = LegacyUnsignedTransaction {

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -43,8 +43,8 @@ pub mod ffi {
 
     #[derive(Default)]
     pub struct TxSenderInfo {
-        address: String,
-        nonce: u64,
+        pub address: String,
+        pub nonce: u64,
     }
 
     // ========== Governance Variable ==========
@@ -99,6 +99,8 @@ pub mod ffi {
         pub chain_id: u64,
         pub priv_key: [u8; 32],
         pub queue_id: u64,
+        pub use_nonce: bool,
+        pub nonce: u64,
     }
 
     #[derive(Default)]

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -171,7 +171,6 @@ pub mod ffi {
             queue_id: u64,
             raw_tx: &str,
             pre_validate: bool,
-            test_tx: bool,
         ) -> ValidateTxMiner;
         fn evm_unsafe_try_push_tx_in_q(
             result: &mut CrossBoundaryResult,

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -183,7 +183,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough, 
         // that it's propagated.
         uint64_t gasUsed{};
-        auto res = ApplyCustomTx(discardCache, inputs, tx, chainparams.GetConsensus(), nSpendHeight, gasUsed, 0, &canSpend, 0, 0, false);
+        auto res = ApplyCustomTx(discardCache, inputs, tx, chainparams.GetConsensus(), nSpendHeight, gasUsed, 0, &canSpend, 0, 0, false, false);
         if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {
             return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-customtx", res.msg);
         }

--- a/src/masternodes/consensus/txvisitor.cpp
+++ b/src/masternodes/consensus/txvisitor.cpp
@@ -63,8 +63,7 @@ CCustomTxVisitor::CCustomTxVisitor(const CTransaction &tx,
                                    const uint64_t evmQueueId,
                                    const bool isEvmEnabledForBlock,
                                    uint64_t &gasUsed,
-                                   const bool evmPreValidate,
-                                   const bool testTx)
+                                   const bool evmPreValidate)
         : height(height),
           mnview(mnview),
           tx(tx),
@@ -75,8 +74,7 @@ CCustomTxVisitor::CCustomTxVisitor(const CTransaction &tx,
           evmQueueId(evmQueueId),
           isEvmEnabledForBlock(isEvmEnabledForBlock),
           gasUsed(gasUsed),
-          evmPreValidate(evmPreValidate),
-          testTx(testTx) {}
+          evmPreValidate(evmPreValidate) {}
 
 Res CCustomTxVisitor::HasAuth(const CScript &auth) const {
     return ::HasAuth(tx, coins, auth);

--- a/src/masternodes/consensus/txvisitor.h
+++ b/src/masternodes/consensus/txvisitor.h
@@ -54,7 +54,6 @@ protected:
     bool isEvmEnabledForBlock;
     uint64_t &gasUsed;
     bool evmPreValidate;
-    bool testTx;
 
 public:
     CCustomTxVisitor(const CTransaction &tx,
@@ -67,8 +66,7 @@ public:
                      const uint64_t evmQueueId,
                      const bool isEvmEnabledForBlock,
                      uint64_t &gasUsed,
-                     const bool evmPreValidate,
-                     const bool testTx);
+                     const bool evmPreValidate);
 
 protected:
     Res HasAuth(const CScript &auth) const;

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -327,7 +327,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Err("evm tx size too large");
 
     CrossBoundaryResult result;
-    auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), evmPreValidate, testTx);
+    auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), evmPreValidate);
     if (!result.ok) {
         LogPrintf("[evm_try_validate_raw_tx] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to validate %s", result.reason);

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -175,7 +175,8 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                   uint256 *canSpend,
                   uint32_t txn,
                   const uint64_t evmQueueId,
-                  const bool isEvmEnabledForBlock);
+                  const bool isEvmEnabledForBlock,
+                  const bool evmPreValidate);
 
 Res CustomTxVisit(CCustomCSView &mnview,
                   const CCoinsViewCache &coins,
@@ -188,8 +189,7 @@ Res CustomTxVisit(CCustomCSView &mnview,
                   const uint32_t txn,
                   const uint64_t evmQueueId,
                   const bool isEvmEnabledForBlock,
-                  const bool evmPreValidate,
-                  const bool testTx);
+                  const bool evmPreValidate);
 
 
 ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -459,7 +459,7 @@ void execTestTx(const CTransaction& tx, uint32_t height, CTransactionRef optAuth
         auto consensus = Params().GetConsensus();
         auto isEvmEnabledForBlock = IsEVMEnabled(height, view, consensus);
         uint64_t gasUsed{};
-        res = CustomTxVisit(view, coins, tx, height, consensus, txMessage, ::ChainActive().Tip()->nTime, gasUsed, 0, 0, isEvmEnabledForBlock, true, true);
+        res = CustomTxVisit(view, coins, tx, height, consensus, txMessage, ::ChainActive().Tip()->nTime, gasUsed, 0, 0, isEvmEnabledForBlock, true);
     }
     if (!res) {
         if (res.code == CustomTxErrCodes::NotEnoughBalance) {
@@ -1132,7 +1132,6 @@ static UniValue clearmempool(const JSONRPCRequest& request)
         LOCK(mempool.cs);
         mempool.queryHashes(vtxid);
         mempool.clear();
-        mempool.wipeEvmQueueId();
     }
 
     {

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -2019,7 +2019,7 @@ UniValue transferdomain(const JSONRPCRequest& request) {
                                             // {"data", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Optional data"},
                                         },
                                     },
-                                    {"nonce", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Transaction nonce"},
+                                    {"nonce", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Optional parameter to specify the transaction nonce"},
                                 },
                             },
                         },
@@ -2051,11 +2051,11 @@ UniValue transferdomain(const JSONRPCRequest& request) {
     try {
         for (unsigned int i=0; i < srcDstArray.size(); i++) {
             const UniValue& elem = srcDstArray[i];
-            RPCTypeCheck(elem, {UniValue::VOBJ, UniValue::VOBJ}, false);
+            RPCTypeCheck(elem, {UniValue::VOBJ, UniValue::VOBJ, UniValue::VNUM}, false);
 
             const UniValue& srcObj = elem["src"].get_obj();
             const UniValue& dstObj = elem["dst"].get_obj();
-            const UniValue& nonceObj = elem["nonce"].get_obj();
+            const UniValue& nonceObj = elem["nonce"];
 
             CTransferDomainItem src, dst;
 

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -2138,7 +2138,10 @@ UniValue transferdomain(const JSONRPCRequest& request) {
             std::string   from = ScriptToString(script);
 
             CrossBoundaryResult result;
-            auto evmQueueId = mempool.getEvmQueueId();
+            auto evmQueueId = evm_unsafe_try_create_queue(result);
+            if (!result.ok) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Unable to create EVM queue");
+            }
             uint64_t nonce = 0;
             bool useNonce = !nonceObj.isNull();
             if (useNonce) {
@@ -2158,6 +2161,11 @@ UniValue transferdomain(const JSONRPCRequest& request) {
                                                                                                                  });
             if (!result.ok) {
                 throw JSONRPCError(RPC_MISC_ERROR, strprintf("Failed to create and sign TX: %s", result.reason.c_str()));
+            }
+
+            evm_unsafe_try_remove_queue(result, evmQueueId);
+            if (!result.ok) {
+                throw JSONRPCError(RPC_MISC_ERROR, "Unable to destroy EVM queue");
             }
 
             std::vector<uint8_t> evmTx(signedTx.size());

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -608,7 +608,7 @@ UniValue getcustomtx(const JSONRPCRequest& request)
         auto isEvmEnabledForBlock = IsEVMEnabled(nHeight, mnview, consensus);
 
         uint64_t gasUsed{};
-        auto res = ApplyCustomTx(mnview, view, *tx, consensus, nHeight, gasUsed, 0, nullptr, 0, 0, isEvmEnabledForBlock);
+        auto res = ApplyCustomTx(mnview, view, *tx, consensus, nHeight, gasUsed, 0, nullptr, 0, 0, isEvmEnabledForBlock, false);
 
         result.pushKV("valid", res.ok);
     } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -40,14 +40,34 @@
 #include <random>
 #include <utility>
 
+struct EvmPackageContext {
+    // Used to track EVM TX fee and TX hash by sender and nonce.
+    std::map<EvmAddressWithNonce, std::pair<uint64_t, uint256>> evmFeeMap;
+    // Quick lookup for EVM fee map
+    using EVMFeeMapIterator = std::map<EvmAddressWithNonce, std::pair<uint64_t, uint256>>::iterator;
+    std::map<uint256, EVMFeeMapIterator> feeMapLookup{};
+    // Quick lookup for mempool time order map
+    using TimeMapIterator = std::multimap<int64_t, CTxMemPool::txiter>::iterator;
+    std::map<uint256, TimeMapIterator> timeOrderLookup{};
+    // Keep track of EVM entries that failed nonce check
+    std::multimap<uint64_t, CTxMemPool::txiter> failedNonces;
+    // Used for replacement Eth TXs ordered by time and nonce
+    std::map<std::pair<uint64_t, uint64_t>, CTxMemPool::txiter> replaceByFee;
+    // Variable to tally total gas used in the block
+    uint64_t totalGas{};
+    // Used to track gas fees of EVM TXs
+    std::map<uint256, uint64_t> evmGasFees;
+};
+
 struct EvmTxPreApplyContext {
     CTxMemPool::txiter& txIter;
     std::vector<unsigned char>& txMetadata;
     CustomTxType txType;
     int height;
     uint64_t evmQueueId;
-    std::multimap<uint64_t, CTxMemPool::txiter> &failedNonces;
-    CTxMemPool::setEntries& failedTxSet;
+    EvmPackageContext& pkgCtx;
+    std::set<uint256>& checkedTXEntries;
+    CTxMemPool::setEntries& failedTxEntries;
 };
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
@@ -598,13 +618,19 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::ve
 
 bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
 {
-    auto txMessage = customTypeToMessage(ctx.txType);
+    auto& txType = ctx.txType;
+    auto txMessage = customTypeToMessage(txType);
     auto& txIter = ctx.txIter;
     auto& evmQueueId = ctx.evmQueueId;
     auto& metadata = ctx.txMetadata;
     auto& height = ctx.height;
-    auto& failedNonces = ctx.failedNonces;
-    auto& failedTxSet = ctx.failedTxSet;
+    auto& checkedDfTxHashSet = ctx.checkedTXEntries;
+    auto& failedTxSet = ctx.failedTxEntries;
+    auto& pkgCtx = ctx.pkgCtx;
+    auto& failedNonces = pkgCtx.failedNonces;
+    auto& replaceByFee = pkgCtx.replaceByFee;
+    auto& totalGas = pkgCtx.totalGas;
+    auto& timeOrderLookup = pkgCtx.timeOrderLookup;
 
     if (!CustomMetadataParse(height, Params().GetConsensus(), metadata, txMessage)) {
         return false;
@@ -614,15 +640,14 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
     ValidateTxMiner txResult;
     if (ctx.txType == CustomTxType::EvmTx) {
         const auto obj = std::get<CEvmTxMessage>(txMessage);
-        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), true, false);
+        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), true);
         if (!result.ok) {
             return false;
         }
-        if (txResult.higher_nonce && !failedTxSet.count(txIter)) {
-            failedNonces.emplace(txResult.nonce, txIter);
-        }
-        if (txResult.higher_nonce || txResult.lower_nonce) {
-            failedTxSet.insert(txIter);
+        if (txResult.higher_nonce) {
+            if (!failedTxSet.count(txIter)) {
+                failedNonces.emplace(txResult.nonce, txIter);
+            }
             return false;
         }
     } else if (ctx.txType == CustomTxType::TransferDomain) {
@@ -631,7 +656,7 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
             return false;
         }
 
-        std::string evmTx = "";
+        std::string evmTx;
         if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
             evmTx = HexStr(obj.transfers[0].second.data);
         }
@@ -642,20 +667,94 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
         if (!result.ok) {
             return false;
         }
-        const auto nonce = evm_unsafe_try_get_next_valid_nonce_in_q(result, evmQueueId, senderInfo.address);
-        if (!result.ok || nonce > senderInfo.nonce) {
+        const auto expectedNonce = evm_unsafe_try_get_next_valid_nonce_in_q(result, evmQueueId, senderInfo.address);
+        if (!result.ok) {
             return false;
         }
-        if (nonce < senderInfo.nonce) {
+        if (senderInfo.nonce < expectedNonce) { // Pays 0 so cannot be RBF
+            return false;
+        } else if (senderInfo.nonce > expectedNonce) {
             if (!failedTxSet.count(txIter)) {
                 failedNonces.emplace(senderInfo.nonce, txIter);
             }
-            failedTxSet.insert(txIter);
             return false;
         }
+        txResult.nonce = senderInfo.nonce;
+        txResult.sender = senderInfo.address;
+        txResult.prepay_fee = 0;
+        txResult.higher_nonce = false;
+        txResult.lower_nonce = false;
     } else {
         return false;
     }
+
+    auto& evmFeeMap = pkgCtx.evmFeeMap;
+    auto& feeMapLookup = pkgCtx.feeMapLookup;
+
+    const std::string txResultSender{txResult.sender.data(), txResult.sender.length()};
+    const EvmAddressWithNonce addrKey{txResult.nonce, txResultSender};
+
+    if (const auto feeEntry = evmFeeMap.find(addrKey); feeEntry != evmFeeMap.end()) {
+        // Key already exists. We check to see if we need to prioritize higher fee tx
+        const auto& [lastFee, prevHash] = feeEntry->second;
+        if (txResult.prepay_fee > lastFee) {
+            // Higher paying fee. Remove all TXs above the TX to be replaced.
+            auto hashes = evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, prevHash.ToString());
+            if (!result.ok) {
+                return Res::Err("%s: Unable to remove TXs from queue\n", __func__);
+            }
+
+            // Set of TXs to remove from the block
+            CTxMemPool::setEntries txsForRemoval;
+
+            // Loop through hashes of removed TXs and remove from block.
+            for (const auto &rustStr : hashes) {
+                const auto txHash = uint256S(std::string{rustStr.data(), rustStr.length()});
+
+                // Check fee map entry and get nonce
+                assert(feeMapLookup.count(txHash));
+                auto it = feeMapLookup.at(txHash);
+                auto &[nonce, hash] = it->first;
+
+                // Check TX time order entry and get time and TX
+                assert(timeOrderLookup.count(txHash));
+                const auto &timeIt = timeOrderLookup.at(txHash);
+                const auto& [txTime, transaction] = *timeIt;
+
+                // Add entry to removal set
+                txsForRemoval.insert(transaction);
+
+                // Reduce fee
+                totalGas -= transaction->GetFee();
+
+                // This is the entry to be replaced
+                if (prevHash == txHash) {
+                    replaceByFee.emplace(std::make_pair(txTime, nonce), txIter);
+                } else { // Add in previous mempool entry
+                    replaceByFee.emplace(std::make_pair(txTime, nonce), transaction);
+                }
+
+                // Remove from checked entries
+                checkedDfTxHashSet.erase(txHash);
+
+                // Remove replace fee entries
+                evmFeeMap.erase(feeMapLookup.at(txHash));
+                feeMapLookup.erase(txHash);
+            }
+
+            RemoveFromBlock(txsForRemoval, true);
+        }
+
+        return false;
+    }
+
+    // If not RBF for a mempool TX then return false
+    if (txResult.lower_nonce) {
+        return false;
+    }
+
+    auto feeMapRes = evmFeeMap.emplace(addrKey, std::make_pair(txResult.prepay_fee, txIter->GetTx().GetHash()));
+    feeMapLookup.emplace(txIter->GetTx().GetHash(), feeMapRes.first);
 
     return true;
 }
@@ -698,13 +797,13 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
     // Copy of the view
     CCoinsViewCache coinsView(&::ChainstateActive().CoinsTip());
 
-    // Keep track of EVM entries that failed nonce check
-    std::multimap<uint64_t, CTxMemPool::txiter> failedNonces;
+    // Track mempool time order
+    std::multimap<int64_t, CTxMemPool::txiter> mempoolTimeOrder{};
 
-    // Track total gas used in the block
-    uint64_t totalGas{};
+    // EVM related context for this package
+    EvmPackageContext evmPackageContext;
 
-    while (mi != mempool.mapTx.get<T>().end() || !mapModifiedTxSet.empty() || !failedNonces.empty()) {
+    while (mi != mempool.mapTx.get<T>().end() || !mapModifiedTxSet.empty() || !evmPackageContext.failedNonces.empty() || !evmPackageContext.replaceByFee.empty()) {
         // First try to find a new transaction in mapTx to evaluate.
         if (mi != mempool.mapTx.get<T>().end() &&
             SkipMapTxEntry(mempool.mapTx.project<0>(mi), mapModifiedTxSet, failedTxSet)) {
@@ -716,8 +815,19 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
         // the next entry from mapTx, or the best from mapModifiedTxSet?
         bool fUsingModified = false;
 
+        auto& replaceByFee = evmPackageContext.replaceByFee;
+
+        // Check whether we are using Eth replaceByFee
+        bool usingReplaceByFee = !replaceByFee.empty();
+
         modtxscoreiter modit = mapModifiedTxSet.get<ancestor_score>().begin();
-        if (mi == mempool.mapTx.get<T>().end() && mapModifiedTxSet.empty()) {
+        if (!replaceByFee.empty()) {
+            const auto it = replaceByFee.begin();
+            iter = it->second;
+            replaceByFee.erase(it);
+            usingReplaceByFee = true;
+        } else if (mi == mempool.mapTx.get<T>().end() && mapModifiedTxSet.empty()) {
+            auto& failedNonces = evmPackageContext.failedNonces;
             const auto it = failedNonces.begin();
             iter = it->second;
             failedNonces.erase(it);
@@ -740,6 +850,8 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                 // Increment mi for the next loop iteration.
                 ++mi;
             }
+            auto timeIt = mempoolTimeOrder.emplace(iter->GetTime(), iter);
+            evmPackageContext.timeOrderLookup.emplace(iter->GetTx().GetHash(), timeIt);
         }
 
         // We skip mapTx entries that are inBlock, and mapModifiedTxSet shouldn't
@@ -839,20 +951,22 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                         txType,
                         nHeight,
                         evmQueueId,
-                        failedNonces,
-                        failedTxSet
+                        evmPackageContext,
+                        checkedDfTxHashSet,
+                        failedTxSet,
                     };
                     auto res = EvmTxPreapply(evmTxCtx);
                     if (res) {
                         customTxPassed = true;
                     } else {
+                        failedTxSet.insert(sortedEntries[i]);
                         customTxPassed = false;
                         break;
                     }
                 }
 
                 uint64_t gasUsed{};
-                const auto res = ApplyCustomTx(view, coins, tx, chainparams.GetConsensus(), nHeight, gasUsed, pblock->nTime, nullptr, 0, evmQueueId, isEvmEnabledForBlock);
+                const auto res = ApplyCustomTx(view, coins, tx, chainparams.GetConsensus(), nHeight, gasUsed, pblock->nTime, nullptr, 0, evmQueueId, isEvmEnabledForBlock, false);
                 // Not okay invalidate, undo and skip
                 if (!res.ok) {
                     customTxPassed = false;
@@ -860,11 +974,13 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                     break;
                 }
 
-                if (totalGas + gasUsed > MAX_BLOCK_GAS_LIMIT) {
+                evmPackageContext.evmGasFees.emplace(tx.GetHash(), gasUsed);
+
+                if (evmPackageContext.totalGas + gasUsed > MAX_BLOCK_GAS_LIMIT) {
                     customTxPassed = false;
                     break;
                 }
-                totalGas += gasUsed;
+                evmPackageContext.totalGas += gasUsed;
 
                 // Track checked TXs to avoid double applying
                 checkedDfTxHashSet.insert(tx.GetHash());
@@ -876,6 +992,10 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
         if (!customTxPassed) {
             if (fUsingModified) {
                 mapModifiedTxSet.get<ancestor_score>().erase(modit);
+            }
+            if (usingReplaceByFee) {
+                // TX failed in chain so remove the rest of the items
+                replaceByFee.clear();
             }
             failedTxSet.insert(iter);
             continue;

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
         uint64_t gasUsed{};
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_EQUAL(res.code, (uint32_t) CustomTxErrCodes::NotEnoughBalance);
         // check that nothing changes:
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, gasUsed, 0, nullptr, 0, 0, false, false);
         BOOST_CHECK(res.ok);
         // check result balances:
         auto const dfi90 = CTokenAmount{DFI, 90};

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -564,7 +564,6 @@ private:
     bool accountsViewDirty;
     bool forceRebuildForReorg;
     std::unique_ptr<CCustomCSView> acview;
-    uint64_t evmQueueId{};
 
     static void AddToStaged(setEntries &staged, std::vector<CTransactionRef> &vtx, const CTransactionRef tx, std::map<uint256, CTxMemPool::txiter> &mempoolIterMap);
 public:
@@ -723,11 +722,10 @@ public:
     boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
 
     CCustomCSView& accountsView();
-    Res rebuildAccountsView(int height, const CCoinsViewCache& coinsCache, const CTransactionRef& ptx, const int64_t time = 0);
+    void rebuildAccountsView(int height, const CCoinsViewCache& coinsCache);
     void setAccountViewDirty();
     bool getAccountViewDirty() const;
-    uint64_t getEvmQueueId();
-    void wipeEvmQueueId();
+
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the

--- a/test/functional/feature_dst20.py
+++ b/test/functional/feature_dst20.py
@@ -446,6 +446,7 @@ class DST20(DefiTestFramework):
         assert_equal(amountBTC, "9.50000000@BTC")
 
     def test_multiple_dvm_evm_bridge(self):
+        nonce = self.nodes[0].w3.eth.get_transaction_count(self.erc55_address)
         self.nodes[0].transferdomain(
             [
                 {
@@ -455,6 +456,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "nonce": nonce,
                 }
             ]
         )
@@ -467,6 +469,7 @@ class DST20(DefiTestFramework):
                         "amount": "2@BTC",
                         "domain": 3,
                     },
+                    "nonce": nonce + 1,
                 }
             ]
         )
@@ -517,7 +520,9 @@ class DST20(DefiTestFramework):
 
         [afterAmount] = [x for x in self.node.getaccount(self.address) if "BTC" in x]
         assert_equal(
-            self.btc.functions.balanceOf(self.key_pair2.address).call(), Decimal(0)
+            self.btc.functions.balanceOf(self.key_pair2.address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
         )
         assert_equal(
             self.btc.functions.totalSupply().call()
@@ -749,6 +754,7 @@ class DST20(DefiTestFramework):
         self.node = self.nodes[0]
         self.w0 = self.node.w3
         self.address = self.node.get_genesis_keys().ownerAuthAddress
+        self.erc55_address = self.node.addressmap(self.address, 1)["format"]["erc55"]
 
         # Contract addresses
         self.contract_address_usdt = self.w0.to_checksum_address(

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -809,7 +809,6 @@ class EVMTest(DefiTestFramework):
         tx2 = self.nodes[0].evmtx(self.eth_address, 2, 21, 21001, self.to_address, 1)
         tx1 = self.nodes[0].evmtx(self.eth_address, 1, 21, 21001, self.to_address, 1)
         tx3 = self.nodes[0].evmtx(self.eth_address, 3, 21, 21001, self.to_address, 1)
-        raw_tx = self.nodes[0].getrawtransaction(tx5)
         self.sync_mempools()
 
         # Check the pending TXs
@@ -952,11 +951,6 @@ class EVMTest(DefiTestFramework):
                 "0xa382aa9f70f15bd0bf70e838f5ac0163e2501dbff2712e9622275e655e42ec1c",
                 "0x05d4cdabc4ad55fb7caf42a7fb6d4e8cea991e2331cd9d98a5eef10d84b5c994",
             ],
-        )
-
-        # Try and send EVM TX a second time
-        assert_raises_rpc_error(
-            -26, "Nonce lower than expected", self.nodes[0].sendrawtransaction, raw_tx
         )
 
     def validate_xvm_coinbase(self):
@@ -1130,62 +1124,13 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].evmtx(self.eth_address, 65, 22, 21001, self.to_address, 1)
         self.nodes[0].evmtx(self.eth_address, 65, 23, 21001, self.to_address, 1)
         tx0 = self.nodes[0].evmtx(self.eth_address, 65, 25, 21001, self.to_address, 1)
-        assert_raises_rpc_error(
-            -26,
-            "Rejected due to same or lower fee as existing mempool entry",
-            self.nodes[0].evmtx,
-            self.eth_address,
-            65,
-            21,
-            21001,
-            self.to_address,
-            1,
-        )
-        assert_raises_rpc_error(
-            -26,
-            "Rejected due to same or lower fee as existing mempool entry",
-            self.nodes[0].evmtx,
-            self.eth_address,
-            65,
-            24,
-            21001,
-            self.to_address,
-            1,
-        )
+        self.nodes[0].evmtx(self.eth_address, 65, 21, 21001, self.to_address, 1)
+        self.nodes[0].evmtx(self.eth_address, 65, 24, 21001, self.to_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 22, 21001, self.eth_address, 1)
         self.nodes[0].evmtx(self.to_address, 0, 23, 21001, self.eth_address, 1)
         tx1 = self.nodes[0].evmtx(self.to_address, 0, 25, 21001, self.eth_address, 1)
-        assert_raises_rpc_error(
-            -26,
-            "Rejected due to same or lower fee as existing mempool entry",
-            self.nodes[0].evmtx,
-            self.to_address,
-            0,
-            21,
-            21001,
-            self.eth_address,
-            1,
-        )
-        assert_raises_rpc_error(
-            -26,
-            "Rejected due to same or lower fee as existing mempool entry",
-            self.nodes[0].evmtx,
-            self.to_address,
-            0,
-            24,
-            21001,
-            self.eth_address,
-            1,
-        )
-
-        # Check mempool only contains two entries
-        assert_equal(
-            sorted(self.nodes[0].getrawmempool()),
-            [
-                "2b13a48b2af32206a2d60d535ad46d4958c25b4ddd4c30f3a2da32f092c23916",
-                "6a6b53538b66e0eb477ce923901e6fa1714c4f52a83f8f1793c92c14ebc0f910",
-            ],
-        )
+        self.nodes[0].evmtx(self.to_address, 0, 21, 21001, self.eth_address, 1)
+        self.nodes[0].evmtx(self.to_address, 0, 24, 21001, self.eth_address, 1)
         self.nodes[0].generate(1)
 
         # Check accounting of EVM fees

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -87,7 +87,7 @@ class EVMRolllbackTest(DefiTestFramework):
         blockPreInvalidation = self.nodes[0].eth_getBlockByNumber(
             blockNumberPreInvalidation
         )
-        assert_equal(blockNumberPreInvalidation, "0x2")
+        assert_equal(blockNumberPreInvalidation, "0x3")
         assert_equal(blockPreInvalidation["number"], blockNumberPreInvalidation)
 
         self.nodes[0].invalidateblock(initialBlockHash)
@@ -101,7 +101,7 @@ class EVMRolllbackTest(DefiTestFramework):
         blockByHash = self.nodes[0].eth_getBlockByHash(blockPreInvalidation["hash"])
         assert_equal(blockByHash, None)
         block = self.nodes[0].eth_getBlockByNumber("latest")
-        assert_equal(block["number"], "0x1")
+        assert_equal(block["number"], "0x2")
 
         self.nodes[0].reconsiderblock(initialBlockHash)
         blockNumber = self.nodes[0].eth_blockNumber()
@@ -160,7 +160,7 @@ class EVMRolllbackTest(DefiTestFramework):
         blockPreInvalidation = self.nodes[0].eth_getBlockByNumber(
             blockNumberPreInvalidation
         )
-        assert_equal(blockNumberPreInvalidation, "0x3")
+        assert_equal(blockNumberPreInvalidation, "0x4")
         assert_equal(blockPreInvalidation["number"], blockNumberPreInvalidation)
 
         txPreInvalidation = self.nodes[0].eth_getTransactionByHash(hash)
@@ -201,6 +201,8 @@ class EVMRolllbackTest(DefiTestFramework):
                 }
             ]
         )
+        self.nodes[0].generate(1)
+
         self.nodes[0].transferdomain(
             [
                 {

--- a/test/functional/feature_evm_transaction_replacement.py
+++ b/test/functional/feature_evm_transaction_replacement.py
@@ -120,27 +120,20 @@ class EVMTest(DefiTestFramework):
 
     def should_prioritize_transaction_with_the_higher_gas_price(self):
         gasPrices = [
-            "0x2540be400",
             "0x2540be401",
-            "0x2540be402",
-            "0x2540be403",
+            "0x2540be400",
             "0x2540be404",
-            "0x2540be405",
             "0x2540be406",
+            "0x2540be401",
             "0x2540be407",
+            "0x2540be402",
+            "0x2540be405",
+            "0x2540be403",
         ]
 
         count = self.nodes[0].eth_getTransactionCount(self.ethAddress)
         for gasPrice in gasPrices:
             self.send_transaction(gasPrice, count)
-
-        assert_raises_rpc_error(
-            -32001,
-            "lower fee as existing mempool entry",
-            self.send_transaction,
-            gasPrices[0],
-            count,
-        )
 
         self.nodes[0].generate(1)
 
@@ -150,8 +143,8 @@ class EVMTest(DefiTestFramework):
 
     def should_replace_pending_transaction_0(self):
         gasPrices = [
-            "0x2540be400",
             "0x2540be401",
+            "0x2540be400",
             # '0x2540be404',
             # '0x2540be406',
             # '0x2540be401',
@@ -221,9 +214,9 @@ class EVMTest(DefiTestFramework):
         gasPrices = [
             # '0x2540be401',
             "0x2540be400",
-            "0x2540be401",
             "0x2540be404",
             "0x2540be406",
+            "0x2540be401",
             # '0x2540be407',
             # '0x2540be402',
             # '0x2540be405',

--- a/test/functional/rpc_mn_basic.py
+++ b/test/functional/rpc_mn_basic.py
@@ -140,7 +140,7 @@ class MasternodesRpcBasicTest(DefiTestFramework):
         fundingTx = self.nodes[0].sendtoaddress(collateral0, 1)
         self.nodes[0].generate(1)
         # resignTx
-        self.nodes[0].resignmasternode(idnode0)
+        resignTx = self.nodes[0].resignmasternode(idnode0)
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].listmasternodes()[idnode0]["state"], "PRE_RESIGNED")
         self.nodes[0].generate(10)
@@ -167,12 +167,9 @@ class MasternodesRpcBasicTest(DefiTestFramework):
         self.sync_blocks(self.nodes[0:2])
 
         # Check that collateral spending tx was deleted
-        # print ("CreateTx", idnode0)
-        # print ("ResignTx", resignTx)
-        # print ("FundingTx", fundingTx)
-        # print ("SpendTx", sendedTxHash)
-        # resignTx is removed for a block
-        assert_equal(self.nodes[0].getrawmempool(), [fundingTx])
+        assert_equal(
+            sorted(self.nodes[0].getrawmempool()), sorted([resignTx, fundingTx])
+        )
         assert_equal(self.nodes[0].listmasternodes()[idnode0]["state"], "ENABLED")
 
         # Revert creation!


### PR DESCRIPTION
## Summary

- Add feature in include optional parameter to transferdomain RPC to specify the transparent tx nonce
- This enables users to send multiple transferdomain txs to be minted in the same EVM block
- Fixes to failing feature_dst20.py test
- Depends on PR #2449 


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
