### PR TITLE
Do not use iter after deletion. Fix compiler warning.

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -414,6 +414,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
 void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 {
     const auto& tx = it->GetTx();
+    const auto txType = it->GetCustomTxType();
     NotifyEntryRemoved(it->GetSharedTx(), reason);
     const uint256 hash = tx.GetHash();
     for (const CTxIn& txin : tx.vin)
@@ -434,7 +435,6 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     mapLinks.erase(it);
     mapTx.erase(it);
 
-    const auto txType = it->GetCustomTxType();
     if (txType == CustomTxType::EvmTx || txType == CustomTxType::TransferDomain) {
         auto found{false};
         EvmAddressData sender{};

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -572,7 +572,7 @@ public:
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
     std::map<EvmAddressData, std::set<uint256>> evmTxsBySender;
-    std::map<EvmAddressData, int> evmReplaceByFeeBySender;
+    std::map<EvmAddressData, uint32_t> evmReplaceByFeeBySender;
 
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
     std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order


### PR DESCRIPTION
## Summary

- Do not use iterator after deletion
- Use uint to avoid compiler warning

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
