### PR TITLE
EVM: Fixes to proper backend error handling on fee deduction and fee refund

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -10,6 +10,7 @@ use sp_core::{hexdisplay::AsBytesRef, Blake2Hasher};
 use vsdb_trie_db::{MptOnce, MptRo};
 
 use crate::{
+    fee::calculate_gas_fee,
     storage::{traits::BlockStorage, Storage},
     transaction::SignedTx,
     trie::TrieDBStore,
@@ -150,7 +151,7 @@ impl EVMBackend {
         self.state.ro_handle(root)
     }
 
-    pub fn deduct_prepay_gas(&mut self, sender: H160, prepay_gas: U256) {
+    pub fn deduct_prepay_gas(&mut self, sender: H160, prepay_gas: U256) -> Result<()> {
         debug!(target: "backend", "[deduct_prepay_gas] Deducting {:#x} from {:#x}", prepay_gas, sender);
 
         let basic = self.basic(sender);
@@ -158,31 +159,34 @@ impl EVMBackend {
         let new_basic = Basic { balance, ..basic };
 
         self.apply(sender, Some(new_basic), None, Vec::new(), false)
-            .expect("Error deducting account balance");
+            .map_err(|e| BackendError::DeductPrepayGasFailed(e.to_string()))?;
         self.commit();
+
+        Ok(())
     }
 
     pub fn refund_unused_gas(
         &mut self,
-        sender: H160,
-        gas_limit: U256,
+        signed_tx: &SignedTx,
         used_gas: U256,
-        gas_price: U256,
-    ) {
-        let refund_gas = gas_limit.saturating_sub(used_gas);
-        let refund_amount = refund_gas.saturating_mul(gas_price);
+        base_fee: U256,
+    ) -> Result<()> {
+        let refund_gas = signed_tx.gas_limit().saturating_sub(used_gas);
+        let refund_amount = calculate_gas_fee(signed_tx, refund_gas, base_fee)?;
 
-        debug!(target: "backend", "[refund_unused_gas] Refunding {:#x} to {:#x}", refund_amount, sender);
+        debug!(target: "backend", "[refund_unused_gas] Refunding {:#x} to {:#x}", refund_amount, signed_tx.sender);
 
-        let basic = self.basic(sender);
+        let basic = self.basic(signed_tx.sender);
         let new_basic = Basic {
             balance: basic.balance.saturating_add(refund_amount),
             ..basic
         };
 
-        self.apply(sender, Some(new_basic), None, Vec::new(), false)
-            .expect("Error refunding account balance");
+        self.apply(signed_tx.sender, Some(new_basic), None, Vec::new(), false)
+            .map_err(|e| BackendError::RefundUnusedGasFailed(e.to_string()))?;
         self.commit();
+
+        Ok(())
     }
 }
 
@@ -434,6 +438,8 @@ pub enum BackendError {
     TrieError(String),
     NoSuchAccount(H160),
     InsufficientBalance(InsufficientBalance),
+    DeductPrepayGasFailed(String),
+    RefundUnusedGasFailed(String),
 }
 
 use std::fmt;
@@ -457,6 +463,12 @@ impl fmt::Display for BackendError {
                 amount,
             }) => {
                 write!(f, "BackendError: Insufficient balance for address {address}, trying to deduct {amount} but address has only {account_balance}")
+            }
+            BackendError::DeductPrepayGasFailed(e) => {
+                write!(f, "BackendError: Deduct prepay gas failed {e}")
+            }
+            BackendError::RefundUnusedGasFailed(e) => {
+                write!(f, "BackendError: Refund unused gas failed {e}")
             }
         }
     }

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -224,6 +224,7 @@ impl EVMCoreService {
         tx: &str,
         queue_id: u64,
         pre_validate: bool,
+        block_fee: U256,
     ) -> Result<ValidateTxInfo> {
         debug!("[validate_raw_tx] queue_id {}", queue_id);
         debug!("[validate_raw_tx] raw transaction : {:#?}", tx);
@@ -305,7 +306,7 @@ impl EVMCoreService {
             // Execute tx
             let mut executor = AinExecutor::new(&mut backend);
             let (tx_response, ..) =
-                executor.exec(&signed_tx, signed_tx.gas_limit(), prepay_fee, None);
+                executor.exec(&signed_tx, signed_tx.gas_limit(), prepay_fee, block_fee)?;
 
             // Validate total gas usage in queued txs exceeds block size
             debug!("[validate_raw_tx] used_gas: {:#?}", tx_response.used_gas);

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -448,7 +448,7 @@ impl EVMServices {
         Ok(())
     }
 
-    pub fn verify_tx_fees(&self, tx: &str) -> Result<()> {
+    pub fn verify_tx_fees(&self, tx: &str) -> Result<U256> {
         trace!("[verify_tx_fees] raw transaction : {:#?}", tx);
         let signed_tx = SignedTx::try_from(tx)
             .map_err(|_| format_err!("Error: decoding raw tx to TransactionV2"))?;
@@ -461,7 +461,7 @@ impl EVMServices {
             return Err(format_err!("tx gas price is lower than block base fee").into());
         }
 
-        Ok(())
+        Ok(block_fee)
     }
 
     ///

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -257,9 +257,10 @@ impl SignedTx {
 
     pub fn effective_gas_price(&self, base_fee: U256) -> U256 {
         match &self.transaction {
-            TransactionV2::Legacy(_) | TransactionV2::EIP2930(_) => self.gas_price(),
-            TransactionV2::EIP1559(t) => {
-                base_fee + min(t.max_priority_fee_per_gas, t.max_fee_per_gas - base_fee)
+            TransactionV2::Legacy(tx) => tx.gas_price,
+            TransactionV2::EIP2930(tx) => tx.gas_price,
+            TransactionV2::EIP1559(tx) => {
+                min(tx.max_fee_per_gas, tx.max_priority_fee_per_gas + base_fee)
             }
         }
     }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -500,7 +500,11 @@ pub fn evm_unsafe_try_prevalidate_raw_tx_in_q(
 ) -> ffi::ValidateTxCompletion {
     debug!("[evm_unsafe_try_prevalidate_raw_tx_in_q]");
     unsafe {
-        match SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id, true) {
+        match SERVICES
+            .evm
+            .core
+            .validate_raw_tx(raw_tx, queue_id, true, U256::zero())
+        {
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,
@@ -564,15 +568,19 @@ pub fn evm_unsafe_try_validate_raw_tx_in_q(
     raw_tx: &str,
 ) -> ffi::ValidateTxCompletion {
     debug!("[evm_unsafe_try_validate_raw_tx_in_q]");
-    match SERVICES.evm.verify_tx_fees(raw_tx) {
-        Ok(()) => (),
+    let block_fee = match SERVICES.evm.verify_tx_fees(raw_tx) {
+        Ok(fee) => fee,
         Err(e) => {
             debug!("evm_try_validate_raw_tx failed with error: {e}");
             return cross_boundary_error_return(result, e.to_string());
         }
-    }
+    };
     unsafe {
-        match SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id, false) {
+        match SERVICES
+            .evm
+            .core
+            .validate_raw_tx(raw_tx, queue_id, false, block_fee)
+        {
             Ok(ValidateTxInfo {
                 signed_tx,
                 prepay_fee,


### PR DESCRIPTION
## Summary

- Proper error handling when applying fee deduction and refunding of unused fees to backend. EVM apply errors are properly propagated now, which is handled correctly in the various validation and construct block pipelines.
- Better refactor of fee calculations to use calculate_gas_fee in fee helper functions, which propagates overflow errors with checked multiplication operation instead.
- Resolves the comments highlighted in PR #2488 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
