### PR TITLE
Consistent logging for MakeStake

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1097,7 +1097,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
 
                 if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                         subNodesBlockTime, timelock, ctxState)) {
-                    LogPrint(BCLog::STAKING, "MakeStake: kernel found\n");
+                    LogPrintf("MakeStake: kernel found\n");
 
                     found = true;
                     break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1075,7 +1075,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
 
                 if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                         subNodesBlockTime, timelock, ctxState)) {
-                    LogPrintf("MakeStake: kernel found\n");
+                    LogPrint(BCLog::STAKING, "MakeStake: kernel found. height: %d time: %d\n", blockHeight, blockTime);
 
                     found = true;
                     break;
@@ -1097,7 +1097,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
 
                 if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                         subNodesBlockTime, timelock, ctxState)) {
-                    LogPrintf("MakeStake: kernel found\n");
+                    LogPrint(BCLog::STAKING, "MakeStake: kernel found. height: %d time: %d\n", blockHeight, blockTime);
 
                     found = true;
                     break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1071,7 +1071,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
             for (uint32_t t = 0; t < currentTime - lastSearchTime; ++t) {
                 if (ShutdownRequested()) break;
 
-                blockTime = ((uint32_t)currentTime - t);
+                blockTime = (static_cast<uint32_t>(currentTime) - t);
 
                 if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                         subNodesBlockTime, timelock, ctxState)) {
@@ -1093,7 +1093,7 @@ Staker::Status Staker::stake(const CChainParams& chainparams, const ThreadStaker
             for (uint32_t t = 1; t <= futureTime - searchTime; ++t) {
                 if (ShutdownRequested()) break;
 
-                blockTime = ((uint32_t)searchTime + t);
+                blockTime = (static_cast<uint32_t>(searchTime) + t);
 
                 if (pos::CheckKernelHash(stakeModifier, nBits, creationHeight, blockTime, blockHeight, masternodeID, chainparams.GetConsensus(),
                         subNodesBlockTime, timelock, ctxState)) {


### PR DESCRIPTION
## Summary

- There are two logging lines for when a kernel is found, one logs with debug STAKING and the other without. This makes both lines log with debug logging enabled and adds block height and block time to the output, block hash will be printed later once TXs are added and the minter is also shown in a further log line.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
