### PR TITLE
Mempool RBF improvements

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1169,6 +1169,9 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry) {
     auto& addressNonceIndex = mapTx.get<address_and_nonce>();
     auto range = addressNonceIndex.equal_range(pendingEntry.GetEVMAddrAndNonce());
 
+    CTxMemPool::setEntries itersToRemove;
+    std::set<CTransactionRef> txsToRemove;
+
     auto result{true};
 
     for (auto it = range.first; it != range.second; ++it) {
@@ -1177,9 +1180,9 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry) {
         if (pendingEntry.GetEVMPrePayFee() > entry.GetEVMPrePayFee()) {
             if (entry.GetCustomTxType() == CustomTxType::EvmTx) {
                 auto txIter = mapTx.project<0>(it);
-                removeUnchecked(txIter, MemPoolRemovalReason::REPLACED);
+                itersToRemove.insert(txIter);
             } else {
-                removeRecursive(entry.GetTx(), MemPoolRemovalReason::REPLACED);
+                txsToRemove.insert(entry.GetSharedTx());
             }
 
             // We might want to set accountsViewDirty to true here but
@@ -1190,6 +1193,14 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry) {
         } else {
             result = false;
         }
+    }
+
+    for (const auto& txIter : itersToRemove) {
+        removeUnchecked(txIter, MemPoolRemovalReason::REPLACED);
+    }
+
+    for (const auto& tx : txsToRemove) {
+        removeRecursive(*tx, MemPoolRemovalReason::REPLACED);
     }
 
     return result;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -356,6 +356,7 @@ struct descendant_score {};
 struct entry_time {};
 struct ancestor_score {};
 struct address_and_nonce {};
+struct txid_tag {};
 
 class CBlockPolicyEstimator;
 
@@ -501,7 +502,11 @@ public:
         CTxMemPoolEntry,
         boost::multi_index::indexed_by<
             // sorted by txid
-            boost::multi_index::hashed_unique<mempoolentry_txid, SaltedTxidHasher>,
+            boost::multi_index::hashed_unique<
+                boost::multi_index::tag<txid_tag>,
+                mempoolentry_txid,
+                SaltedTxidHasher
+            >,
             // sorted by fee rate
             boost::multi_index::ordered_non_unique<
                 boost::multi_index::tag<descendant_score>,

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -483,7 +483,8 @@ class EVMTest(DefiTestFramework):
             ]
         )
         self.nodes[0].evmtx(self.ethAddress, nonce, 21, 21001, self.toAddress, 1)
-        self.nodes[0].evmtx(self.ethAddress, nonce, 30, 21001, self.toAddress, 1)
+        tx = self.nodes[0].evmtx(self.ethAddress, nonce, 30, 21001, self.toAddress, 1)
+        assert_equal(self.nodes[0].getrawmempool(), [tx])
         self.nodes[0].generate(1)
         block_height = self.nodes[0].getblockcount()
         assert_equal(block_height, self.start_height + 1)

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -466,6 +466,28 @@ class EVMTest(DefiTestFramework):
             block_info["tx"][0]["vm"]["xvmHeader"]["gasUsed"], correct_gas_used
         )
 
+    def same_nonce_transferdomain_and_evm_txs(self):
+        self.rollback_to(self.start_height)
+        nonce = self.nodes[0].w3.eth.get_transaction_count(self.ethAddress)
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.ethAddress, "amount": "1@DFI", "domain": 3},
+                    "dst": {
+                        "address": self.address,
+                        "amount": "1@DFI",
+                        "domain": 2,
+                    },
+                    "nonce": nonce,
+                }
+            ]
+        )
+        self.nodes[0].evmtx(self.ethAddress, nonce, 21, 21001, self.toAddress, 1)
+        tx = self.nodes[0].evmtx(self.ethAddress, nonce, 30, 21001, self.toAddress, 1)
+        self.nodes[0].generate(1)
+        block_height = self.nodes[0].getblockcount()
+        assert_equal(block_height, self.start_height + 1)
+
     def run_test(self):
         self.setup()
 
@@ -477,6 +499,9 @@ class EVMTest(DefiTestFramework):
 
         # Test for block size overflow from fee mismatch between tx queue and block
         self.state_dependent_txs_in_block_and_queue()
+
+        # Test for transferdomain and evmtx with same nonce
+        self.same_nonce_transferdomain_and_evm_txs()
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -483,7 +483,7 @@ class EVMTest(DefiTestFramework):
             ]
         )
         self.nodes[0].evmtx(self.ethAddress, nonce, 21, 21001, self.toAddress, 1)
-        tx = self.nodes[0].evmtx(self.ethAddress, nonce, 30, 21001, self.toAddress, 1)
+        self.nodes[0].evmtx(self.ethAddress, nonce, 30, 21001, self.toAddress, 1)
         self.nodes[0].generate(1)
         block_height = self.nodes[0].getblockcount()
         assert_equal(block_height, self.start_height + 1)


### PR DESCRIPTION
- Remove entries from the mempool after iterating over the matching EVM sender and nonce entries.
- When removing transfer domain TXs remove any auto auth TX if present.