### PR TITLE
Restore legacy minter info

### DIFF
--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -430,7 +430,7 @@ class BlockchainTest(DefiTestFramework):
         assert_equal(genesis["strippedsize"], 1288)
         assert_equal(genesis["weight"], 5152)
         assert_equal(genesis["height"], 0)
-        assert genesis["masternode"]
+        assert "masternode" not in genesis
         assert_equal(genesis["mintedBlocks"], 0)
         assert_equal(
             genesis["stakeModifier"],


### PR DESCRIPTION
Restores the behaviour found in release 3.8.5 and before when printing out minter information for blocks. The previous behaviour can be found in the link below. This prevents masternode being printed in the genesis block, also regardless of a valid MN ID both mintedBlocks and stakeModifier should be added as these are based on the on block index.

https://github.com/DeFiCh/ain/blob/5786fb81d9d679a12ee5cc6d516581af03468c25/src/rpc/blockchain.cpp#L137