### PR TITLE
chore: Read client version in `web_clientVersion` RPC from `cpp` ffi 

### DIFF
--- a/lib/ain-cpp-imports/src/bridge.rs
+++ b/lib/ain-cpp-imports/src/bridge.rs
@@ -20,5 +20,6 @@ pub mod ffi {
         fn getCurrentHeight() -> i32;
         fn pastChangiIntermediateHeight2() -> bool;
         fn pastChangiIntermediateHeight3() -> bool;
+        fn getClientVersion() -> [u64; 3];
     }
 }

--- a/lib/ain-cpp-imports/src/bridge.rs
+++ b/lib/ain-cpp-imports/src/bridge.rs
@@ -20,6 +20,6 @@ pub mod ffi {
         fn getCurrentHeight() -> i32;
         fn pastChangiIntermediateHeight2() -> bool;
         fn pastChangiIntermediateHeight3() -> bool;
-        fn getClientVersion() -> [u64; 3];
+        fn getClientVersion() -> String;
     }
 }

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -61,7 +61,7 @@ mod ffi {
     pub fn pastChangiIntermediateHeight3() -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
-    pub fn getClientVersion() -> [u64; 3] {
+    pub fn getClientVersion() -> String {
         unimplemented("{}", UNIMPL_MSG)
     }
 }
@@ -71,9 +71,8 @@ pub fn get_chain_id() -> Result<u64, Box<dyn Error>> {
     Ok(chain_id)
 }
 
-pub fn get_client_version() -> Result<[u64; 3], Box<dyn Error>> {
-    let version = ffi::getClientVersion();
-    Ok(version)
+pub fn get_client_version() -> String {
+    ffi::getClientVersion()
 }
 
 pub fn is_mining() -> Result<bool, Box<dyn Error>> {

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -61,11 +61,17 @@ mod ffi {
     pub fn pastChangiIntermediateHeight3() -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
+    pub fn getClientVersion() -> [u64; 3] { unimplemented("{}", UNIMPL_MSG) }
 }
 
 pub fn get_chain_id() -> Result<u64, Box<dyn Error>> {
     let chain_id = ffi::getChainId();
     Ok(chain_id)
+}
+
+pub fn get_client_version() -> Result<[u64; 3], Box<dyn Error>> {
+    let version = ffi::getClientVersion();
+    Ok(version)
 }
 
 pub fn is_mining() -> Result<bool, Box<dyn Error>> {

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -61,7 +61,9 @@ mod ffi {
     pub fn pastChangiIntermediateHeight3() -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
-    pub fn getClientVersion() -> [u64; 3] { unimplemented("{}", UNIMPL_MSG) }
+    pub fn getClientVersion() -> [u64; 3] {
+        unimplemented("{}", UNIMPL_MSG)
+    }
 }
 
 pub fn get_chain_id() -> Result<u64, Box<dyn Error>> {

--- a/lib/ain-grpc/src/rpc/web3.rs
+++ b/lib/ain-grpc/src/rpc/web3.rs
@@ -1,8 +1,8 @@
 use ain_evm::bytes::Bytes;
-use sha3::Digest;
 use jsonrpsee::core::{Error, RpcResult};
 use jsonrpsee::proc_macros::rpc;
 use primitive_types::H256;
+use sha3::Digest;
 
 #[rpc(server, client, namespace = "web3")]
 pub trait MetachainWeb3RPC {
@@ -22,9 +22,8 @@ impl MetachainWeb3RPCServer for MetachainWeb3RPCModule {
         let version: [u64; 3] = ain_cpp_imports::get_client_version().map_err(|e| {
             Error::Custom(format!("ain_cpp_imports::get_client_version error : {e:?}"))
         })?;
-        let commit = option_env!("GIT_HASH").ok_or_else(|| {
-            Error::Custom(format!("missing GIT_HASH env var"))
-        })?;
+        let commit = option_env!("GIT_HASH")
+            .ok_or_else(|| Error::Custom(format!("missing GIT_HASH env var")))?;
         let os = std::env::consts::OS;
 
         let version_str = format!("{}.{}.{}", version[0], version[1], version[2]);

--- a/lib/ain-grpc/src/rpc/web3.rs
+++ b/lib/ain-grpc/src/rpc/web3.rs
@@ -19,16 +19,12 @@ pub struct MetachainWeb3RPCModule {}
 
 impl MetachainWeb3RPCServer for MetachainWeb3RPCModule {
     fn client_version(&self) -> RpcResult<String> {
-        let version: [u64; 3] = ain_cpp_imports::get_client_version().map_err(|e| {
-            Error::Custom(format!("ain_cpp_imports::get_client_version error : {e:?}"))
-        })?;
+        let version: String = ain_cpp_imports::get_client_version();
         let commit = option_env!("GIT_HASH")
             .ok_or_else(|| Error::Custom(format!("missing GIT_HASH env var")))?;
         let os = std::env::consts::OS;
 
-        let version_str = format!("{}.{}.{}", version[0], version[1], version[2]);
-
-        Ok(format!("Metachain/v{}/{}-{}", version_str, os, commit))
+        Ok(format!("Metachain/v{}/{}-{}", version, os, commit))
     }
 
     fn sha3(&self, input: Bytes) -> RpcResult<H256> {

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -209,14 +209,9 @@ int getHighestBlock() {
                             : (int) ::ChainActive().Height(); // return current block count if no peers
 }
 
-// Returns Major, Minor, Revision
-std::array<uint64_t, 3> getClientVersion() {
-    // Refer to "clientversion.h" for arbitrary divisions
-    uint64_t clientVersionMajor = CLIENT_VERSION / 1000000;
-    uint64_t clientVersionMinor = (CLIENT_VERSION - (clientVersionMajor * 1000000)) / 10000;
-    uint64_t clientVersionRevision = (CLIENT_VERSION - (clientVersionMajor * 1000000) - (clientVersionMinor * 10000)) / 100;
-
-    return { clientVersionMajor, clientVersionMinor, clientVersionRevision };
+// Returns Major, Minor, Revision in format: "X.Y.Z"
+rust::string getClientVersion() {
+    return rust::String(FormatVersion(CLIENT_VERSION));
 }
 
 int getCurrentHeight() {

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -2,6 +2,7 @@
 #include <util/system.h>
 #include <masternodes/mn_rpc.h>
 #include <key_io.h>
+#include <clientversion.h>
 
 
 uint64_t getChainId() {
@@ -206,6 +207,16 @@ rust::string getStateInputJSON() {
 int getHighestBlock() {
     return pindexBestHeader ? pindexBestHeader->nHeight
                             : (int) ::ChainActive().Height(); // return current block count if no peers
+}
+
+// Returns Major, Minor, Revision
+std::array<uint64_t, 3> getClientVersion() {
+    // Refer to "clientversion.h" for arbitrary divisions
+    uint64_t clientVersionMajor = CLIENT_VERSION / 1000000;
+    uint64_t clientVersionMinor = (CLIENT_VERSION - (clientVersionMajor * 1000000)) / 10000;
+    uint64_t clientVersionRevision = (CLIENT_VERSION - (clientVersionMajor * 1000000) - (clientVersionMinor * 10000)) / 100;
+
+    return { clientVersionMajor, clientVersionMinor, clientVersionRevision };
 }
 
 int getCurrentHeight() {

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -21,5 +21,6 @@ int getHighestBlock();
 int getCurrentHeight();
 bool pastChangiIntermediateHeight2();
 bool pastChangiIntermediateHeight3();
+std::array<uint64_t, 3> getClientVersion();
 
 #endif // DEFI_FFI_FFIEXPORTS_H

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -21,6 +21,6 @@ int getHighestBlock();
 int getCurrentHeight();
 bool pastChangiIntermediateHeight2();
 bool pastChangiIntermediateHeight3();
-std::array<uint64_t, 3> getClientVersion();
+rust::string getClientVersion();
 
 #endif // DEFI_FFI_FFIEXPORTS_H


### PR DESCRIPTION
## Summary

- As per title, instead of reading client version from environment variable flags, we read it from `cpp` ffi  
- As per request from @prasannavl https://github.com/DeFiCh/ain/pull/2107#discussion_r1239250167 


## RPCs
- `web_clientVersion` 
<img width="570" alt="image" src="https://github.com/DeFiCh/ain/assets/15076300/cd423600-0261-4cb0-9533-edf17a6c709e">

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
