### PR TITLE
[test-only] Switch endianess for WitnessV16EthHash

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -133,7 +133,6 @@ inline uint160 EthHash160(const std::vector<unsigned char>& vch) {
     sha3_256_safe(vch, result);
     const size_t ADDRESS_OFFSET{12};
     std::vector<unsigned char> output(result.begin() + ADDRESS_OFFSET, result.end());
-    std::reverse(output.begin(), output.end());
     return uint160(output);
 }
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -63,7 +63,7 @@ public:
     {
         // Raw addr = ETH_ADDR_PREFIX + HexStr(id);
         // Produce ERC55 checksum address: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
-        const auto address = id.GetHex();
+        const auto address = HexStr(id);
         std::vector<unsigned char> input(address.begin(), address.end());
         std::vector<unsigned char> output;
         sha3_256_safe(input, output);
@@ -93,7 +93,6 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
             return CNoDestination();
         }
         data = ParseHex(hex);
-        std::reverse(data.begin(), data.end());
         return WitnessV16EthHash(uint160(data));
     }
     if (DecodeBase58Check(str, data)) {

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -203,7 +203,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
 
             // Check if destination address is a contract
-            auto isSmartContract = evm_is_smart_contract_in_q(result, toAddress->GetHex(), evmQueueId);
+            auto isSmartContract = evm_is_smart_contract_in_q(result, HexStr(*toAddress), evmQueueId);
             if (!result.ok) {
                 return Res::Err("Error checking contract address: %s", result.reason);
             }
@@ -267,7 +267,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
 
             // Check if source address is a contract
-            auto isSmartContract = evm_is_smart_contract_in_q(result, fromAddress->GetHex(), evmQueueId);
+            auto isSmartContract = evm_is_smart_contract_in_q(result, HexStr(*fromAddress), evmQueueId);
             if (!result.ok) {
                 return Res::Err("Error checking contract address: %s", result.reason);
             }

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -477,7 +477,7 @@ UniValue getaccount(const JSONRPCRequest& request) {
     CTxDestination dest;
     if (ExtractDestination(reqOwner, dest) && dest.index() == WitV16KeyEthHashType) {
         const auto keyID = std::get<WitnessV16EthHash>(dest);
-        auto r = XResultValue(evm_try_get_balance(result, keyID.GetHex()));
+        auto r = XResultValue(evm_try_get_balance(result, HexStr(keyID)));
         if (!r) throw JSONRPCError(RPC_MISC_ERROR, r.msg);
         if (const auto balance = *r) {
             balances[DCT_ID{}] = balance;
@@ -605,7 +605,7 @@ UniValue gettokenbalances(const JSONRPCRequest& request) {
     if (evm_dfi_lookup) {
         for (const auto keyID : pwallet->GetKeys()) {
             // TODO: Use GetHex when eth key is fixed to be stored in LE
-            auto res = XResultValue(evm_try_get_balance(result, keyID.GetHex()));
+            auto res = XResultValue(evm_try_get_balance(result, HexStr(keyID)));
             if (res) {
                 auto evmAmount = *res;
                 totalBalances.Add({{}, static_cast<CAmount>(evmAmount)});

--- a/src/masternodes/rpc_evm.cpp
+++ b/src/masternodes/rpc_evm.cpp
@@ -75,7 +75,7 @@ UniValue evmtx(const JSONRPCRequest &request) {
 
     const auto fromEth = std::get<WitnessV16EthHash>(fromDest);
     const CKeyID keyId{fromEth};
-    const auto from = fromEth.GetHex();
+    const auto from = HexStr(fromEth);
 
     CKey key;
     if (!pwallet->GetKey(keyId, key)) {
@@ -108,7 +108,7 @@ UniValue evmtx(const JSONRPCRequest &request) {
         }
 
         const auto toEth = std::get<WitnessV16EthHash>(toDest);
-        to = toEth.GetHex();
+        to = HexStr(toEth);
     }
 
     rust::Vec<uint8_t> input{};

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1080,7 +1080,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
     if (pubKey.IsCompressed()) {
         pubKey.Decompress();
     }
-    const auto evmBeneficiary = pubKey.GetEthID().GetHex();
+    const auto evmBeneficiary = HexStr(pubKey.GetEthID());
     auto res = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey, blockTime, evmBeneficiary);
     if (!res) {
         LogPrintf("Error: WalletStaker: %s\n", res.msg);

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -174,6 +174,7 @@ class EVMTest(DefiTestFramework):
         # Import Eth private key for:
         # Bech32: bcrt1q25m0h24ef4njmjznwwe85w99cn78k04te6w3qt
         # Eth: 0xe5BBbf6eEDc1F217D72DD97E23049ab4B21AB84E
+        eth_address_import = "0xe5BBbf6eEDc1F217D72DD97E23049ab4B21AB84E"
         self.nodes[0].importprivkey(
             "56c679ab38001e7d427e3fbc4363fcd2100e74d8ac650a2d2ff3a69254d4dae4"
         )
@@ -186,9 +187,7 @@ class EVMTest(DefiTestFramework):
             bech32_info["pubkey"],
             "02ed3add70f9d3fde074bc74310d5684f5e5d2836106a8286aef1324f9791658da",
         )
-        eth_info = self.nodes[0].getaddressinfo(
-            "0xe5BBbf6eEDc1F217D72DD97E23049ab4B21AB84E"
-        )
+        eth_info = self.nodes[0].getaddressinfo(eth_address_import)
         assert_equal(eth_info["ismine"], True)
         assert_equal(eth_info["solvable"], True)
         assert_equal(
@@ -222,18 +221,18 @@ class EVMTest(DefiTestFramework):
         )
 
         # Dump Eth address and import into node 1
-        priv_key = self.nodes[0].dumpprivkey(
-            "0xe5BBbf6eEDc1F217D72DD97E23049ab4B21AB84E"
-        )
+        priv_key = self.nodes[0].dumpprivkey(eth_address_import)
         assert_equal(
             priv_key, "56c679ab38001e7d427e3fbc4363fcd2100e74d8ac650a2d2ff3a69254d4dae4"
         )
         self.nodes[1].importprivkey(priv_key)
 
+        # Check that the script pubkey matches the order of the address
+        pubkey = self.nodes[1].getaddressinfo(eth_address_import)["scriptPubKey"][4:]
+        assert_equal(pubkey, eth_address_import[2:].lower())
+
         # Check key is now present in node 1
-        result = self.nodes[1].getaddressinfo(
-            "0xe5BBbf6eEDc1F217D72DD97E23049ab4B21AB84E"
-        )
+        result = self.nodes[1].getaddressinfo(eth_address_import)
         assert_equal(result["ismine"], True)
 
         # Check creation and private key dump of new Eth key


### PR DESCRIPTION
## Summary

- Switch endianess for WitV16KeyEthHash. The order of the ERC55 address will then match the order found over the wire.
- Test added which compares the scriptPubKey order to the address order, this scriptPubKey represent the data sent over the wire.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
