### PR TITLE
SignedTx Caches 

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -66,7 +66,7 @@ impl SignedTxCache {
 
     pub fn try_get_or_create_from_tx(&self, tx: &TransactionV2) -> Result<SignedTx> {
         let data = EnvelopedEncodable::encode(tx);
-        let key =  hex::encode(&data);
+        let key = hex::encode(&data);
         let mut guard = self.inner.lock().unwrap();
         debug!("[signed-tx-cache]::get from tx: {}", &key);
         let res = guard.try_get_or_insert(key.clone(), || {

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -66,7 +66,7 @@ impl SignedTxCache {
 
     pub fn try_get_or_create_from_tx(&self, tx: &TransactionV2) -> Result<SignedTx> {
         let data = EnvelopedEncodable::encode(tx);
-        let key =  data.iter().map(|b: &u8| format!("{:02x}", b)).collect::<String>();
+        let key =  hex::encode(&data);
         let mut guard = self.inner.lock().unwrap();
         debug!("[signed-tx-cache]::get from tx: {}", &key);
         let res = guard.try_get_or_insert(key.clone(), || {

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -56,21 +56,21 @@ impl SignedTxCache {
 
     pub fn try_get_or_create(&self, key: &str) -> Result<SignedTx> {
         let mut guard = self.inner.lock().unwrap();
-        debug!("[signed-tx-cache]::get: {:?}", key);
+        debug!("[signed-tx-cache]::get: {}", key);
         let res = guard.try_get_or_insert(key.to_string(), || {
-            debug!("[signed-tx-cache]::create {:?}", key);
+            debug!("[signed-tx-cache]::create {}", key);
             SignedTx::try_from(key)
         })?;
         Ok(res.clone())
     }
 
     pub fn try_get_or_create_from_tx(&self, tx: &TransactionV2) -> Result<SignedTx> {
-        let data = EnvelopedEncodable::encode_payload(tx).to_vec();
-        let key = String::from_utf8(data).map_err(|e| format_err!("{:?}", e))?;
+        let data = EnvelopedEncodable::encode(tx);
+        let key =  data.iter().map(|b: &u8| format!("{:02x}", b)).collect::<String>();
         let mut guard = self.inner.lock().unwrap();
-        debug!("[signed-tx-cache]::get from tx: {:?}", &key);
+        debug!("[signed-tx-cache]::get from tx: {}", &key);
         let res = guard.try_get_or_insert(key.clone(), || {
-            debug!("[signed-tx-cache]::create from tx {:?}", &key);
+            debug!("[signed-tx-cache]::create from tx {}", &key);
             SignedTx::try_from(key.as_str())
         })?;
         Ok(res.clone())

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -454,7 +454,10 @@ impl EVMServices {
 
     pub fn verify_tx_fees(&self, tx: &str) -> Result<U256> {
         trace!("[verify_tx_fees] raw transaction : {:#?}", tx);
-        let signed_tx = SignedTx::try_from(tx)
+        let signed_tx = self
+            .core
+            .signed_tx_cache
+            .try_get_or_create(tx)
             .map_err(|_| format_err!("Error: decoding raw tx to TransactionV2"))?;
         trace!("[verify_tx_fees] signed_tx : {:#?}", signed_tx);
 

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -5,7 +5,6 @@ use ethereum::{
     TransactionSignature, TransactionV2,
 };
 use ethereum_types::{H160, H256, U256};
-use libsecp256k1::PublicKey;
 use rlp::RlpStream;
 use sha3::Digest;
 
@@ -101,7 +100,6 @@ impl From<&LegacyTransaction> for LegacyUnsignedTransaction {
 pub struct SignedTx {
     pub transaction: TransactionV2,
     pub sender: H160,
-    pub pubkey: PublicKey,
 }
 
 impl fmt::Debug for SignedTx {
@@ -181,7 +179,6 @@ impl TryFrom<TransactionV2> for SignedTx {
         Ok(SignedTx {
             transaction: src,
             sender: public_key_to_address(&pubkey),
-            pubkey,
         })
     }
 }
@@ -400,7 +397,6 @@ mod tests {
         // Legacy
         let signed_tx = crate::transaction::SignedTx::try_from("f86b8085689451eee18252089434c1ca09a2dc717d89baef2f30ff6a6b2975e17e872386f26fc10000802da0ae5c76f8073460cbc7a911d3cc1b367072db64848a9532343559ce6917c51a46a01d2e4928450c59acca3de8340eb15b7446b37936265a51ab35e63f749a048002").unwrap();
 
-        assert_eq!(hex::encode(signed_tx.pubkey.serialize()), "044c6412f7cd3ac0e2538c3c9843d27d1e03b422eaf655c6a699da22b57a89802989318dbaeea62f5fc751fa8cd1404e687d67b8ab8513fe0d37bafbf407aa6cf7");
         assert_eq!(
             hex::encode(signed_tx.sender.as_fixed_bytes()),
             "f829754bae400b679febefdcfc9944c323e1f94e"

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -719,7 +719,11 @@ impl MetachainRPCServer for MetachainRPCModule {
         match ain_cpp_imports::publish_eth_transaction(hex) {
             Ok(res_string) => {
                 if res_string.is_empty() {
-                    let signed_tx = SignedTx::try_from(raw_tx)
+                    let signed_tx: SignedTx = self
+                        .handler
+                        .core
+                        .signed_tx_cache
+                        .try_get_or_create(raw_tx)
                         .map_err(|e| Error::Custom(format!("TX error {e:?}")))?;
 
                     debug!(target:"rpc",

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -9,7 +9,6 @@ use ain_evm::{
     transaction::{
         self,
         system::{DST20Data, DeployContractData, SystemTx, TransferDirection, TransferDomainData},
-        SignedTx,
     },
     txqueue::QueueTx,
     weiamount::{try_from_gwei, try_from_satoshi, WeiAmount},
@@ -322,7 +321,11 @@ fn unsafe_remove_txs_above_hash_in_q(queue_id: u64, target_hash: String) -> Resu
 /// * `hash` - The hash value as a byte array.
 #[ffi_fallible]
 fn unsafe_add_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Result<()> {
-    let signed_tx = SignedTx::try_from(raw_tx)?;
+    let signed_tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
     let native_hash = XHash::from(native_hash);
 
     let queue_tx = QueueTx::SystemTx(SystemTx::TransferDomain(TransferDomainData {
@@ -358,7 +361,11 @@ fn unsafe_add_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Re
 /// Returns `true` if the balance subtraction is successful, `false` otherwise.
 #[ffi_fallible]
 fn unsafe_sub_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Result<bool> {
-    let signed_tx = SignedTx::try_from(raw_tx)?;
+    let signed_tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
     let native_hash = XHash::from(native_hash);
 
     let queue_tx = QueueTx::SystemTx(SystemTx::TransferDomain(TransferDomainData {
@@ -551,7 +558,12 @@ fn unsafe_push_tx_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Result
     let native_hash = native_hash.to_string();
 
     unsafe {
-        let signed_tx = SignedTx::try_from(raw_tx)?;
+        let signed_tx = SERVICES
+            .evm
+            .core
+            .signed_tx_cache
+            .try_get_or_create(raw_tx)?;
+
         SERVICES
             .evm
             .push_tx_in_queue(queue_id, signed_tx.into(), native_hash)
@@ -737,7 +749,12 @@ fn get_tx_by_hash(tx_hash: &str) -> Result<ffi::EVMTransaction> {
         .get_transaction_by_hash(&tx_hash)?
         .ok_or("Unable to get evm tx from tx hash")?;
 
-    let tx = SignedTx::try_from(tx)?;
+    let tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create_from_tx(&tx)?;
+
     let nonce = u64::try_from(tx.nonce())?;
     let gas_limit = u64::try_from(tx.gas_limit())?;
     let value = u64::try_from(WeiAmount(tx.value()).to_satoshi())?;
@@ -825,7 +842,11 @@ fn unsafe_bridge_dst20(
 ) -> Result<()> {
     let native_hash = XHash::from(native_hash);
     let contract_address = ain_contracts::dst20_address_from_token_id(token_id)?;
-    let signed_tx = SignedTx::try_from(raw_tx)?;
+    let signed_tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
     let system_tx = QueueTx::SystemTx(SystemTx::DST20Bridge(DST20Data {
         signed_tx: Box::new(signed_tx),
         contract_address,
@@ -849,7 +870,11 @@ fn unsafe_bridge_dst20(
 /// Returns the transaction's hash
 #[ffi_fallible]
 fn get_tx_hash(raw_tx: &str) -> Result<String> {
-    let signed_tx = SignedTx::try_from(raw_tx)?;
+    let signed_tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
     Ok(format!("{:?}", signed_tx.hash()))
 }
 
@@ -886,7 +911,11 @@ fn unsafe_is_smart_contract_in_q(address: &str, queue_id: u64) -> Result<bool> {
 
 #[ffi_fallible]
 fn get_tx_info_from_raw_tx(raw_tx: &str) -> Result<TxInfo> {
-    let signed_tx = SignedTx::try_from(raw_tx)?;
+    let signed_tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
 
     let nonce = u64::try_from(signed_tx.nonce())?;
 

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -759,7 +759,11 @@ fn get_tx_by_hash(tx_hash: &str) -> Result<ffi::EVMTransaction> {
 
 #[ffi_fallible]
 fn parse_tx_from_raw(raw_tx: &str) -> Result<ffi::EVMTransaction> {
-    let tx = SignedTx::try_from(raw_tx)?;
+    let tx = SERVICES
+        .evm
+        .core
+        .signed_tx_cache
+        .try_get_or_create(raw_tx)?;
     let nonce = u64::try_from(tx.nonce())?;
     let gas_limit = u64::try_from(tx.gas_limit())?;
     let value = u64::try_from(WeiAmount(tx.value()).to_satoshi())?;

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -580,37 +580,39 @@ public:
         if (auto evmTxHash =  mnview.GetVMDomainTxEdge(VMDomainEdge::DVMToEVM, txHash)) {
             CrossBoundaryResult result;
             auto txInfo = evm_try_get_tx_by_hash(result, *evmTxHash);
-            if (result.ok) {
-                std::string tx_type;
-                switch (txInfo.tx_type) {
-                    case CEVMTxType::LegacyTransaction: {
-                        tx_type = "legacy";
-                        break;
-                    }
-                    case CEVMTxType::EIP2930Transaction: {
-                        tx_type = "eip2930";
-                        break;
-                    }
-                    case CEVMTxType::EIP1559Transaction: {
-                        tx_type = "eip1559";
-                        break;
-                    }
-                    default: {
-                        break;
-                    }
-                }
-                rpcInfo.pushKV("type", tx_type);
-                rpcInfo.pushKV("hash", *evmTxHash);
-                rpcInfo.pushKV("sender", std::string(txInfo.sender.data(), txInfo.sender.length()));
-                rpcInfo.pushKV("nonce", txInfo.nonce);
-                rpcInfo.pushKV("gasPrice", txInfo.gas_price);
-                rpcInfo.pushKV("gasLimit", txInfo.gas_limit);
-                rpcInfo.pushKV("maxFeePerGas", txInfo.max_fee_per_gas);
-                rpcInfo.pushKV("maxPriorityFeePerGas", txInfo.max_priority_fee_per_gas);
-                rpcInfo.pushKV("createTx", txInfo.create_tx);
-                rpcInfo.pushKV("to", std::string(txInfo.to.data(), txInfo.to.length()));
-                rpcInfo.pushKV("value", txInfo.value);
+            if (!result.ok) {
+                LogPrintf("Failed to get EVM tx info for tx %s: %s\n", txHash, result.reason.c_str());
+                return;
             }
+            std::string tx_type;
+            switch (txInfo.tx_type) {
+                case CEVMTxType::LegacyTransaction: {
+                    tx_type = "legacy";
+                    break;
+                }
+                case CEVMTxType::EIP2930Transaction: {
+                    tx_type = "eip2930";
+                    break;
+                }
+                case CEVMTxType::EIP1559Transaction: {
+                    tx_type = "eip1559";
+                    break;
+                }
+                default: {
+                    break;
+                }
+            }
+            rpcInfo.pushKV("type", tx_type);
+            rpcInfo.pushKV("hash", *evmTxHash);
+            rpcInfo.pushKV("sender", std::string(txInfo.sender.data(), txInfo.sender.length()));
+            rpcInfo.pushKV("nonce", txInfo.nonce);
+            rpcInfo.pushKV("gasPrice", txInfo.gas_price);
+            rpcInfo.pushKV("gasLimit", txInfo.gas_limit);
+            rpcInfo.pushKV("maxFeePerGas", txInfo.max_fee_per_gas);
+            rpcInfo.pushKV("maxPriorityFeePerGas", txInfo.max_priority_fee_per_gas);
+            rpcInfo.pushKV("createTx", txInfo.create_tx);
+            rpcInfo.pushKV("to", std::string(txInfo.to.data(), txInfo.to.length()));
+            rpcInfo.pushKV("value", txInfo.value);
         }
     }
 


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Cache all SignedTxs as they're used and replace all tx parsing pipeline to go through cache.
- ECC key recovery is the highest hotspot on EVM Txs. This caches it to ensure same TXs skip the key recovery.  

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
