### PR TITLE
EVM: Fix transferdomain EVM to DVM validation pipeline

### DIFF
--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -285,8 +285,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
             }
             if (evmPreValidate) {
-                // Pre-validate DVM balance transfer
-                return mnview.AddBalance(dst.address, dst.amount);
+                return Res::Ok();
             }
 
             auto hash = evm_try_get_tx_hash(result, evmTx);

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -188,10 +188,10 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
     auto attributes = mnview.GetAttributes();
     auto stats = attributes->GetValue(CTransferDomainStatsLive::Key, CTransferDomainStatsLive{});
     std::string evmTxHash;
+    CrossBoundaryResult result;
 
     // Iterate over array of transfers
     for (const auto &[src, dst] : obj.transfers) {
-        CrossBoundaryResult result;
         if (src.domain == static_cast<uint8_t>(VMDomain::DVM) && dst.domain == static_cast<uint8_t>(VMDomain::EVM)) {
             CTxDestination dest;
             if (!ExtractDestination(dst.address, dest)) {
@@ -341,7 +341,12 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
     }
 
     attributes->SetValue(CTransferDomainStatsLive::Key, stats);
-    return mnview.SetVariable(*attributes);
+    res = mnview.SetVariable(*attributes);
+    if (!res) {
+        evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, tx.GetHash().GetHex());
+        return res;
+    }
+    return Res::Ok();
 }
 
 Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -285,7 +285,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
             }
             if (evmPreValidate) {
-                return Res::Ok();
+                // Pre-validate DVM balance transfer
+                return mnview.AddBalance(dst.address, dst.amount);
             }
 
             auto hash = evm_try_get_tx_hash(result, evmTx);
@@ -317,6 +318,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             // Add balance to DFI address
             res = mnview.AddBalance(dst.address, dst.amount);
             if (!res) {
+                evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, tx.GetHash().GetHex());
                 return res;
             }
             stats.evmDvmTotal.Add(dst.amount);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -911,7 +911,7 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
                     // then remove from queue, otherwise it has not been added.
                     if (entryHash != failedCustomTx) {
                         CrossBoundaryResult result;
-                        auto hashes = evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, entryHash.ToString());
+                        evm_unsafe_try_remove_txs_above_hash_in_q(result, evmQueueId, entryHash.ToString());
                         if (!result.ok) {
                             LogPrintf("%s: Unable to remove %s from queue. Will result in a block hash mismatch.\n", __func__, entryHash.ToString());
                         }

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -832,7 +832,11 @@ class DST20(DefiTestFramework):
         self.nodes[0].transferdomain(
             [
                 {
-                    "src": {"address": self.key_pair.address, "amount": "1@BTC", "domain": 3},
+                    "src": {
+                        "address": self.key_pair.address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
                     "dst": {
                         "address": self.address,
                         "amount": "1@BTC",
@@ -867,7 +871,11 @@ class DST20(DefiTestFramework):
         self.nodes[0].transferdomain(
             [
                 {
-                    "src": {"address": self.key_pair.address, "amount": "1@BTC", "domain": 3},
+                    "src": {
+                        "address": self.key_pair.address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
                     "dst": {
                         "address": self.address,
                         "amount": "1@BTC",
@@ -995,7 +1003,9 @@ class DST20(DefiTestFramework):
         self.node.minttokens("10@BTC")
         self.node.generate(1)
 
-        self.start_height = self.nodes[0].getblockcount() # Use post-token deployment as start height
+        self.start_height = self.nodes[
+            0
+        ].getblockcount()  # Use post-token deployment as start height
 
         self.test_dst20_dvm_to_evm_bridge()
 
@@ -1009,6 +1019,7 @@ class DST20(DefiTestFramework):
         self.test_loan_token()
 
         self.test_dst20_back_and_forth()
+
 
 if __name__ == "__main__":
     DST20().main()


### PR DESCRIPTION
## Summary

- Remove transparent EVM tx from txqueue if add balance validation check on the DVM layer fails to prevent block state mismatch
- Fix pipeline to remove transparent evm tx fro queue for failure in setting attributes in transferdomain pipeline


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
