### PR TITLE
EVM: Refund prepay gas fees for failed EVM tx

### DIFF
--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -189,7 +189,8 @@ impl<'backend> AinExecutor<'backend> {
         let block_gas_limit = self.backend.vicinity.block_gas_limit;
         if !system_tx && total_gas_used + U256::from(used_gas) > block_gas_limit {
             if !prepay_fee != U256::zero() {
-                self.backend.refund_unused_gas_fee(signed_tx, U256::zero(), base_fee)?;
+                self.backend
+                    .refund_unused_gas_fee(signed_tx, U256::zero(), base_fee)?;
             }
             return Err(EVMError::BlockSizeLimit(
                 "Block size limit exceeded, tx cannot make it into the block".to_string(),

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -188,6 +188,9 @@ impl<'backend> AinExecutor<'backend> {
         let total_gas_used = self.backend.vicinity.total_gas_used;
         let block_gas_limit = self.backend.vicinity.block_gas_limit;
         if !system_tx && total_gas_used + U256::from(used_gas) > block_gas_limit {
+            if !prepay_fee != U256::zero() {
+                self.backend.refund_unused_gas_fee(signed_tx, U256::zero(), base_fee)?;
+            }
             return Err(EVMError::BlockSizeLimit(
                 "Block size limit exceeded, tx cannot make it into the block".to_string(),
             ));


### PR DESCRIPTION
## Summary

- Refund the prepay gas fee deduction if a failed EVM tx fails to make it into the block due to block size limit in execution pipeline.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
