### PR TITLE
EVM: Shift prepay fee calculation into execution, fix failed transactions pipeline

### DIFF
--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -133,7 +133,6 @@ impl<'backend> AinExecutor<'backend> {
         &mut self,
         signed_tx: &SignedTx,
         gas_limit: U256,
-        prepay_fee: U256,
         base_fee: U256,
         system_tx: bool,
     ) -> Result<(TxResponse, ReceiptV3)> {
@@ -151,7 +150,12 @@ impl<'backend> AinExecutor<'backend> {
             access_list: signed_tx.access_list(),
         };
 
-        if !system_tx && prepay_fee != U256::zero() {
+        let prepay_fee = if system_tx {
+            U256::zero()
+        } else {
+            calculate_current_prepay_gas_fee(signed_tx, base_fee)?
+        };
+        if !system_tx {
             self.backend
                 .deduct_prepay_gas_fee(signed_tx.sender, prepay_fee)?;
         }
@@ -188,10 +192,8 @@ impl<'backend> AinExecutor<'backend> {
         let total_gas_used = self.backend.vicinity.total_gas_used;
         let block_gas_limit = self.backend.vicinity.block_gas_limit;
         if !system_tx && total_gas_used + U256::from(used_gas) > block_gas_limit {
-            if !prepay_fee != U256::zero() {
-                self.backend
-                    .refund_unused_gas_fee(signed_tx, U256::zero(), base_fee)?;
-            }
+            self.backend
+                .refund_unused_gas_fee(signed_tx, U256::zero(), base_fee)?;
             return Err(EVMError::BlockSizeLimit(
                 "Block size limit exceeded, tx cannot make it into the block".to_string(),
             ));
@@ -202,7 +204,7 @@ impl<'backend> AinExecutor<'backend> {
         ApplyBackend::apply(self.backend, values, logs.clone(), true);
         self.backend.commit();
 
-        if !system_tx && prepay_fee != U256::zero() {
+        if !system_tx {
             self.backend
                 .refund_unused_gas_fee(signed_tx, U256::from(used_gas), base_fee)?;
         }
@@ -243,14 +245,8 @@ impl<'backend> AinExecutor<'backend> {
                     .into());
                 }
 
-                let prepay_fee = calculate_current_prepay_gas_fee(&signed_tx, base_fee)?;
-                let (tx_response, receipt) = self.exec(
-                    &signed_tx,
-                    signed_tx.gas_limit(),
-                    prepay_fee,
-                    base_fee,
-                    false,
-                )?;
+                let (tx_response, receipt) =
+                    self.exec(&signed_tx, signed_tx.gas_limit(), base_fee, false)?;
 
                 debug!(
                     "[apply_queue_tx]receipt : {:?}, exit_reason {:#?} for signed_tx : {:#x}",
@@ -316,7 +312,7 @@ impl<'backend> AinExecutor<'backend> {
                 }
 
                 let (tx_response, receipt) =
-                    self.exec(&signed_tx, U256::MAX, U256::zero(), U256::zero(), true)?;
+                    self.exec(&signed_tx, U256::MAX, U256::zero(), true)?;
                 if !tx_response.exit_reason.is_succeed() {
                     return Err(format_err!(
                         "[apply_queue_tx] Transfer domain failed VM execution {:?}",
@@ -373,7 +369,7 @@ impl<'backend> AinExecutor<'backend> {
                 self.commit();
 
                 let (tx_response, receipt) =
-                    self.exec(&signed_tx, U256::MAX, U256::zero(), U256::zero(), true)?;
+                    self.exec(&signed_tx, U256::MAX, U256::zero(), true)?;
                 if !tx_response.exit_reason.is_succeed() {
                     debug!(
                         "[apply_queue_tx] DST20 bridge failed VM execution {:?}, data {}",

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -353,20 +353,20 @@ fn unsafe_prevalidate_raw_tx_in_q(
     unsafe {
         let ValidateTxInfo {
             signed_tx,
-            prepay_fee,
+            max_prepay_fee,
         } = SERVICES
             .evm
             .core
             .validate_raw_tx(raw_tx, queue_id, true, U256::zero())?;
 
         let nonce = u64::try_from(signed_tx.nonce())?;
-        let prepay_fee = u64::try_from(prepay_fee)?;
+        let max_prepay_fee = u64::try_from(max_prepay_fee)?;
 
         Ok(ffi::ValidateTxCompletion {
             nonce,
             sender: format!("{:?}", signed_tx.sender),
             tx_hash: format!("{:?}", signed_tx.hash()),
-            prepay_fee,
+            max_prepay_fee,
         })
     }
 }
@@ -403,7 +403,7 @@ fn unsafe_validate_raw_tx_in_q(queue_id: u64, raw_tx: &str) -> Result<ffi::Valid
     unsafe {
         let ValidateTxInfo {
             signed_tx,
-            prepay_fee,
+            max_prepay_fee,
         } = SERVICES
             .evm
             .core
@@ -411,13 +411,13 @@ fn unsafe_validate_raw_tx_in_q(queue_id: u64, raw_tx: &str) -> Result<ffi::Valid
 
         let nonce = u64::try_from(signed_tx.nonce())?;
 
-        let prepay_fee = u64::try_from(prepay_fee)?;
+        let max_prepay_fee = u64::try_from(max_prepay_fee)?;
 
         Ok(ffi::ValidateTxCompletion {
             nonce,
             sender: format!("{:?}", signed_tx.sender),
             tx_hash: format!("{:?}", signed_tx.hash()),
-            prepay_fee,
+            max_prepay_fee,
         })
     }
 }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -133,7 +133,7 @@ pub mod ffi {
         pub nonce: u64,
         pub sender: String,
         pub tx_hash: String,
-        pub prepay_fee: u64,
+        pub max_prepay_fee: u64,
     }
 
     extern "Rust" {


### PR DESCRIPTION
## Summary

- More correct execution of EVM txs, fixes validate_evm_txs from passing max prepay gas fees into execution.
- Once an EVM tx fails, subsequent evm txs may fail as ordering is no longer ensured. We will queue all subsequent failed txs and remove them from the DVM block.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
