### PR TITLE
Use txType, nonce and sender from mempool

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -50,7 +50,6 @@ pub struct EthCallArgs<'a> {
 pub struct ValidateTxInfo {
     pub signed_tx: SignedTx,
     pub prepay_fee: U256,
-    pub higher_nonce: bool,
 }
 
 fn init_vsdb(path: PathBuf) {
@@ -286,11 +285,9 @@ impl EVMCoreService {
                 .into());
             }
 
-            let higher_nonce = nonce < signed_tx.nonce();
             return Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
-                higher_nonce,
             });
         } else {
             // Validate tx prepay fees with account balance
@@ -324,7 +321,6 @@ impl EVMCoreService {
         Ok(ValidateTxInfo {
             signed_tx,
             prepay_fee,
-            higher_nonce: false,
         })
     }
 

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -504,7 +504,6 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
-                higher_nonce,
             }) => {
                 let Ok(nonce) = u64::try_from(signed_tx.nonce()) else {
                     return cross_boundary_error_return(result, "nonce value overflow");
@@ -521,7 +520,6 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
                         sender: format!("{:?}", signed_tx.sender),
                         tx_hash: format!("{:?}", signed_tx.hash()),
                         prepay_fee,
-                        higher_nonce,
                     },
                 )
             }
@@ -576,7 +574,6 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
-                higher_nonce,
             }) => {
                 let Ok(nonce) = u64::try_from(signed_tx.nonce()) else {
                     return cross_boundary_error_return(result, "nonce value overflow");
@@ -593,7 +590,6 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
                         sender: format!("{:?}", signed_tx.sender),
                         tx_hash: format!("{:?}", signed_tx.hash()),
                         prepay_fee,
-                        higher_nonce,
                     },
                 )
             }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -123,7 +123,6 @@ pub mod ffi {
         pub sender: String,
         pub tx_hash: String,
         pub prepay_fee: u64,
-        pub higher_nonce: bool,
     }
 
     extern "Rust" {


### PR DESCRIPTION
## Summary

-  Currently the miner fully parses EVM and TD TXs to get the nonce when this is already available from the mempool entry. The TX type is also obtained from the TX itself when the mempool entry can be used. This PR updates the miner code to use the sender address, TX nonce and TX type from the mempool. This saves full TX deserialisation and EVM TX parsing happening twice, once for the nonce check and a second time when the TX is checked via ApplyCustomTx.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
