### PR TITLE
Enable frame pointers on debug by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,17 +6,19 @@
 target-dir = "./build/lib/target"
 
 rustflags = [
-  "-C",
-  "link-arg=-z",
-  "-C",
-  "link-arg=undefs",
+  "-C", "link-arg=-z",
+  "-C", "link-arg=undefs",
   ## Enable below for debug when needed to force frame pointers
   # "-C", "force-frame-pointers=y",
   # "-C", "force-unwind-tables=y",
 ]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+rustflags = [
+  "-C", "link-arg=-undefined", 
+  "-C", "link-arg=dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+rustflags = [
+  "-C", "link-arg=-undefined", 
+  "-C", "link-arg=dynamic_lookup"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,12 +14,12 @@ rustflags = [
 
 [target.x86_64-apple-darwin]
 rustflags = [
-  "-C", "link-arg=-undefined", 
+  "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
-  "-C", "link-arg=-undefined", 
+  "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,3 @@
-
 [build]
 # We set this so that Makefile based
 # builds and ad-hoc cargo invocations all
@@ -16,9 +15,11 @@ rustflags = [
 [target.x86_64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined", 
-  "-C", "link-arg=dynamic_lookup"]
+  "-C", "link-arg=dynamic_lookup",
+]
 
 [target.aarch64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined", 
-  "-C", "link-arg=dynamic_lookup"]
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
+
 [build]
 # We set this so that Makefile based
 # builds and ad-hoc cargo invocations all
@@ -5,18 +6,17 @@
 target-dir = "./build/lib/target"
 
 rustflags = [
-  "-C", "link-arg=-z",
-  "-C", "link-arg=undefs",
+  "-C",
+  "link-arg=-z",
+  "-C",
+  "link-arg=undefs",
+  ## Enable below for debug when needed to force frame pointers
+  # "-C", "force-frame-pointers=y",
+  # "-C", "force-unwind-tables=y",
 ]
 
 [target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/make.sh
+++ b/make.sh
@@ -52,6 +52,7 @@ setup_vars() {
     MAKE_CONF_ARGS="$(get_default_conf_args) ${MAKE_CONF_ARGS:-}"
     if [[ "${MAKE_DEBUG}" == "1" ]]; then
       MAKE_CONF_ARGS="${MAKE_CONF_ARGS} --enable-debug";
+      MAKE_CONF_ARGS="${MAKE_CONF_ARGS} CXXFLAGS=-fno-omit-frame-pointer";
     fi
 
     MAKE_CONF_ARGS_OVERRIDE="${MAKE_CONF_ARGS_OVERRIDE:-}"


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Enables frame pointers by default on debug build to provide better stack traces 
- This enables perf to provide deeper profiles without omitting stack frames. It's common for most software to be built with `fno-omit-frame-pointer` on debug. 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
