### PR TITLE
Remove redundant validation checks

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -431,7 +431,7 @@ impl EVMServices {
         queue_id: u64,
         tx: QueueTx,
     ) -> Result<(SignedTx, U256, H256)> {
-        let (target_block, state_root, timestamp, is_first_tx) = {
+        let (target_block, state_root, timestamp, total_gas_used, is_first_tx) = {
             let queue = self.core.tx_queues.get(queue_id)?;
 
             let state_root = queue.get_latest_state_root();
@@ -441,6 +441,7 @@ impl EVMServices {
                 data.target_block,
                 state_root,
                 data.timestamp,
+                data.total_gas_used,
                 data.transactions.is_empty(),
             )
         };
@@ -481,6 +482,7 @@ impl EVMServices {
             executor.commit();
         }
 
+        executor.update_total_gas_used(total_gas_used);
         let apply_tx = executor.apply_queue_tx(tx, base_fee)?;
 
         Ok((

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -364,9 +364,9 @@ impl<'backend> AinExecutor<'backend> {
                 let amount = U256::from_big_endian(&input[100..132]);
 
                 debug!(
-                "[apply_queue_tx] DST20Bridge from {}, contract_address {}, amount {}, direction {}",
-                signed_tx.sender, contract_address, amount, direction
-            );
+                    "[apply_queue_tx] DST20Bridge from {}, contract_address {}, amount {}, direction {}",
+                    signed_tx.sender, contract_address, amount, direction
+                );
 
                 if direction == TransferDirection::EvmIn {
                     let DST20BridgeInfo { address, storage } =

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -349,6 +349,17 @@ impl<'backend> AinExecutor<'backend> {
                 contract_address,
                 direction,
             })) => {
+                // Validate nonce
+                let nonce = self.backend.get_nonce(&signed_tx.sender);
+                if nonce != signed_tx.nonce() {
+                    return Err(format_err!(
+                        "[apply_queue_tx] nonce check failed. Account nonce {}, signed_tx nonce {}",
+                        nonce,
+                        signed_tx.nonce(),
+                    )
+                    .into());
+                }
+
                 let input = signed_tx.data();
                 let amount = U256::from_big_endian(&input[100..132]);
 

--- a/lib/ain-evm/src/services.rs
+++ b/lib/ain-evm/src/services.rs
@@ -6,10 +6,9 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use parking_lot::Mutex;
-
 use anyhow::Result;
 use jsonrpsee_server::ServerHandle as HttpServerHandle;
+use parking_lot::Mutex;
 use tokio::{
     runtime::{Builder, Handle as AsyncHandle},
     sync::mpsc::{self, Sender},

--- a/lib/ain-evm/src/txqueue.rs
+++ b/lib/ain-evm/src/txqueue.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
-use parking_lot::{Mutex, RwLock};
-
 use ethereum::{Block, TransactionV2};
 use ethereum_types::{H256, U256};
+use parking_lot::{Mutex, RwLock};
 use rand::Rng;
 
 use crate::{

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -351,22 +351,14 @@ fn unsafe_prevalidate_raw_tx_in_q(
 ) -> Result<ffi::ValidateTxCompletion> {
     debug!("[unsafe_prevalidate_raw_tx_in_q]");
     unsafe {
-        let ValidateTxInfo {
-            signed_tx,
-            prepay_fee,
-        } = SERVICES
-            .evm
-            .core
-            .validate_raw_tx(raw_tx, queue_id, true, U256::zero())?;
-
-        let nonce = u64::try_from(signed_tx.nonce())?;
-        let prepay_fee = u64::try_from(prepay_fee)?;
+        let ValidateTxInfo { signed_tx, .. } =
+            SERVICES
+                .evm
+                .core
+                .validate_raw_tx(raw_tx, queue_id, true, U256::zero())?;
 
         Ok(ffi::ValidateTxCompletion {
-            nonce,
-            sender: format!("{:?}", signed_tx.sender),
             tx_hash: format!("{:?}", signed_tx.hash()),
-            prepay_fee,
         })
     }
 }
@@ -401,23 +393,13 @@ fn unsafe_validate_raw_tx_in_q(queue_id: u64, raw_tx: &str) -> Result<ffi::Valid
     debug!("[unsafe_validate_raw_tx_in_q]");
     let block_fee = SERVICES.evm.verify_tx_fees(raw_tx)?;
     unsafe {
-        let ValidateTxInfo {
-            signed_tx,
-            prepay_fee,
-        } = SERVICES
+        let ValidateTxInfo { signed_tx, .. } = SERVICES
             .evm
             .core
             .validate_raw_tx(raw_tx, queue_id, false, block_fee)?;
 
-        let nonce = u64::try_from(signed_tx.nonce())?;
-
-        let prepay_fee = u64::try_from(prepay_fee)?;
-
         Ok(ffi::ValidateTxCompletion {
-            nonce,
-            sender: format!("{:?}", signed_tx.sender),
             tx_hash: format!("{:?}", signed_tx.hash()),
-            prepay_fee,
         })
     }
 }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -320,7 +320,7 @@ fn unsafe_sub_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Re
     }
 }
 
-/// Pre-validates a raw EVM transaction.
+/// Validates a raw EVM transaction.
 ///
 /// # Arguments
 ///
@@ -333,10 +333,11 @@ fn unsafe_sub_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Re
 /// Returns an Error if:
 /// - The hex data is invalid
 /// - The EVM transaction is invalid
-/// - The EVM transaction fee is lower than the next block's base fee
+/// - The EVM transaction fee is lower than the initial block base fee
+/// - The EVM transaction values exceed money range.
 /// - Could not fetch the underlying EVM account
 /// - Account's nonce is more than raw tx's nonce
-/// - The EVM transaction prepay gas is invalid
+/// - The EVM transaction max prepay gas is invalid
 /// - The EVM transaction gas limit is lower than the transaction intrinsic gas
 ///
 /// # Returns
@@ -352,7 +353,7 @@ fn unsafe_prevalidate_raw_tx_in_q(
     debug!("[unsafe_prevalidate_raw_tx_in_q]");
     unsafe {
         let ValidateTxInfo { signed_tx, .. } =
-            SERVICES.evm.core.prevalidate_raw_tx(raw_tx, queue_id)?;
+            SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id)?;
 
         Ok(ffi::ValidateTxCompletion {
             tx_hash: format!("{:?}", signed_tx.hash()),

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -130,10 +130,7 @@ pub mod ffi {
 
     #[derive(Default)]
     pub struct ValidateTxCompletion {
-        pub nonce: u64,
-        pub sender: String,
         pub tx_hash: String,
-        pub prepay_fee: u64,
     }
 
     extern "Rust" {

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -173,11 +173,6 @@ pub mod ffi {
             queue_id: u64,
             raw_tx: &str,
         ) -> ValidateTxCompletion;
-        fn evm_try_unsafe_validate_raw_tx_in_q(
-            result: &mut CrossBoundaryResult,
-            queue_id: u64,
-            raw_tx: &str,
-        ) -> ValidateTxCompletion;
         fn evm_try_unsafe_validate_transferdomain_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
@@ -189,7 +184,7 @@ pub mod ffi {
             queue_id: u64,
             raw_tx: &str,
             native_hash: &str,
-        );
+        ) -> ValidateTxCompletion;
         fn evm_try_unsafe_construct_block_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -394,13 +394,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Ok();
     }
 
-    const auto validateResults = evm_try_unsafe_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
-    if (!result.ok) {
-        LogPrintf("[evm_try_validate_raw_tx_in_q] failed, reason : %s\n", result.reason);
-        return Res::Err("evm tx failed to validate %s\n", result.reason);
-    }
-
-    evm_try_unsafe_push_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), tx.GetHash().GetHex());
+    const auto validateResults = evm_try_unsafe_push_tx_in_q(result, evmQueueId, HexStr(obj.evmTx), tx.GetHash().GetHex());
     if (!result.ok) {
         LogPrintf("[evm_try_push_tx_in_q] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to queue %s\n", result.reason);


### PR DESCRIPTION
## Summary

- `evm_try_unsafe_validate_raw_tx_in_q` has seen some major overhaul recently. Since then, it's only checking for nonce and total_gas_used. These checks are also part of `evm_try_unsafe_push_tx_in_q`.
Both these calls are called one after the other and executing the same checks. TX validation is now handled only by `evm_try_unsafe_push_tx_in_q`.
- Port TD DST20 nonce check to `apply_queue_tx`.
- Remove `evm_try_unsafe_validate_raw_tx_in_q` which was always called before `evm_try_unsafe_push_tx_in_q`.
- Non-consensus since this PR only removes redundant checks. 

- Depends on https://github.com/DeFiCh/ain/pull/2532