### PR TITLE
Enable stack frame pointers for debug in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,9 @@ if test "x$enable_debug" = xyes; then
   # Disable all optimizations
   AX_CHECK_COMPILE_FLAG([-O0], [[DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -O0"]],,[[$CXXFLAG_WERROR]])
 
+  # Store frame pointer
+  AX_CHECK_COMPILE_FLAG([-fno-omit-frame-pointer], [[DEBUG_CXXFLAGS="$DEBUG_CXXFLAGS -fno-omit-frame-pointer"]],,[[$CXXFLAG_WERROR]])
+
   # Prefer -g3, fall back to -g if that is unavailable.
   AX_CHECK_COMPILE_FLAG(
     [-g3],

--- a/make.sh
+++ b/make.sh
@@ -52,7 +52,6 @@ setup_vars() {
     MAKE_CONF_ARGS="$(get_default_conf_args) ${MAKE_CONF_ARGS:-}"
     if [[ "${MAKE_DEBUG}" == "1" ]]; then
       MAKE_CONF_ARGS="${MAKE_CONF_ARGS} --enable-debug";
-      MAKE_CONF_ARGS="${MAKE_CONF_ARGS} CXXFLAGS=-fno-omit-frame-pointer";
     fi
 
     MAKE_CONF_ARGS_OVERRIDE="${MAKE_CONF_ARGS_OVERRIDE:-}"


### PR DESCRIPTION
## Summary

- Moves `-fno-omit-frame-pointer` to `configure.ac` for users that do not use `make.sh`.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
