### PR TITLE
Evm: Fix missing nonce check in validation pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -198,7 +198,7 @@ impl EVMCoreService {
     /// 5. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
     ///
     /// The validation checks with state context of the tx before we consider it to be valid are:
-    /// 1. Nonce check: Returns flag if nonce is lower or higher than the current state account nonce.
+    /// 1. Nonce check: Verify that the tx nonce must equl to the current state account nonce.
     /// 2. Execute the tx with the state root from the txqueue.
     /// 3. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
     /// 4. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
@@ -279,7 +279,7 @@ impl EVMCoreService {
             // Validate tx nonce
             if nonce > signed_tx.nonce() {
                 return Err(format_err!(
-                    "Invalid nonce. Account nonce {}, signed_tx nonce {}",
+                    "invalid nonce. Account nonce {}, signed_tx nonce {}",
                     nonce,
                     signed_tx.nonce()
                 )
@@ -291,6 +291,15 @@ impl EVMCoreService {
                 prepay_fee,
             });
         } else {
+            if nonce != signed_tx.nonce() {
+                return Err(format_err!(
+                    "invalid nonce. Account nonce {}, signed_tx nonce {}",
+                    nonce,
+                    signed_tx.nonce()
+                )
+                .into());
+            }
+
             // Validate tx prepay fees with account balance
             let balance = backend.get_balance(&signed_tx.sender);
             debug!("[validate_raw_tx] Account balance : {:x?}", balance);

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -960,7 +960,7 @@ class EVMTest(DefiTestFramework):
         # Try and send an already sent transaction
         assert_raises_rpc_error(
             -26,
-            "evm tx failed to pre-validate Invalid nonce. Account nonce 6, signed_tx nonce 5",
+            "evm tx failed to pre-validate invalid nonce. Account nonce 6, signed_tx nonce 5",
             self.nodes[0].sendrawtransaction,
             raw_tx,
         )

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -441,7 +441,9 @@ class EVMTest(DefiTestFramework):
 
         self.should_deploy_contract_less_than_1KB()
 
-        self.start_height = self.nodes[0].getblockcount() # start height after contract deployment
+        self.start_height = self.nodes[
+            0
+        ].getblockcount()  # start height after contract deployment
 
         self.should_contract_get_set()
 
@@ -454,6 +456,7 @@ class EVMTest(DefiTestFramework):
         self.fail_deploy_contract_extremely_large_init_code()
 
         self.non_payable_proxied_contract()
+
 
 if __name__ == "__main__":
     EVMTest().main()


### PR DESCRIPTION
## Summary

- Restore missing account nonce and evm tx nonce check in validation pipeline
- PR #2465 removed the higher / lower nonce flag in validation pipeline, but validation pipeline requires an account nonce check with the updated state with the signed tx to ensure that they are equal and the evm tx is valid

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
