### PR TITLE
EVM: Cleanup construct block

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -304,23 +304,8 @@ impl EVMServices {
                 Ok(result) => result,
                 Err(EVMError::BlockSizeLimit(message)) => {
                     debug!("[construct_block] {}", message);
-                    if let Some(index) = queue
-                        .transactions
-                        .iter()
-                        .position(|item| item.tx_hash == queue_item.tx_hash)
-                    {
-                        failed_transactions = queue
-                            .transactions
-                            .drain(index..)
-                            .map(|item| item.tx_hash)
-                            .collect();
-                        break;
-                    } else {
-                        return Err(format_err!(
-                            "exceed block size limit but unable to get failed transaction from queue"
-                        )
-                        .into());
-                    }
+                    failed_transactions.push(queue_item.tx_hash);
+                    continue;
                 }
                 Err(e) => {
                     return Err(e);


### PR DESCRIPTION
## Summary

- Remove early return out of txqueue since this could potentially lead to transferdomain txs going into the failed txs which is undesirable
- Iterate through the full txqueue, and append evm txs that fail to make it into the block due to block size limit into the failed txs, which will be handled accordingly to be removed out of the DVM block to maintain state consistency
- If EVM tx fails to make it to the block, backend state will not be commited to ensure state consistency


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
