### PR TITLE
Clean up pre-validation pipeline for transferdomain

### DIFF
--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -220,7 +220,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
                 return Res::Err("transferdomain evm tx failed to pre-validate : %s", result.reason);
             }
-
             if (evmPreValidate) {
                 return Res::Ok();
             }
@@ -284,7 +283,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
                 return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
             }
-
             if (evmPreValidate) {
                 return Res::Ok();
             }

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -215,9 +215,19 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
             }
             const auto evmTx = HexStr(dst.data);
+            evm_unsafe_try_validate_transferdomain_tx_in_q(result, evmQueueId, evmTx);
+            if (!result.ok) {
+                LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
+                return Res::Err("transferdomain evm tx failed to pre-validate : %s", result.reason);
+            }
+
+            if (evmPreValidate) {
+                return Res::Ok();
+            }
+
             auto hash = evm_try_get_tx_hash(result, evmTx);
             if (!result.ok) {
-                return Res::Err("Error bridging DFI: %s", result.reason);
+                return Res::Err("Error getting tx hash: %s", result.reason);
             }
             evmTxHash = std::string(hash.data(), hash.length()).substr(2);
 
@@ -231,16 +241,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
 
             // Add balance to ERC55 address
             auto tokenId = dst.amount.nTokenId;
-            evm_unsafe_try_validate_transferdomain_tx_in_q(result, evmQueueId, evmTx);
-            if (!result.ok) {
-                LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
-                return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
-            }
-
-            if (evmPreValidate) {
-                return Res::Ok();
-            }
-
             if (tokenId == DCT_ID{0}) {
                 evm_unsafe_try_add_balance_in_q(result, evmQueueId, evmTx, tx.GetHash().GetHex());
                 if (!result.ok) {
@@ -279,14 +279,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
             }
             const auto evmTx = HexStr(src.data);
-            auto hash = evm_try_get_tx_hash(result, evmTx);
-            if (!result.ok) {
-                return Res::Err("Error bridging DFI: %s", result.reason);
-            }
-            evmTxHash = std::string(hash.data(), hash.length()).substr(2);
-
-            // Subtract balance from ERC55 address
-            auto tokenId = dst.amount.nTokenId;
             evm_unsafe_try_validate_transferdomain_tx_in_q(result, evmQueueId, evmTx);
             if (!result.ok) {
                 LogPrintf("[evm_try_prevalidate_transferdomain_tx] failed, reason : %s\n", result.reason);
@@ -297,6 +289,14 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return Res::Ok();
             }
 
+            auto hash = evm_try_get_tx_hash(result, evmTx);
+            if (!result.ok) {
+                return Res::Err("Error getting tx hash: %s", result.reason);
+            }
+            evmTxHash = std::string(hash.data(), hash.length()).substr(2);
+
+            // Subtract balance from ERC55 address
+            auto tokenId = dst.amount.nTokenId;
             if (tokenId == DCT_ID{0}) {
                 if (!evm_unsafe_try_sub_balance_in_q(result, evmQueueId, evmTx, tx.GetHash().GetHex())) {
                     return DeFiErrors::TransferDomainNotEnoughBalance(EncodeDestination(dest));

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -63,6 +63,7 @@ class EVMTest(DefiTestFramework):
         )
         self.eth_address1 = self.nodes[0].getnewaddress("", "erc55")
         self.no_auth_eth_address = "0x6c34cbb9219d8caa428835d2073e8ec88ba0a110"
+        self.address_erc55 = self.nodes[0].addressmap(self.address, 1)["format"]["erc55"]
 
         symbolDFI = "DFI"
         symbolBTC = "BTC"
@@ -142,14 +143,6 @@ class EVMTest(DefiTestFramework):
             {self.address: ["1@" + symbolBTC, "100@" + symbolDFI]}, self.address, []
         )
         self.nodes[0].generate(1)
-
-    def check_initial_balance(self):
-        # Check initial balances
-        self.dfi_balance = self.nodes[0].getaccount(self.address, {}, True)["0"]
-        self.eth_balance = self.nodes[0].eth_getBalance(self.eth_address)
-        assert_equal(self.dfi_balance, Decimal("101"))
-        assert_equal(self.eth_balance, int_to_eth_u256(0))
-        assert_equal(len(self.nodes[0].getaccount(self.eth_address, {}, True)), 0)
 
     def invalid_before_fork_and_disabled(self):
         assert_raises_rpc_error(
@@ -256,7 +249,19 @@ class EVMTest(DefiTestFramework):
 
         self.start_height = self.nodes[0].getblockcount()
 
+    def check_initial_balance(self):
+        self.rollback_to(self.start_height)
+
+        # Check initial balances
+        self.dfi_balance = self.nodes[0].getaccount(self.address, {}, True)["0"]
+        self.eth_balance = self.nodes[0].eth_getBalance(self.eth_address)
+        assert_equal(self.dfi_balance, Decimal("101"))
+        assert_equal(self.eth_balance, int_to_eth_u256(0))
+        assert_equal(len(self.nodes[0].getaccount(self.eth_address, {}, True)), 0)
+
     def invalid_parameters(self):
+        self.rollback_to(self.start_height)
+
         # Check for invalid parameters in transferdomain rpc
         assert_raises_rpc_error(
             -8,
@@ -395,6 +400,8 @@ class EVMTest(DefiTestFramework):
         )
 
     def invalid_values_dvm_evm(self):
+        self.rollback_to(self.start_height)
+
         assert_raises_rpc_error(
             -1,
             "Invalid address",
@@ -450,6 +457,8 @@ class EVMTest(DefiTestFramework):
         )
 
     def valid_transfer_dvm_evm(self):
+        self.rollback_to(self.start_height)
+
         # Transfer 100 DFI from DVM to EVM
         tx1 = transfer_domain(
             self.nodes[0], self.address, self.eth_address, "100@DFI", 2, 3
@@ -504,6 +513,8 @@ class EVMTest(DefiTestFramework):
         )
 
     def invalid_values_evm_dvm(self):
+        self.rollback_to(self.start_height)
+
         # Check for valid values EVM->DVM in transferdomain rpc
         assert_raises_rpc_error(
             -32600,
@@ -702,6 +713,8 @@ class EVMTest(DefiTestFramework):
         )
 
     def invalid_transfer_sc(self):
+        self.rollback_to(self.start_height)
+
         self.evm_key_pair = EvmKeyPair.from_node(self.nodes[0])
         self.nodes[0].transferdomain(
             [
@@ -761,6 +774,8 @@ class EVMTest(DefiTestFramework):
         )
 
     def invalid_transfer_no_auth(self):
+        self.rollback_to(self.start_height)
+
         assert_raises_rpc_error(
             -5,
             "no full public key for address " + self.address1,
@@ -984,21 +999,15 @@ class EVMTest(DefiTestFramework):
         assert_equal(block["transactions"][0], evm_tx)
 
     def conflicting_transferdomain_evmtx(self):
+        self.rollback_to(self.start_height)
+
+        self.nodes[0].utxostoaccount({self.address: "200@DFI"})
+        transfer_domain(self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3)
+        self.nodes[0].generate(1)
+
         burn_address = self.nodes[0].w3.to_checksum_address(
             "0x0000000000000000000000000000000000000000"
         )
-        self.nodes[0].utxostoaccount({self.address: "200@DFI"})
-        self.nodes[0].generate(1)
-
-        self.address_erc55 = self.nodes[0].addressmap(self.address, 1)["format"][
-            "erc55"
-        ]
-
-        transfer_domain(
-            self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3
-        )
-        self.nodes[0].generate(1)
-
         self.nodes[0].eth_sendTransaction(
             {
                 "nonce": self.nodes[0].w3.to_hex(
@@ -1059,9 +1068,13 @@ class EVMTest(DefiTestFramework):
         assert balance_after < balance  # sender should have less balance
 
     def should_find_empty_nonce(self):
-        self.nodes[0].clearmempool()
-        nonce = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
+        self.rollback_to(self.start_height)
 
+        self.nodes[0].utxostoaccount({self.address: "200@DFI"})
+        transfer_domain(self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3)
+        self.nodes[0].generate(1)
+
+        nonce = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
         evm_nonces = [nonce, nonce + 2, nonce + 3]
 
         # send evmtxs with nonces
@@ -1091,13 +1104,50 @@ class EVMTest(DefiTestFramework):
             ]
         )
         balance_before = self.nodes[0].w3.eth.get_balance(self.address_erc55)
-        self.nodes[0].generate(5)
+        self.nodes[0].generate(1)
         balance_after = self.nodes[0].w3.eth.get_balance(self.address_erc55)
 
         assert_equal(
             len(self.nodes[0].getrawmempool()), 0
         )  # all TXs should make it through
         assert balance_after > balance_before  # transferdomain should succeed
+
+    def invalidate_transfer_invalid_nonce(self):
+        self.rollback_to(self.start_height)
+
+        self.nodes[0].utxostoaccount({self.address: "200@DFI"})
+        nonce = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "dst": {
+                        "address": self.address_erc55,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
+                    "nonce": nonce,
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+
+        assert_raises_rpc_error(
+            -32600,
+            "transferdomain evm tx failed to pre-validate : Invalid nonce. Account nonce 1, signed_tx nonce 0",
+            self.nodes[0].transferdomain,
+            [
+                {
+                    "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "dst": {
+                        "address": self.address_erc55,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
+                    "nonce": nonce,
+                }
+            ],
+        )
 
     def run_test(self):
         self.setup()
@@ -1128,6 +1178,7 @@ class EVMTest(DefiTestFramework):
 
         self.should_find_empty_nonce()
 
+        self.invalidate_transfer_invalid_nonce()
 
 if __name__ == "__main__":
     EVMTest().main()

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -63,7 +63,9 @@ class EVMTest(DefiTestFramework):
         )
         self.eth_address1 = self.nodes[0].getnewaddress("", "erc55")
         self.no_auth_eth_address = "0x6c34cbb9219d8caa428835d2073e8ec88ba0a110"
-        self.address_erc55 = self.nodes[0].addressmap(self.address, 1)["format"]["erc55"]
+        self.address_erc55 = self.nodes[0].addressmap(self.address, 1)["format"][
+            "erc55"
+        ]
 
         symbolDFI = "DFI"
         symbolBTC = "BTC"
@@ -1002,7 +1004,9 @@ class EVMTest(DefiTestFramework):
         self.rollback_to(self.start_height)
 
         self.nodes[0].utxostoaccount({self.address: "200@DFI"})
-        transfer_domain(self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3)
+        transfer_domain(
+            self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3
+        )
         self.nodes[0].generate(1)
 
         burn_address = self.nodes[0].w3.to_checksum_address(
@@ -1071,7 +1075,9 @@ class EVMTest(DefiTestFramework):
         self.rollback_to(self.start_height)
 
         self.nodes[0].utxostoaccount({self.address: "200@DFI"})
-        transfer_domain(self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3)
+        transfer_domain(
+            self.nodes[0], self.address, self.address_erc55, "100@DFI", 2, 3
+        )
         self.nodes[0].generate(1)
 
         nonce = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
@@ -1179,6 +1185,7 @@ class EVMTest(DefiTestFramework):
         self.should_find_empty_nonce()
 
         self.invalidate_transfer_invalid_nonce()
+
 
 if __name__ == "__main__":
     EVMTest().main()


### PR DESCRIPTION
## Summary

- Cleanup pre-validation pipeline for EVM transferdomain transactions to shift DVM balance check into validation pipeline.
- DVM balance check will fail since accounts view is based on the tip. Balance check should be done only on transferdomain validation with context.
- Add pre-validation nonce check in transferdomain tests.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
