### PR TITLE
EVM: Fix tx fee calculations in validation and miner

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -22,7 +22,7 @@ use crate::{
     backend::{BackendError, EVMBackend, Vicinity},
     block::INITIAL_BASE_FEE,
     executor::{AinExecutor, ExecutorContext, TxResponse},
-    fee::calculate_prepay_gas_fee,
+    fee::calculate_max_prepay_gas_fee,
     gas::check_tx_intrinsic_gas,
     receipt::ReceiptService,
     storage::{traits::BlockStorage, Storage},
@@ -401,7 +401,7 @@ impl EVMCoreService {
                 return Err(format_err!("gas limit higher than max_gas_per_block").into());
             }
 
-            let prepay_fee = calculate_prepay_gas_fee(&signed_tx, block_fee)?;
+            let prepay_fee = calculate_max_prepay_gas_fee(&signed_tx)?;
             debug!("[validate_raw_tx] prepay_fee : {:x?}", prepay_fee);
 
             self.tx_validation_cache.set_stateless(

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -414,15 +414,8 @@ impl EVMCoreService {
         };
 
         // Start of stateful checks
-        let mut backend = self.get_backend(state_root)?;
-        let nonce = backend.get_nonce(&signed_tx.sender);
-        debug!(
-            "[validate_raw_tx] signed_tx nonce : {:#?}",
-            signed_tx.nonce()
-        );
-        debug!("[validate_raw_tx] nonce : {:#?}", nonce);
-
         // Validate tx prepay fees with account balance
+        let mut backend = self.get_backend(state_root)?;
         let balance = backend.get_balance(&signed_tx.sender);
         debug!("[validate_raw_tx] Account balance : {:x?}", balance);
         if balance < prepay_fee {
@@ -430,6 +423,12 @@ impl EVMCoreService {
             return Err(format_err!("insufficient balance to pay fees").into());
         }
 
+        let nonce = backend.get_nonce(&signed_tx.sender);
+        debug!(
+            "[validate_raw_tx] signed_tx nonce : {:#?}",
+            signed_tx.nonce()
+        );
+        debug!("[validate_raw_tx] nonce : {:#?}", nonce);
         if pre_validate {
             // Validate tx nonce with account nonce
             if nonce > signed_tx.nonce() {
@@ -454,6 +453,7 @@ impl EVMCoreService {
                 },
             ));
         } else {
+            // Validate tx nonce equal to account nonce
             if nonce != signed_tx.nonce() {
                 return Err(format_err!(
                     "invalid nonce. Account nonce {}, signed_tx nonce {}",

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     core::EVMCoreService,
     evm::ReceiptAndOptionalContractAddress,
-    fee::{calculate_gas_fee, calculate_prepay_gas_fee},
+    fee::{calculate_current_prepay_gas_fee, calculate_gas_fee},
     precompiles::MetachainPrecompiles,
     transaction::{
         system::{DST20Data, DeployContractData, SystemTx, TransferDirection, TransferDomainData},
@@ -225,7 +225,7 @@ impl<'backend> AinExecutor<'backend> {
                     .into());
                 }
 
-                let prepay_gas = calculate_prepay_gas_fee(&signed_tx, base_fee)?;
+                let prepay_gas = calculate_current_prepay_gas_fee(&signed_tx, base_fee)?;
                 let (tx_response, receipt) =
                     self.exec(&signed_tx, signed_tx.gas_limit(), prepay_gas, base_fee)?;
                 debug!(

--- a/lib/ain-evm/src/fee.rs
+++ b/lib/ain-evm/src/fee.rs
@@ -1,14 +1,39 @@
 use anyhow::format_err;
+use ethereum::TransactionV2;
 use ethereum_types::U256;
 
 use crate::{transaction::SignedTx, Result};
 
-pub fn calculate_prepay_gas_fee(signed_tx: &SignedTx, base_fee: U256) -> Result<U256> {
+pub fn calculate_max_tip_gas_fee(signed_tx: &SignedTx, base_fee: U256) -> Result<U256> {
+    match &signed_tx.transaction {
+        TransactionV2::Legacy(tx) => {
+            let tip_fee_per_gas = tx.gas_price.saturating_sub(base_fee);
+            tx.gas_limit.checked_mul(tip_fee_per_gas)
+        }
+        TransactionV2::EIP2930(tx) => {
+            let tip_fee_per_gas = tx.gas_price.saturating_sub(base_fee);
+            tx.gas_limit.checked_mul(tip_fee_per_gas)
+        }
+        TransactionV2::EIP1559(tx) => tx.gas_limit.checked_mul(tx.max_priority_fee_per_gas),
+    }
+    .ok_or_else(|| format_err!("calculate max tip fee failed from overflow").into())
+}
+
+pub fn calculate_current_prepay_gas_fee(signed_tx: &SignedTx, base_fee: U256) -> Result<U256> {
     let gas_limit = signed_tx.gas_limit();
 
     gas_limit
         .checked_mul(signed_tx.effective_gas_price(base_fee))
-        .ok_or_else(|| format_err!("calculate prepay gas failed from overflow").into())
+        .ok_or_else(|| format_err!("calculate current prepay fee failed from overflow").into())
+}
+
+pub fn calculate_max_prepay_gas_fee(signed_tx: &SignedTx) -> Result<U256> {
+    match &signed_tx.transaction {
+        TransactionV2::Legacy(tx) => tx.gas_limit.checked_mul(tx.gas_price),
+        TransactionV2::EIP2930(tx) => tx.gas_limit.checked_mul(tx.gas_price),
+        TransactionV2::EIP1559(tx) => tx.gas_limit.checked_mul(tx.max_fee_per_gas),
+    }
+    .ok_or_else(|| format_err!("calculate max prepay fee failed from overflow").into())
 }
 
 // Gas prices are denoted in wei

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -45,7 +45,7 @@ pub mod ffi {
     pub struct TxInfo {
         pub address: String,
         pub nonce: u64,
-        pub prepay_fee: u64,
+        pub tip_fee: u64,
         pub used_gas: u64,
     }
 

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -149,7 +149,7 @@ rust::vec<TransactionData> getPoolTransactions() {
             }
 
             const auto obj = std::get<CEvmTxMessage>(txMessage);
-            poolTransactionsByFee.emplace(mi->GetEVMPrePayFee(), TransactionData{
+            poolTransactionsByFee.emplace(mi->GetEVMPromisedTipFee(), TransactionData{
                 static_cast<uint8_t>(TransactionDataTxType::EVM),
                 HexStr(obj.evmTx),
                 static_cast<uint8_t>(TransactionDataDirection::None),
@@ -168,13 +168,13 @@ rust::vec<TransactionData> getPoolTransactions() {
             }
 
             if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::DVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::EVM)) {
-                poolTransactionsByFee.emplace(mi->GetEVMPrePayFee(), TransactionData{
+                poolTransactionsByFee.emplace(mi->GetEVMPromisedTipFee(), TransactionData{
                     static_cast<uint8_t>(TransactionDataTxType::TransferDomain),
                     HexStr(obj.transfers[0].second.data),
                     static_cast<uint8_t>(TransactionDataDirection::DVMToEVM),
                 });
             } else if (obj.transfers[0].first.domain == static_cast<uint8_t>(VMDomain::EVM) && obj.transfers[0].second.domain == static_cast<uint8_t>(VMDomain::DVM)) {
-                poolTransactionsByFee.emplace(mi->GetEVMPrePayFee(), TransactionData{
+                poolTransactionsByFee.emplace(mi->GetEVMPromisedTipFee(), TransactionData{
                     static_cast<uint8_t>(TransactionDataTxType::TransferDomain),
                     HexStr(obj.transfers[0].first.data),
                     static_cast<uint8_t>(TransactionDataDirection::EVMToDVM),

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1205,7 +1205,7 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry, co
     for (auto it = range.first; it != range.second; ++it) {
         const auto& entry = *it;
 
-        if (pendingEntry.GetEVMPrePayFee() > entry.GetEVMPrePayFee()) {
+        if (pendingEntry.GetEVMPromisedTipFee() > entry.GetEVMPromisedTipFee()) {
             if (entry.GetCustomTxType() == CustomTxType::EvmTx) {
                 auto txIter = mapTx.project<0>(it);
                 itersToRemove.insert(txIter);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -107,7 +107,7 @@ private:
     int64_t nSigOpCostWithAncestors;
 
     // EVM related data
-    uint64_t evmPrePayFee{};
+    uint64_t evmMaxPromisedTipFee{};
     arith_uint256 evmGasUsed{};
     EvmAddressWithNonce evmAddressAndNonce;
     CustomTxType customTxType{CustomTxType::None};
@@ -133,8 +133,8 @@ public:
     // Getter / Setter for EVM related data
     void SetCustomTxType(const CustomTxType type) { customTxType = type; }
     [[nodiscard]] CustomTxType GetCustomTxType() const { return customTxType; }
-    void SetEVMPrePayFee(const uint64_t prePayFee) { evmPrePayFee = prePayFee; }
-    [[nodiscard]] uint64_t GetEVMPrePayFee() const { return evmPrePayFee; }
+    void SetEVMPomisedTipFee(const uint64_t maxPromisedTipFee) { evmMaxPromisedTipFee = maxPromisedTipFee; }
+    [[nodiscard]] uint64_t GetEVMPromisedTipFee() const { return evmMaxPromisedTipFee; }
     void SetEVMGasUsed(const arith_uint256 gasUsed) { evmGasUsed = gasUsed; }
     [[nodiscard]] arith_uint256 GetEVMGasUsed() const { return evmGasUsed; }
     void SetEVMAddrAndNonce(const EvmAddressWithNonce addrAndNonce) { evmAddressAndNonce = addrAndNonce; }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -945,12 +945,12 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
             EvmAddressWithNonce evmAddrAndNonce{txResult.nonce, txResult.address.c_str()};
 
-            const auto prePayFee = isEVMTx ? txResult.prepay_fee : std::numeric_limits<uint64_t>::max();
+            const auto tipFee = isEVMTx ? txResult.tip_fee : std::numeric_limits<uint64_t>::max();
             const auto usedGas = isEVMTx ? txResult.used_gas : std::numeric_limits<uint64_t>::min();
             const auto txResultSender = std::string(txResult.address.data(), txResult.address.length());
 
             entry.SetEVMAddrAndNonce(evmAddrAndNonce);
-            entry.SetEVMPrePayFee(prePayFee);
+            entry.SetEVMPomisedTipFee(tipFee);
             entry.SetEVMGasUsed(usedGas);
 
             auto senderLimitFlag{false};

--- a/test/functional/feature_evm_eip1559_fees.py
+++ b/test/functional/feature_evm_eip1559_fees.py
@@ -337,8 +337,8 @@ class EIP1559Fees(DefiTestFramework):
         )
         assert_equal(len(self.nodes[0].getrawmempool()), 1)
 
-        # send higher max fee tx but lower priority fee tx, RBF should not happen
-        priority_fee3 = self.node.w3.to_wei("25", "gwei")
+        # send same priority fees, RBF should not happen
+        priority_fee3 = self.node.w3.to_wei("30", "gwei")
         max_fee3 = self.node.w3.to_wei("100", "gwei")
         tx = self.contract.functions.store(10).build_transaction(
             {
@@ -348,6 +348,29 @@ class EIP1559Fees(DefiTestFramework):
                 ),
                 "maxPriorityFeePerGas": priority_fee3,
                 "maxFeePerGas": max_fee3,
+            }
+        )
+        signed = self.node.w3.eth.account.sign_transaction(
+            tx, self.evm_key_pair.privkey
+        )
+        assert_raises_web3_error(
+            -32001,
+            "evm-low-fee",
+            self.node.w3.eth.send_raw_transaction,
+            signed.rawTransaction,
+        )
+
+        # send higher max fee tx but lower priority fee tx, RBF should not happen
+        priority_fee4 = self.node.w3.to_wei("25", "gwei")
+        max_fee4 = self.node.w3.to_wei("100", "gwei")
+        tx = self.contract.functions.store(10).build_transaction(
+            {
+                "chainId": self.node.w3.eth.chain_id,
+                "nonce": self.node.w3.eth.get_transaction_count(
+                    self.evm_key_pair.address
+                ),
+                "maxPriorityFeePerGas": priority_fee4,
+                "maxFeePerGas": max_fee4,
             }
         )
         signed = self.node.w3.eth.account.sign_transaction(


### PR DESCRIPTION
## Summary

- Fixes to prepay fees when calculating the maximum prepay fees of EIP1559 txs
- Fix stateless pre-validation of EVM tx calculation of prepay fees to use maximum prepay fee validation for account balance check
- For stateful validation and adding of EVM txs into the txqueues, current prepay fee calculations is used, which calculates the tx prepay fees with the context of the base fee of the current / target block
- When EVM txs are included in the mempool, the PR fixes the fee calculations to align with Ethereum, which the replace-by-fee replace conditions are based on the promised tip fees that will go to the miner
- The old pipeline calculates the evm tx fees based on prepay fees of the current block, which uses effective gas price which is incorrect since it is a stateful calculation and does not guarantee that the tx with the highest promised priority fees that would go to the miner is selected
- In addition, fee calculation should not be stateful as it may cause incorrect txs to be replaced
- New design of EVM tx fee calculation in the mempool:
   - Promised miner fees for Legacy/EIP2930 txs will always use INITIAL_BLOCK_FEES (10 gwei) for the stateless fee calculations
   - Promised miner fees for EIP1559 calculation will use the specified priority fee per gas
   - Thus fees calculated for Legacy/EIP2930 txs which might not be the fees that eventually go into the miner since block base fees may differ on the block that the tx is minted
   - This ensures that evm txs that are replaced by the same type (for example, Legacy replaced with Legacy) will always be correct
- However the downside of the stateless fee calculation is that if the tx replacement is not of the same type, for example: a Legacy/EIP2930 tx is replaced with a EIP1559 tx, the fee replacement will take the assumption that miner promised fees for Legacy/EIP2930 txs is gasPrice - INITIAL_BLOCK_FEES, which may not be the most accurate RBF of the EVM tx

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
