### PR TITLE
EVM: Fix and cleanup validation evm tx pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -192,7 +192,7 @@ impl EVMCoreService {
     /// 3. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
     /// 4. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
     /// 5. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
-    /// 
+    ///
     /// The validation checks with state context of the tx before we consider it to be valid are:
     /// 1. Nonce check: Returns flag if nonce is lower or higher than the current state account nonce.
     /// 2. Execute the tx with the state root from the txqueue.
@@ -330,7 +330,9 @@ impl EVMCoreService {
                 .unwrap_or_default();
 
             let block_gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
-            if total_current_gas_used + U256::from(tx_response.used_gas) > U256::from(block_gas_limit) {
+            if total_current_gas_used + U256::from(tx_response.used_gas)
+                > U256::from(block_gas_limit)
+            {
                 return Err(format_err!("Tx can't make it in block. Block size limit {}, pending block gas used : {:x?}, tx used gas : {:x?}, total : {:x?}", block_gas_limit, total_current_gas_used, U256::from(tx_response.used_gas), total_current_gas_used + U256::from(tx_response.used_gas)).into());
             }
         }

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -186,21 +186,24 @@ impl EVMCoreService {
 
     /// Validates a raw tx.
     ///
-    /// The validation checks of the tx before we consider it to be valid are:
-    /// 1. Account nonce check: verify that the tx nonce must equal to the account nonce (for validation)
-    /// 2. Gas price check: verify that the maximum gas price is minimally of the block initial base fee.
-    /// 3. Gas price and tx value check: verify that amount is within money range.
-    /// 4. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
-    /// 5. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
-    /// 6. Verify if tx nonce is greater or less than current account nonce.
-    /// 7. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// The pre-validation checks of the tx before we consider it to be valid are:
+    /// 1. Gas price check: verify that the maximum gas price is minimally of the block initial base fee.
+    /// 2. Gas price and tx value check: verify that amount is within money range.
+    /// 3. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
+    /// 4. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
+    /// 5. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
+    /// 
+    /// The validation checks with state context of the tx before we consider it to be valid are:
+    /// 1. Nonce check: Returns flag if nonce is lower or higher than the current state account nonce.
+    /// 2. Execute the tx with the state root from the txqueue.
+    /// 3. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// 4. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
     ///
     /// # Arguments
     ///
     /// * `tx` - The raw tx.
     /// * `queue_id` - The queue_id queue number.
     /// * `pre_validate` - Validate the raw tx with or without state context.
-    /// * `test_tx` - Test the validity of the raw transaction with block context.
     ///
     /// # Returns
     ///
@@ -226,7 +229,7 @@ impl EVMCoreService {
         let state_root = self.tx_queues.get_latest_state_root_in(queue_id)?;
         debug!("[validate_raw_tx] state_root : {:#?}", state_root);
 
-        let backend = self.get_backend(state_root)?;
+        let mut backend = self.get_backend(state_root)?;
 
         let signed_tx: SignedTx = tx.try_into()?;
         let nonce = backend.get_nonce(&signed_tx.sender);
@@ -239,15 +242,6 @@ impl EVMCoreService {
             signed_tx.nonce()
         );
         debug!("[validate_raw_tx] nonce : {:#?}", nonce);
-
-        if !pre_validate && nonce != signed_tx.nonce() {
-            return Err(format_err!(
-                "Invalid nonce. Account nonce {}, signed_tx nonce {}",
-                nonce,
-                signed_tx.nonce()
-            )
-            .into());
-        }
 
         // Validate tx gas price with initial block base fee
         let tx_gas_price = signed_tx.gas_price();
@@ -276,65 +270,69 @@ impl EVMCoreService {
         let prepay_fee = calculate_prepay_gas_fee(&signed_tx)?;
         debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
 
-        // Should be queued for now and don't go through VM validation
-        match signed_tx.nonce().cmp(&nonce) {
-            Ordering::Greater => {
-                return Ok(ValidateTxInfo {
-                    signed_tx,
-                    prepay_fee,
-                    higher_nonce: true,
-                    lower_nonce: false,
-                });
+        if pre_validate {
+            // Validate tx nonce
+            if nonce > signed_tx.nonce() {
+                return Err(format_err!(
+                    "Invalid nonce. Account nonce {}, signed_tx nonce {}",
+                    nonce,
+                    signed_tx.nonce()
+                )
+                .into());
             }
-            Ordering::Less => {
-                return Ok(ValidateTxInfo {
-                    signed_tx,
-                    prepay_fee,
-                    higher_nonce: false,
-                    lower_nonce: true,
-                });
+
+            return Ok(ValidateTxInfo {
+                signed_tx,
+                prepay_fee,
+                higher_nonce: false,
+                lower_nonce: false,
+            });
+        } else {
+            // Should be queued for now and don't go through VM validation
+            match signed_tx.nonce().cmp(&nonce) {
+                Ordering::Greater => {
+                    return Ok(ValidateTxInfo {
+                        signed_tx,
+                        prepay_fee,
+                        higher_nonce: true,
+                        lower_nonce: false,
+                    });
+                }
+                Ordering::Less => {
+                    return Ok(ValidateTxInfo {
+                        signed_tx,
+                        prepay_fee,
+                        higher_nonce: false,
+                        lower_nonce: true,
+                    });
+                }
+                _ => {}
             }
-            _ => {}
-        }
 
-        // Validate tx prepay fees with account balance
-        let balance = backend.get_balance(&signed_tx.sender);
-        debug!("[validate_raw_tx] Account balance : {:x?}", balance);
+            // Execute tx
+            let mut executor = AinExecutor::new(&mut backend);
+            let (tx_response, ..) = executor.exec(&signed_tx, prepay_fee);
 
-        if balance < prepay_fee {
-            debug!("[validate_raw_tx] insufficient balance to pay fees");
-            return Err(format_err!("insufficient balance to pay fees").into());
-        }
+            // Validate tx prepay fees with account balance
+            let balance = backend.get_balance(&signed_tx.sender);
+            debug!("[validate_raw_tx] Account balance : {:x?}", balance);
 
-        // Get previous block number
-        let prev_block_number = self
-            .tx_queues
-            .get_target_block_in(queue_id)?
-            .saturating_sub(U256::one());
+            if balance < prepay_fee {
+                debug!("[validate_raw_tx] insufficient balance to pay fees");
+                return Err(format_err!("insufficient balance to pay fees").into());
+            }
 
-        let TxResponse { used_gas, .. } = self.call(EthCallArgs {
-            caller: Some(signed_tx.sender),
-            to: signed_tx.to(),
-            value: signed_tx.value(),
-            data: signed_tx.data(),
-            gas_limit: signed_tx.gas_limit().as_u64(),
-            access_list: signed_tx.access_list(),
-            block_number: prev_block_number,
-            gas_price: Some(tx_gas_price),
-            max_fee_per_gas: signed_tx.max_fee_per_gas(),
-            transaction_type: Some(signed_tx.get_tx_type()),
-        })?;
+            // Validate total gas usage in queued txs exceeds block size
+            debug!("[validate_raw_tx] used_gas: {:#?}", tx_response.used_gas);
+            let total_current_gas_used = self
+                .tx_queues
+                .get_total_gas_used_in(queue_id)
+                .unwrap_or_default();
 
-        // Validate total gas usage in queued txs exceeds block size
-        debug!("[validate_raw_tx] used_gas: {:#?}", used_gas);
-        let total_current_gas_used = self
-            .tx_queues
-            .get_total_gas_used_in(queue_id)
-            .unwrap_or_default();
-
-        let block_gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
-        if total_current_gas_used + U256::from(used_gas) > U256::from(block_gas_limit) {
-            return Err(format_err!("Tx can't make it in block. Block size limit {}, pending block gas used : {:x?}, tx used gas : {:x?}, total : {:x?}", block_gas_limit, total_current_gas_used, U256::from(used_gas), total_current_gas_used + U256::from(used_gas)).into());
+            let block_gas_limit = self.storage.get_attributes_or_default()?.block_gas_limit;
+            if total_current_gas_used + U256::from(tx_response.used_gas) > U256::from(block_gas_limit) {
+                return Err(format_err!("Tx can't make it in block. Block size limit {}, pending block gas used : {:x?}, tx used gas : {:x?}, total : {:x?}", block_gas_limit, total_current_gas_used, U256::from(tx_response.used_gas), total_current_gas_used + U256::from(tx_response.used_gas)).into());
+            }
         }
 
         Ok(ValidateTxInfo {
@@ -347,7 +345,7 @@ impl EVMCoreService {
 
     /// Validates a raw transfer domain tx.
     ///
-    /// The validation checks of the tx before we consider it to be valid are:
+    /// The pre-validation checks of the tx before we consider it to be valid are:
     /// 1. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
     /// 2. tx value check: verify that amount is set to zero.
     /// 3. Verify that transaction action is a call to the transferdomain contract address.

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -468,11 +468,7 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
 ) -> ffi::ValidateTxCompletion {
     debug!("[evm_unsafe_try_prevalidate_raw_tx_in_q]");
     unsafe {
-        match SERVICES
-            .evm
-            .core
-            .validate_raw_tx(raw_tx, queue_id, true)
-        {
+        match SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id, true) {
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
@@ -546,11 +542,7 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
         }
     }
     unsafe {
-        match SERVICES
-            .evm
-            .core
-            .validate_raw_tx(raw_tx, queue_id, false)
-        {
+        match SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id, false) {
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -156,11 +156,15 @@ pub mod ffi {
             raw_tx: &str,
             native_hash: &str,
         ) -> bool;
+        fn evm_unsafe_try_prevalidate_raw_tx_in_q(
+            result: &mut CrossBoundaryResult,
+            queue_id: u64,
+            raw_tx: &str,
+        ) -> ValidateTxCompletion;
         fn evm_unsafe_try_validate_raw_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             raw_tx: &str,
-            pre_validate: bool,
         ) -> ValidateTxCompletion;
         fn evm_unsafe_try_validate_transferdomain_tx_in_q(
             result: &mut CrossBoundaryResult,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -117,14 +117,6 @@ pub mod ffi {
         pub sender: String,
         pub tx_hash: String,
         pub prepay_fee: u64,
-    }
-
-    #[derive(Default)]
-    pub struct ValidateTxMiner {
-        pub nonce: u64,
-        pub sender: String,
-        pub tx_hash: String,
-        pub prepay_fee: u64,
         pub higher_nonce: bool,
         pub lower_nonce: bool,
     }
@@ -157,21 +149,24 @@ pub mod ffi {
             queue_id: u64,
             raw_tx: &str,
             native_hash: &str,
-            pre_validate: bool,
         );
         fn evm_unsafe_try_sub_balance_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             raw_tx: &str,
             native_hash: &str,
-            pre_validate: bool,
         ) -> bool;
         fn evm_unsafe_try_validate_raw_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             raw_tx: &str,
             pre_validate: bool,
-        ) -> ValidateTxMiner;
+        ) -> ValidateTxCompletion;
+        fn evm_unsafe_try_validate_transferdomain_tx_in_q(
+            result: &mut CrossBoundaryResult,
+            queue_id: u64,
+            raw_tx: &str,
+        );
         fn evm_unsafe_try_push_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
@@ -233,7 +228,6 @@ pub mod ffi {
             native_hash: &str,
             token_id: u64,
             out: bool,
-            pre_validate: bool,
         );
         fn evm_try_is_dst20_deployed_or_queued(
             result: &mut CrossBoundaryResult,

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -351,7 +351,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
     CrossBoundaryResult result;
     ValidateTxCompletion validateResults;
     if (evmPreValidate) {
-        validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), true);
+        validateResults = evm_unsafe_try_prevalidate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
         if (!result.ok) {
             LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
             return Res::Err("evm tx failed to pre-validate %s", result.reason);
@@ -359,7 +359,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Ok();
     }
 
-    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), false);
+    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
     if (validateResults.higher_nonce) {
         return Res::Ok();
     }

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -211,7 +211,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractDestAddress();
             }
 
-            auto hash = evm_try_get_tx_hash(result, HexStr(dst.data));
+            const auto evmTx = HexStr(dst.data);
+            auto hash = evm_try_get_tx_hash(result, evmTx);
             if (!result.ok) {
                 return Res::Err("Error bridging DFI: %s", result.reason);
             }
@@ -227,14 +228,24 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
 
             // Add balance to ERC55 address
             auto tokenId = dst.amount.nTokenId;
+            evm_unsafe_try_validate_transferdomain_tx_in_q(result, evmQueueId, evmTx);
+            if (!result.ok) {
+                LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
+                return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
+            }
+
+            if (evmPreValidate) {
+                return Res::Ok();
+            }
+
             if (tokenId == DCT_ID{0}) {
-                evm_unsafe_try_add_balance_in_q(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex(), evmPreValidate);
+                evm_unsafe_try_add_balance_in_q(result, evmQueueId, evmTx, tx.GetHash().GetHex());
                 if (!result.ok) {
                     return Res::Err("Error bridging DFI: %s", result.reason);
                 }
             }
             else {
-                evm_try_bridge_dst20(result, evmQueueId, HexStr(dst.data), tx.GetHash().GetHex(), tokenId.v, true, evmPreValidate);
+                evm_try_bridge_dst20(result, evmQueueId, evmTx, tx.GetHash().GetHex(), tokenId.v, true);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }
@@ -261,7 +272,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractSourceAddress();
             }
 
-            auto hash = evm_try_get_tx_hash(result, HexStr(src.data));
+            const auto evmTx = HexStr(src.data);
+            auto hash = evm_try_get_tx_hash(result, evmTx);
             if (!result.ok) {
                 return Res::Err("Error bridging DFI: %s", result.reason);
             }
@@ -269,8 +281,18 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
 
             // Subtract balance from ERC55 address
             auto tokenId = dst.amount.nTokenId;
+            evm_unsafe_try_validate_transferdomain_tx_in_q(result, evmQueueId, evmTx);
+            if (!result.ok) {
+                LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
+                return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
+            }
+
+            if (evmPreValidate) {
+                return Res::Ok();
+            }
+
             if (tokenId == DCT_ID{0}) {
-                if (!evm_unsafe_try_sub_balance_in_q(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex(), evmPreValidate)) {
+                if (!evm_unsafe_try_sub_balance_in_q(result, evmQueueId, evmTx, tx.GetHash().GetHex())) {
                     return DeFiErrors::TransferDomainNotEnoughBalance(EncodeDestination(dest));
                 }
                 if (!result.ok) {
@@ -278,7 +300,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 }
             }
             else {
-                evm_try_bridge_dst20(result, evmQueueId, HexStr(src.data), tx.GetHash().GetHex(), tokenId.v, false, evmPreValidate);
+                evm_try_bridge_dst20(result, evmQueueId, evmTx, tx.GetHash().GetHex(), tokenId.v, false);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }
@@ -327,13 +349,24 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Err("evm tx size too large");
 
     CrossBoundaryResult result;
-    auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), evmPreValidate);
-    if (!result.ok) {
-        LogPrintf("[evm_try_validate_raw_tx] failed, reason : %s\n", result.reason);
-        return Res::Err("evm tx failed to validate %s", result.reason);
+    ValidateTxCompletion validateResults;
+    if (evmPreValidate) {
+        validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), true);
+        if (!result.ok) {
+            LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
+            return Res::Err("evm tx failed to pre-validate %s", result.reason);
+        }
+        return Res::Ok();
     }
+
+    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), false);
     if (validateResults.higher_nonce) {
         return Res::Ok();
+    }
+
+    if (!result.ok) {
+        LogPrintf("[evm_try_validate_raw_tx_in_q] failed, reason : %s\n", result.reason);
+        return Res::Err("evm tx failed to validate %s\n", result.reason);
     }
 
     evm_unsafe_try_push_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), tx.GetHash().GetHex());

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -637,10 +637,10 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
     }
 
     CrossBoundaryResult result;
-    ValidateTxMiner txResult;
+    ValidateTxCompletion txResult;
     if (ctx.txType == CustomTxType::EvmTx) {
         const auto obj = std::get<CEvmTxMessage>(txMessage);
-        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), true);
+        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), false);
         if (!result.ok) {
             return false;
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -640,7 +640,7 @@ bool BlockAssembler::EvmTxPreapply(const EvmTxPreApplyContext& ctx)
     ValidateTxCompletion txResult;
     if (ctx.txType == CustomTxType::EvmTx) {
         const auto obj = std::get<CEvmTxMessage>(txMessage);
-        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), false);
+        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
         if (!result.ok) {
             return false;
         }

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -221,7 +221,7 @@ class EVMFeeTest(DefiTestFramework):
 
         assert_raises_rpc_error(
             -32001,
-            "evm tx failed to validate gas limit is below the minimum gas per tx",
+            "evm tx failed to pre-validate gas limit is below the minimum gas per tx",
             self.nodes[0].eth_sendTransaction,
             {
                 "from": self.ethAddress,
@@ -242,7 +242,7 @@ class EVMFeeTest(DefiTestFramework):
 
         assert_raises_rpc_error(
             -32001,
-            "evm tx failed to validate gas limit higher than max_gas_per_block",
+            "evm tx failed to pre-validate gas limit higher than max_gas_per_block",
             self.nodes[0].eth_sendTransaction,
             {
                 "from": self.ethAddress,

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -131,7 +131,7 @@ class EVMFeeTest(DefiTestFramework):
 
         assert_raises_rpc_error(
             -32001,
-            "tx gas price is lower than block base fee",
+            "evm tx failed to pre-validate tx gas price is lower than initial block base fee",
             self.nodes[0].eth_sendTransaction,
             {
                 "from": self.ethAddress,


### PR DESCRIPTION
## Summary

- Cleanup pre-validation and validation evmtx pipelines
- Pre-validation of evm transactions should be stateless checks to verify evm transactions
- Validation pipeline implements state checks using state root of the tx queue
- Fix fee verification pipeline to be only inside validation of evm tx check. This PR will resolve the issue of txs being rejected from the mempool due to fees being lower than the next block fees, when the correct behaviour is that it should accept the tx if the evm tx is valid on pre-validation (tx fee has to be minimally of initial block base fee.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [x] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
