### PR TITLE
Fix miner max sender rbf test

### DIFF
--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -259,7 +259,7 @@ class EVMTest(DefiTestFramework):
         hashes = []
         start_nonce = self.nodes[0].w3.eth.get_transaction_count(self.ethAddress)
         start_time = time()
-        for i in range(40):
+        for i in range(64):
             # tx call actual used gas: 1_761_626
             tx = contract.functions.loop(10_000).build_transaction(
                 {
@@ -290,8 +290,8 @@ class EVMTest(DefiTestFramework):
         # Accounting
         first_block_total_txs = 17
         second_block_total_txs = 17
-        third_block_total_txs = 6
-        fourth_block_total_txs = 0
+        third_block_total_txs = 17
+        fourth_block_total_txs = 13
 
         self.nodes[0].generate(1)
         block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)


### PR DESCRIPTION
## Summary
- Fix feature EVM miner RBF test to send maximum evm tx sender limit to mempool

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
