### PR TITLE
EVM: Shift transferdomain invalid data size check into pre-validation

### DIFF
--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -211,6 +211,9 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractDestAddress();
             }
 
+            if (dst.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN) {
+                return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
+            }
             const auto evmTx = HexStr(dst.data);
             auto hash = evm_try_get_tx_hash(result, evmTx);
             if (!result.ok) {
@@ -272,6 +275,9 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractSourceAddress();
             }
 
+            if (src.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN) {
+                return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
+            }
             const auto evmTx = HexStr(src.data);
             auto hash = evm_try_get_tx_hash(result, evmTx);
             if (!result.ok) {
@@ -320,10 +326,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
         else {
             return DeFiErrors::TransferDomainInvalidDomain();
         }
-
-        if (src.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN || dst.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN) {
-            return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
-        }
     }
 
     auto txHash = tx.GetHash().GetHex();
@@ -359,7 +361,6 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
     }
 
     const auto validateResults = evm_unsafe_try_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
-
     if (!result.ok) {
         LogPrintf("[evm_try_validate_raw_tx_in_q] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to validate %s\n", result.reason);


### PR DESCRIPTION
## Summary

- Clean up transferdomain validation pipeline to shift invalid data size check into pre-validation pipeline 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
