### PR TITLE
Evm: Shift account balance check into pre-validation pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -289,6 +289,7 @@ impl EVMCoreService {
             return Ok(tx_info);
         }
 
+        let mut backend = self.get_backend(state_root)?;
         debug!("[validate_raw_tx] queue_id {}", queue_id);
         debug!("[validate_raw_tx] raw transaction : {:#?}", tx);
 
@@ -354,7 +355,6 @@ impl EVMCoreService {
         };
 
         // Start of stateful checks
-        let mut backend = self.get_backend(state_root)?;
         let nonce = backend.get_nonce(&signed_tx.sender);
         debug!(
             "[validate_raw_tx] signed_tx nonce : {:#?}",

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -259,9 +259,10 @@ impl EVMCoreService {
     /// 6. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
     ///
     /// The validation checks with state context of the tx before we consider it to be valid are:
-    /// 1. Nonce check: Verify that the tx nonce must equl to the current state account nonce.
-    /// 2. Execute the tx with the state root from the txqueue.
-    /// 3. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
+    /// 1. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// 2. Nonce check: Verify that the tx nonce must equl to the current state account nonce.
+    /// 3. Execute the tx with the state root from the txqueue.
+    /// 4. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
     ///
     /// # Arguments
     ///

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -242,13 +242,13 @@ impl EVMCoreService {
     /// 2. Gas price and tx value check: verify that amount is within money range.
     /// 3. Intrinsic gas limit check: verify that the tx intrinsic gas is within the tx gas limit.
     /// 4. Gas limit check: verify that the tx gas limit is not higher than the maximum gas per block.
-    /// 5. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
+    /// 5. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
+    /// 6. Account nonce check: verify that the tx nonce must be more than or equal to the account nonce.
     ///
     /// The validation checks with state context of the tx before we consider it to be valid are:
     /// 1. Nonce check: Verify that the tx nonce must equl to the current state account nonce.
     /// 2. Execute the tx with the state root from the txqueue.
-    /// 3. Account balance check: verify that the account balance must minimally have the tx prepay gas fee.
-    /// 4. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
+    /// 3. Check the total gas used in the queue with the addition of the tx do not exceed the block size limit.
     ///
     /// # Arguments
     ///
@@ -336,6 +336,14 @@ impl EVMCoreService {
             let prepay_fee = calculate_prepay_gas_fee(&signed_tx, block_fee)?;
             debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
 
+            // Validate tx prepay fees with account balance
+            let balance = backend.get_balance(&signed_tx.sender);
+            debug!("[validate_raw_tx] Account balance : {:x?}", balance);
+            if balance < prepay_fee {
+                debug!("[validate_raw_tx] insufficient balance to pay fees");
+                return Err(format_err!("insufficient balance to pay fees").into());
+            }
+
             self.tx_validation_cache.set_stateless(
                 String::from(tx),
                 ValidateTxInfo {
@@ -355,7 +363,7 @@ impl EVMCoreService {
         debug!("[validate_raw_tx] nonce : {:#?}", nonce);
 
         if pre_validate {
-            // Validate tx nonce
+            // Validate tx nonce with account nonce
             if nonce > signed_tx.nonce() {
                 return Err(format_err!(
                     "invalid nonce. Account nonce {}, signed_tx nonce {}",
@@ -385,15 +393,6 @@ impl EVMCoreService {
                     signed_tx.nonce()
                 )
                 .into());
-            }
-
-            // Validate tx prepay fees with account balance
-            let balance = backend.get_balance(&signed_tx.sender);
-            debug!("[validate_raw_tx] Account balance : {:x?}", balance);
-
-            if balance < prepay_fee {
-                debug!("[validate_raw_tx] insufficient balance to pay fees");
-                return Err(format_err!("insufficient balance to pay fees").into());
             }
 
             // Execute tx


### PR DESCRIPTION
## Summary

- Shift EVM balance check into pre-validation pipeline for EVM txs
- EVM txs will now be invalid and rejected/evicted from the mempool if it fails balance check based on the state of the chain tip
- Prevents mempool from being spammed with invalid evm txs that will never be executed

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
