### PR TITLE
Add nonce check in update queue tx

### DIFF
--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -208,6 +208,17 @@ impl<'backend> AinExecutor<'backend> {
     pub fn apply_queue_tx(&mut self, tx: QueueTx, base_fee: U256) -> Result<ApplyTxResult> {
         match tx {
             QueueTx::SignedTx(signed_tx) => {
+                // Validate nonce
+                let nonce = self.backend.get_nonce(&signed_tx.sender);
+                if nonce != signed_tx.nonce() {
+                    return Err(format_err!(
+                        "[apply_queue_tx] nonce check failed. Account nonce {}, signed_tx nonce {}",
+                        nonce,
+                        signed_tx.nonce(),
+                    )
+                    .into());
+                }
+
                 let prepay_gas = calculate_prepay_gas_fee(&signed_tx)?;
                 let (tx_response, receipt) = self.exec(&signed_tx, prepay_gas);
                 debug!(
@@ -232,6 +243,17 @@ impl<'backend> AinExecutor<'backend> {
                 signed_tx,
                 direction,
             })) => {
+                // Validate nonce
+                let nonce = self.backend.get_nonce(&signed_tx.sender);
+                if nonce != signed_tx.nonce() {
+                    return Err(format_err!(
+                        "[apply_queue_tx] nonce check failed. Account nonce {}, signed_tx nonce {}",
+                        nonce,
+                        signed_tx.nonce(),
+                    )
+                    .into());
+                }
+
                 let to = signed_tx.to().unwrap();
                 let input = signed_tx.data();
                 let amount = U256::from_big_endian(&input[68..100]);


### PR DESCRIPTION
## Summary

- Add additional layer of security for tx nonce check when executing and updating queued transactions 


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
