### PR TITLE
Evm: Miner fixes

### DIFF
--- a/src/masternodes/customtx.cpp
+++ b/src/masternodes/customtx.cpp
@@ -200,7 +200,7 @@ std::string ToString(CustomTxType type) {
         case CustomTxType::TransferDomain:
             return "TransferDomain";
         case CustomTxType::EvmTx:
-            return "EvmTx";
+            return "Evm";
         case CustomTxType::None:
             return "None";
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -866,6 +866,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                 // Not okay invalidate, undo and skip
                 if (!res.ok) {
                     customTxPassed = false;
+                    failedCustomTx = tx.GetHash();
                     LogPrintf("%s: Failed %s TX %s: %s\n", __func__, ToString(txType), tx.GetHash().GetHex(), res.msg);
                     break;
                 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -16,6 +16,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <ffi/cxx.h>
+#include <ffi/ffihelpers.h>
 #include <masternodes/anchors.h>
 #include <masternodes/govvariables/attributes.h>
 #include <masternodes/masternodes.h>
@@ -34,7 +35,6 @@
 #include <util/system.h>
 #include <util/validation.h>
 #include <wallet/wallet.h>
-#include <ffi/ffihelpers.h>
 
 #include <algorithm>
 #include <random>
@@ -638,8 +638,7 @@ bool BlockAssembler::EvmTxPreapply(EvmTxPreApplyContext& ctx)
         std::string evmTx;
         if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
             evmTx = HexStr(obj.transfers[0].second.data);
-        }
-        else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
+        } else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
             evmTx = HexStr(obj.transfers[0].first.data);
         }
         auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, evmTx);
@@ -821,7 +820,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
         uint256 failedCustomTx;
 
         // Apply and check custom TXs in order
-        for (const auto &entry : sortedEntries) {
+        for (const auto& entry : sortedEntries) {
             const CTransaction& tx = entry->GetTx();
 
             // Do not double check already checked custom TX. This will be an ancestor of current TX.
@@ -891,7 +890,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
             }
 
             // Remove from checked TX set
-            for (const auto &entry : sortedEntries) {
+            for (const auto& entry : sortedEntries) {
                 checkedDfTxHashSet.erase(entry->GetTx().GetHash());
             }
 
@@ -900,7 +899,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
             }
 
             // Remove entries from queue if first EVM TX is not the failed TX.
-            for (const auto &entry : sortedEntries) {
+            for (const auto& entry : sortedEntries) {
                 auto entryTxType = entry->GetCustomTxType();
                 auto entryHash = entry->GetTx().GetHash();
 
@@ -928,11 +927,10 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
         cache.Flush();
         coinsCache.Flush();
 
-        for (size_t i = 0; i < sortedEntries.size(); ++i) {
-            auto& entry = sortedEntries[i];
+        for (const auto& entry : sortedEntries) {
             auto& hash = entry->GetTx().GetHash();
             if (failedNoncesLookup.count(hash)) {
-                auto &it = failedNoncesLookup.at(hash);
+                auto& it = failedNoncesLookup.at(hash);
                 failedNonces.erase(it);
                 failedNoncesLookup.erase(hash);
             }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -908,7 +908,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                     // then remove from queue, otherwise it has not been added.
                     if (entryHash != failedCustomTx) {
                         CrossBoundaryResult result;
-                        auto hashes = evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, entry->GetTx().GetHash().ToString());
+                        auto hashes = evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, entryHash.ToString());
                         if (!result.ok) {
                             LogPrintf("%s: Unable to remove %s from queue. Will result in a block hash mismatch.\n", __func__, entry->GetTx().GetHash().ToString());
                         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -634,12 +634,15 @@ bool BlockAssembler::EvmTxPreapply(EvmTxPreApplyContext& ctx)
         if (obj.transfers.size() != 1) {
             return false;
         }
-
+        
         std::string evmTx;
-        if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
-            evmTx = HexStr(obj.transfers[0].second.data);
-        } else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
-            evmTx = HexStr(obj.transfers[0].first.data);
+        {
+            auto& [itemSrc, itemDest] = obj.transfers[0];
+            if (itemSrc.domain == static_cast<uint8_t>(VMDomain::DVM) && itemDest.domain == static_cast<uint8_t>(VMDomain::EVM)) {
+                evmTx = HexStr(itemDest.data);
+            } else if (itemSrc.domain == static_cast<uint8_t>(VMDomain::EVM) && itemDest.domain == static_cast<uint8_t>(VMDomain::DVM)) {
+                evmTx = HexStr(itemSrc.data);
+            }
         }
         auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, evmTx);
         if (!result.ok) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -862,8 +862,9 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                 const auto res = ApplyCustomTx(cache, coins, tx, chainparams.GetConsensus(), nHeight, pblock->nTime, nullptr, 0, evmQueueId, isEvmEnabledForBlock, false);
                 // Not okay invalidate, undo and skip
                 if (!res.ok) {
-                    customTxPassed = false;
+                    failedTxSet.insert(sortedEntries[i]);
                     failedCustomTx = tx.GetHash();
+                    customTxPassed = false;
                     LogPrintf("%s: Failed %s TX %s: %s\n", __func__, ToString(txType), tx.GetHash().GetHex(), res.msg);
                     break;
                 }
@@ -879,7 +880,6 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
             if (fUsingModified) {
                 mapModifiedTxSet.get<ancestor_score>().erase(modit);
             }
-            failedTxSet.insert(iter);
 
             // Remove from checked TX set
             for (const auto &entry : sortedEntries) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -700,9 +700,6 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
     // Copy of the view
     CCoinsViewCache coinsView(&::ChainstateActive().CoinsTip());
 
-    // Track mempool time order
-    std::multimap<int64_t, CTxMemPool::txiter> mempoolTimeOrder{};
-
     // Keep track of EVM entries that failed nonce check
     std::multimap<uint64_t, CTxMemPool::txiter> failedNonces;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -910,7 +910,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                         CrossBoundaryResult result;
                         auto hashes = evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, entryHash.ToString());
                         if (!result.ok) {
-                            LogPrintf("%s: Unable to remove %s from queue. Will result in a block hash mismatch.\n", __func__, entry->GetTx().GetHash().ToString());
+                            LogPrintf("%s: Unable to remove %s from queue. Will result in a block hash mismatch.\n", __func__, entryHash.ToString());
                         }
                     }
                     break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -634,14 +634,14 @@ bool BlockAssembler::EvmTxPreapply(EvmTxPreApplyContext& ctx)
         if (obj.transfers.size() != 1) {
             return false;
         }
-        
+
         std::string evmTx;
         {
-            auto& [itemSrc, itemDest] = obj.transfers[0];
-            if (itemSrc.domain == static_cast<uint8_t>(VMDomain::DVM) && itemDest.domain == static_cast<uint8_t>(VMDomain::EVM)) {
-                evmTx = HexStr(itemDest.data);
-            } else if (itemSrc.domain == static_cast<uint8_t>(VMDomain::EVM) && itemDest.domain == static_cast<uint8_t>(VMDomain::DVM)) {
-                evmTx = HexStr(itemSrc.data);
+            auto& [src, dest] = obj.transfers[0];
+            if (src.domain == static_cast<uint8_t>(VMDomain::DVM) && dest.domain == static_cast<uint8_t>(VMDomain::EVM)) {
+                evmTx = HexStr(dest.data);
+            } else if (src.domain == static_cast<uint8_t>(VMDomain::EVM) && dest.domain == static_cast<uint8_t>(VMDomain::DVM)) {
+                evmTx = HexStr(src.data);
             }
         }
         auto senderInfo = evm_try_get_tx_sender_info_from_raw_tx(result, evmTx);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -573,6 +573,9 @@ public:
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
     std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
 
+    /** Map iterator for tracking failed nonces */
+    using FailedNonceIterator = std::multimap<uint64_t, txiter>::iterator;
+
     struct CompareIteratorByHash {
         bool operator()(const txiter &a, const txiter &b) const {
             return a->GetTx().GetHash() < b->GetTx().GetHash();

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -340,7 +340,7 @@ class EVMTest(DefiTestFramework):
 
         assert_raises_web3_error(
             -32001,
-            "Test EvmTxTx execution failed:\nevm tx size too large",
+            "Test EvmTx execution failed:\nevm tx size too large",
             self.node.w3.eth.send_raw_transaction,
             signed.rawTransaction,
         )

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -529,7 +529,7 @@ class EVMTest(DefiTestFramework):
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
             self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
 
-        for i in range(5):
+        for i in range(6):
             self.nodes[0].transferdomain(
                 [
                     {

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -489,7 +489,7 @@ class EVMTest(DefiTestFramework):
         block_height = self.nodes[0].getblockcount()
         assert_equal(block_height, self.start_height + 1)
 
-    def tx_ordering_in_block_with_evm_and_transferdomain_txs(self):
+    def multiple_evm_and_transferdomain_txs(self):
         self.rollback_to(self.start_height)
         abi, bytecode, _ = EVMContract.from_file("Loop.sol", "Loop").compile()
         compiled = self.nodes[0].w3.eth.contract(abi=abi, bytecode=bytecode)
@@ -550,7 +550,7 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
-    def mine_transferdomain_txs(self):
+    def multiple_transferdomain_txs(self):
         self.rollback_to(self.start_height)
         start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(
             self.address_erc55
@@ -615,10 +615,10 @@ class EVMTest(DefiTestFramework):
         # self.same_nonce_transferdomain_and_evm_txs()
 
         # Test for invalid transferdomain txs nonce
-        self.tx_ordering_in_block_with_evm_and_transferdomain_txs()
+        self.multiple_evm_and_transferdomain_txs()
 
         # Test for multiple transferdomain txs in the same block
-        self.mine_transferdomain_txs()
+        self.multiple_transferdomain_txs()
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -555,7 +555,6 @@ class EVMTest(DefiTestFramework):
         start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(
             self.address_erc55
         )
-        assert_equal(start_nonce_erc55, False)
         for i in range(10):
             self.nodes[0].transferdomain(
                 [
@@ -579,32 +578,29 @@ class EVMTest(DefiTestFramework):
         for i in range(10):
             assert_raises_rpc_error(
                 -32600,
-                "Invalid nonce. Account nonce 11, signed_tx nonce {}".format(
-                    start_nonce_erc55 + i
-                ),
-                self.nodes[0].transferdomain(
-                    [
-                        {
-                            "src": {
-                                "address": self.address,
-                                "amount": "1@DFI",
-                                "domain": 2,
-                            },
-                            "dst": {
-                                "address": self.ethAddress,
-                                "amount": "1@DFI",
-                                "domain": 3,
-                            },
-                            "nonce": start_nonce_erc55 + i,
-                        }
-                    ]
-                ),
+                "transferdomain evm tx failed to pre-validate : Invalid nonce. Account nonce 11, signed_tx nonce {}".format(start_nonce_erc55 + i),    
+                self.nodes[0].transferdomain,
+                [
+                    {
+                        "src": {
+                            "address": self.address,
+                            "amount": "1@DFI",
+                            "domain": 2,
+                        },
+                        "dst": {
+                            "address": self.ethAddress,
+                            "amount": "1@DFI",
+                            "domain": 3,
+                        },
+                        "nonce": start_nonce_erc55 + i,
+                    }
+                ],
             )
 
     def run_test(self):
         self.setup()
 
-        # # Multiple mempool fee replacement
+        # Multiple mempool fee replacement
         # self.block_size_gas_limit()
 
         # # Test invalid tx in block creation

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -603,18 +603,18 @@ class EVMTest(DefiTestFramework):
         self.setup()
 
         # Multiple mempool fee replacement
-        # self.block_size_gas_limit()
+        self.block_size_gas_limit()
 
         # # Test invalid tx in block creation
-        # self.invalid_evm_tx_in_block_creation()
+        self.invalid_evm_tx_in_block_creation()
 
         # # Test for block size overflow from fee mismatch between tx queue and block
-        # self.state_dependent_txs_in_block_and_queue()
+        self.state_dependent_txs_in_block_and_queue()
 
         # # Test for transferdomain and evmtx with same nonce
-        # self.same_nonce_transferdomain_and_evm_txs()
+        self.same_nonce_transferdomain_and_evm_txs()
 
-        # Test for invalid transferdomain txs nonce
+        # Test for multiple expensive evm txs and transferdomain txs in the same block
         self.multiple_evm_and_transferdomain_txs()
 
         # Test for multiple transferdomain txs in the same block

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -489,7 +489,7 @@ class EVMTest(DefiTestFramework):
         block_height = self.nodes[0].getblockcount()
         assert_equal(block_height, self.start_height + 1)
 
-    def block_size_limit_with_transferdomain_txs(self):
+    def tx_ordering_in_block_with_evm_and_transferdomain_txs(self):
         self.rollback_to(self.start_height)
         abi, bytecode, _ = EVMContract.from_file("Loop.sol", "Loop").compile()
         compiled = self.nodes[0].w3.eth.contract(abi=abi, bytecode=bytecode)
@@ -610,7 +610,7 @@ class EVMTest(DefiTestFramework):
         # self.same_nonce_transferdomain_and_evm_txs()
 
         # Test for invalid transferdomain txs nonce
-        self.block_size_limit_with_transferdomain_txs()
+        self.tx_ordering_in_block_with_evm_and_transferdomain_txs()
 
         # self.mine_transferdomain_txs()
 

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -529,38 +529,7 @@ class EVMTest(DefiTestFramework):
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
             self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
 
-        for i in range(10):
-            self.nodes[0].transferdomain(
-                [
-                    {
-                        "src": {
-                            "address": self.address,
-                            "amount": "1@DFI",
-                            "domain": 2,
-                        },
-                        "dst": {
-                            "address": self.ethAddress,
-                            "amount": "1@DFI",
-                            "domain": 3,
-                        },
-                        "nonce": start_nonce_erc55 + i,
-                    }
-                ]
-            )
-
-        tx = contract.functions.loop(10_000).build_transaction(
-            {
-                "chainId": self.nodes[0].w3.eth.chain_id,
-                "nonce": start_nonce + 26,
-                "gasPrice": 25_000_000_000,
-                "gas": 30_000_000,
-            }
-        )
-        signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
-
-        self.nodes[0].generate(1)
-        for i in range(10):
+        for i in range(5):
             self.nodes[0].transferdomain(
                 [
                     {
@@ -579,6 +548,7 @@ class EVMTest(DefiTestFramework):
                 ]
             )
         self.nodes[0].generate(1)
+        assert_equal(len(self.nodes[0].getrawmempool()), True)
 
     def mine_transferdomain_txs(self):
         self.rollback_to(self.start_height)
@@ -641,6 +611,8 @@ class EVMTest(DefiTestFramework):
 
         # Test for invalid transferdomain txs nonce
         self.block_size_limit_with_transferdomain_txs()
+
+        # self.mine_transferdomain_txs()
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -275,7 +275,7 @@ class EVMTest(DefiTestFramework):
         assert_equal(len(block_info["tx"]) - 1, 20)
 
     def state_dependent_txs_in_block_and_queue(self):
-        self.rollback_and_clear_mempool()
+        self.rollback_to(self.start_height)
         before_balance = Decimal(
             self.nodes[0].getaccount(self.ethAddress)[0].split("@")[0]
         )

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -579,7 +579,9 @@ class EVMTest(DefiTestFramework):
         for i in range(10):
             assert_raises_rpc_error(
                 -32600,
-                "Invalid nonce. Account nonce 11, signed_tx nonce {}".format(start_nonce_erc55 + i),
+                "Invalid nonce. Account nonce 11, signed_tx nonce {}".format(
+                    start_nonce_erc55 + i
+                ),
                 self.nodes[0].transferdomain(
                     [
                         {
@@ -596,7 +598,7 @@ class EVMTest(DefiTestFramework):
                             "nonce": start_nonce_erc55 + i,
                         }
                     ]
-                )
+                ),
             )
 
     def run_test(self):

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -178,7 +178,7 @@ class EVMTest(DefiTestFramework):
             if idx == 0:
                 continue
             assert_equal(tx_info["vm"]["vmtype"], "evm")
-            assert_equal(tx_info["vm"]["txtype"], "EvmTx")
+            assert_equal(tx_info["vm"]["txtype"], "Evm")
             assert_equal(tx_info["vm"]["msg"]["sender"], self.ethAddress)
             assert_equal(tx_info["vm"]["msg"]["nonce"], start_nonce + idx)
             assert_equal(tx_info["vm"]["msg"]["hash"], hashes[idx])
@@ -190,7 +190,7 @@ class EVMTest(DefiTestFramework):
         assert_equal(len(block_info["tx"]) - 1, second_block_total_txs)
         for idx, tx_info in enumerate(block_info["tx"][1:]):
             assert_equal(tx_info["vm"]["vmtype"], "evm")
-            assert_equal(tx_info["vm"]["txtype"], "EvmTx")
+            assert_equal(tx_info["vm"]["txtype"], "Evm")
             assert_equal(tx_info["vm"]["msg"]["sender"], self.ethAddress)
             assert_equal(
                 tx_info["vm"]["msg"]["nonce"], start_nonce + first_block_total_txs + idx
@@ -208,7 +208,7 @@ class EVMTest(DefiTestFramework):
         tx_infos = block_info["tx"][1:]
         for idx in range(1, (40 - first_block_total_txs - second_block_total_txs)):
             assert_equal(tx_infos[idx]["vm"]["vmtype"], "evm")
-            assert_equal(tx_infos[idx]["vm"]["txtype"], "EvmTx")
+            assert_equal(tx_infos[idx]["vm"]["txtype"], "Evm")
             assert_equal(tx_infos[idx]["vm"]["msg"]["sender"], self.ethAddress)
             assert_equal(
                 tx_infos[idx]["vm"]["msg"]["nonce"],
@@ -223,7 +223,7 @@ class EVMTest(DefiTestFramework):
             )
         for idx in range(6, third_block_total_txs):
             assert_equal(tx_infos[idx]["vm"]["vmtype"], "evm")
-            assert_equal(tx_infos[idx]["vm"]["txtype"], "EvmTx")
+            assert_equal(tx_infos[idx]["vm"]["txtype"], "Evm")
             assert_equal(tx_infos[idx]["vm"]["msg"]["sender"], self.ethAddress)
             assert_equal(
                 tx_infos[idx]["vm"]["msg"]["nonce"],

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -507,7 +507,9 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
         start_nonce = self.nodes[0].w3.eth.get_transaction_count(self.ethAddress)
-        start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
+        start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(
+            self.address_erc55
+        )
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
             address=receipt["contractAddress"], abi=abi
@@ -531,7 +533,11 @@ class EVMTest(DefiTestFramework):
             self.nodes[0].transferdomain(
                 [
                     {
-                        "src": {"address": self.address, "amount": "1@DFI", "domain": 2},
+                        "src": {
+                            "address": self.address,
+                            "amount": "1@DFI",
+                            "domain": 2,
+                        },
                         "dst": {
                             "address": self.ethAddress,
                             "amount": "1@DFI",
@@ -558,7 +564,11 @@ class EVMTest(DefiTestFramework):
             self.nodes[0].transferdomain(
                 [
                     {
-                        "src": {"address": self.address, "amount": "1@DFI", "domain": 2},
+                        "src": {
+                            "address": self.address,
+                            "amount": "1@DFI",
+                            "domain": 2,
+                        },
                         "dst": {
                             "address": self.ethAddress,
                             "amount": "1@DFI",
@@ -572,12 +582,18 @@ class EVMTest(DefiTestFramework):
 
     def mine_transferdomain_txs(self):
         self.rollback_to(self.start_height)
-        start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(self.address_erc55)
+        start_nonce_erc55 = self.nodes[0].w3.eth.get_transaction_count(
+            self.address_erc55
+        )
         for i in range(10):
             self.nodes[0].transferdomain(
                 [
                     {
-                        "src": {"address": self.address, "amount": "1@DFI", "domain": 2},
+                        "src": {
+                            "address": self.address,
+                            "amount": "1@DFI",
+                            "domain": 2,
+                        },
                         "dst": {
                             "address": self.ethAddress,
                             "amount": "1@DFI",
@@ -592,7 +608,11 @@ class EVMTest(DefiTestFramework):
             self.nodes[0].transferdomain(
                 [
                     {
-                        "src": {"address": self.address, "amount": "1@DFI", "domain": 2},
+                        "src": {
+                            "address": self.address,
+                            "amount": "1@DFI",
+                            "domain": 2,
+                        },
                         "dst": {
                             "address": self.ethAddress,
                             "amount": "1@DFI",
@@ -621,6 +641,7 @@ class EVMTest(DefiTestFramework):
 
         # Test for invalid transferdomain txs nonce
         self.block_size_limit_with_transferdomain_txs()
+
 
 if __name__ == "__main__":
     EVMTest().main()

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -578,7 +578,9 @@ class EVMTest(DefiTestFramework):
         for i in range(10):
             assert_raises_rpc_error(
                 -32600,
-                "transferdomain evm tx failed to pre-validate : Invalid nonce. Account nonce 11, signed_tx nonce {}".format(start_nonce_erc55 + i),    
+                "transferdomain evm tx failed to pre-validate : Invalid nonce. Account nonce 11, signed_tx nonce {}".format(
+                    start_nonce_erc55 + i
+                ),
                 self.nodes[0].transferdomain,
                 [
                     {

--- a/test/functional/feature_evm_rpc_transaction.py
+++ b/test/functional/feature_evm_rpc_transaction.py
@@ -548,7 +548,7 @@ class EVMTest(DefiTestFramework):
         # assert all 6 txs are minted (including 2 auto-auth tx and coinbase)
         assert_equal(len(block_tx_info), 9)
         # test 2nd evm tx
-        assert_equal(block_tx_info[4]["vm"]["txtype"], "EvmTx")
+        assert_equal(block_tx_info[4]["vm"]["txtype"], "Evm")
         assert_equal(block_tx_info[4]["vm"]["msg"]["hash"], hash[2:])
         # test 5th transfer domain
         assert_equal(block_tx_info[7]["vm"]["txtype"], "TransferDomain")


### PR DESCRIPTION
## Summary

- Fixes EVM block hash mismatch due to evm/transferdomain txs processed in different order on the miner and on connect block.
- Fixes adding incorrect txiter to failed tx set on miner pipeline that causes missing transferdomain txs inside evm block.
- Fixes segfault error on miner happening due to incorrect assertion from evm tx iters being processed again inside failedNonces set when they were already successfully minted into the block from another transferdomain tx iter descendant.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
