### PR TITLE
EVM: Fix transferdomain DVM balance check in validation pipeline

### DIFF
--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -287,7 +287,7 @@ impl<'backend> AinExecutor<'backend> {
                 }
 
                 if direction == TransferDirection::EvmIn {
-                    let storage = bridge_dfi(&self.backend, amount, direction)?;
+                    let storage = bridge_dfi(self.backend, amount, direction)?;
                     self.update_storage(fixed_address, storage)?;
                     self.add_balance(fixed_address, amount)?;
                     self.commit();
@@ -312,7 +312,7 @@ impl<'backend> AinExecutor<'backend> {
                 );
 
                 if direction == TransferDirection::EvmOut {
-                    let storage = bridge_dfi(&self.backend, amount, direction)?;
+                    let storage = bridge_dfi(self.backend, amount, direction)?;
                     self.update_storage(fixed_address, storage)?;
                     self.sub_balance(signed_tx.sender, amount)?;
                 }

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -211,6 +211,15 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractDestAddress();
             }
 
+            // Subtract balance from DFI address
+            res = mnview.SubBalance(src.address, src.amount);
+            if (!res) {
+                return res;
+            }
+            stats.dvmEvmTotal.Add(src.amount);
+            stats.dvmOut.Add(src.amount);
+            stats.dvmCurrent.Sub(src.amount);
+
             if (dst.data.size() > MAX_TRANSFERDOMAIN_EVM_DATA_LEN) {
                 return DeFiErrors::TransferDomainInvalidDataSize(MAX_TRANSFERDOMAIN_EVM_DATA_LEN);
             }
@@ -229,14 +238,6 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return Res::Err("Error getting tx hash: %s", result.reason);
             }
             evmTxHash = std::string(hash.data(), hash.length()).substr(2);
-
-            // Subtract balance from DFI address
-            res = mnview.SubBalance(src.address, src.amount);
-            if (!res)
-                return res;
-            stats.dvmEvmTotal.Add(src.amount);
-            stats.dvmOut.Add(src.amount);
-            stats.dvmCurrent.Sub(src.amount);
 
             // Add balance to ERC55 address
             auto tokenId = dst.amount.nTokenId;
@@ -315,8 +316,9 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
 
             // Add balance to DFI address
             res = mnview.AddBalance(dst.address, dst.amount);
-            if (!res)
+            if (!res) {
                 return res;
+            }
             stats.evmDvmTotal.Add(dst.amount);
             stats.dvmIn.Add(dst.amount);
             stats.dvmCurrent.Add(dst.amount);

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -5,7 +5,12 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import DefiTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error, int_to_eth_u256, get_solc_artifact_path
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    int_to_eth_u256,
+    get_solc_artifact_path,
+)
 from test_framework.evm_contract import EVMContract
 from test_framework.evm_key_pair import EvmKeyPair
 
@@ -1219,13 +1224,23 @@ class EVMTest(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
-        assert_equal(contract.functions.totalSupply().call(), self.nodes[0].w3.to_wei(100, "ether"))
-        assert_equal(contract.functions.balanceOf(self.address_erc55).call(), self.nodes[0].w3.to_wei(0, "ether")) # Don't track balance per address
+        assert_equal(
+            contract.functions.totalSupply().call(),
+            self.nodes[0].w3.to_wei(100, "ether"),
+        )
+        assert_equal(
+            contract.functions.balanceOf(self.address_erc55).call(),
+            self.nodes[0].w3.to_wei(0, "ether"),
+        )  # Don't track balance per address
 
         self.nodes[0].transferdomain(
             [
                 {
-                    "src": {"address": self.address_erc55, "amount": "100@DFI", "domain": 3},
+                    "src": {
+                        "address": self.address_erc55,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
                     "dst": {
                         "address": self.address,
                         "amount": "100@DFI",
@@ -1238,7 +1253,6 @@ class EVMTest(DefiTestFramework):
 
         assert_equal(contract.functions.totalSupply().call(), 0)
         assert_equal(contract.functions.balanceOf(self.address_erc55).call(), 0)
-
 
     def run_test(self):
         self.setup()
@@ -1275,6 +1289,7 @@ class EVMTest(DefiTestFramework):
         self.invalid_transfer_invalid_nonce()
 
         self.test_contract_methods()
+
 
 if __name__ == "__main__":
     EVMTest().main()


### PR DESCRIPTION
## Summary

- Shift DVM balance check into pre-validation pipeline for transferdomain transactions for DVM to EVM

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
