### PR TITLE
Always fail bad nonce on validation

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -279,10 +279,11 @@ impl EVMCoreService {
                 .into());
             }
 
+            let higher_nonce = nonce < signed_tx.nonce();
             return Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
-                higher_nonce: nonce < signed_tx.nonce(),
+                higher_nonce,
             });
         } else {
             // Validate tx prepay fees with account balance

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -277,18 +277,12 @@ impl EVMCoreService {
                     signed_tx.nonce()
                 )
                 .into());
-            } else if nonce < signed_tx.nonce() {
-                return Ok(ValidateTxInfo {
-                    signed_tx,
-                    prepay_fee,
-                    higher_nonce: true,
-                });
             }
 
             return Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
-                higher_nonce: false,
+                higher_nonce: nonce < signed_tx.nonce(),
             });
         } else {
             // Validate tx prepay fees with account balance

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -474,7 +474,6 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
                 signed_tx,
                 prepay_fee,
                 higher_nonce,
-                lower_nonce,
             }) => {
                 let Ok(nonce) = u64::try_from(signed_tx.nonce()) else {
                     return cross_boundary_error_return(result, "nonce value overflow");
@@ -492,7 +491,6 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
                         tx_hash: format!("{:?}", signed_tx.hash()),
                         prepay_fee,
                         higher_nonce,
-                        lower_nonce,
                     },
                 )
             }
@@ -548,7 +546,6 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
                 signed_tx,
                 prepay_fee,
                 higher_nonce,
-                lower_nonce,
             }) => {
                 let Ok(nonce) = u64::try_from(signed_tx.nonce()) else {
                     return cross_boundary_error_return(result, "nonce value overflow");
@@ -566,7 +563,6 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
                         tx_hash: format!("{:?}", signed_tx.hash()),
                         prepay_fee,
                         higher_nonce,
-                        lower_nonce,
                     },
                 )
             }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -119,7 +119,6 @@ pub mod ffi {
         pub tx_hash: String,
         pub prepay_fee: u64,
         pub higher_nonce: bool,
-        pub lower_nonce: bool,
     }
 
     extern "Rust" {

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -359,9 +359,6 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
     }
 
     const auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
-    if (validateResults.higher_nonce) {
-        return Res::Ok();
-    }
 
     if (!result.ok) {
         LogPrintf("[evm_try_validate_raw_tx_in_q] failed, reason : %s\n", result.reason);

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -358,8 +358,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Ok();
     }
 
-    ValidateTxCompletion validateResults;
-    validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
+    const auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
     if (validateResults.higher_nonce) {
         return Res::Ok();
     }

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -349,9 +349,8 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Err("evm tx size too large");
 
     CrossBoundaryResult result;
-    ValidateTxCompletion validateResults;
     if (evmPreValidate) {
-        validateResults = evm_unsafe_try_prevalidate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
+        evm_unsafe_try_prevalidate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
         if (!result.ok) {
             LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
             return Res::Err("evm tx failed to pre-validate %s", result.reason);
@@ -359,6 +358,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Ok();
     }
 
+    ValidateTxCompletion validateResults;
     validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
     if (validateResults.higher_nonce) {
         return Res::Ok();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -616,7 +616,7 @@ bool BlockAssembler::EvmTxPreapply(EvmTxPreApplyContext& ctx)
         const auto obj = std::get<CEvmTxMessage>(txMessage);
 
         ValidateTxCompletion txResult;
-        txResult = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
+        txResult = evm_unsafe_try_prevalidate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
         if (!result.ok) {
             return false;
         }


### PR DESCRIPTION
- TX Prevalidate should return whether the nonce is too high
- TX non-prevalidation should always fail on incorrect nonce otherwise we can have multiple same nonces in a block.
- Miner should call evm_unsafe_try_prevalidate_raw_tx_in_q as it only need this for the nonce check.
- lower_nonce was unused and is now removed.