### PR TITLE
TransferDomain DST20 refinements

### DIFF
--- a/lib/ain-contracts/transfer_domain/TransferDomain.sol
+++ b/lib/ain-contracts/transfer_domain/TransferDomain.sol
@@ -79,7 +79,7 @@ contract TransferDomain is IERC20Metadata {
      * name.
      */
     function symbol() public view virtual override returns (string memory) {
-        return "XVM";
+        return "DFI";
     }
 
     /**

--- a/lib/ain-contracts/transfer_domain/TransferDomain.sol
+++ b/lib/ain-contracts/transfer_domain/TransferDomain.sol
@@ -54,8 +54,6 @@ contract TransferDomain is IERC20Metadata {
         uint256 amount,
         string memory vmAddress
     ) external {
-        address transferFrom = from;
-
         if (to != address(this)) {
             require(
                 address(this).balance >= amount,
@@ -63,11 +61,9 @@ contract TransferDomain is IERC20Metadata {
             );
 
             to.transfer(amount);
-
-            transferFrom = address(this);
         }
 
-        emit Transfer(transferFrom, to, amount);
+        emit Transfer(from, to, amount);
         emit VMTransfer(vmAddress);
     }
 
@@ -110,9 +106,7 @@ contract TransferDomain is IERC20Metadata {
         uint256 amount,
         string memory vmAddress
     ) external {
-        if (to != address(this)) {
-            IERC20(contractAddress).transferFrom(from, to, amount);
-        }
+        IERC20(contractAddress).transferFrom(from, to, amount);
         emit VMTransfer(vmAddress);
     }
 

--- a/lib/ain-evm/src/contract.rs
+++ b/lib/ain-evm/src/contract.rs
@@ -162,15 +162,10 @@ pub fn bridge_dst20_in(
 
     // balance has slot 0
     let contract_balance_storage_index = get_address_storage_index(H256::zero(), fixed_address);
-    let contract_balance =
-        backend.get_contract_storage(contract, contract_balance_storage_index.as_bytes())?;
 
     let total_supply_index = H256::from_low_u64_be(2);
     let total_supply = backend.get_contract_storage(contract, total_supply_index.as_bytes())?;
 
-    let new_contract_balance = contract_balance
-        .checked_add(amount)
-        .ok_or_else(|| format_err!("Balance overflow/underflow"))?;
     let new_total_supply = total_supply
         .checked_add(amount)
         .ok_or_else(|| format_err!("Total supply overflow/underflow"))?;
@@ -178,10 +173,7 @@ pub fn bridge_dst20_in(
     Ok(DST20BridgeInfo {
         address: contract,
         storage: vec![
-            (
-                contract_balance_storage_index,
-                u256_to_h256(new_contract_balance),
-            ),
+            (contract_balance_storage_index, u256_to_h256(amount)),
             (total_supply_index, u256_to_h256(new_total_supply)),
         ],
     })

--- a/lib/ain-evm/src/contract.rs
+++ b/lib/ain-evm/src/contract.rs
@@ -143,12 +143,10 @@ pub fn dst20_contract(
     })
 }
 
-pub fn bridge_dst20(
+pub fn bridge_dst20_in(
     backend: &EVMBackend,
     contract: H160,
-    from: H160,
     amount: U256,
-    direction: TransferDirection,
 ) -> Result<DST20BridgeInfo> {
     // check if code of address matches DST20 bytecode
     let account = backend
@@ -163,41 +161,87 @@ pub fn bridge_dst20(
     }
 
     // balance has slot 0
-    let balance_storage_index = get_address_storage_index(H256::zero(), from);
-    let balance = backend.get_contract_storage(contract, balance_storage_index.as_bytes())?;
-
-    // allowance has slot 1
-    let allowance_storage_index = get_address_storage_index(H256::from_low_u64_be(1), from);
-    let address_allowance_storage_index =
-        get_address_storage_index(allowance_storage_index, fixed_address);
+    let contract_balance_storage_index = get_address_storage_index(H256::zero(), fixed_address);
+    let contract_balance =
+        backend.get_contract_storage(contract, contract_balance_storage_index.as_bytes())?;
 
     let total_supply_index = H256::from_low_u64_be(2);
     let total_supply = backend.get_contract_storage(contract, total_supply_index.as_bytes())?;
 
-    let (new_balance, new_total_supply) = if direction == TransferDirection::EvmOut {
-        (
-            balance.checked_sub(amount),
-            total_supply.checked_sub(amount),
-        )
-    } else {
-        (
-            balance.checked_add(amount),
-            total_supply.checked_add(amount),
-        )
-    };
-
-    let new_balance = new_balance.ok_or_else(|| format_err!("Balance overflow/underflow"))?;
-    let new_total_supply =
-        new_total_supply.ok_or_else(|| format_err!("Total supply overflow/underflow"))?;
+    let new_contract_balance = contract_balance
+        .checked_add(amount)
+        .ok_or_else(|| format_err!("Balance overflow/underflow"))?;
+    let new_total_supply = total_supply
+        .checked_add(amount)
+        .ok_or_else(|| format_err!("Total supply overflow/underflow"))?;
 
     Ok(DST20BridgeInfo {
         address: contract,
         storage: vec![
-            (balance_storage_index, u256_to_h256(new_balance)),
+            (
+                contract_balance_storage_index,
+                u256_to_h256(new_contract_balance),
+            ),
             (total_supply_index, u256_to_h256(new_total_supply)),
-            (address_allowance_storage_index, u256_to_h256(amount)),
         ],
     })
+}
+
+pub fn bridge_dst20_out(
+    backend: &EVMBackend,
+    contract: H160,
+    amount: U256,
+) -> Result<DST20BridgeInfo> {
+    // check if code of address matches DST20 bytecode
+    let account = backend
+        .get_account(&contract)
+        .ok_or_else(|| format_err!("DST20 token address is not a contract"))?;
+
+    let FixedContract { fixed_address, .. } = get_transferdomain_contract();
+
+    let Contract { codehash, .. } = get_dst20_contract();
+    if account.code_hash != codehash {
+        return Err(format_err!("DST20 token code is not valid").into());
+    }
+
+    let contract_balance_storage_index = get_address_storage_index(H256::zero(), fixed_address);
+
+    let total_supply_index = H256::from_low_u64_be(2);
+    let total_supply = backend.get_contract_storage(contract, total_supply_index.as_bytes())?;
+
+    let new_total_supply = total_supply
+        .checked_sub(amount)
+        .ok_or_else(|| format_err!("Total supply overflow/underflow"))?;
+
+    Ok(DST20BridgeInfo {
+        address: contract,
+        storage: vec![
+            (contract_balance_storage_index, u256_to_h256(U256::zero())), // Reset contract balance to 0
+            (total_supply_index, u256_to_h256(new_total_supply)),
+        ],
+    })
+}
+
+pub fn dst20_allowance(
+    direction: TransferDirection,
+    from: H160,
+    amount: U256,
+) -> Vec<(H256, H256)> {
+    let FixedContract { fixed_address, .. } = get_transferdomain_contract();
+
+    // allowance has slot 1
+    let allowance_storage_index = get_address_storage_index(
+        H256::from_low_u64_be(1),
+        if direction == TransferDirection::EvmIn {
+            fixed_address
+        } else {
+            from
+        },
+    );
+    let address_allowance_storage_index =
+        get_address_storage_index(allowance_storage_index, fixed_address);
+
+    vec![(address_allowance_storage_index, u256_to_h256(amount))]
 }
 
 pub fn bridge_dfi(

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -112,14 +112,16 @@ pub fn evm_try_create_and_sign_transfer_domain_tx(
     let FixedContract { fixed_address, .. } = get_transferdomain_contract();
     let action = TransactionAction::Call(fixed_address);
 
+    let Ok(sender) = ctx.from.parse::<H160>() else {
+        return cross_boundary_error_return(result, format!("Invalid address {}", ctx.from));
+    };
+
     let (from_address, to_address) = if ctx.direction {
         let Ok(to_address) = ctx.to.parse() else {
             return cross_boundary_error_return(result, format!("Invalid address {}", ctx.to));
         };
-        let Ok(from_address) = ctx.from.parse::<H160>() else {
-            return cross_boundary_error_return(result, format!("Invalid address {}", ctx.from));
-        };
-        (from_address, to_address)
+        // Send EvmIn from contract address
+        (fixed_address, to_address)
     } else {
         let Ok(from_address) = ctx.from.parse() else {
             return cross_boundary_error_return(result, format!("Invalid address {}", ctx.from));
@@ -236,14 +238,10 @@ pub fn evm_try_create_and_sign_transfer_domain_tx(
     let nonce = if ctx.use_nonce {
         U256::from(ctx.nonce)
     } else {
-        let Ok(nonce) = SERVICES
-            .evm
-            .core
-            .get_next_account_nonce(from_address, state_root)
-        else {
+        let Ok(nonce) = SERVICES.evm.core.get_next_account_nonce(sender, state_root) else {
             return cross_boundary_error_return(
                 result,
-                format!("Could not get nonce for {from_address:x?}"),
+                format!("Could not get nonce for {sender:x?}"),
             );
         };
         nonce

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -17,6 +17,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     get_solc_artifact_path,
 )
+from web3 import Web3
 
 
 class DST20(DefiTestFramework):
@@ -235,6 +236,7 @@ class DST20(DefiTestFramework):
             ]
         )
         self.node.generate(1)
+
         [afterUSDT] = [x for x in self.node.getaccount(self.address) if "USDT" in x]
 
         assert_equal(
@@ -257,6 +259,7 @@ class DST20(DefiTestFramework):
             ]
         )
         self.node.generate(1)
+
         [afterUSDT] = [x for x in self.node.getaccount(self.address) if "USDT" in x]
         assert_equal(afterUSDT, "10.00000000@USDT")
         assert_equal(
@@ -751,6 +754,151 @@ class DST20(DefiTestFramework):
             Decimal(1),
         )
 
+    def test_dst20_back_and_forth(self):
+        self.rollback_to(self.start_height)
+
+        self.node.transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "1@BTC", "domain": 2},
+                    "dst": {
+                        "address": self.key_pair.address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.node.generate(1)
+        block = self.nodes[0].eth_getBlockByNumber("latest", True)
+        sender_address = Web3.to_checksum_address(block["transactions"][0]["from"])
+
+        assert_equal(
+            self.btc.functions.balanceOf(sender_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.key_pair.address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.contract_address_transfer_domain).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "1@BTC", "domain": 2},
+                    "dst": {
+                        "address": self.key_pair.address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.node.generate(1)
+
+        assert_equal(
+            self.btc.functions.balanceOf(sender_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.key_pair.address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(2),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.contract_address_transfer_domain).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(2),
+        )
+
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.key_pair.address, "amount": "1@BTC", "domain": 3},
+                    "dst": {
+                        "address": self.address,
+                        "amount": "1@BTC",
+                        "domain": 2,
+                    },
+                }
+            ]
+        )
+        self.node.generate(1)
+
+        assert_equal(
+            self.btc.functions.balanceOf(sender_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.key_pair.address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.contract_address_transfer_domain).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.key_pair.address, "amount": "1@BTC", "domain": 3},
+                    "dst": {
+                        "address": self.address,
+                        "amount": "1@BTC",
+                        "domain": 2,
+                    },
+                }
+            ]
+        )
+        self.node.generate(1)
+
+        assert_equal(
+            self.btc.functions.balanceOf(sender_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.key_pair.address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.balanceOf(self.contract_address_transfer_domain).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+
     def run_test(self):
         self.node = self.nodes[0]
         self.w0 = self.node.w3
@@ -758,6 +906,9 @@ class DST20(DefiTestFramework):
         self.erc55_address = self.node.addressmap(self.address, 1)["format"]["erc55"]
 
         # Contract addresses
+        self.contract_address_transfer_domain = self.w0.to_checksum_address(
+            "0xdf00000000000000000000000000000000000001"
+        )
         self.contract_address_usdt = self.w0.to_checksum_address(
             "0xff00000000000000000000000000000000000001"
         )
@@ -844,6 +995,8 @@ class DST20(DefiTestFramework):
         self.node.minttokens("10@BTC")
         self.node.generate(1)
 
+        self.start_height = self.nodes[0].getblockcount() # Use post-token deployment as start height
+
         self.test_dst20_dvm_to_evm_bridge()
 
         self.test_dst20_evm_to_dvm_bridge()
@@ -855,6 +1008,7 @@ class DST20(DefiTestFramework):
         self.test_different_tokens()
         self.test_loan_token()
 
+        self.test_dst20_back_and_forth()
 
 if __name__ == "__main__":
     DST20().main()

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -1170,7 +1170,7 @@ class EVMTest(DefiTestFramework):
         )
 
         assert_equal(contract.functions.name().call(), "TransferDomain")
-        assert_equal(contract.functions.symbol().call(), "XVM")
+        assert_equal(contract.functions.symbol().call(), "DFI")
         assert_equal(contract.functions.totalSupply().call(), 0)
         assert_equal(contract.functions.balanceOf(self.address_erc55).call(), 0)
 


### PR DESCRIPTION
## Summary

- Change EVM TX input in DST20 Transferdomain.
- Restore TD symbol to `DFI`
- Simplify TD contract
- Keep DST20 contract balance in check (set amount on EVM in and reset to 0 on EVM out)

Explorer output :

<img width="1341" alt="Screenshot 2023-09-22 at 17 13 35" src="https://github.com/DeFiCh/ain/assets/15011228/a0d4d6d6-aeb8-4dab-9464-0aa4a48ea301">
