### PR TITLE
Add missing Dakota fork to tests

### DIFF
--- a/test/functional/feature_address_map.py
+++ b/test/functional/feature_address_map.py
@@ -25,6 +25,7 @@ class addressmapTests(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_contract_env_vars.py
+++ b/test/functional/feature_evm_contract_env_vars.py
@@ -21,6 +21,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -23,6 +23,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_dfi_intrinsics.py
+++ b/test/functional/feature_evm_dfi_intrinsics.py
@@ -22,6 +22,7 @@ class DFIIntrinsicsTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -30,6 +30,7 @@ class DST20(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -22,6 +22,7 @@ class EVMFeeTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_logs.py
+++ b/test/functional/feature_evm_logs.py
@@ -22,6 +22,7 @@ class EVMTestLogs(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -23,6 +23,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_proxy.py
+++ b/test/functional/feature_evm_proxy.py
@@ -22,6 +22,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -19,6 +19,7 @@ class EVMRolllbackTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -24,6 +24,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -30,6 +30,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_rpc_filters.py
+++ b/test/functional/feature_evm_rpc_filters.py
@@ -25,6 +25,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_rpc_transaction.py
+++ b/test/functional/feature_evm_rpc_transaction.py
@@ -33,6 +33,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_smart_contract.py
+++ b/test/functional/feature_evm_smart_contract.py
@@ -21,6 +21,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_transaction_replacement.py
+++ b/test/functional/feature_evm_transaction_replacement.py
@@ -28,6 +28,7 @@ class EVMTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=50",
                 "-bayfrontheight=51",
+                "-dakotaheight=51",
                 "-eunosheight=80",
                 "-fortcanningheight=82",
                 "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -37,6 +37,7 @@ class EVMTest(DefiTestFramework):
             "-txnotokens=0",
             "-amkheight=50",
             "-bayfrontheight=51",
+            "-dakotaheight=51",
             "-eunosheight=80",
             "-fortcanningheight=82",
             "-fortcanninghillheight=84",

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -28,6 +28,7 @@ class VMMapTests(DefiTestFramework):
             "-txnotokens=0",
             "-amkheight=50",
             "-bayfrontheight=51",
+            "-dakotaheight=51",
             "-eunosheight=80",
             "-fortcanningheight=82",
             "-fortcanninghillheight=84",


### PR DESCRIPTION
The Dakota fork will mark custom transactions that fail as FATAL meaning they will be removed from the mempool. This PR adds the Dakota fork to all EVM tests which resolves the observation that transactions that failed to make it into the block and are now invalid remained in the mempool. These invalid transactions will now be removed from the mempool.