### PR TITLE
EVM: Housekeeping and cleanup validation cache

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -333,9 +333,9 @@ impl EVMCoreService {
         let state_root = self.tx_queues.get_latest_state_root_in(queue_id)?;
         debug!("[validate_raw_tx] state_root : {:#?}", state_root);
 
-        if let Some(tx_info) =
-            self.tx_validation_cache
-                .get(&(state_root, String::from(tx)))
+        if let Some(tx_info) = self
+            .tx_validation_cache
+            .get(&(state_root, String::from(tx)))
         {
             return Ok(tx_info);
         }

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -81,7 +81,7 @@ impl SignedTxCache {
 }
 
 struct TxValidationCache {
-    validated: spin::Mutex<LruCache<(U256, H256, String), ValidateTxInfo>>,
+    validated: spin::Mutex<LruCache<(H256, String), ValidateTxInfo>>,
     stateless: spin::Mutex<LruCache<String, ValidateTxInfo>>,
 }
 
@@ -99,7 +99,7 @@ impl TxValidationCache {
         }
     }
 
-    pub fn get(&self, key: &(U256, H256, String)) -> Option<ValidateTxInfo> {
+    pub fn get(&self, key: &(H256, String)) -> Option<ValidateTxInfo> {
         self.validated.lock().get(key).cloned()
     }
 
@@ -107,7 +107,7 @@ impl TxValidationCache {
         self.stateless.lock().get(key).cloned()
     }
 
-    pub fn set(&self, key: (U256, H256, String), value: ValidateTxInfo) -> ValidateTxInfo {
+    pub fn set(&self, key: (H256, String), value: ValidateTxInfo) -> ValidateTxInfo {
         let mut cache = self.validated.lock();
         cache.put(key, value.clone());
         value
@@ -333,14 +333,9 @@ impl EVMCoreService {
         let state_root = self.tx_queues.get_latest_state_root_in(queue_id)?;
         debug!("[validate_raw_tx] state_root : {:#?}", state_root);
 
-        let total_current_gas_used = self
-            .tx_queues
-            .get_total_gas_used_in(queue_id)
-            .unwrap_or_default();
-
         if let Some(tx_info) =
             self.tx_validation_cache
-                .get(&(total_current_gas_used, state_root, String::from(tx)))
+                .get(&(state_root, String::from(tx)))
         {
             return Ok(tx_info);
         }
@@ -430,7 +425,7 @@ impl EVMCoreService {
         }
 
         Ok(self.tx_validation_cache.set(
-            (total_current_gas_used, state_root, String::from(tx)),
+            (state_root, String::from(tx)),
             ValidateTxInfo {
                 signed_tx,
                 max_prepay_fee,

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -3,7 +3,7 @@ use ain_contracts::{
     get_transferdomain_native_transfer_function, FixedContract,
 };
 use ain_evm::{
-    core::{EthCallArgs, TransferDomainTxInfo, ValidateTxInfo, XHash},
+    core::{EthCallArgs, TransferDomainTxInfo, XHash},
     evm::FinalizedBlockInfo,
     executor::TxResponse,
     fee::calculate_max_tip_gas_fee,
@@ -342,22 +342,16 @@ fn unsafe_sub_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Re
 ///
 /// # Returns
 ///
-/// Returns the transaction nonce, sender address, transaction hash, transaction prepay fees,
-/// gas used, higher nonce flag and lower nonce flag. Logs and set the error reason to result
-/// object otherwise.
+/// Returns the validation result.
 #[ffi_fallible]
-fn unsafe_prevalidate_raw_tx_in_q(
+fn unsafe_validate_raw_tx_in_q(
     queue_id: u64,
     raw_tx: &str,
-) -> Result<ffi::ValidateTxCompletion> {
-    debug!("[unsafe_prevalidate_raw_tx_in_q]");
+) -> Result<()> {
+    debug!("[unsafe_validate_raw_tx_in_q]");
     unsafe {
-        let ValidateTxInfo { signed_tx, .. } =
-            SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id)?;
-
-        Ok(ffi::ValidateTxCompletion {
-            tx_hash: format!("{:?}", signed_tx.hash()),
-        })
+        let _ = SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id)?;
+        Ok(())
     }
 }
 
@@ -382,7 +376,7 @@ fn unsafe_prevalidate_raw_tx_in_q(
 ///
 /// # Returns
 ///
-/// Returns the valiadtion result.
+/// Returns the validation result.
 #[ffi_fallible]
 fn unsafe_validate_transferdomain_tx_in_q(
     queue_id: u64,

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -344,10 +344,7 @@ fn unsafe_sub_balance_in_q(queue_id: u64, raw_tx: &str, native_hash: &str) -> Re
 ///
 /// Returns the validation result.
 #[ffi_fallible]
-fn unsafe_validate_raw_tx_in_q(
-    queue_id: u64,
-    raw_tx: &str,
-) -> Result<()> {
+fn unsafe_validate_raw_tx_in_q(queue_id: u64, raw_tx: &str) -> Result<()> {
     debug!("[unsafe_validate_raw_tx_in_q]");
     unsafe {
         let _ = SERVICES.evm.core.validate_raw_tx(raw_tx, queue_id)?;

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -168,11 +168,11 @@ pub mod ffi {
             raw_tx: &str,
             native_hash: &str,
         ) -> bool;
-        fn evm_try_unsafe_prevalidate_raw_tx_in_q(
+        fn evm_try_unsafe_validate_raw_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,
             raw_tx: &str,
-        ) -> ValidateTxCompletion;
+        );
         fn evm_try_unsafe_validate_transferdomain_tx_in_q(
             result: &mut CrossBoundaryResult,
             queue_id: u64,

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -386,9 +386,9 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
 
     CrossBoundaryResult result;
     if (evmPreValidate) {
-        evm_try_unsafe_prevalidate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
+        evm_try_unsafe_validate_raw_tx_in_q(result, evmQueueId, HexStr(obj.evmTx));
         if (!result.ok) {
-            LogPrintf("[evm_try_prevalidate_raw_tx] failed, reason : %s\n", result.reason);
+            LogPrintf("[evm_try_validate_raw_tx] failed, reason : %s\n", result.reason);
             return Res::Err("evm tx failed to pre-validate %s", result.reason);
         }
         return Res::Ok();


### PR DESCRIPTION
## Summary

- Housekeeping, clean up validation cache to remove using total_gas_used as key
- Fix naming convention from unsafe_prevalidate_raw_tx_in_q to unsafe_validate_raw_tx_in_q
- Cleanup FFI validate raw tx function to return validation result.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
