### PR TITLE
Add fast EVM RBF to mempool

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -345,6 +345,11 @@ impl EVMCoreService {
         })
     }
 
+    pub fn calculate_prepay_gas_fee(&self, signed_tx: &SignedTx) -> Result<U256> {
+        let result = calculate_prepay_gas_fee(&signed_tx)?;
+        Ok(result)
+    }
+
     /// Validates a raw transfer domain tx.
     ///
     /// The pre-validation checks of the tx before we consider it to be valid are:

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -1136,11 +1136,20 @@ pub fn evm_try_get_tx_sender_info_from_raw_tx(
         return cross_boundary_error_return(result, "nonce value overflow");
     };
 
+    let Ok(prepay_fee) = SERVICES.evm.core.calculate_prepay_gas_fee(&signed_tx) else {
+        return cross_boundary_error_return(result, "failed to get fee from transaction");
+    };
+
+    let Ok(prepay_fee) = u64::try_from(prepay_fee) else {
+        return cross_boundary_error_return(result, "prepay fee value overflow");
+    };
+
     cross_boundary_success_return(
         result,
         TxSenderInfo {
             nonce,
             address: format!("{:?}", signed_tx.sender),
+            prepay_fee,
         },
     )
 }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -45,6 +45,7 @@ pub mod ffi {
     pub struct TxSenderInfo {
         pub address: String,
         pub nonce: u64,
+        pub prepay_fee: u64,
     }
 
     // ========== Governance Variable ==========

--- a/src/miner.h
+++ b/src/miner.h
@@ -222,7 +222,7 @@ private:
       * of updated descendants. */
     int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
     /** Run EVM transaction checks */
-    bool EvmTxPreapply(const EvmTxPreApplyContext& ctx);
+    bool EvmTxPreapply(EvmTxPreApplyContext& ctx);
 };
 
 /** Modify the extranonce in a block */

--- a/test/functional/feature_evm_transaction_replacement.py
+++ b/test/functional/feature_evm_transaction_replacement.py
@@ -121,19 +121,25 @@ class EVMTest(DefiTestFramework):
     def should_prioritize_transaction_with_the_higher_gas_price(self):
         gasPrices = [
             "0x2540be401",
-            "0x2540be400",
-            "0x2540be404",
-            "0x2540be406",
-            "0x2540be401",
-            "0x2540be407",
             "0x2540be402",
-            "0x2540be405",
             "0x2540be403",
+            "0x2540be404",
+            "0x2540be405",
+            "0x2540be406",
+            "0x2540be407",
         ]
 
         count = self.nodes[0].eth_getTransactionCount(self.ethAddress)
         for gasPrice in gasPrices:
             self.send_transaction(gasPrice, count)
+
+        assert_raises_rpc_error(
+            -32001,
+            "evm-low-fee",
+            self.send_transaction,
+            gasPrices[0],
+            count,
+        )
 
         self.nodes[0].generate(1)
 
@@ -143,8 +149,8 @@ class EVMTest(DefiTestFramework):
 
     def should_replace_pending_transaction_0(self):
         gasPrices = [
-            "0x2540be401",
             "0x2540be400",
+            "0x2540be401",
             # '0x2540be404',
             # '0x2540be406',
             # '0x2540be401',
@@ -214,9 +220,9 @@ class EVMTest(DefiTestFramework):
         gasPrices = [
             # '0x2540be401',
             "0x2540be400",
+            "0x2540be401",
             "0x2540be404",
             "0x2540be406",
-            "0x2540be401",
             # '0x2540be407',
             # '0x2540be402',
             # '0x2540be405',

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -977,9 +977,16 @@ class EVMTest(DefiTestFramework):
             self.eth_address, 0, 21, 21001, erc55_address, 50
         )  # Spend half balance
 
-        # Transfer 100 DFI from EVM to DVM
-        tx2 = transfer_domain(
-            self.nodes[0], self.eth_address, self.address, "100@DFI", 3, 2
+        assert_raises_rpc_error(
+            -26,
+            "evm-low-fee",
+            transfer_domain,
+            self.nodes[0],
+            self.eth_address,
+            self.address,
+            "100@DFI",
+            3,
+            2,
         )
         self.nodes[0].generate(1)
 
@@ -987,9 +994,6 @@ class EVMTest(DefiTestFramework):
         assert_equal(len(block["transactions"]), 1)
         evm_tx = self.nodes[0].vmmap(tx1, 0)["output"]
         assert_equal(block["transactions"][0], evm_tx)
-
-        mempool = self.nodes[0].getrawmempool()
-        assert_equal([tx2], mempool)
 
     def run_test(self):
         self.setup()


### PR DESCRIPTION
- Adds the following to the CTxMemPoolEntry
  - EvmAddressWithNonce
  - CustomTxType
  - EVM Prepay Fee
- Adds to the mempool multi-index an order by EvmAddressWithNonce

Using these two when a new TX goes to enter the mempool we can look up any existing entires with EvmAddressWithNonce and check against the existing prepay fee. If the new fee is more then we will replace the existing entry.

When removing entries from the mempool we do not rebuild the attached account view as this would incur a performance cost on each transfer domain transaction. It is likely sufficient to suffer an imperfect attached account view which would not have the transfers in the transfer domains transaction removed. The account view will be rebuilt on each new block so this state should not be in place for long.