### PR TITLE
EVM: Remove eth call on mempool and miner pipeline

### DIFF
--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -3,9 +3,8 @@ use ain_contracts::{
     get_transferdomain_native_transfer_function, FixedContract,
 };
 use ain_evm::{
-    core::{EthCallArgs, TransferDomainTxInfo, ValidateTxInfo, XHash},
+    core::{TransferDomainTxInfo, ValidateTxInfo, XHash},
     evm::FinalizedBlockInfo,
-    executor::TxResponse,
     fee::calculate_max_tip_gas_fee,
     services::SERVICES,
     storage::traits::{BlockStorage, Rollback, TransactionStorage},
@@ -877,36 +876,14 @@ fn get_tx_info_from_raw_tx(raw_tx: &str) -> Result<TxInfo> {
         .try_get_or_create(raw_tx)?;
 
     let nonce = u64::try_from(signed_tx.nonce())?;
-
-    let (parent_hash, parent_number) = SERVICES
-        .evm
-        .block
-        .get_latest_block_hash_and_number()?
-        .unwrap_or_default();
-
     let initial_base_fee = SERVICES.evm.block.calculate_base_fee(H256::zero())?;
     let tip_fee = calculate_max_tip_gas_fee(&signed_tx, initial_base_fee)?;
     let tip_fee = u64::try_from(tip_fee)?;
-
-    let base_fee = SERVICES.evm.block.calculate_base_fee(parent_hash)?;
-    let TxResponse { used_gas, .. } = SERVICES.evm.core.call(EthCallArgs {
-        caller: Some(signed_tx.sender),
-        to: signed_tx.to(),
-        value: signed_tx.value(),
-        data: signed_tx.data(),
-        gas_limit: u64::try_from(signed_tx.gas_limit()).unwrap_or(u64::MAX),
-        gas_price: Some(signed_tx.effective_gas_price(base_fee)),
-        max_fee_per_gas: signed_tx.max_fee_per_gas(),
-        access_list: signed_tx.access_list(),
-        block_number: parent_number,
-        transaction_type: Some(signed_tx.get_tx_type()),
-    })?;
 
     Ok(TxInfo {
         nonce,
         address: format!("{:?}", signed_tx.sender),
         tip_fee,
-        used_gas,
     })
 }
 

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -46,7 +46,6 @@ pub mod ffi {
         pub address: String,
         pub nonce: u64,
         pub tip_fee: u64,
-        pub used_gas: u64,
     }
 
     // ========== Governance Variable ==========

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -108,7 +108,6 @@ private:
 
     // EVM related data
     uint64_t evmMaxPromisedTipFee{};
-    arith_uint256 evmGasUsed{};
     EvmAddressWithNonce evmAddressAndNonce;
     CustomTxType customTxType{CustomTxType::None};
 
@@ -135,8 +134,6 @@ public:
     [[nodiscard]] CustomTxType GetCustomTxType() const { return customTxType; }
     void SetEVMPomisedTipFee(const uint64_t maxPromisedTipFee) { evmMaxPromisedTipFee = maxPromisedTipFee; }
     [[nodiscard]] uint64_t GetEVMPromisedTipFee() const { return evmMaxPromisedTipFee; }
-    void SetEVMGasUsed(const arith_uint256 gasUsed) { evmGasUsed = gasUsed; }
-    [[nodiscard]] arith_uint256 GetEVMGasUsed() const { return evmGasUsed; }
     void SetEVMAddrAndNonce(const EvmAddressWithNonce addrAndNonce) { evmAddressAndNonce = addrAndNonce; }
     [[nodiscard]] const EvmAddressWithNonce& GetEVMAddrAndNonce() const { return evmAddressAndNonce; }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -946,12 +946,10 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             EvmAddressWithNonce evmAddrAndNonce{txResult.nonce, txResult.address.c_str()};
 
             const auto tipFee = isEVMTx ? txResult.tip_fee : std::numeric_limits<uint64_t>::max();
-            const auto usedGas = isEVMTx ? txResult.used_gas : std::numeric_limits<uint64_t>::min();
             const auto txResultSender = std::string(txResult.address.data(), txResult.address.length());
 
             entry.SetEVMAddrAndNonce(evmAddrAndNonce);
             entry.SetEVMPomisedTipFee(tipFee);
-            entry.SetEVMGasUsed(usedGas);
 
             auto senderLimitFlag{false};
             if (!pool.checkAddressNonceAndFee(entry, txResultSender, senderLimitFlag)) {


### PR DESCRIPTION
## Summary

- Clean up and optimize mempool pipeline by removing eth call on the EVM to get tx entries' gas used when adding to the mempool
- Remove block gas limit check on miner pipeline that skips queuing an evm tx if block gas limit will exceed, as this is no longer since caching is added on validation of EVM txs
- baseline test: feature_evm_miner test timing reduces by more than 30% with this PR

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
