### PR TITLE
Numeric prefix to all network upgrades

### DIFF
--- a/contrib/devtools/mocknet.patch
+++ b/contrib/devtools/mocknet.patch
@@ -12,7 +12,7 @@ index 1ad8d066d..01b13b8aa 100644
 +    }
 +
      int nHeight{pindexLast->nHeight + 1};
-     bool newDifficultyAdjust{nHeight > params.EunosHeight};
+     bool newDifficultyAdjust{nHeight > params.DF8EunosHeight};
  
 diff --git a/src/version.h b/src/version.h
 index 3ab303d56..fb84cea92 100644

--- a/src/chain.h
+++ b/src/chain.h
@@ -330,7 +330,7 @@ public:
         std::sort(pbegin, pend);
 
         // Only after FC and when we have a full set of times.
-        if (nHeight >= Params().GetConsensus().FortCanningHeight && pend - pbegin == nMedianTimeSpan) {
+        if (nHeight >= Params().GetConsensus().DF11FortCanningHeight && pend - pbegin == nMedianTimeSpan) {
             // Take the median of the top five.
             return pbegin[8];
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -119,28 +119,28 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 0; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 0; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        consensus.AMKHeight = 356500; // Oct 12th, 2020.
-        consensus.BayfrontHeight = 405000; // Nov 2nd, 2020.
-        consensus.BayfrontMarinaHeight = 465150; // Nov 28th, 2020.
+        consensus.DF1AMKHeight = 356500; // Oct 12th, 2020.
+        consensus.DF2BayfrontHeight = 405000; // Nov 2nd, 2020.
+        consensus.DF3DF4BayfrontGardensHeight = 465150; // Nov 28th, 2020.
         consensus.BayfrontGardensHeight = 488300; // Dec 8th, 2020.
-        consensus.ClarkeQuayHeight = 595738; // Jan 24th, 2021.
-        consensus.DakotaHeight = 678000; // Mar 1st, 2021.
-        consensus.DakotaCrescentHeight = 733000; // Mar 25th, 2021.
-        consensus.EunosHeight = 894000; // Jun 3rd, 2021.
-        consensus.EunosKampungHeight = 895743; // Jun 4th, 2021.
-        consensus.EunosPayaHeight = 1072000; // Aug 5th, 2021.
-        consensus.FortCanningHeight = 1367000; // Nov 15th, 2021.
-        consensus.FortCanningMuseumHeight = 1430640; // Dec 7th, 2021.
-        consensus.FortCanningParkHeight = 1503143; // Jan 2nd, 2022.
-        consensus.FortCanningHillHeight = 1604999; // Feb 7th, 2022.
-        consensus.FortCanningRoadHeight = 1786000; // April 11th, 2022.
-        consensus.FortCanningCrunchHeight = 1936000; // June 2nd, 2022.
-        consensus.FortCanningSpringHeight = 2033000; // July 6th, 2022.
-        consensus.FortCanningGreatWorldHeight = 2212000; // Sep 7th, 2022.
-        consensus.FortCanningEpilogueHeight = 2257500; // Sep 22nd, 2022.
-        consensus.GrandCentralHeight = 2479000; // Dec 8th, 2022.
-        consensus.GrandCentralEpilogueHeight = 2574000; // Jan 10th, 2023.
-        consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();
+        consensus.DF5ClarkeQuayHeight = 595738; // Jan 24th, 2021.
+        consensus.DF6DakotaHeight = 678000; // Mar 1st, 2021.
+        consensus.DF7DakotaCrescentHeight = 733000; // Mar 25th, 2021.
+        consensus.DF8EunosHeight = 894000; // Jun 3rd, 2021.
+        consensus.DF9EunosKampungHeight = 895743; // Jun 4th, 2021.
+        consensus.DF10EunosPayaHeight = 1072000; // Aug 5th, 2021.
+        consensus.DF11FortCanningHeight = 1367000; // Nov 15th, 2021.
+        consensus.DF12FortCanningMuseumHeight = 1430640; // Dec 7th, 2021.
+        consensus.DF13FortCanningParkHeight = 1503143; // Jan 2nd, 2022.
+        consensus.DF14FortCanningHillHeight = 1604999; // Feb 7th, 2022.
+        consensus.DF15FortCanningRoadHeight = 1786000; // April 11th, 2022.
+        consensus.DF16FortCanningCrunchHeight = 1936000; // June 2nd, 2022.
+        consensus.DF17FortCanningSpringHeight = 2033000; // July 6th, 2022.
+        consensus.DF18FortCanningGreatWorldHeight = 2212000; // Sep 7th, 2022.
+        consensus.DF19FortCanningEpilogueHeight = 2257500; // Sep 22nd, 2022.
+        consensus.DF20GrandCentralHeight = 2479000; // Dec 8th, 2022.
+        consensus.DF21GrandCentralEpilogueHeight = 2574000; // Jan 10th, 2023.
+        consensus.DF22NextHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -396,28 +396,28 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 0; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 0; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-        consensus.AMKHeight = 150;
-        consensus.BayfrontHeight = 3000;
-        consensus.BayfrontMarinaHeight = 90470;
+        consensus.DF1AMKHeight = 150;
+        consensus.DF2BayfrontHeight = 3000;
+        consensus.DF3DF4BayfrontGardensHeight = 90470;
         consensus.BayfrontGardensHeight = 101342;
-        consensus.ClarkeQuayHeight = 155000;
-        consensus.DakotaHeight = 220680;
-        consensus.DakotaCrescentHeight = 287700;
-        consensus.EunosHeight = 354950;
-        consensus.EunosKampungHeight = consensus.EunosHeight;
-        consensus.EunosPayaHeight = 463300;
-        consensus.FortCanningHeight = 686200;
-        consensus.FortCanningMuseumHeight = 724000;
-        consensus.FortCanningParkHeight = 828800;
-        consensus.FortCanningHillHeight = 828900;
-        consensus.FortCanningRoadHeight = 893700;
-        consensus.FortCanningCrunchHeight = 1011600;
-        consensus.FortCanningSpringHeight = 1086000;
-        consensus.FortCanningGreatWorldHeight = 1223000;
-        consensus.FortCanningEpilogueHeight = 1244000;
-        consensus.GrandCentralHeight = 1366000;
-        consensus.GrandCentralEpilogueHeight = 1438200;
-        consensus.NextNetworkUpgradeHeight = std::numeric_limits<int>::max();;
+        consensus.DF5ClarkeQuayHeight = 155000;
+        consensus.DF6DakotaHeight = 220680;
+        consensus.DF7DakotaCrescentHeight = 287700;
+        consensus.DF8EunosHeight = 354950;
+        consensus.DF9EunosKampungHeight = consensus.DF8EunosHeight;
+        consensus.DF10EunosPayaHeight = 463300;
+        consensus.DF11FortCanningHeight = 686200;
+        consensus.DF12FortCanningMuseumHeight = 724000;
+        consensus.DF13FortCanningParkHeight = 828800;
+        consensus.DF14FortCanningHillHeight = 828900;
+        consensus.DF15FortCanningRoadHeight = 893700;
+        consensus.DF16FortCanningCrunchHeight = 1011600;
+        consensus.DF17FortCanningSpringHeight = 1086000;
+        consensus.DF18FortCanningGreatWorldHeight = 1223000;
+        consensus.DF19FortCanningEpilogueHeight = 1244000;
+        consensus.DF20GrandCentralHeight = 1366000;
+        consensus.DF21GrandCentralEpilogueHeight = 1438200;
+        consensus.DF22NextHeight = std::numeric_limits<int>::max();;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -615,28 +615,28 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
-        consensus.AMKHeight = 150;
-        consensus.BayfrontHeight = 3000;
-        consensus.BayfrontMarinaHeight = 90470;
+        consensus.DF1AMKHeight = 150;
+        consensus.DF2BayfrontHeight = 3000;
+        consensus.DF3DF4BayfrontGardensHeight = 90470;
         consensus.BayfrontGardensHeight = 101342;
-        consensus.ClarkeQuayHeight = 155000;
-        consensus.DakotaHeight = 220680;
-        consensus.DakotaCrescentHeight = 287700;
-        consensus.EunosHeight = 354950;
-        consensus.EunosKampungHeight = consensus.EunosHeight;
-        consensus.EunosPayaHeight = 463300;
-        consensus.FortCanningHeight = 686200;
-        consensus.FortCanningMuseumHeight = 724000;
-        consensus.FortCanningParkHeight = 828800;
-        consensus.FortCanningHillHeight = 828900;
-        consensus.FortCanningRoadHeight = 893700;
-        consensus.FortCanningCrunchHeight = 1011600;
-        consensus.FortCanningSpringHeight = 1086000;
-        consensus.FortCanningGreatWorldHeight = 1223000;
-        consensus.FortCanningEpilogueHeight = 1244000;
-        consensus.GrandCentralHeight = 1366000;
-        consensus.GrandCentralEpilogueHeight = 1438200;
-        consensus.NextNetworkUpgradeHeight = 1586750;
+        consensus.DF5ClarkeQuayHeight = 155000;
+        consensus.DF6DakotaHeight = 220680;
+        consensus.DF7DakotaCrescentHeight = 287700;
+        consensus.DF8EunosHeight = 354950;
+        consensus.DF9EunosKampungHeight = consensus.DF8EunosHeight;
+        consensus.DF10EunosPayaHeight = 463300;
+        consensus.DF11FortCanningHeight = 686200;
+        consensus.DF12FortCanningMuseumHeight = 724000;
+        consensus.DF13FortCanningParkHeight = 828800;
+        consensus.DF14FortCanningHillHeight = 828900;
+        consensus.DF15FortCanningRoadHeight = 893700;
+        consensus.DF16FortCanningCrunchHeight = 1011600;
+        consensus.DF17FortCanningSpringHeight = 1086000;
+        consensus.DF18FortCanningGreatWorldHeight = 1223000;
+        consensus.DF19FortCanningEpilogueHeight = 1244000;
+        consensus.DF20GrandCentralHeight = 1366000;
+        consensus.DF21GrandCentralEpilogueHeight = 1438200;
+        consensus.DF22NextHeight = 1586750;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -831,28 +831,28 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 0;
         consensus.BIP66Height = 0;
-        consensus.AMKHeight = 150;
-        consensus.BayfrontHeight = 3000;
-        consensus.BayfrontMarinaHeight = 90470;
+        consensus.DF1AMKHeight = 150;
+        consensus.DF2BayfrontHeight = 3000;
+        consensus.DF3DF4BayfrontGardensHeight = 90470;
         consensus.BayfrontGardensHeight = 101342;
-        consensus.ClarkeQuayHeight = 155000;
-        consensus.DakotaHeight = 220680;
-        consensus.DakotaCrescentHeight = 287700;
-        consensus.EunosHeight = 354950;
-        consensus.EunosKampungHeight = consensus.EunosHeight;
-        consensus.EunosPayaHeight = 463300;
-        consensus.FortCanningHeight = 686200;
-        consensus.FortCanningMuseumHeight = 724000;
-        consensus.FortCanningParkHeight = 828800;
-        consensus.FortCanningHillHeight = 828900;
-        consensus.FortCanningRoadHeight = 893700;
-        consensus.FortCanningCrunchHeight = 1011600;
-        consensus.FortCanningSpringHeight = 1086000;
-        consensus.FortCanningGreatWorldHeight = 1223000;
-        consensus.FortCanningEpilogueHeight = 1244000;
-        consensus.GrandCentralHeight = 1366000;
-        consensus.GrandCentralEpilogueHeight = 1438200;
-        consensus.NextNetworkUpgradeHeight = 1586750;
+        consensus.DF5ClarkeQuayHeight = 155000;
+        consensus.DF6DakotaHeight = 220680;
+        consensus.DF7DakotaCrescentHeight = 287700;
+        consensus.DF8EunosHeight = 354950;
+        consensus.DF9EunosKampungHeight = consensus.DF8EunosHeight;
+        consensus.DF10EunosPayaHeight = 463300;
+        consensus.DF11FortCanningHeight = 686200;
+        consensus.DF12FortCanningMuseumHeight = 724000;
+        consensus.DF13FortCanningParkHeight = 828800;
+        consensus.DF14FortCanningHillHeight = 828900;
+        consensus.DF15FortCanningRoadHeight = 893700;
+        consensus.DF16FortCanningCrunchHeight = 1011600;
+        consensus.DF17FortCanningSpringHeight = 1086000;
+        consensus.DF18FortCanningGreatWorldHeight = 1223000;
+        consensus.DF19FortCanningEpilogueHeight = 1244000;
+        consensus.DF20GrandCentralHeight = 1366000;
+        consensus.DF21GrandCentralEpilogueHeight = 1438200;
+        consensus.DF22NextHeight = 1586750;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks
@@ -1050,28 +1050,28 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in functional tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in functional tests)
-        consensus.AMKHeight = 10000000;
-        consensus.BayfrontHeight = 10000000;
-        consensus.BayfrontMarinaHeight = 10000000;
+        consensus.DF1AMKHeight = 10000000;
+        consensus.DF2BayfrontHeight = 10000000;
+        consensus.DF3DF4BayfrontGardensHeight = 10000000;
         consensus.BayfrontGardensHeight = 10000000;
-        consensus.ClarkeQuayHeight = 10000000;
-        consensus.DakotaHeight = 10000000;
-        consensus.DakotaCrescentHeight = 10000000;
-        consensus.EunosHeight = 10000000;
-        consensus.EunosKampungHeight = 10000000;
-        consensus.EunosPayaHeight = 10000000;
-        consensus.FortCanningHeight = 10000000;
-        consensus.FortCanningMuseumHeight = 10000000;
-        consensus.FortCanningParkHeight = 10000000;
-        consensus.FortCanningHillHeight = 10000000;
-        consensus.FortCanningRoadHeight = 10000000;
-        consensus.FortCanningCrunchHeight = 10000000;
-        consensus.FortCanningSpringHeight = 10000000;
-        consensus.FortCanningGreatWorldHeight = 10000000;
-        consensus.FortCanningEpilogueHeight = 10000000;
-        consensus.GrandCentralHeight = 10000000;
-        consensus.GrandCentralEpilogueHeight = 10000000;
-        consensus.NextNetworkUpgradeHeight = 10000000;
+        consensus.DF5ClarkeQuayHeight = 10000000;
+        consensus.DF6DakotaHeight = 10000000;
+        consensus.DF7DakotaCrescentHeight = 10000000;
+        consensus.DF8EunosHeight = 10000000;
+        consensus.DF9EunosKampungHeight = 10000000;
+        consensus.DF10EunosPayaHeight = 10000000;
+        consensus.DF11FortCanningHeight = 10000000;
+        consensus.DF12FortCanningMuseumHeight = 10000000;
+        consensus.DF13FortCanningParkHeight = 10000000;
+        consensus.DF14FortCanningHillHeight = 10000000;
+        consensus.DF15FortCanningRoadHeight = 10000000;
+        consensus.DF16FortCanningCrunchHeight = 10000000;
+        consensus.DF17FortCanningSpringHeight = 10000000;
+        consensus.DF18FortCanningGreatWorldHeight = 10000000;
+        consensus.DF19FortCanningEpilogueHeight = 10000000;
+        consensus.DF20GrandCentralHeight = 10000000;
+        consensus.DF21GrandCentralEpilogueHeight = 10000000;
+        consensus.DF22NextHeight = 10000000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -1315,30 +1315,30 @@ std::optional<int> UpdateHeightValidation(const std::string& argName, const std:
 
 void SetupCommonArgActivationParams(Consensus::Params &consensus) {
     UpdateHeightValidation("Segwit", "-segwitheight", consensus.SegwitHeight);
-    UpdateHeightValidation("AMK", "-amkheight", consensus.AMKHeight);
-    UpdateHeightValidation("Bayfront", "-bayfrontheight", consensus.BayfrontHeight);
+    UpdateHeightValidation("AMK", "-amkheight", consensus.DF1AMKHeight);
+    UpdateHeightValidation("Bayfront", "-bayfrontheight", consensus.DF2BayfrontHeight);
     UpdateHeightValidation("Bayfront Gardens", "-bayfrontgardensheight", consensus.BayfrontGardensHeight);
-    UpdateHeightValidation("Clarke Quay", "-clarkequayheight", consensus.ClarkeQuayHeight);
-    UpdateHeightValidation("Dakota", "-dakotaheight", consensus.DakotaHeight);
-    UpdateHeightValidation("Dakota Crescent", "-dakotacrescentheight", consensus.DakotaCrescentHeight);
-    auto eunosHeight = UpdateHeightValidation("Eunos", "-eunosheight", consensus.EunosHeight);
+    UpdateHeightValidation("Clarke Quay", "-clarkequayheight", consensus.DF5ClarkeQuayHeight);
+    UpdateHeightValidation("Dakota", "-dakotaheight", consensus.DF6DakotaHeight);
+    UpdateHeightValidation("Dakota Crescent", "-dakotacrescentheight", consensus.DF7DakotaCrescentHeight);
+    auto eunosHeight = UpdateHeightValidation("Eunos", "-eunosheight", consensus.DF8EunosHeight);
     if (eunosHeight.has_value()){
-        consensus.EunosKampungHeight = static_cast<int>(eunosHeight.value());
+        consensus.DF9EunosKampungHeight = static_cast<int>(eunosHeight.value());
     }
-    UpdateHeightValidation("Eunos Paya", "-eunospayaheight", consensus.EunosPayaHeight);
-    UpdateHeightValidation("Fort Canning", "-fortcanningheight", consensus.FortCanningHeight);
-    UpdateHeightValidation("Fort Canning Museum", "-fortcanningmuseumheight", consensus.FortCanningMuseumHeight);
-    UpdateHeightValidation("Fort Canning Park", "-fortcanningparkheight", consensus.FortCanningParkHeight);
-    UpdateHeightValidation("Fort Canning Hill", "-fortcanninghillheight", consensus.FortCanningHillHeight);
-    UpdateHeightValidation("Fort Canning Road", "-fortcanningroadheight", consensus.FortCanningRoadHeight);
-    UpdateHeightValidation("Fort Canning Crunch", "-fortcanningcrunchheight", consensus.FortCanningCrunchHeight);
-    UpdateHeightValidation("Fort Canning Spring", "-fortcanningspringheight", consensus.FortCanningSpringHeight);
-    UpdateHeightValidation("Fort Canning Great World", "-fortcanninggreatworldheight", consensus.FortCanningGreatWorldHeight);
-    UpdateHeightValidation("Fort Canning Great World", "-greatworldheight", consensus.FortCanningGreatWorldHeight);
-    UpdateHeightValidation("Fort Canning Epilogue", "-fortcanningepilogueheight", consensus.FortCanningEpilogueHeight);
-    UpdateHeightValidation("Grand Central", "-grandcentralheight", consensus.GrandCentralHeight);
-    UpdateHeightValidation("Grand Central Epilogue", "-grandcentralepilogueheight", consensus.GrandCentralEpilogueHeight);
-    UpdateHeightValidation("Next Network Upgrade", "-nextnetworkupgradeheight", consensus.NextNetworkUpgradeHeight);
+    UpdateHeightValidation("Eunos Paya", "-eunospayaheight", consensus.DF10EunosPayaHeight);
+    UpdateHeightValidation("Fort Canning", "-fortcanningheight", consensus.DF11FortCanningHeight);
+    UpdateHeightValidation("Fort Canning Museum", "-fortcanningmuseumheight", consensus.DF12FortCanningMuseumHeight);
+    UpdateHeightValidation("Fort Canning Park", "-fortcanningparkheight", consensus.DF13FortCanningParkHeight);
+    UpdateHeightValidation("Fort Canning Hill", "-fortcanninghillheight", consensus.DF14FortCanningHillHeight);
+    UpdateHeightValidation("Fort Canning Road", "-fortcanningroadheight", consensus.DF15FortCanningRoadHeight);
+    UpdateHeightValidation("Fort Canning Crunch", "-fortcanningcrunchheight", consensus.DF16FortCanningCrunchHeight);
+    UpdateHeightValidation("Fort Canning Spring", "-fortcanningspringheight", consensus.DF17FortCanningSpringHeight);
+    UpdateHeightValidation("Fort Canning Great World", "-fortcanninggreatworldheight", consensus.DF18FortCanningGreatWorldHeight);
+    UpdateHeightValidation("Fort Canning Great World", "-greatworldheight", consensus.DF18FortCanningGreatWorldHeight);
+    UpdateHeightValidation("Fort Canning Epilogue", "-fortcanningepilogueheight", consensus.DF19FortCanningEpilogueHeight);
+    UpdateHeightValidation("Grand Central", "-grandcentralheight", consensus.DF20GrandCentralHeight);
+    UpdateHeightValidation("Grand Central Epilogue", "-grandcentralepilogueheight", consensus.DF21GrandCentralEpilogueHeight);
+    UpdateHeightValidation("Next Network Upgrade", "-nextnetworkupgradeheight", consensus.DF22NextHeight);
 
     if (gArgs.GetBoolArg("-simulatemainnet", false)) {
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -76,32 +76,32 @@ struct Params {
      * BIP 16 exception blocks. */
     int SegwitHeight;
     /** Block height at which tokens, liquidity pools and new block rewards becomes active */
-    int AMKHeight;
+    int DF1AMKHeight;
     /** What exactly? Changes to mint DAT, new updatetokens? */
-    int BayfrontHeight;
-    int BayfrontMarinaHeight;
+    int DF2BayfrontHeight;
+    int DF3DF4BayfrontGardensHeight;
     int BayfrontGardensHeight;
     /** Third major fork. */
-    int ClarkeQuayHeight;
+    int DF5ClarkeQuayHeight;
     /** Fourth major fork **/
-    int DakotaHeight;
-    int DakotaCrescentHeight;
+    int DF6DakotaHeight;
+    int DF7DakotaCrescentHeight;
     /** Fifth major fork **/
-    int EunosHeight;
-    int EunosKampungHeight;
-    int EunosPayaHeight;
-    int FortCanningHeight;
-    int FortCanningMuseumHeight;
-    int FortCanningParkHeight;
-    int FortCanningHillHeight;
-    int FortCanningRoadHeight;
-    int FortCanningCrunchHeight;
-    int FortCanningSpringHeight;
-    int FortCanningGreatWorldHeight;
-    int FortCanningEpilogueHeight;
-    int GrandCentralHeight;
-    int GrandCentralEpilogueHeight;
-    int NextNetworkUpgradeHeight;
+    int DF8EunosHeight;
+    int DF9EunosKampungHeight;
+    int DF10EunosPayaHeight;
+    int DF11FortCanningHeight;
+    int DF12FortCanningMuseumHeight;
+    int DF13FortCanningParkHeight;
+    int DF14FortCanningHillHeight;
+    int DF15FortCanningRoadHeight;
+    int DF16FortCanningCrunchHeight;
+    int DF17FortCanningSpringHeight;
+    int DF18FortCanningGreatWorldHeight;
+    int DF19FortCanningEpilogueHeight;
+    int DF20GrandCentralHeight;
+    int DF21GrandCentralEpilogueHeight;
+    int DF22NextHeight;
 
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -178,7 +178,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     std::vector<unsigned char> dummy;
     const auto txType = GuessCustomTxType(tx, dummy);
 
-    if (IsBelowDakotaMintTokenOrAccountToUtxos(txType, nSpendHeight) || (nSpendHeight >= chainparams.GetConsensus().GrandCentralHeight && txType == CustomTxType::UpdateMasternode)) {
+    if (IsBelowDakotaMintTokenOrAccountToUtxos(txType, nSpendHeight) || (nSpendHeight >= chainparams.GetConsensus().DF20GrandCentralHeight && txType == CustomTxType::UpdateMasternode)) {
         CCustomCSView discardCache(mnview, nullptr, nullptr, nullptr);
         // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough, 
         // that it's propagated.

--- a/src/masternodes/anchors.cpp
+++ b/src/masternodes/anchors.cpp
@@ -759,14 +759,14 @@ bool ValidateAnchor(const CAnchor &anchor) {
         // Post-fork anchor, will be added to pending anchors to validate in chain context
         if (GetAnchorEmbeddedData(teamData, anchorCreationHeight, prefix)) {
             // Make sure anchor created after fork.
-            if (anchorCreationHeight >= static_cast<uint64_t>(Params().GetConsensus().DakotaHeight)) {
+            if (anchorCreationHeight >= static_cast<uint64_t>(Params().GetConsensus().DF6DakotaHeight)) {
                 return true;
             } else {
                 LogPrint(BCLog::ANCHORING,
                          "%s: Post fork anchor created before fork height. Anchor %ld fork %d\n",
                          __func__,
                          anchorCreationHeight,
-                         Params().GetConsensus().DakotaHeight);
+                         Params().GetConsensus().DF6DakotaHeight);
                 return false;
             }
         }
@@ -875,7 +875,7 @@ bool ContextualValidateAnchor(const CAnchorData &anchor, CBlockIndex &anchorBloc
     }
 
     // Recreate deeper anchor depth
-    if (anchorCreationHeight >= static_cast<uint64_t>(Params().GetConsensus().FortCanningHeight)) {
+    if (anchorCreationHeight >= static_cast<uint64_t>(Params().GetConsensus().DF11FortCanningHeight)) {
         timeDepth += Params().GetConsensus().mn.anchoringAdditionalTimeDepth;
         while (anchorHeight > 0 && ::ChainActive()[anchorHeight]->nTime + timeDepth > anchorCreationBlock->nTime) {
             --anchorHeight;
@@ -1147,7 +1147,7 @@ const PendingOrderType PendingOrder =
     PendingOrderType([](const CAnchorIndex::AnchorRec &a, const CAnchorIndex::AnchorRec &b) {
         if (a.btcHeight == b.btcHeight) {
             if (a.anchor.height == b.anchor.height) {
-                if (a.anchor.height >= static_cast<THeight>(Params().GetConsensus().EunosHeight)) {
+                if (a.anchor.height >= static_cast<THeight>(Params().GetConsensus().DF8EunosHeight)) {
                     const auto blockHash = panchors->ReadBlockHash(a.btcHeight);
                     auto aHash           = Hash(a.txHash.begin(), a.txHash.end(), blockHash.begin(), blockHash.end());
                     auto bHash           = Hash(b.txHash.begin(), b.txHash.end(), blockHash.begin(), blockHash.end());

--- a/src/masternodes/consensus/governance.cpp
+++ b/src/masternodes/consensus/governance.cpp
@@ -153,7 +153,7 @@ Res CGovernanceConsensus::operator()(const CGovernanceHeightMessage &obj) const 
     }
 
     // Validate GovVariables before storing
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) &&
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight) &&
         obj.govVar->GetName() == "ATTRIBUTES") {
         auto govVar = mnview.GetAttributes();
         if (!govVar) {
@@ -173,7 +173,7 @@ Res CGovernanceConsensus::operator()(const CGovernanceHeightMessage &obj) const 
         }
 
         // After GW exclude TokenSplit if split will have already been performed by startHeight
-        if (height >= static_cast<uint32_t>(consensus.GrandCentralHeight)) {
+        if (height >= static_cast<uint32_t>(consensus.DF20GrandCentralHeight)) {
             if (const auto attrVar = std::dynamic_pointer_cast<ATTRIBUTES>(govVar); attrVar) {
                 const auto attrMap = attrVar->GetAttributesMap();
                 std::vector<CDataStructureV0> keysToErase;

--- a/src/masternodes/consensus/loans.cpp
+++ b/src/masternodes/consensus/loans.cpp
@@ -139,7 +139,7 @@ static Res PaybackWithCollateral(CCustomCSView &view,
 }
 
 bool CLoansConsensus::IsTokensMigratedToGovVar() const {
-    return static_cast<int>(height) > consensus.FortCanningCrunchHeight + 1;
+    return static_cast<int>(height) > consensus.DF16FortCanningCrunchHeight + 1;
 }
 
 Res CLoansConsensus::operator()(const CLoanSetCollateralTokenMessage &obj) const {
@@ -147,7 +147,7 @@ Res CLoansConsensus::operator()(const CLoanSetCollateralTokenMessage &obj) const
 
     Require(HasFoundationAuth(), "tx not from foundation member!");
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
         const auto &tokenId = obj.idToken.v;
 
         auto attributes  = mnview.GetAttributes();
@@ -214,7 +214,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
 
     Require(HasFoundationAuth(), "tx not from foundation member!");
 
-    if (height < static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+    if (height < static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
         Require(obj.interest >= 0, "interest rate cannot be less than 0!");
     }
 
@@ -234,7 +234,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
     auto tokenId = mnview.CreateToken(token, false, isEvmEnabledForBlock, evmQueueId);
     Require(tokenId);
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
         const auto &id = tokenId.val->v;
 
         auto attributes  = mnview.GetAttributes();
@@ -292,7 +292,7 @@ Res CLoansConsensus::operator()(const CLoanUpdateLoanTokenMessage &obj) const {
 
     Require(HasFoundationAuth(), "tx not from foundation member!");
 
-    if (height < static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+    if (height < static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
         Require(obj.interest >= 0, "interest rate cannot be less than 0!");
     }
 
@@ -300,7 +300,7 @@ Res CLoansConsensus::operator()(const CLoanUpdateLoanTokenMessage &obj) const {
     Require(pair, "Loan token (%s) does not exist!", obj.tokenTx.GetHex());
 
     auto loanToken =
-            (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
+            (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight) && IsTokensMigratedToGovVar())
             ? mnview.GetLoanTokenByID(pair->first)
             : mnview.GetLoanToken(obj.tokenTx);
 
@@ -323,7 +323,7 @@ Res CLoansConsensus::operator()(const CLoanUpdateLoanTokenMessage &obj) const {
 
     Require(mnview.UpdateToken(pair->second));
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight) && IsTokensMigratedToGovVar()) {
         const auto &id = pair->first.v;
 
         auto attributes  = mnview.GetAttributes();
@@ -495,13 +495,13 @@ Res CLoansConsensus::operator()(const CLoanTakeLoanMessage &obj) const {
     auto hasDUSDLoans = false;
 
     std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl> > > tokenDUSD;
-    if (static_cast<int>(height) >= consensus.FortCanningRoadHeight) {
+    if (static_cast<int>(height) >= consensus.DF15FortCanningRoadHeight) {
         tokenDUSD = mnview.GetToken("DUSD");
     }
 
     uint64_t totalLoansActivePrice = 0, totalLoansNextPrice = 0;
     for (const auto &[tokenId, tokenAmount] : obj.amounts.balances) {
-        if (height >= static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+        if (height >= static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
             Require(tokenAmount > 0, "Valid loan amount required (input: %d@%d)", tokenAmount, tokenId.v);
         }
 
@@ -654,12 +654,12 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message &obj) const {
 
     if (!HasAuth(obj.from)) return DeFiErrors::TXMissingInput();
 
-    if (static_cast<int>(height) < consensus.FortCanningRoadHeight) {
+    if (static_cast<int>(height) < consensus.DF15FortCanningRoadHeight) {
         if (!IsVaultPriceValid(mnview, obj.vaultId, height)) return DeFiErrors::LoanAssetPriceInvalid();
     }
 
     // Handle payback with collateral special case
-    if (static_cast<int>(height) >= consensus.FortCanningEpilogueHeight &&
+    if (static_cast<int>(height) >= consensus.DF19FortCanningEpilogueHeight &&
         IsPaybackWithCollateral(mnview, obj.loans)) {
         return PaybackWithCollateral(mnview, *vault, obj.vaultId, height, time);
     }
@@ -676,7 +676,7 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message &obj) const {
             const auto &paybackTokenId = kv.first;
             auto paybackAmount         = kv.second;
 
-            if (height >= static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+            if (height >= static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
                 if (paybackAmount <= 0) return DeFiErrors::LoanPaymentAmountInvalid(paybackAmount, paybackTokenId.v);
             }
 
@@ -793,8 +793,8 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message &obj) const {
             if (!res)
                 return res;
 
-            if (height >= static_cast<uint32_t>(consensus.FortCanningMuseumHeight) && subLoan < currentLoanAmount &&
-                height < static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+            if (height >= static_cast<uint32_t>(consensus.DF12FortCanningMuseumHeight) && subLoan < currentLoanAmount &&
+                height < static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
                 auto newRate = mnview.GetInterestRate(obj.vaultId, loanTokenId, height);
                 if (!newRate) return DeFiErrors::TokenInterestRateInvalid(loanToken->symbol);
 
@@ -812,7 +812,7 @@ Res CLoansConsensus::operator()(const CLoanPaybackLoanV2Message &obj) const {
                     return res;
 
                 // If interest was negative remove it from sub amount
-                if (height >= static_cast<uint32_t>(consensus.FortCanningEpilogueHeight) && subInterest < 0)
+                if (height >= static_cast<uint32_t>(consensus.DF19FortCanningEpilogueHeight) && subInterest < 0)
                     subLoan += subInterest;
 
                 // Do not sub balance if negative interest fully negates the current loan amount

--- a/src/masternodes/consensus/masternodes.cpp
+++ b/src/masternodes/consensus/masternodes.cpp
@@ -21,10 +21,10 @@ Res CMasternodesConsensus::CheckMasternodeCreationTx() const {
 Res CMasternodesConsensus::operator()(const CCreateMasterNodeMessage &obj) const {
     Require(CheckMasternodeCreationTx());
 
-    if (height >= static_cast<uint32_t>(consensus.EunosHeight))
+    if (height >= static_cast<uint32_t>(consensus.DF8EunosHeight))
         Require(HasAuth(tx.vout[1].scriptPubKey), "masternode creation needs owner auth");
 
-    if (height >= static_cast<uint32_t>(consensus.EunosPayaHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF10EunosPayaHeight)) {
         switch (obj.timelock) {
             case CMasternode::ZEROYEAR:
             case CMasternode::FIVEYEAR:
@@ -52,7 +52,7 @@ Res CMasternodesConsensus::operator()(const CCreateMasterNodeMessage &obj) const
     node.operatorAuthAddress = obj.operatorAuthAddress;
 
     // Set masternode version2 after FC for new serialisation
-    if (height >= static_cast<uint32_t>(consensus.FortCanningHeight))
+    if (height >= static_cast<uint32_t>(consensus.DF11FortCanningHeight))
         node.version = CMasternode::VERSION0;
 
     bool duplicate{};
@@ -80,11 +80,11 @@ Res CMasternodesConsensus::operator()(const CCreateMasterNodeMessage &obj) const
     Require(mnview.CreateMasternode(tx.GetHash(), node, obj.timelock));
     // Build coinage from the point of masternode creation
 
-    if (height >= static_cast<uint32_t>(consensus.EunosPayaHeight))
+    if (height >= static_cast<uint32_t>(consensus.DF10EunosPayaHeight))
         for (uint8_t i{0}; i < SUBNODE_COUNT; ++i)
             mnview.SetSubNodesBlockTime(node.operatorAuthAddress, static_cast<uint32_t>(height), i, time);
 
-    else if (height >= static_cast<uint32_t>(consensus.DakotaCrescentHeight))
+    else if (height >= static_cast<uint32_t>(consensus.DF7DakotaCrescentHeight))
         mnview.SetMasternodeLastBlockTime(node.operatorAuthAddress, static_cast<uint32_t>(height), time);
 
     return Res::Ok();
@@ -220,7 +220,7 @@ Res CMasternodesConsensus::operator()(const CUpdateMasterNodeMessage &obj) const
             }
             rewardType = true;
 
-            if (height < static_cast<uint32_t>(consensus.NextNetworkUpgradeHeight)) {
+            if (height < static_cast<uint32_t>(consensus.DF22NextHeight)) {
                 if (addressType != PKHashType && addressType != WitV0KeyHashType) {
                     return Res::Err("Reward address must be P2PKH or P2WPKH type");
                 }

--- a/src/masternodes/consensus/oracles.cpp
+++ b/src/masternodes/consensus/oracles.cpp
@@ -52,7 +52,7 @@ Res COraclesConsensus::operator()(const CSetOracleDataMessage &obj) const {
     if (!HasAuth(oracle.val->oracleAddress)) {
         return Res::Err("tx must have at least one input from account owner");
     }
-    if (height >= uint32_t(consensus.FortCanningHeight)) {
+    if (height >= uint32_t(consensus.DF11FortCanningHeight)) {
         for (const auto &tokenPrice : obj.tokenPrices) {
             for (const auto &price : tokenPrice.second) {
                 if (price.second <= 0) {

--- a/src/masternodes/consensus/poolpairs.cpp
+++ b/src/masternodes/consensus/poolpairs.cpp
@@ -26,7 +26,7 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     Require(HasFoundationAuth());
     Require(obj.commission >= 0 && obj.commission <= COIN, "wrong commission");
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight)) {
         Require(obj.pairSymbol.find('/') == std::string::npos, "token symbol should not contain '/'");
     }
 
@@ -44,7 +44,7 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     auto tokenB = mnview.GetToken(poolPair.idTokenB);
     Require(tokenB, "token %s does not exist!", poolPair.idTokenB.ToString());
 
-    const auto symbolLength = height >= static_cast<uint32_t>(consensus.FortCanningHeight)
+    const auto symbolLength = height >= static_cast<uint32_t>(consensus.DF11FortCanningHeight)
                               ? CToken::MAX_TOKEN_POOLPAIR_LENGTH
                               : CToken::MAX_TOKEN_SYMBOL_LENGTH;
     if (pairSymbol.empty()) {
@@ -134,7 +134,7 @@ Res CPoolPairsConsensus::operator()(const CLiquidityMessage &obj) const {
     if (amountA.first != pool.idTokenA)
         std::swap(amountA, amountB);
 
-    bool slippageProtection = static_cast<int>(height) >= consensus.BayfrontMarinaHeight;
+    bool slippageProtection = static_cast<int>(height) >= consensus.DF3DF4BayfrontGardensHeight;
     Require(pool.AddLiquidity(
             amountA.second,
             amountB.second,

--- a/src/masternodes/consensus/smartcontracts.cpp
+++ b/src/masternodes/consensus/smartcontracts.cpp
@@ -44,7 +44,7 @@ Res CSmartContractsConsensus::HandleDFIP2201Contract(const CSmartContractMessage
     Require(token->symbol == "BTC" && token->name == "Bitcoin" && token->IsDAT(),
             "Only Bitcoin can be swapped in " + obj.name);
 
-    if (height >= static_cast<uint32_t>(consensus.NextNetworkUpgradeHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF22NextHeight)) {
         mnview.CalculateOwnerRewards(script, height);
     }
 
@@ -156,7 +156,7 @@ Res CSmartContractsConsensus::operator()(const CFutureSwapMessage &obj) const {
     CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, economyKey};
     auto balances = attributes->GetValue(liveKey, CBalances{});
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningCrunchHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF16FortCanningCrunchHeight)) {
         CalculateOwnerRewards(obj.owner);
     }
 

--- a/src/masternodes/consensus/txvisitor.cpp
+++ b/src/masternodes/consensus/txvisitor.cpp
@@ -133,9 +133,9 @@ Res CCustomTxVisitor::HasFoundationAuth() const {
 }
 
 Res CCustomTxVisitor::CheckCustomTx() const {
-    if (static_cast<int>(height) < consensus.EunosPayaHeight)
+    if (static_cast<int>(height) < consensus.DF10EunosPayaHeight)
         Require(tx.vout.size() == 2, "malformed tx vouts ((wrong number of vouts)");
-    if (static_cast<int>(height) >= consensus.EunosPayaHeight)
+    if (static_cast<int>(height) >= consensus.DF10EunosPayaHeight)
         Require(tx.vout[0].nValue == 0, "malformed tx vouts, first vout must be OP_RETURN vout with value 0");
     return Res::Ok();
 }
@@ -230,7 +230,7 @@ Res CCustomTxVisitor::CollateralPctCheck(const bool hasDUSDLoans,
                        const CVaultAssets &vaultAssets,
                        const uint32_t ratio) const {
     std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl> > > tokenDUSD;
-    if (static_cast<int>(height) >= consensus.FortCanningRoadHeight) {
+    if (static_cast<int>(height) >= consensus.DF15FortCanningRoadHeight) {
         tokenDUSD = mnview.GetToken("DUSD");
     }
 
@@ -262,12 +262,12 @@ Res CCustomTxVisitor::CollateralPctCheck(const bool hasDUSDLoans,
     }
 
     // Height checks
-    auto isPostFCH = static_cast<int>(height) >= consensus.FortCanningHillHeight;
-    auto isPreFCH  = static_cast<int>(height) < consensus.FortCanningHillHeight;
-    auto isPostFCE = static_cast<int>(height) >= consensus.FortCanningEpilogueHeight;
-    auto isPostFCR = static_cast<int>(height) >= consensus.FortCanningRoadHeight;
-    auto isPostGC  = static_cast<int>(height) >= consensus.GrandCentralHeight;
-    auto isPostNext =  static_cast<int>(height) >= consensus.NextNetworkUpgradeHeight;
+    auto isPostFCH = static_cast<int>(height) >= consensus.DF14FortCanningHillHeight;
+    auto isPreFCH  = static_cast<int>(height) < consensus.DF14FortCanningHillHeight;
+    auto isPostFCE = static_cast<int>(height) >= consensus.DF19FortCanningEpilogueHeight;
+    auto isPostFCR = static_cast<int>(height) >= consensus.DF15FortCanningRoadHeight;
+    auto isPostGC  = static_cast<int>(height) >= consensus.DF20GrandCentralHeight;
+    auto isPostNext =  static_cast<int>(height) >= consensus.DF22NextHeight;
 
     if(isPostNext) {
         const CDataStructureV0 enabledKey{AttributeTypes::Vaults, VaultIDs::DUSDVault, VaultKeys::DUSDVaultEnabled};

--- a/src/masternodes/consensus/vaults.cpp
+++ b/src/masternodes/consensus/vaults.cpp
@@ -122,7 +122,7 @@ Res CVaultsConsensus::operator()(const CUpdateVaultMessage &obj) const {
                     return std::move(collateralsLoans);
             }
         }
-        if (height >= static_cast<uint32_t>(consensus.FortCanningGreatWorldHeight)) {
+        if (height >= static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
             if (const auto loanTokens = mnview.GetLoanTokens(obj.vaultId)) {
                 for (const auto &[tokenId, tokenAmount] : loanTokens->balances) {
                     const auto loanToken = mnview.GetLoanTokenByID(tokenId);
@@ -203,7 +203,7 @@ Res CVaultsConsensus::operator()(const CWithdrawFromVaultMessage &obj) const {
     auto hasDUSDLoans = false;
 
     std::optional<std::pair<DCT_ID, std::optional<CTokensView::CTokenImpl> > > tokenDUSD;
-    if (static_cast<int>(height) >= consensus.FortCanningRoadHeight) {
+    if (static_cast<int>(height) >= consensus.DF15FortCanningRoadHeight) {
         tokenDUSD = mnview.GetToken("DUSD");
     }
 
@@ -259,7 +259,7 @@ Res CVaultsConsensus::operator()(const CWithdrawFromVaultMessage &obj) const {
         }
     }
 
-    if (height >= static_cast<uint32_t>(consensus.NextNetworkUpgradeHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF22NextHeight)) {
         mnview.CalculateOwnerRewards(obj.to, height);
     }
 
@@ -294,14 +294,14 @@ Res CVaultsConsensus::operator()(const CAuctionBidMessage &obj) const {
                 "First bid should include liquidation penalty of %d%%",
                 data->liquidationPenalty * 100 / COIN);
 
-        if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight && data->liquidationPenalty &&
+        if (static_cast<int>(height) >= consensus.DF12FortCanningMuseumHeight && data->liquidationPenalty &&
             obj.amount.nValue == batch->loanAmount.nValue)
             return Res::Err("First bid should be higher than batch one");
     } else {
         auto amount = MultiplyAmounts(bid->second.nValue, COIN + (COIN / 100));
         Require(amount <= obj.amount.nValue, "Bid override should be at least 1%% higher than current one");
 
-        if (static_cast<int>(height) >= consensus.FortCanningMuseumHeight &&
+        if (static_cast<int>(height) >= consensus.DF12FortCanningMuseumHeight &&
             obj.amount.nValue == bid->second.nValue)
             return Res::Err("Bid override should be higher than last one");
 

--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -16,7 +16,7 @@
 constexpr uint32_t MAX_TRANSFERDOMAIN_EVM_DATA_LEN = 1024;
 
 static bool IsTransferDomainEnabled(const int height, const CCustomCSView &view, const Consensus::Params &consensus) {
-    if (height < consensus.NextNetworkUpgradeHeight) {
+    if (height < consensus.DF22NextHeight) {
         return false;
     }
 

--- a/src/masternodes/customtx.cpp
+++ b/src/masternodes/customtx.cpp
@@ -277,6 +277,6 @@ CAmount GetNonMintedValueOut(const CTransaction &tx, DCT_ID tokenID) {
 
 // it's disabled after Dakota height
 bool IsBelowDakotaMintTokenOrAccountToUtxos(CustomTxType txType, int height) {
-    return (height < Params().GetConsensus().DakotaHeight &&
+    return (height < Params().GetConsensus().DF6DakotaHeight &&
             (txType == CustomTxType::MintToken || txType == CustomTxType::AccountToUtxos));
 }

--- a/src/masternodes/govvariables/attributes.cpp
+++ b/src/masternodes/govvariables/attributes.cpp
@@ -911,7 +911,7 @@ void TrackLiveBalances(CCustomCSView &mnview, const CBalances &balances, const u
 }
 
 bool IsEVMEnabled(const int height, const CCustomCSView &view, const Consensus::Params &consensus) {
-    if (height < consensus.NextNetworkUpgradeHeight) {
+    if (height < consensus.DF22NextHeight) {
         return false;
     }
 
@@ -1735,7 +1735,7 @@ UniValue ATTRIBUTES::Export() const {
 }
 
 Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
-    if (view.GetLastHeight() < Params().GetConsensus().FortCanningHillHeight) {
+    if (view.GetLastHeight() < Params().GetConsensus().DF14FortCanningHillHeight) {
         return DeFiErrors::GovVarValidateFortCanningHill();
     }
 
@@ -1748,7 +1748,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
             case AttributeTypes::Token:
                 switch (attrV0->key) {
                     case TokenKeys::LoanPaybackCollateral:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningEpilogueHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF19FortCanningEpilogueHeight) {
                             return DeFiErrors::GovVarValidateFortCanningEpilogue();
                         }
 
@@ -1761,7 +1761,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         break;
                     case TokenKeys::LoanPayback:
                     case TokenKeys::LoanPaybackFeePCT:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                             return DeFiErrors::GovVarValidateFortCanningRoad();
                         }
                         if (!view.GetLoanTokenByID({attrV0->typeId})) {
@@ -1773,7 +1773,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         break;
                     case TokenKeys::DexInFeePct:
                     case TokenKeys::DexOutFeePct:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                             return DeFiErrors::GovVarValidateFortCanningRoad();
                         }
                         if (!view.GetToken(DCT_ID{attrV0->typeId})) {
@@ -1781,7 +1781,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
                         break;
                     case TokenKeys::LoanCollateralFactor:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningEpilogueHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF19FortCanningEpilogueHeight) {
                             const auto amount = std::get_if<CAmount>(&value);
                             if (amount) {
                                 if (*amount > COIN) {
@@ -1791,7 +1791,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
                         [[fallthrough]];
                     case TokenKeys::LoanMintingInterest:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningGreatWorldHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF18FortCanningGreatWorldHeight) {
                             const auto amount = std::get_if<CAmount>(&value);
                             if (amount) {
                                 if (*amount < 0) {
@@ -1801,12 +1801,12 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
                         [[fallthrough]];
                     case TokenKeys::LoanCollateralEnabled: {
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                             return DeFiErrors::GovVarValidateFortCanningCrunch();
                         }
                         // Post fork remove this guard as long as there were no non-DAT loan tokens before
                         // the fork. A full sync test on the removal of this guard will tell.
-                        if (view.GetLastHeight() >= Params().GetConsensus().NextNetworkUpgradeHeight) {
+                        if (view.GetLastHeight() >= Params().GetConsensus().DF22NextHeight) {
                             if (!VerifyDATToken(view, attrV0->typeId)) {
                                 return DeFiErrors::GovVarValidateToken(attrV0->typeId);
                             }
@@ -1823,7 +1823,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         break;
                     }
                     case TokenKeys::LoanMintingEnabled: {
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                             return DeFiErrors::GovVarValidateFortCanningCrunch();
                         }
                         const auto tokenID = DCT_ID{attrV0->typeId};
@@ -1833,7 +1833,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
                         // Post fork remove this guard as long as there were no non-DAT loan tokens before
                         // the fork. A full sync test on the removal of this guard will tell.
-                        if (view.GetLastHeight() >= Params().GetConsensus().NextNetworkUpgradeHeight) {
+                        if (view.GetLastHeight() >= Params().GetConsensus().DF22NextHeight) {
                             if (!token->IsDAT()) {
                                 return DeFiErrors::GovVarValidateToken(attrV0->typeId);
                             }
@@ -1846,7 +1846,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         break;
                     }
                     case TokenKeys::FixedIntervalPriceId:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                             return DeFiErrors::GovVarValidateFortCanningCrunch();
                         }
                         if (!VerifyToken(view, attrV0->typeId)) {
@@ -1854,7 +1854,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
                         break;
                     case TokenKeys::DFIP2203Enabled:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                             return DeFiErrors::GovVarValidateFortCanningRoad();
                         }
                         if (!view.GetLoanTokenByID({attrV0->typeId})) {
@@ -1873,7 +1873,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
             case AttributeTypes::Consortium:
                 switch (attrV0->key) {
                     case ConsortiumKeys::MemberValues: {
-                        if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight)
+                        if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight)
                             return Res::Err("Cannot be set before GrandCentral");
 
                         if (!view.GetToken(DCT_ID{attrV0->typeId}))
@@ -1905,7 +1905,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                     }
                     case ConsortiumKeys::MintLimit:
                     case ConsortiumKeys::DailyMintLimit:
-                        if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight)
+                        if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight)
                             return Res::Err("Cannot be set before GrandCentral");
 
                         if (!view.GetToken(DCT_ID{attrV0->typeId}))
@@ -1917,7 +1917,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                 break;
 
             case AttributeTypes::Oracles:
-                if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                     return DeFiErrors::GovVarValidateFortCanningCrunch();
                 }
                 if (attrV0->typeId == OracleIDs::Splits) {
@@ -1959,7 +1959,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         break;
                     case PoolKeys::TokenAFeeDir:
                     case PoolKeys::TokenBFeeDir:
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF17FortCanningSpringHeight) {
                             return DeFiErrors::GovVarValidateFortCanningSpring();
                         }
                         if (!view.GetPoolPair({attrV0->typeId})) {
@@ -1973,32 +1973,32 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
 
             case AttributeTypes::Param:
                 if (attrV0->typeId == ParamIDs::Feature) {
-                    if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
+                    if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }
                     if (attrV0->key == DFIPKeys::MintTokens) {
-                        if (view.GetLastHeight() < Params().GetConsensus().GrandCentralEpilogueHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF21GrandCentralEpilogueHeight) {
                             return Res::Err("Cannot be set before GrandCentralEpilogueHeight");
                         }
                     } else if (attrV0->key == DFIPKeys::EVMEnabled || attrV0->key == DFIPKeys::TransferDomain) {
-                        if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF22NextHeight) {
                             return Res::Err("Cannot be set before NextNetworkUpgradeHeight");
                         }
                     }
                 } else if (attrV0->typeId == ParamIDs::Foundation) {
-                    if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
+                    if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight) {
                         return Res::Err("Cannot be set before GrandCentralHeight");
                     }
                 } else if (attrV0->typeId == ParamIDs::DFIP2206F || attrV0->typeId == ParamIDs::DFIP2206A) {
-                    if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
+                    if (view.GetLastHeight() < Params().GetConsensus().DF17FortCanningSpringHeight) {
                         return Res::Err("Cannot be set before FortCanningSpringHeight");
                     }
                 } else if (attrV0->typeId == ParamIDs::DFIP2203) {
-                    if (view.GetLastHeight() < Params().GetConsensus().FortCanningRoadHeight) {
+                    if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                         return DeFiErrors::GovVarValidateFortCanningRoad();
                     }
                     if (attrV0->key == DFIPKeys::StartBlock) {
-                        if (view.GetLastHeight() < Params().GetConsensus().FortCanningSpringHeight) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF17FortCanningSpringHeight) {
                             return Res::Err("Cannot be set before FortCanningSpringHeight");
                         }
                     }
@@ -2012,7 +2012,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                 break;
 
             case AttributeTypes::Locks:
-                if (view.GetLastHeight() < Params().GetConsensus().FortCanningCrunchHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                     return Res::Err("Cannot be set before FortCanningCrunch");
                 }
                 if (attrV0->typeId != ParamIDs::TokenID) {
@@ -2024,19 +2024,19 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                 break;
 
             case AttributeTypes::Governance:
-                if (view.GetLastHeight() < Params().GetConsensus().GrandCentralHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight) {
                     return Res::Err("Cannot be set before GrandCentral");
                 }
                 break;
 
             case AttributeTypes::EVMType:
-                if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF22NextHeight) {
                     return Res::Err("Cannot be set before NextNetworkUpgrade");
                 }
                 break;
 
             case AttributeTypes::Transfer:
-                if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF22NextHeight) {
                     return Res::Err("Cannot be set before NextNetworkUpgrade");
                 }
                 if ((attrV0->typeId == TransferIDs::DVMToEVM || attrV0->typeId == TransferIDs::EVMToDVM) &&
@@ -2053,14 +2053,14 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
 
             case AttributeTypes::Vaults:
                 if (attrV0->typeId == VaultIDs::DUSDVault && attrV0->key == VaultKeys::DUSDVaultEnabled) {
-                    if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                    if (view.GetLastHeight() < Params().GetConsensus().DF22NextHeight) {
                         return Res::Err("Cannot be set before NextNetworkUpgrade");
                     }
                 }
                 break;
 
             case AttributeTypes::Rules:
-                if (view.GetLastHeight() < Params().GetConsensus().NextNetworkUpgradeHeight) {
+                if (view.GetLastHeight() < Params().GetConsensus().DF22NextHeight) {
                     return Res::Err("Cannot be set before NextNetworkUpgrade");
                 }
                 break;
@@ -2160,7 +2160,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                     return res;
                 }
             } else if (attrV0->key == TokenKeys::LoanMintingInterest) {
-                if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningGreatWorldHeight) &&
+                if (height >= static_cast<uint32_t>(Params().GetConsensus().DF18FortCanningGreatWorldHeight) &&
                     interestTokens.count(attrV0->typeId)) {
                     const auto tokenInterest = std::get_if<CAmount>(&attribute.second);
                     if (!tokenInterest) {
@@ -2186,7 +2186,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
                     }
                 }
             } else if (attrV0->key == TokenKeys::LoanCollateralFactor) {
-                if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningEpilogueHeight)) {
+                if (height >= static_cast<uint32_t>(Params().GetConsensus().DF19FortCanningEpilogueHeight)) {
                     // Skip on if skip collateral check is passed
                     if (Params().NetworkIDString() == CBaseChainParams::REGTEST &&
                         gArgs.GetBoolArg("-regtest-skip-loan-collateral-validation", false)) {

--- a/src/masternodes/govvariables/loan_daily_reward.cpp
+++ b/src/masternodes/govvariables/loan_daily_reward.cpp
@@ -22,7 +22,7 @@ UniValue LP_DAILY_LOAN_TOKEN_REWARD::Export() const {
 }
 
 Res LP_DAILY_LOAN_TOKEN_REWARD::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(view.GetLastHeight() >= Params().GetConsensus().DF11FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
     return Res::Err("Cannot be set manually.");
 }
 

--- a/src/masternodes/govvariables/loan_liquidation_penalty.cpp
+++ b/src/masternodes/govvariables/loan_liquidation_penalty.cpp
@@ -22,7 +22,7 @@ UniValue LOAN_LIQUIDATION_PENALTY::Export() const {
 }
 
 Res LOAN_LIQUIDATION_PENALTY::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(view.GetLastHeight() >= Params().GetConsensus().DF11FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
     Require(penalty >= COIN / 100, []{ return "Penalty cannot be less than 0.01 DFI"; });
 
     return Res::Ok();

--- a/src/masternodes/govvariables/loan_splits.cpp
+++ b/src/masternodes/govvariables/loan_splits.cpp
@@ -32,7 +32,7 @@ UniValue LP_LOAN_TOKEN_SPLITS::Export() const {
 }
 
 Res LP_LOAN_TOKEN_SPLITS::Validate(const CCustomCSView &mnview) const {
-    Require(mnview.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(mnview.GetLastHeight() >= Params().GetConsensus().DF11FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
 
     CAmount total{0};
     for (const auto &kv : splits) {

--- a/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
+++ b/src/masternodes/govvariables/lp_daily_dfi_reward.cpp
@@ -22,7 +22,7 @@ UniValue LP_DAILY_DFI_REWARD::Export() const {
 }
 
 Res LP_DAILY_DFI_REWARD::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() < Params().GetConsensus().EunosHeight, []{ return "Cannot be set manually after Eunos hard fork"; });
+    Require(view.GetLastHeight() < Params().GetConsensus().DF8EunosHeight, []{ return "Cannot be set manually after Eunos hard fork"; });
     // nothing to do
     return Res::Ok();
 }

--- a/src/masternodes/govvariables/oracle_block_interval.cpp
+++ b/src/masternodes/govvariables/oracle_block_interval.cpp
@@ -24,7 +24,7 @@ UniValue ORACLE_BLOCK_INTERVAL::Export() const {
 }
 
 Res ORACLE_BLOCK_INTERVAL::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(view.GetLastHeight() >= Params().GetConsensus().DF11FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
     Require(blockInterval > 0, []{ return "Block interval cannot be less than 1"; });
 
     return Res::Ok();

--- a/src/masternodes/govvariables/oracle_deviation.cpp
+++ b/src/masternodes/govvariables/oracle_deviation.cpp
@@ -22,7 +22,7 @@ UniValue ORACLE_DEVIATION::Export() const {
 }
 
 Res ORACLE_DEVIATION::Validate(const CCustomCSView &view) const {
-    Require(view.GetLastHeight() >= Params().GetConsensus().FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
+    Require(view.GetLastHeight() >= Params().GetConsensus().DF11FortCanningHeight, []{ return "Cannot be set before FortCanning"; });
     Require(deviation >= COIN / 100, []{ return "Deviation cannot be less than 1 percent"; });
 
     return Res::Ok();

--- a/src/masternodes/historywriter.cpp
+++ b/src/masternodes/historywriter.cpp
@@ -116,7 +116,7 @@ void CHistoryWriters::EraseHistory(uint32_t height, std::vector<AccountHistoryKe
         historyView->EraseAccountHistoryHeight(height);
     }
 
-    if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningHeight)) {
+    if (height >= static_cast<uint32_t>(Params().GetConsensus().DF11FortCanningHeight)) {
         // erase auction fee history
         if (historyView) {
             historyView->EraseAuctionHistoryHeight(height);
@@ -135,13 +135,13 @@ void CHistoryWriters::EraseHistory(uint32_t height, std::vector<AccountHistoryKe
             burnView->EraseAccountHistory(entries);
         }
 
-        if (height == static_cast<uint32_t>(Params().GetConsensus().EunosHeight)) {
+        if (height == static_cast<uint32_t>(Params().GetConsensus().DF8EunosHeight)) {
             // Make sure to initialize lastTxOut, otherwise it never finds the block and
             // ends up looping through uninitialized garbage value.
             uint32_t firstTxOut{}, lastTxOut{};
             auto shouldContinueToNextAccountHistory = [&](AccountHistoryKey const & key, AccountHistoryValue const &) -> bool
             {
-                if (key.owner != Params().GetConsensus().burnAddress || key.blockHeight != static_cast<uint32_t>(Params().GetConsensus().EunosHeight)) {
+                if (key.owner != Params().GetConsensus().burnAddress || key.blockHeight != static_cast<uint32_t>(Params().GetConsensus().DF8EunosHeight)) {
                     return false;
                 }
 
@@ -153,13 +153,13 @@ void CHistoryWriters::EraseHistory(uint32_t height, std::vector<AccountHistoryKe
                 return true;
             };
 
-            AccountHistoryKey startKey({Params().GetConsensus().burnAddress, static_cast<uint32_t>(Params().GetConsensus().EunosHeight), std::numeric_limits<uint32_t>::max()});
+            AccountHistoryKey startKey({Params().GetConsensus().burnAddress, static_cast<uint32_t>(Params().GetConsensus().DF8EunosHeight), std::numeric_limits<uint32_t>::max()});
             burnView->ForEachAccountHistory(shouldContinueToNextAccountHistory,
                                             Params().GetConsensus().burnAddress,
-                                            Params().GetConsensus().EunosHeight);
+                                            Params().GetConsensus().DF8EunosHeight);
 
             for (auto i = firstTxOut; i <= lastTxOut; ++i) {
-                burnView->EraseAccountHistory({Params().GetConsensus().burnAddress, static_cast<uint32_t>(Params().GetConsensus().EunosHeight), i});
+                burnView->EraseAccountHistory({Params().GetConsensus().burnAddress, static_cast<uint32_t>(Params().GetConsensus().DF8EunosHeight), i});
             }
         }
     }

--- a/src/masternodes/masternodes.cpp
+++ b/src/masternodes/masternodes.cpp
@@ -32,9 +32,9 @@ std::unique_ptr<CStorageLevelDB> pcustomcsDB;
 
 int GetMnActivationDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight ||
+    if (height < Params().GetConsensus().DF8EunosHeight ||
        (IsTestNetwork() &&
-       height >= Params().GetConsensus().FortCanningHeight)) {
+       height >= Params().GetConsensus().DF11FortCanningHeight)) {
         return Params().GetConsensus().mn.activationDelay;
     }
 
@@ -43,9 +43,9 @@ int GetMnActivationDelay(int height) {
 
 int GetMnResignDelay(int height) {
     // Restore previous activation delay on testnet after FC
-    if (height < Params().GetConsensus().EunosHeight ||
+    if (height < Params().GetConsensus().DF8EunosHeight ||
        (IsTestNetwork() &&
-       height >= Params().GetConsensus().FortCanningHeight)) {
+       height >= Params().GetConsensus().DF11FortCanningHeight)) {
         return Params().GetConsensus().mn.resignDelay;
     }
 
@@ -57,7 +57,7 @@ int GetMnResignDelay(int height) {
 
 CAmount GetMnCollateralAmount(int height) {
     auto &consensus = Params().GetConsensus();
-    if (height < consensus.DakotaHeight) {
+    if (height < consensus.DF6DakotaHeight) {
         return consensus.mn.collateralAmount;
     } else {
         return consensus.mn.collateralAmountDakota;
@@ -119,7 +119,7 @@ CMasternode::CMasternode()
       collateralTx() {}
 
 CMasternode::State CMasternode::GetState(int height, const CMasternodesView &mnview) const {
-    int EunosPayaHeight = Params().GetConsensus().EunosPayaHeight;
+    int DF10EunosPayaHeight = Params().GetConsensus().DF10EunosPayaHeight;
 
     if (height < creationHeight) {
         return State::UNKNOWN;
@@ -143,7 +143,7 @@ CMasternode::State CMasternode::GetState(int height, const CMasternodesView &mnv
     if (resignHeight == -1 || height < resignHeight) {  // enabled or pre-enabled
         // Special case for genesis block
         int activationDelay =
-            height < EunosPayaHeight ? GetMnActivationDelay(height) : GetMnActivationDelay(creationHeight);
+            height < DF10EunosPayaHeight ? GetMnActivationDelay(height) : GetMnActivationDelay(creationHeight);
         if (creationHeight == 0 || height >= creationHeight + activationDelay) {
             return State::ENABLED;
         }
@@ -151,7 +151,7 @@ CMasternode::State CMasternode::GetState(int height, const CMasternodesView &mnv
     }
 
     if (resignHeight != -1) {  // pre-resigned or resigned
-        int resignDelay = height < EunosPayaHeight ? GetMnResignDelay(height) : GetMnResignDelay(resignHeight);
+        int resignDelay = height < DF10EunosPayaHeight ? GetMnResignDelay(height) : GetMnResignDelay(resignHeight);
         if (height < resignHeight + resignDelay) {
             return State::PRE_RESIGNED;
         }
@@ -162,7 +162,7 @@ CMasternode::State CMasternode::GetState(int height, const CMasternodesView &mnv
 
 bool CMasternode::IsActive(int height, const CMasternodesView &mnview) const {
     State state = GetState(height, mnview);
-    if (height >= Params().GetConsensus().EunosPayaHeight) {
+    if (height >= Params().GetConsensus().DF10EunosPayaHeight) {
         return state == ENABLED;
     }
     return state == ENABLED || state == PRE_RESIGNED;
@@ -316,7 +316,7 @@ Res CMasternodesView::CreateMasternode(const uint256 &nodeId, const CMasternode 
 
 Res CMasternodesView::ResignMasternode(CMasternode &node, const uint256 &nodeId, const uint256 &txid, int height) {
     auto state = node.GetState(height, *this);
-    if (height >= Params().GetConsensus().EunosPayaHeight) {
+    if (height >= Params().GetConsensus().DF10EunosPayaHeight) {
         Require(state == CMasternode::ENABLED, [=]{ return strprintf("node %s state is not 'ENABLED'", nodeId.ToString()); });
     } else if ((state != CMasternode::PRE_ENABLED && state != CMasternode::ENABLED)) {
         return Res::Err("node %s state is not 'PRE_ENABLED' or 'ENABLED'", nodeId.ToString());
@@ -494,7 +494,7 @@ std::vector<int64_t> CMasternodesView::GetSubNodesBlockTime(const CKeyID &minter
     for (uint8_t i{0}; i < SUBNODE_COUNT; ++i) {
         ForEachSubNode(
             [&](const SubNodeBlockTimeKey &key, int64_t blockTime) {
-                if (height >= static_cast<uint32_t>(Params().GetConsensus().FortCanningHeight)) {
+                if (height >= static_cast<uint32_t>(Params().GetConsensus().DF11FortCanningHeight)) {
                     if (key.masternodeID == nodeId && key.subnode == i) {
                         times[i] = blockTime;
                     }
@@ -566,7 +566,7 @@ std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID &keyID,
     // Get last block time for non-subnode staking
     std::optional<int64_t> stakerBlockTime = GetMasternodeLastBlockTime(keyID, blockHeight);
 
-    // Get times for sub nodes, defaults to {0, 0, 0, 0} for MNs created before EunosPayaHeight
+    // Get times for sub nodes, defaults to {0, 0, 0, 0} for MNs created before DF10EunosPayaHeight
     std::vector<int64_t> subNodesBlockTime = GetSubNodesBlockTime(keyID, blockHeight);
 
     // Set first entry to previous accrued multiplier.
@@ -574,10 +574,10 @@ std::vector<int64_t> CMasternodesView::GetBlockTimes(const CKeyID &keyID,
         subNodesBlockTime[0] = *stakerBlockTime;
     }
 
-    if (auto block = ::ChainActive()[Params().GetConsensus().EunosPayaHeight]) {
-        if (creationHeight < Params().GetConsensus().DakotaCrescentHeight && !stakerBlockTime &&
+    if (auto block = ::ChainActive()[Params().GetConsensus().DF10EunosPayaHeight]) {
+        if (creationHeight < Params().GetConsensus().DF7DakotaCrescentHeight && !stakerBlockTime &&
             !subNodesBlockTime[0]) {
-            if (auto dakotaBlock = ::ChainActive()[Params().GetConsensus().DakotaCrescentHeight]) {
+            if (auto dakotaBlock = ::ChainActive()[Params().GetConsensus().DF7DakotaCrescentHeight]) {
                 subNodesBlockTime[0] = dakotaBlock->GetBlockTime();
             }
         }
@@ -640,11 +640,11 @@ CTeamView::CTeam CTeamView::GetCurrentTeam() const {
 
 void CTeamView::SetAnchorTeams(const CTeam &authTeam, const CTeam &confirmTeam, const int height) {
     // Called after fork height
-    if (height < Params().GetConsensus().DakotaHeight) {
+    if (height < Params().GetConsensus().DF6DakotaHeight) {
         LogPrint(BCLog::ANCHORING,
                  "%s: Called below fork. Fork: %d Arg height: %d\n",
                  __func__,
-                 Params().GetConsensus().DakotaHeight,
+                 Params().GetConsensus().DF6DakotaHeight,
                  height);
         return;
     }

--- a/src/masternodes/mn_checks.cpp
+++ b/src/masternodes/mn_checks.cpp
@@ -179,17 +179,17 @@ class CCustomMetadataParseVisitor {
 
     Res IsHardforkEnabled(const uint32_t startHeight) const {
         const std::unordered_map<int, std::string> hardforks = {
-                { consensus.AMKHeight,                    "called before AMK height" },
-                { consensus.BayfrontHeight,               "called before Bayfront height" },
+                { consensus.DF1AMKHeight,                    "called before AMK height" },
+                { consensus.DF2BayfrontHeight,               "called before Bayfront height" },
                 { consensus.BayfrontGardensHeight,        "called before Bayfront Gardens height" },
-                { consensus.EunosHeight,                  "called before Eunos height" },
-                { consensus.EunosPayaHeight,              "called before EunosPaya height" },
-                { consensus.FortCanningHeight,            "called before FortCanning height" },
-                { consensus.FortCanningHillHeight,        "called before FortCanningHill height" },
-                { consensus.FortCanningRoadHeight,        "called before FortCanningRoad height" },
-                { consensus.FortCanningEpilogueHeight,    "called before FortCanningEpilogue height" },
-                { consensus.GrandCentralHeight,           "called before GrandCentral height" },
-                { consensus.NextNetworkUpgradeHeight,     "called before NextNetworkUpgrade height" },
+                { consensus.DF8EunosHeight,                  "called before Eunos height" },
+                { consensus.DF10EunosPayaHeight,              "called before EunosPaya height" },
+                { consensus.DF11FortCanningHeight,            "called before FortCanning height" },
+                { consensus.DF14FortCanningHillHeight,        "called before FortCanningHill height" },
+                { consensus.DF15FortCanningRoadHeight,        "called before FortCanningRoad height" },
+                { consensus.DF19FortCanningEpilogueHeight,    "called before FortCanningEpilogue height" },
+                { consensus.DF20GrandCentralHeight,           "called before GrandCentral height" },
+                { consensus.DF22NextHeight,     "called before NextNetworkUpgrade height" },
         };
         if (startHeight && height < startHeight) {
             auto it = hardforks.find(startHeight);
@@ -217,7 +217,7 @@ public:
                 CAccountToUtxosMessage,
                 CAccountToAccountMessage,
                 CMintTokensMessage>())
-            return IsHardforkEnabled(consensus.AMKHeight);
+            return IsHardforkEnabled(consensus.DF1AMKHeight);
         else if constexpr (IsOneOf<T,
                 CUpdateTokenMessage,
                 CPoolSwapMessage,
@@ -226,7 +226,7 @@ public:
                 CCreatePoolPairMessage,
                 CUpdatePoolPairMessage,
                 CGovernanceMessage>())
-            return IsHardforkEnabled(consensus.BayfrontHeight);
+            return IsHardforkEnabled(consensus.DF2BayfrontHeight);
         else if constexpr (IsOneOf<T,
                 CAppointOracleMessage,
                 CRemoveOracleAppointMessage,
@@ -239,7 +239,7 @@ public:
                 CICXClaimDFCHTLCMessage,
                 CICXCloseOrderMessage,
                 CICXCloseOfferMessage>())
-            return IsHardforkEnabled(consensus.EunosHeight);
+            return IsHardforkEnabled(consensus.DF8EunosHeight);
         else if constexpr (IsOneOf<T,
                 CPoolSwapMessageV2,
                 CLoanSetCollateralTokenMessage,
@@ -257,31 +257,31 @@ public:
                 CLoanPaybackLoanMessage,
                 CAuctionBidMessage,
                 CGovernanceHeightMessage>())
-            return IsHardforkEnabled(consensus.FortCanningHeight);
+            return IsHardforkEnabled(consensus.DF11FortCanningHeight);
         else if constexpr (IsOneOf<T,
                 CAnyAccountsToAccountsMessage>())
             return IsHardforkEnabled(consensus.BayfrontGardensHeight);
         else if constexpr (IsOneOf<T,
                 CSmartContractMessage>())
-            return IsHardforkEnabled(consensus.FortCanningHillHeight);
+            return IsHardforkEnabled(consensus.DF14FortCanningHillHeight);
         else if constexpr (IsOneOf<T,
                 CLoanPaybackLoanV2Message,
                 CFutureSwapMessage>())
-            return IsHardforkEnabled(consensus.FortCanningRoadHeight);
+            return IsHardforkEnabled(consensus.DF15FortCanningRoadHeight);
         else if constexpr (IsOneOf<T,
                 CPaybackWithCollateralMessage>())
-            return IsHardforkEnabled(consensus.FortCanningEpilogueHeight);
+            return IsHardforkEnabled(consensus.DF19FortCanningEpilogueHeight);
         else if constexpr (IsOneOf<T,
                 CUpdateMasterNodeMessage,
                 CBurnTokensMessage,
                 CCreateProposalMessage,
                 CProposalVoteMessage,
                 CGovernanceUnsetMessage>())
-            return IsHardforkEnabled(consensus.GrandCentralHeight);
+            return IsHardforkEnabled(consensus.DF20GrandCentralHeight);
         else if constexpr (IsOneOf<T,
                 CTransferDomainMessage,
                 CEvmTxMessage>())
-            return IsHardforkEnabled(consensus.NextNetworkUpgradeHeight);
+            return IsHardforkEnabled(consensus.DF22NextHeight);
         else if constexpr (IsOneOf<T,
                 CCreateMasterNodeMessage,
                 CResignMasterNodeMessage>())
@@ -293,7 +293,7 @@ public:
     template<typename T>
     Res DisabledAfter() const {
         if constexpr (IsOneOf<T, CUpdateTokenPreAMKMessage>())
-            return IsHardforkEnabled(consensus.BayfrontHeight) ? Res::Err("called after Bayfront height") : Res::Ok();
+            return IsHardforkEnabled(consensus.DF2BayfrontHeight) ? Res::Err("called after Bayfront height") : Res::Ok();
 
         return Res::Ok();
     }
@@ -408,8 +408,8 @@ Res CustomMetadataParse(uint32_t height,
 
 bool IsDisabledTx(uint32_t height, CustomTxType type, const Consensus::Params &consensus) {
     // All the heights that are involved in disabled Txs
-    auto fortCanningParkHeight = static_cast<uint32_t>(consensus.FortCanningParkHeight);
-    auto fortCanningHillHeight = static_cast<uint32_t>(consensus.FortCanningHillHeight);
+    auto fortCanningParkHeight = static_cast<uint32_t>(consensus.DF13FortCanningParkHeight);
+    auto fortCanningHillHeight = static_cast<uint32_t>(consensus.DF14FortCanningHillHeight);
 
     if (height < fortCanningParkHeight)
         return false;
@@ -567,7 +567,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
         return res;
     }
     std::vector<unsigned char> metadata;
-    const auto metadataValidation = height >= static_cast<uint32_t>(consensus.FortCanningHeight);
+    const auto metadataValidation = height >= static_cast<uint32_t>(consensus.DF11FortCanningHeight);
     const auto txType = GuessCustomTxType(tx, metadata, metadataValidation);
 
     auto attributes = mnview.GetAttributes();
@@ -649,7 +649,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
             }
             res.code |= CustomTxErrCodes::Fatal;
         }
-        if (height >= static_cast<uint32_t>(consensus.DakotaHeight)) {
+        if (height >= static_cast<uint32_t>(consensus.DF6DakotaHeight)) {
             res.code |= CustomTxErrCodes::Fatal;
         }
         return res;
@@ -673,7 +673,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
                                     const uint256 &prevStakeModifier,
                                     const std::vector<unsigned char> &metadata,
                                     const Consensus::Params &consensusParams) {
-    Require(height < consensusParams.DakotaHeight, "Old anchor TX type after Dakota fork. Height %d", height);
+    Require(height < consensusParams.DF6DakotaHeight, "Old anchor TX type after Dakota fork. Height %d", height);
 
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
     CAnchorFinalizationMessage finMsg;
@@ -699,7 +699,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
     }
 
     // check reward sum
-    if (height >= consensusParams.AMKHeight) {
+    if (height >= consensusParams.DF1AMKHeight) {
         const auto cbValues = tx.GetValuesOut();
         if (cbValues.size() != 1 || cbValues.begin()->first != DCT_ID{0})
             return Res::ErrDbg("bad-ar-wrong-tokens", "anchor reward should be payed only in Defi coins");
@@ -732,7 +732,7 @@ ResVal<uint256> ApplyAnchorRewardTx(CCustomCSView &mnview,
         return Res::ErrDbg("bad-ar-nextteam", "anchor wrong next team");
     }
     mnview.SetTeam(finMsg.nextTeam);
-    if (height >= consensusParams.AMKHeight) {
+    if (height >= consensusParams.DF1AMKHeight) {
         LogPrint(BCLog::ACCOUNTCHANGE,
                  "AccountChange: hash=%s fund=%s change=%s\n",
                  tx.GetHash().ToString(),
@@ -751,7 +751,7 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView &mnview,
                                         int height,
                                         const std::vector<unsigned char> &metadata,
                                         const Consensus::Params &consensusParams) {
-    Require(height >= consensusParams.DakotaHeight, "New anchor TX type before Dakota fork. Height %d", height);
+    Require(height >= consensusParams.DF6DakotaHeight, "New anchor TX type before Dakota fork. Height %d", height);
 
     CDataStream ss(metadata, SER_NETWORK, PROTOCOL_VERSION);
     CAnchorFinalizationMessagePlus finMsg;
@@ -803,7 +803,7 @@ ResVal<uint256> ApplyAnchorRewardTxPlus(CCustomCSView &mnview,
             anchorReward);
 
     CTxDestination destination;
-    if (height < consensusParams.NextNetworkUpgradeHeight) {
+    if (height < consensusParams.DF22NextHeight) {
         destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, TxDestTypeToKeyType(finMsg.rewardKeyType), KeyType::MNOwnerKeyType);
     } else {
         destination = FromOrDefaultKeyIDToDestination(finMsg.rewardKeyID, TxDestTypeToKeyType(finMsg.rewardKeyType), KeyType::MNRewardKeyType);
@@ -953,13 +953,13 @@ std::vector<std::vector<DCT_ID> > CPoolSwap::CalculatePoolPaths(CCustomCSView &v
 Res CPoolSwap::ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, const Consensus::Params &consensus, bool testOnly) {
     Res poolResult = Res::Ok();
     // No composite swap allowed before Fort Canning
-    if (height < static_cast<uint32_t>(consensus.FortCanningHeight) && !poolIDs.empty()) {
+    if (height < static_cast<uint32_t>(consensus.DF11FortCanningHeight) && !poolIDs.empty()) {
         poolIDs.clear();
     }
 
     Require(obj.amountFrom > 0, "Input amount should be positive");
 
-    if (height >= static_cast<uint32_t>(consensus.FortCanningHillHeight) &&
+    if (height >= static_cast<uint32_t>(consensus.DF14FortCanningHillHeight) &&
         poolIDs.size() > MAX_POOL_SWAPS) {
         return Res::Err(
             strprintf("Too many pool IDs provided, max %d allowed, %d provided", MAX_POOL_SWAPS, poolIDs.size()));
@@ -1014,7 +1014,7 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, con
 
         const auto swapAmount = swapAmountResult;
 
-        if (height >= static_cast<uint32_t>(consensus.FortCanningHillHeight) && lastSwap) {
+        if (height >= static_cast<uint32_t>(consensus.DF14FortCanningHillHeight) && lastSwap) {
             Require(obj.idTokenTo != swapAmount.nTokenId,
                     "Final swap should have idTokenTo as destination, not source");
 
@@ -1085,7 +1085,7 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, con
                 intermediateView.Flush();
 
                 auto &addView = lastSwap ? view : intermediateView;
-                if (height >= static_cast<uint32_t>(consensus.GrandCentralHeight)) {
+                if (height >= static_cast<uint32_t>(consensus.DF20GrandCentralHeight)) {
                     res = addView.AddBalance(lastSwap ? (obj.to.empty() ? obj.from : obj.to) : obj.from,
                                              swapAmountResult);
                 } else {
@@ -1132,14 +1132,14 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView &view, std::vector<DCT_ID> poolIDs, con
         }
     }
 
-    if (height >= static_cast<uint32_t>(consensus.GrandCentralHeight)) {
+    if (height >= static_cast<uint32_t>(consensus.DF20GrandCentralHeight)) {
         if (swapAmountResult.nTokenId != obj.idTokenTo) {
             return Res::Err("Final swap output is not same as idTokenTo");
         }
     }
 
     // Reject if price paid post-swap above max price provided
-    if (height >= static_cast<uint32_t>(consensus.FortCanningHeight) && !obj.maxPrice.isAboveValid()) {
+    if (height >= static_cast<uint32_t>(consensus.DF11FortCanningHeight) && !obj.maxPrice.isAboveValid()) {
         if (swapAmountResult.nValue != 0) {
             const auto userMaxPrice = arith_uint256(obj.maxPrice.integer) * COIN + obj.maxPrice.fraction;
             if (arith_uint256(obj.amountFrom) * COIN / swapAmountResult.nValue > userMaxPrice) {
@@ -1355,7 +1355,7 @@ struct OpReturnLimitsKeys {
 OpReturnLimits OpReturnLimits::From(const uint64_t height, const Consensus::Params &consensus, const ATTRIBUTES &attributes) {
     OpReturnLimitsKeys k{};
     auto item = OpReturnLimits::Default();
-    item.shouldEnforce = height >= static_cast<uint64_t>(consensus.NextNetworkUpgradeHeight);
+    item.shouldEnforce = height >= static_cast<uint64_t>(consensus.DF22NextHeight);
     item.coreSizeBytes = attributes.GetValue(k.coreKey, item.coreSizeBytes);
     item.dvmSizeBytes = attributes.GetValue(k.dvmKey, item.dvmSizeBytes);
     item.evmSizeBytes = attributes.GetValue(k.evmKey, item.evmSizeBytes);

--- a/src/masternodes/mn_rpc.cpp
+++ b/src/masternodes/mn_rpc.cpp
@@ -963,7 +963,7 @@ UniValue listgovs(const JSONRPCRequest& request) {
                 if (mode == GovVarsFilter::NoAttributes) {
                     skip = true;
                 } else {
-                    if (height >= Params().GetConsensus().NextNetworkUpgradeHeight) {
+                    if (height >= Params().GetConsensus().DF22NextHeight) {
                         if (auto attributes = dynamic_cast<ATTRIBUTES*>(var.get()); attributes) {
                             AddDefaultVars(height, Params(), *attributes);
                         }
@@ -1047,7 +1047,7 @@ UniValue isappliedcustomtx(const JSONRPCRequest& request) {
 
     // post Dakota it's not allowed tx to be skipped
     // so tx that can be found in a block is applyed
-    if (blockHeight >= Params().GetConsensus().DakotaHeight) {
+    if (blockHeight >= Params().GetConsensus().DF6DakotaHeight) {
         result.setBool(true);
     } else {
         result.setBool(!IsSkippedTx(tx->GetHash()));

--- a/src/masternodes/poolpairs.cpp
+++ b/src/masternodes/poolpairs.cpp
@@ -217,7 +217,7 @@ auto InitPoolVars(CPoolPairView &view, PoolHeightKey poolKey, uint32_t end) {
     auto it     = view.LowerBound<By>(poolKey);
 
     auto height                       = poolKey.height;
-    static const uint32_t startHeight = Params().GetConsensus().GrandCentralHeight;
+    static const uint32_t startHeight = Params().GetConsensus().DF20GrandCentralHeight;
     poolKey.height                    = std::max(height, startHeight);
 
     while (!MatchPoolId(it, poolId) && poolKey.height < end) {
@@ -418,7 +418,7 @@ Res CPoolPair::Swap(CTokenAmount in,
 
     const auto maxPrice256 = arith_uint256(maxPrice.integer) * PRECISION + maxPrice.fraction;
     // NOTE it has a bug prior Dakota hardfork
-    const auto price = height < Params().GetConsensus().DakotaHeight ? arith_uint256(reserveT) * PRECISION / reserveF
+    const auto price = height < Params().GetConsensus().DF6DakotaHeight ? arith_uint256(reserveT) * PRECISION / reserveF
                                                                      : arith_uint256(reserveF) * PRECISION / reserveT;
 
     Require(price <= maxPrice256, []{ return "Price is higher than indicated."; });
@@ -474,7 +474,7 @@ CAmount CPoolPair::slopeSwap(CAmount unswapped, CAmount &poolFrom, CAmount &pool
         arith_uint256 unswappedA = arith_uint256(unswapped);
 
         swapped = poolT - (poolT * poolF / (poolF + unswappedA));
-        if (height >= Params().GetConsensus().FortCanningHillHeight && swapped != 0) {
+        if (height >= Params().GetConsensus().DF14FortCanningHillHeight && swapped != 0) {
             // floor the result
             --swapped;
         }
@@ -492,8 +492,8 @@ std::pair<CAmount, CAmount> CPoolPairView::UpdatePoolRewards(
     std::function<Res(const CScript &, const CScript &, CTokenAmount)> onTransfer,
     int nHeight) {
     bool newRewardCalc    = nHeight >= Params().GetConsensus().BayfrontGardensHeight;
-    bool newRewardLogic   = nHeight >= Params().GetConsensus().EunosHeight;
-    bool newCustomRewards = nHeight >= Params().GetConsensus().ClarkeQuayHeight;
+    bool newRewardLogic   = nHeight >= Params().GetConsensus().DF8EunosHeight;
+    bool newCustomRewards = nHeight >= Params().GetConsensus().DF5ClarkeQuayHeight;
 
     constexpr const uint32_t PRECISION = 10000;  // (== 100%) just searching the way to avoid arith256 inflating
     CAmount totalDistributed           = 0;

--- a/src/masternodes/rpc_accounts.cpp
+++ b/src/masternodes/rpc_accounts.cpp
@@ -142,7 +142,7 @@ static void onPoolRewards(CCustomCSView &view,
                           uint32_t end,
                           std::function<void(uint32_t, DCT_ID, RewardType, CTokenAmount)> onReward) {
     CCustomCSView mnview(view);
-    static const uint32_t eunosHeight = Params().GetConsensus().EunosHeight;
+    static const uint32_t eunosHeight = Params().GetConsensus().DF8EunosHeight;
     view.ForEachPoolId([&] (DCT_ID const & poolId) {
         auto height = view.GetShare(poolId, owner);
         if (!height || *height >= end) {
@@ -1848,7 +1848,7 @@ UniValue listcommunitybalances(const JSONRPCRequest& request) {
         }
 
         if (kv.first == CommunityAccountType::Loan) {
-            if (::ChainActive().Height() >= Params().GetConsensus().FortCanningHeight) {
+            if (::ChainActive().Height() >= Params().GetConsensus().DF11FortCanningHeight) {
                 burnt += pcustomcsview->GetCommunityBalance(kv.first);
             }
             continue;
@@ -2260,7 +2260,7 @@ UniValue getburninfo(const JSONRPCRequest& request) {
 
     auto height = ::ChainActive().Height();
     auto hash = ::ChainActive().Tip()->GetBlockHash();
-    auto fortCanningHeight = Params().GetConsensus().FortCanningHeight;
+    auto fortCanningHeight = Params().GetConsensus().DF11FortCanningHeight;
     auto burnAddress = Params().GetConsensus().burnAddress;
     auto view = *pcustomcsview;
     auto attributes = view.GetAttributes();

--- a/src/masternodes/rpc_icxorderbook.cpp
+++ b/src/masternodes/rpc_icxorderbook.cpp
@@ -447,7 +447,7 @@ UniValue icxmakeoffer(const JSONRPCRequest& request) {
 
         targetHeight = ::ChainActive().Height() + 1;
 
-        if (targetHeight < Params().GetConsensus().EunosPayaHeight)
+        if (targetHeight < Params().GetConsensus().DF10EunosPayaHeight)
             makeoffer.expiry = CICXMakeOffer::DEFAULT_EXPIRY;
         else
             makeoffer.expiry = CICXMakeOffer::EUNOSPAYA_DEFAULT_EXPIRY;
@@ -579,14 +579,14 @@ UniValue icxsubmitdfchtlc(const JSONRPCRequest& request) {
             authScript = order->ownerAddress;
 
             if (!submitdfchtlc.timeout)
-                submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
+                submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().DF10EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_TIMEOUT;
         }
         else if (order->orderType == CICXOrder::TYPE_EXTERNAL)
         {
             authScript = offer->ownerAddress;
 
             if (!submitdfchtlc.timeout)
-            submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
+            submitdfchtlc.timeout = (targetHeight < Params().GetConsensus().DF10EunosPayaHeight) ? CICXSubmitDFCHTLC::MINIMUM_2ND_TIMEOUT : CICXSubmitDFCHTLC::EUNOSPAYA_MINIMUM_2ND_TIMEOUT;
 
             CTokenAmount balance = pcustomcsview->GetBalance(offer->ownerAddress,order->idToken);
             if (balance.nValue < offer->amount)

--- a/src/masternodes/rpc_loan.cpp
+++ b/src/masternodes/rpc_loan.cpp
@@ -1197,7 +1197,7 @@ UniValue paybackloan(const JSONRPCRequest& request) {
         LOCK(cs_main);
         targetHeight = ::ChainActive().Height() + 1;
     }
-    bool isFCR = targetHeight >= Params().GetConsensus().FortCanningRoadHeight;
+    bool isFCR = targetHeight >= Params().GetConsensus().DF15FortCanningRoadHeight;
     CBalances amounts;
     if (hasAmounts){
         if(hasLoans)
@@ -1526,9 +1526,9 @@ UniValue getinterest(const JSONRPCRequest& request) {
         return true;
     };
 
-    if (height >= Params().GetConsensus().FortCanningGreatWorldHeight) {
+    if (height >= Params().GetConsensus().DF18FortCanningGreatWorldHeight) {
         pcustomcsview->ForEachVaultInterestV3(vaultInterest);
-    } else if (height >= Params().GetConsensus().FortCanningHillHeight) {
+    } else if (height >= Params().GetConsensus().DF14FortCanningHillHeight) {
         pcustomcsview->ForEachVaultInterestV2([&](const CVaultId& vaultId, DCT_ID tokenId, const CInterestRateV2 &rate) {
             return vaultInterest(vaultId, tokenId, ConvertInterestRateToV3(rate));
         });
@@ -1551,7 +1551,7 @@ UniValue getinterest(const JSONRPCRequest& request) {
         obj.pushKV("token", token->CreateSymbolKey(tokenId));
         obj.pushKV("totalInterest", ValueFromAmount(totalInterest));
         obj.pushKV("interestPerBlock", ValueFromAmount(interestPerBlock));
-        if (height >= Params().GetConsensus().FortCanningHillHeight)
+        if (height >= Params().GetConsensus().DF14FortCanningHillHeight)
         {
             obj.pushKV("realizedInterestPerBlock", UniValue(UniValue::VNUM, GetInterestPerBlockHighPrecisionString(totalInterestPerBlock)));
         }

--- a/src/masternodes/rpc_masternodes.cpp
+++ b/src/masternodes/rpc_masternodes.cpp
@@ -48,7 +48,7 @@ UniValue mnToJSON(CCustomCSView& view, uint256 const & nodeId, CMasternode const
             // Get block times with next block as height
             const auto subNodesBlockTime = pcustomcsview->GetBlockTimes(node.operatorAuthAddress, currentHeight + 1, node.creationHeight, *timelock);
 
-            if (currentHeight >= Params().GetConsensus().EunosPayaHeight) {
+            if (currentHeight >= Params().GetConsensus().DF10EunosPayaHeight) {
                 const uint8_t loops = *timelock == CMasternode::TENYEAR ? 4 : *timelock == CMasternode::FIVEYEAR ? 3 : 2;
                 UniValue multipliers(UniValue::VARR);
                 for (uint8_t i{0}; i < loops; ++i) {
@@ -135,7 +135,7 @@ UniValue createmasternode(const JSONRPCRequest& request)
     bool eunosPaya;
     {
         LOCK(cs_main);
-        eunosPaya = ::ChainActive().Tip()->nHeight >= Params().GetConsensus().EunosPayaHeight;
+        eunosPaya = ::ChainActive().Tip()->nHeight >= Params().GetConsensus().DF10EunosPayaHeight;
     }
 
     // Get timelock if any
@@ -680,7 +680,7 @@ UniValue getmasternodeblocks(const JSONRPCRequest& request) {
         return masternodeBlocks(key.masternodeID, key.blockHeight);
     }, MNBlockTimeKey{mn_id, std::numeric_limits<uint32_t>::max()});
 
-    auto tip = ::ChainActive()[std::min(lastHeight, Params().GetConsensus().DakotaCrescentHeight) - 1];
+    auto tip = ::ChainActive()[std::min(lastHeight, Params().GetConsensus().DF7DakotaCrescentHeight) - 1];
 
     for (; tip && tip->nHeight > creationHeight && tip->nHeight > startBlock; tip = tip->pprev) {
         auto id = pcustomcsview->GetMasternodeIdByOperator(tip->minterKey());

--- a/src/masternodes/rpc_oracles.cpp
+++ b/src/masternodes/rpc_oracles.cpp
@@ -487,7 +487,7 @@ UniValue setoracledata(const JSONRPCRequest &request) {
     }
 
     // timestamp is checked at consensus level
-    if (targetHeight < Params().GetConsensus().FortCanningHeight) {
+    if (targetHeight < Params().GetConsensus().DF11FortCanningHeight) {
         if (timestamp <= 0 || timestamp > GetSystemTimeInSeconds() + 300) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "timestamp cannot be negative, zero or over 5 minutes in the future");
         }

--- a/src/masternodes/rpc_poolpair.cpp
+++ b/src/masternodes/rpc_poolpair.cpp
@@ -659,7 +659,7 @@ UniValue createpoolpair(const JSONRPCRequest &request) {
         targetHeight = ::ChainActive().Height() + 1;
     }
 
-    const auto symbolLength = targetHeight >= Params().GetConsensus().FortCanningHeight
+    const auto symbolLength = targetHeight >= Params().GetConsensus().DF11FortCanningHeight
                                   ? CToken::MAX_TOKEN_POOLPAIR_LENGTH
                                   : CToken::MAX_TOKEN_SYMBOL_LENGTH;
     if (pairSymbol.length() > symbolLength) {
@@ -674,7 +674,7 @@ UniValue createpoolpair(const JSONRPCRequest &request) {
     poolPairMsg.ownerAddress = ownerAddress;
     poolPairMsg.pairSymbol = pairSymbol;
 
-    if (targetHeight >= Params().GetConsensus().ClarkeQuayHeight) {
+    if (targetHeight >= Params().GetConsensus().DF5ClarkeQuayHeight) {
         poolPairMsg.rewards = rewards;
     }
 
@@ -835,7 +835,7 @@ UniValue updatepoolpair(const JSONRPCRequest &request) {
              // serialize poolId as raw integer
              << poolId.v << status << commission << ownerAddress;
 
-    if (targetHeight >= Params().GetConsensus().ClarkeQuayHeight) {
+    if (targetHeight >= Params().GetConsensus().DF5ClarkeQuayHeight) {
         metadata << rewards;
     }
 
@@ -1050,7 +1050,7 @@ UniValue compositeswap(const JSONRPCRequest &request) {
     pwallet->BlockUntilSyncedToCurrentChain();
 
     int targetHeight = chainHeight(*pwallet->chain().lock()) + 1;
-    if (targetHeight < Params().GetConsensus().FortCanningHeight) {
+    if (targetHeight < Params().GetConsensus().DF11FortCanningHeight) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "compositeswap is available post Fort Canning");
     }
 

--- a/src/masternodes/rpc_tokens.cpp
+++ b/src/masternodes/rpc_tokens.cpp
@@ -268,12 +268,12 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
 
-    if (targetHeight < Params().GetConsensus().BayfrontHeight) {
+    if (targetHeight < Params().GetConsensus().DF2BayfrontHeight) {
         if (metaObj.size() > 1 || !metaObj.exists("isDAT")) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Only 'isDAT' flag modification allowed before Bayfront fork (<" + std::to_string(Params().GetConsensus().BayfrontHeight) + ")");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Only 'isDAT' flag modification allowed before Bayfront fork (<" + std::to_string(Params().GetConsensus().DF2BayfrontHeight) + ")");
         }
 
-        // before BayfrontHeight it needs only founders auth
+        // before DF2BayfrontHeight it needs only founders auth
         rawTx.vin = GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, true, optAuthTx, txInputs, request.metadata.coinSelectOpts);
     }
     else
@@ -300,7 +300,7 @@ UniValue updatetoken(const JSONRPCRequest& request) {
     CDataStream metadata(DfTxMarker, SER_NETWORK, PROTOCOL_VERSION);
 
     // tx type and serialized data differ:
-    if (targetHeight < Params().GetConsensus().BayfrontHeight) {
+    if (targetHeight < Params().GetConsensus().DF2BayfrontHeight) {
         metadata << static_cast<unsigned char>(CustomTxType::UpdateToken)
                  << tokenImpl.creationTx <<  metaObj["isDAT"].getBool();
     }
@@ -611,7 +611,7 @@ UniValue getcustomtx(const JSONRPCRequest& request)
 
         result.pushKV("valid", res.ok);
     } else {
-        if (nHeight >= Params().GetConsensus().DakotaHeight) {
+        if (nHeight >= Params().GetConsensus().DF6DakotaHeight) {
             result.pushKV("valid", actualHeight);
         } else {
             result.pushKV("valid", !IsSkippedTx(tx->GetHash()));

--- a/src/masternodes/rpc_vault.cpp
+++ b/src/masternodes/rpc_vault.cpp
@@ -178,10 +178,10 @@ namespace {
                             totalInterests += interestCalculation;
                         }
                         if (verbose) {
-                            if (height >= Params().GetConsensus().FortCanningGreatWorldHeight) {
+                            if (height >= Params().GetConsensus().DF18FortCanningGreatWorldHeight) {
                                 interestsPerBlockValueHighPrecision = InterestAddition(interestsPerBlockValueHighPrecision, {rate->interestPerBlock.negative, static_cast<base_uint<128>>(price) * rate->interestPerBlock.amount / COIN});
                                 interestsPerBlockHighPrecission[tokenId] = rate->interestPerBlock;
-                            } else if (height >= Params().GetConsensus().FortCanningHillHeight) {
+                            } else if (height >= Params().GetConsensus().DF14FortCanningHillHeight) {
                                 interestsPerBlockValueHighPrecision.amount += static_cast<base_uint<128>>(price) * rate->interestPerBlock.amount / COIN;
                                 interestsPerBlockHighPrecission[tokenId] = rate->interestPerBlock;
                             } else {
@@ -232,7 +232,7 @@ namespace {
                 nextCollateralRatio = int(rate.val->ratio());
                 result.pushKV("nextCollateralRatio", nextCollateralRatio);
             }
-            if (height >= Params().GetConsensus().FortCanningHillHeight) {
+            if (height >= Params().GetConsensus().DF14FortCanningHillHeight) {
                 if(isVaultTokenLocked){
                     result.pushKV("interestPerBlockValue", -1);
                 } else {

--- a/src/masternodes/tokens.cpp
+++ b/src/masternodes/tokens.cpp
@@ -259,7 +259,7 @@ inline Res CTokenImplementation::IsValidSymbol() const {
     if (symbol.find('#') != std::string::npos) {
         return invalidTokenSymbol();
     }
-    if (creationHeight >= Params().GetConsensus().FortCanningCrunchHeight) {
+    if (creationHeight >= Params().GetConsensus().DF16FortCanningCrunchHeight) {
         if (symbol.find('/') != std::string::npos) {
             return invalidTokenSymbol();
         };

--- a/src/masternodes/validation.cpp
+++ b/src/masternodes/validation.cpp
@@ -48,14 +48,14 @@ static void UpdateDailyGovVariables(const std::map<CommunityAccountType, uint32_
 static void ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams) {
 
     // Hard coded LP_DAILY_DFI_REWARD change
-    if (pindex->nHeight >= chainparams.GetConsensus().EunosHeight)
+    if (pindex->nHeight >= chainparams.GetConsensus().DF8EunosHeight)
     {
         const auto& incentivePair = chainparams.GetConsensus().blockTokenRewards.find(CommunityAccountType::IncentiveFunding);
         UpdateDailyGovVariables<LP_DAILY_DFI_REWARD>(incentivePair, cache, pindex->nHeight);
     }
 
     // Hard coded LP_DAILY_LOAN_TOKEN_REWARD change
-    if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight)
+    if (pindex->nHeight >= chainparams.GetConsensus().DF11FortCanningHeight)
     {
         const auto& incentivePair = chainparams.GetConsensus().blockTokenRewards.find(CommunityAccountType::Loan);
         UpdateDailyGovVariables<LP_DAILY_LOAN_TOKEN_REWARD>(incentivePair, cache, pindex->nHeight);
@@ -96,7 +96,7 @@ static void ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& cache,
             LogPrint(BCLog::ACCOUNTCHANGE, "AccountChange: event=ProcessRewardEvents fund=%s change=%s\n", GetCommunityAccountName(CommunityAccountType::IncentiveFunding), (CBalances{{{{0}, -distributed.first}}}.ToString()));
     }
 
-    if (pindex->nHeight >= chainparams.GetConsensus().FortCanningHeight) {
+    if (pindex->nHeight >= chainparams.GetConsensus().DF11FortCanningHeight) {
         res = cache.SubCommunityBalance(CommunityAccountType::Loan, distributed.second);
         if (!res.ok) {
             LogPrintf("Pool rewards: can't update community balance: %s. Block %ld (%s)\n", res.msg, pindex->nHeight, pindex->phashBlock->GetHex());
@@ -109,11 +109,11 @@ static void ProcessRewardEvents(const CBlockIndex* pindex, CCustomCSView& cache,
 
 
 static void ProcessICXEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams) {
-    if (pindex->nHeight < chainparams.GetConsensus().EunosHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF8EunosHeight) {
         return;
     }
 
-    bool isPreEunosPaya = pindex->nHeight < chainparams.GetConsensus().EunosPayaHeight;
+    bool isPreEunosPaya = pindex->nHeight < chainparams.GetConsensus().DF10EunosPayaHeight;
 
     cache.ForEachICXOrderExpire([&](CICXOrderView::StatusKey const& key, uint8_t status) {
         if (static_cast<int>(key.first) != pindex->nHeight)
@@ -265,7 +265,7 @@ Res AddNonTxToBurnIndex(const CScript& from, const CBalances& amounts)
 }
 
 static void ProcessEunosEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams) {
-    if (pindex->nHeight != chainparams.GetConsensus().EunosHeight) {
+    if (pindex->nHeight != chainparams.GetConsensus().DF8EunosHeight) {
         return;
     }
 
@@ -328,7 +328,7 @@ static void ProcessEunosEvents(const CBlockIndex* pindex, CCustomCSView& cache, 
 }
 
 static void ProcessOracleEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams){
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF11FortCanningHeight) {
         return;
     }
     auto blockInterval = cache.GetIntervalBlock();
@@ -445,7 +445,7 @@ std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets& vaultAssets
 
 static void ProcessLoanEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams)
 {
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF11FortCanningHeight) {
         return;
     }
 
@@ -783,7 +783,7 @@ static void ProcessLoanEvents(const CBlockIndex* pindex, CCustomCSView& cache, c
 
 static void ProcessFutures(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams)
 {
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningRoadHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF15FortCanningRoadHeight) {
         return;
     }
 
@@ -983,7 +983,7 @@ static void ProcessFutures(const CBlockIndex* pindex, CCustomCSView& cache, cons
 }
 
 static void ProcessGovEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams, const uint64_t evmQueueId) {
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF11FortCanningHeight) {
         return;
     }
 
@@ -1071,7 +1071,7 @@ static void ProcessTokenToGovVar(const CBlockIndex* pindex, CCustomCSView& cache
 
     // Migrate at +1 height so that GetLastHeight() in Gov var
     // Validate() has a height equal to the GW fork.
-    if (pindex->nHeight != chainparams.GetConsensus().FortCanningCrunchHeight + 1) {
+    if (pindex->nHeight != chainparams.GetConsensus().DF16FortCanningCrunchHeight + 1) {
         return;
     }
 
@@ -1522,7 +1522,7 @@ static Res VaultSplits(CCustomCSView& view, ATTRIBUTES& attributes, const DCT_ID
 
     CVaultId failedVault;
     std::vector<std::tuple<CVaultId, CInterestRateV3, std::string>> loanInterestRates;
-    if (height >= Params().GetConsensus().FortCanningGreatWorldHeight) {
+    if (height >= Params().GetConsensus().DF18FortCanningGreatWorldHeight) {
         view.ForEachVaultInterestV3([&](const CVaultId& vaultId, DCT_ID tokenId, const CInterestRateV3& rate) {
             if (tokenId == oldTokenId) {
                 const auto vaultData = view.GetVault(vaultId);
@@ -1736,7 +1736,7 @@ static Res GetTokenSuffix(const CCustomCSView& view, const ATTRIBUTES& attribute
 }
 
 static void ProcessTokenSplits(const CBlock& block, const CBlockIndex* pindex, CCustomCSView& cache, const CreationTxs& creationTxs, const CChainParams& chainparams) {
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningCrunchHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF16FortCanningCrunchHeight) {
         return;
     }
     const auto attributes = cache.GetAttributes();
@@ -1946,7 +1946,7 @@ static void ProcessTokenSplits(const CBlock& block, const CBlockIndex* pindex, C
         view.SetVariable(*attributes);
 
         // Migrate stored unlock
-        if (pindex->nHeight >= chainparams.GetConsensus().GrandCentralHeight) {
+        if (pindex->nHeight >= chainparams.GetConsensus().DF20GrandCentralHeight) {
             bool updateStoredVar{};
             auto storedGovVars = view.GetStoredVariablesRange(pindex->nHeight, std::numeric_limits<uint32_t>::max());
             for (const auto& [varHeight, var] : storedGovVars) {
@@ -1987,7 +1987,7 @@ static void ProcessTokenSplits(const CBlock& block, const CBlockIndex* pindex, C
 
 static void ProcessFuturesDUSD(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams)
 {
-    if (pindex->nHeight < chainparams.GetConsensus().FortCanningSpringHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF17FortCanningSpringHeight) {
         return;
     }
 
@@ -2161,7 +2161,7 @@ static void ProcessNegativeInterest(const CBlockIndex* pindex, CCustomCSView& ca
 }
 
 static void ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams) {
-    if (pindex->nHeight < chainparams.GetConsensus().GrandCentralHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF20GrandCentralHeight) {
         return;
     }
 
@@ -2247,7 +2247,7 @@ static void ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView& cach
                     LogPrintf("Proposal fee redistribution failed: %s Address: %s Amount: %d\n", res.msg, scriptPubKey.GetHex(), amountPerVoter);
                 }
 
-                if (pindex->nHeight >= chainparams.GetConsensus().NextNetworkUpgradeHeight) {
+                if (pindex->nHeight >= chainparams.GetConsensus().DF22NextHeight) {
                     subView.CalculateOwnerRewards(scriptPubKey, pindex->nHeight);
                 }
 
@@ -2270,10 +2270,10 @@ static void ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView& cach
             return true;
         }
 
-        if (pindex->nHeight < chainparams.GetConsensus().NextNetworkUpgradeHeight && lround(voteYes * 10000.f / voters.size()) <= prop.approvalThreshold) {
+        if (pindex->nHeight < chainparams.GetConsensus().DF22NextHeight && lround(voteYes * 10000.f / voters.size()) <= prop.approvalThreshold) {
             cache.UpdateProposalStatus(propId, pindex->nHeight, CProposalStatusType::Rejected);
             return true;
-        } else if (pindex->nHeight >= chainparams.GetConsensus().NextNetworkUpgradeHeight) {
+        } else if (pindex->nHeight >= chainparams.GetConsensus().DF22NextHeight) {
                 auto onlyNeutral = voters.size() == voteNeutral;
                 if (onlyNeutral || lround(voteYes * 10000.f / (voters.size() - voteNeutral)) <= prop.approvalThreshold) {
                     cache.UpdateProposalStatus(propId, pindex->nHeight, CProposalStatusType::Rejected);
@@ -2305,7 +2305,7 @@ static void ProcessProposalEvents(const CBlockIndex* pindex, CCustomCSView& cach
 }
 
 static void ProcessMasternodeUpdates(const CBlockIndex* pindex, CCustomCSView& cache, const CCoinsViewCache& view, const CChainParams& chainparams) {
-    if (pindex->nHeight < chainparams.GetConsensus().GrandCentralHeight) {
+    if (pindex->nHeight < chainparams.GetConsensus().DF20GrandCentralHeight) {
         return;
     }
     // Apply any pending masternode owner changes
@@ -2339,7 +2339,7 @@ static void ProcessMasternodeUpdates(const CBlockIndex* pindex, CCustomCSView& c
 
 static void ProcessGrandCentralEvents(const CBlockIndex* pindex, CCustomCSView& cache, const CChainParams& chainparams) {
 
-    if (pindex->nHeight != chainparams.GetConsensus().GrandCentralHeight) {
+    if (pindex->nHeight != chainparams.GetConsensus().DF20GrandCentralHeight) {
         return;
     }
 
@@ -2513,7 +2513,7 @@ void ProcessDeFiEvent(const CBlock &block, const CBlockIndex* pindex, CCustomCSV
     ProcessICXEvents(pindex, cache, chainparams);
 
     // Remove `Finalized` and/or `LPS` flags _possibly_set_ by bytecoded (cheated) txs before bayfront fork
-    if (pindex->nHeight == chainparams.GetConsensus().BayfrontHeight - 1) { // call at block _before_ fork
+    if (pindex->nHeight == chainparams.GetConsensus().DF2BayfrontHeight - 1) { // call at block _before_ fork
         cache.BayfrontFlagsCleanup();
     }
 

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -74,17 +74,17 @@ bool ContextualCheckProofOfStake(const CBlockHeader& blockHeader, const Consensu
         }
         creationHeight = int64_t(nodePtr->creationHeight);
 
-        if (height >= params.EunosPayaHeight) {
+        if (height >= params.DF10EunosPayaHeight) {
              const auto optTimeLock = mnView->GetTimelock(masternodeID, *nodePtr, height);
              if (!optTimeLock)
                  return false;
             timelock = *optTimeLock;
         }
 
-        // Check against EunosPayaHeight here for regtest, does not hurt other networks.
+        // Check against DF10EunosPayaHeight here for regtest, does not hurt other networks.
         // Redundant checks, but intentionally kept for easier fork accounting.
-        if (height >= params.DakotaCrescentHeight || height >= params.EunosPayaHeight) {
-            const auto usedHeight = height <= params.EunosHeight ? creationHeight : height;
+        if (height >= params.DF7DakotaCrescentHeight || height >= params.DF10EunosPayaHeight) {
+            const auto usedHeight = height <= params.DF8EunosHeight ? creationHeight : height;
 
             // Get block times
             subNodesBlockTime = mnView->GetBlockTimes(nodePtr->operatorAuthAddress, usedHeight, creationHeight, timelock);
@@ -148,15 +148,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, int64_t blockTim
     }
 
     int nHeight{pindexLast->nHeight + 1};
-    bool newDifficultyAdjust{nHeight > params.EunosHeight};
+    bool newDifficultyAdjust{nHeight > params.DF8EunosHeight};
 
     // Restore previous difficulty adjust on testnet after FC
-    if (IsTestNetwork() && nHeight >= params.FortCanningHeight) {
+    if (IsTestNetwork() && nHeight >= params.DF11FortCanningHeight) {
         newDifficultyAdjust = false;
     }
 
     const auto interval = newDifficultyAdjust ? params.pos.DifficultyAdjustmentIntervalV2() : params.pos.DifficultyAdjustmentInterval();
-    bool skipChange = newDifficultyAdjust ? (nHeight - params.EunosHeight) % interval != 0 : nHeight % interval != 0;
+    bool skipChange = newDifficultyAdjust ? (nHeight - params.DF8EunosHeight) % interval != 0 : nHeight % interval != 0;
 
     // Only change once per difficulty adjustment interval
     if (skipChange)

--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -43,7 +43,7 @@ namespace pos {
         arith_uint256 targetProofOfStake;
         targetProofOfStake.SetCompact(nBits);
 
-        if (blockHeight >= static_cast<uint64_t>(params.EunosPayaHeight)) {
+        if (blockHeight >= static_cast<uint64_t>(params.DF10EunosPayaHeight)) {
             const uint8_t loops = timelock == CMasternode::TENYEAR ? 4 : timelock == CMasternode::FIVEYEAR ? 3 : 2;
 
             // Check whether we meet hash for each subnode in turn
@@ -66,7 +66,7 @@ namespace pos {
 
         // New difficulty calculation to make staking easier the longer it has
         // been since a masternode staked a block.
-        if (blockHeight >= static_cast<uint64_t>(params.DakotaCrescentHeight))
+        if (blockHeight >= static_cast<uint64_t>(params.DF7DakotaCrescentHeight))
         {
             auto coinDayWeight = CalcCoinDayWeight(params, coinstakeTime, subNodesBlockTime[0]);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -191,7 +191,7 @@ struct RewardInfo {
     TokenRewardItems TokenRewards{};
 
     static std::optional<RewardInfo> TryFrom(const CBlock& block, const CBlockIndex* blockindex, const Consensus::Params& consensus) {
-        if (blockindex->nHeight < consensus.AMKHeight)
+        if (blockindex->nHeight < consensus.DF1AMKHeight)
             return {};
 
         RewardInfo result{};
@@ -199,7 +199,7 @@ struct RewardInfo {
         CAmount blockReward = GetBlockSubsidy(blockindex->nHeight, consensus);
         result.BlockReward = blockReward;
 
-        if (blockindex->nHeight < consensus.EunosHeight) {
+        if (blockindex->nHeight < consensus.DF8EunosHeight) {
             for (const auto& [accountType, accountVal] : consensus.blockTokenRewardsLegacy)
             {
                 CAmount subsidy = blockReward * accountVal / COIN;
@@ -215,7 +215,7 @@ struct RewardInfo {
 
         for (const auto& [accountType, accountVal] : consensus.blockTokenRewards)
         {
-            if (blockindex->nHeight < consensus.GrandCentralHeight
+            if (blockindex->nHeight < consensus.DF20GrandCentralHeight
             && accountType == CommunityAccountType::CommunityDevFunds) {
                 continue;
             }
@@ -1527,25 +1527,25 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     UniValue softforks(UniValue::VOBJ);
-    BuriedForkDescPushBack(softforks, "amk", consensusParams.AMKHeight);
-    BuriedForkDescPushBack(softforks, "bayfront", consensusParams.BayfrontHeight);
-    BuriedForkDescPushBack(softforks, "clarkequay", consensusParams.ClarkeQuayHeight);
-    BuriedForkDescPushBack(softforks, "dakota", consensusParams.DakotaHeight);
-    BuriedForkDescPushBack(softforks, "dakotacrescent", consensusParams.DakotaCrescentHeight);
-    BuriedForkDescPushBack(softforks, "eunos", consensusParams.EunosHeight);
-    BuriedForkDescPushBack(softforks, "eunospaya", consensusParams.EunosPayaHeight);
-    BuriedForkDescPushBack(softforks, "fortcanning", consensusParams.FortCanningHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningmuseum", consensusParams.FortCanningMuseumHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningpark", consensusParams.FortCanningParkHeight);
-    BuriedForkDescPushBack(softforks, "fortcanninghill", consensusParams.FortCanningHillHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningroad", consensusParams.FortCanningRoadHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningcrunch", consensusParams.FortCanningCrunchHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningspring", consensusParams.FortCanningSpringHeight);
-    BuriedForkDescPushBack(softforks, "fortcanninggreatworld", consensusParams.FortCanningGreatWorldHeight);
-    BuriedForkDescPushBack(softforks, "fortcanningepilogue", consensusParams.FortCanningEpilogueHeight);
-    BuriedForkDescPushBack(softforks, "grandcentral", consensusParams.GrandCentralHeight);
-    BuriedForkDescPushBack(softforks, "grandcentralepilogue", consensusParams.GrandCentralEpilogueHeight);
-    BuriedForkDescPushBack(softforks, "nextnetworkupgrade", consensusParams.NextNetworkUpgradeHeight);
+    BuriedForkDescPushBack(softforks, "amk", consensusParams.DF1AMKHeight);
+    BuriedForkDescPushBack(softforks, "bayfront", consensusParams.DF2BayfrontHeight);
+    BuriedForkDescPushBack(softforks, "clarkequay", consensusParams.DF5ClarkeQuayHeight);
+    BuriedForkDescPushBack(softforks, "dakota", consensusParams.DF6DakotaHeight);
+    BuriedForkDescPushBack(softforks, "dakotacrescent", consensusParams.DF7DakotaCrescentHeight);
+    BuriedForkDescPushBack(softforks, "eunos", consensusParams.DF8EunosHeight);
+    BuriedForkDescPushBack(softforks, "eunospaya", consensusParams.DF10EunosPayaHeight);
+    BuriedForkDescPushBack(softforks, "fortcanning", consensusParams.DF11FortCanningHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningmuseum", consensusParams.DF12FortCanningMuseumHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningpark", consensusParams.DF13FortCanningParkHeight);
+    BuriedForkDescPushBack(softforks, "fortcanninghill", consensusParams.DF14FortCanningHillHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningroad", consensusParams.DF15FortCanningRoadHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningcrunch", consensusParams.DF16FortCanningCrunchHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningspring", consensusParams.DF17FortCanningSpringHeight);
+    BuriedForkDescPushBack(softforks, "fortcanninggreatworld", consensusParams.DF18FortCanningGreatWorldHeight);
+    BuriedForkDescPushBack(softforks, "fortcanningepilogue", consensusParams.DF19FortCanningEpilogueHeight);
+    BuriedForkDescPushBack(softforks, "grandcentral", consensusParams.DF20GrandCentralHeight);
+    BuriedForkDescPushBack(softforks, "grandcentralepilogue", consensusParams.DF21GrandCentralEpilogueHeight);
+    BuriedForkDescPushBack(softforks, "nextnetworkupgrade", consensusParams.DF22NextHeight);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -303,7 +303,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
             // Get block times
             const auto subNodesBlockTime = pcustomcsview->GetBlockTimes(nodePtr->operatorAuthAddress, height, nodePtr->creationHeight, *timelock);
 
-            if (height >= Params().GetConsensus().EunosPayaHeight) {
+            if (height >= Params().GetConsensus().DF10EunosPayaHeight) {
                 const uint8_t loops = *timelock == CMasternode::TENYEAR ? 4 : *timelock == CMasternode::FIVEYEAR ? 3 : 2;
                 UniValue multipliers(UniValue::VARR);
                 for (uint8_t i{0}; i < loops; ++i) {

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -82,7 +82,7 @@ CScript CreateMetaA2A(CAccountToAccountMessage const & msg) {
 BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 {
     Consensus::Params amkCheated = Params().GetConsensus();
-    amkCheated.AMKHeight = 0;
+    amkCheated.DF1AMKHeight = 0;
 
 
     CCustomCSView mnview(*pcustomcsview);

--- a/src/test/dip1fork_tests.cpp
+++ b/src/test/dip1fork_tests.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(blockreward_dfip1)
 {
     const CScript SCRIPT_PUB{CScript(OP_TRUE)};
     const Consensus::Params & consensus = Params().GetConsensus();
-    auto height = consensus.AMKHeight;
+    auto height = consensus.DF1AMKHeight;
 
     CMutableTransaction coinbaseTx{};
 
@@ -83,9 +83,9 @@ BOOST_AUTO_TEST_CASE(blockreward_dfip8)
 {
     const CScript SCRIPT_PUB{CScript(OP_TRUE)};
     Consensus::Params consensus = Params().GetConsensus();
-    consensus.EunosHeight = 10000000;
-    consensus.GrandCentralHeight = 10000001;
-    auto height = consensus.EunosHeight;
+    consensus.DF8EunosHeight = 10000000;
+    consensus.DF20GrandCentralHeight = 10000001;
+    auto height = consensus.DF8EunosHeight;
     CAmount blockReward = GetBlockSubsidy(height, consensus);
 
     CMutableTransaction coinbaseTx{};
@@ -147,11 +147,11 @@ BOOST_AUTO_TEST_CASE(blockreward_dfip8)
 BOOST_AUTO_TEST_CASE(blockreward_dfip8_reductions)
 {
     Consensus::Params consensus = Params().GetConsensus();
-    consensus.EunosHeight = 10000000;
+    consensus.DF8EunosHeight = 10000000;
 
     auto GetReductionsHeight = [consensus](const uint32_t reductions)
     {
-        return consensus.EunosHeight + (reductions * Params().GetConsensus().emissionReductionPeriod);
+        return consensus.DF8EunosHeight + (reductions * Params().GetConsensus().emissionReductionPeriod);
     };
 
     // Test coinbase rewards reduction 0

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -79,7 +79,7 @@ struct CLiquidityRewardsTest : public TestingSetup
 {
     CLiquidityRewardsTest()
     {
-        const_cast<int&>(Params().GetConsensus().FortCanningHillHeight) = 7;
+        const_cast<int&>(Params().GetConsensus().DF14FortCanningHillHeight) = 7;
     }
 };
 

--- a/src/test/loan_tests.cpp
+++ b/src/test/loan_tests.cpp
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(loan_interest_rate)
 BOOST_AUTO_TEST_CASE(loan_total_interest_calculation)
 {
     // Activate negative interest rate
-    const_cast<int&>(Params().GetConsensus().FortCanningGreatWorldHeight) = 1;
+    const_cast<int&>(Params().GetConsensus().DF18FortCanningGreatWorldHeight) = 1;
 
     CCustomCSView mnview(*pcustomcsview);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1210,10 +1210,10 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     if (Params().NetworkIDString() != CBaseChainParams::REGTEST ||
             (Params().NetworkIDString() == CBaseChainParams::REGTEST && gArgs.GetBoolArg("-subsidytest", false)))
     {
-        if (nHeight >= consensusParams.EunosHeight)
+        if (nHeight >= consensusParams.DF8EunosHeight)
         {
             nSubsidy = consensusParams.newBaseBlockSubsidy;
-            const size_t reductions = (nHeight - consensusParams.EunosHeight) / consensusParams.emissionReductionPeriod;
+            const size_t reductions = (nHeight - consensusParams.DF8EunosHeight) / consensusParams.emissionReductionPeriod;
 
             // See if we already have this reduction calculated and return if found.
             if (subsidyReductions.find(reductions) != subsidyReductions.end())
@@ -1849,7 +1849,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
                 mnview.SetTeam(finMsg.currentTeam);
 
-                if (pindex->nHeight >= Params().GetConsensus().AMKHeight) {
+                if (pindex->nHeight >= Params().GetConsensus().DF1AMKHeight) {
                     mnview.AddCommunityBalance(CommunityAccountType::AnchorReward, tx.GetValueOut()); // or just 'Set..'
                     LogPrint(BCLog::ANCHORING, "%s: post AMK logic, add community balance %d\n", __func__, tx.GetValueOut());
                 }
@@ -1905,7 +1905,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     }
 
     // one time downgrade to revert CInterestRateV2 structure
-    if (pindex->nHeight == consensus.FortCanningHillHeight) {
+    if (pindex->nHeight == consensus.DF14FortCanningHillHeight) {
         auto time = GetTimeMillis();
         LogPrintf("Interest rate reverting ...\n");
         mnview.RevertInterestRateToV1();
@@ -1913,7 +1913,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     }
 
     // one time downgrade to revert CInterestRateV3 structure
-    if (pindex->nHeight == consensus.FortCanningGreatWorldHeight) {
+    if (pindex->nHeight == consensus.DF18FortCanningGreatWorldHeight) {
         auto time = GetTimeMillis();
         LogPrintf("Interest rate reverting ...\n");
         mnview.RevertInterestRateToV2();
@@ -1927,7 +1927,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
     if (!fIsFakeNet) {
         mnview.DecrementMintedBy(*nodeId);
-        if (pindex->nHeight >= consensus.EunosPayaHeight) {
+        if (pindex->nHeight >= consensus.DF10EunosPayaHeight) {
             mnview.EraseSubNodesLastBlockTime(*nodeId, static_cast<uint32_t>(pindex->nHeight));
         } else {
             mnview.EraseMasternodeLastBlockTime(*nodeId, static_cast<uint32_t>(pindex->nHeight));
@@ -2095,14 +2095,14 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
         return Res::ErrDbg("bad-cb-wrong-tokens", "coinbase should pay only Defi coins");
 
 
-    if (height >= consensus.AMKHeight)
+    if (height >= consensus.DF1AMKHeight)
     {
         CAmount foundationReward{0};
-        if (height >= consensus.GrandCentralHeight)
+        if (height >= consensus.DF20GrandCentralHeight)
         {
             // no foundation utxo reward check anymore
         }
-        else if (height >= consensus.EunosHeight)
+        else if (height >= consensus.DF8EunosHeight)
         {
             foundationReward = CalculateCoinbaseReward(blockReward, consensus.dist.community);
         }
@@ -2136,13 +2136,13 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
 
         // count and subtract for non-UTXO community rewards
         CAmount nonUtxoTotal = 0;
-        if (height >= consensus.EunosHeight)
+        if (height >= consensus.DF8EunosHeight)
         {
             CAmount subsidy;
             for (const auto& kv : consensus.blockTokenRewards)
             {
                 if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                    if (height < consensus.GrandCentralHeight) {
+                    if (height < consensus.DF20GrandCentralHeight) {
                         continue;
                     }
                 }
@@ -2152,8 +2152,8 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 Res res = Res::Ok();
 
                 // Loan below FC and Options are unused and all go to Unallocated (burnt) pot.
-                if ((height < consensus.FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
-                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
+                if ((height < consensus.DF11FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
+                    (height < consensus.DF20GrandCentralHeight && kv.first == CommunityAccountType::Options))
                 {
                     res = mnview.AddCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                     if (res)
@@ -2161,7 +2161,7 @@ Res ApplyGeneralCoinbaseTx(CCustomCSView & mnview, CTransaction const & tx, int 
                 }
                 else
                 {
-                    if (height >= consensus.GrandCentralHeight)
+                    if (height >= consensus.DF20GrandCentralHeight)
                     {
                         const auto attributes = mnview.GetAttributes();
                         assert(attributes);
@@ -2244,14 +2244,14 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensu
 {
     CAmount blockReward = GetBlockSubsidy(height, Params().GetConsensus());
 
-    if (height >= Params().GetConsensus().AMKHeight)
+    if (height >= Params().GetConsensus().DF1AMKHeight)
     {
-        if (height >= Params().GetConsensus().EunosHeight)
+        if (height >= Params().GetConsensus().DF8EunosHeight)
         {
             for (const auto& kv : Params().GetConsensus().blockTokenRewards)
             {
                 if (kv.first == CommunityAccountType::CommunityDevFunds) {
-                    if (height < Params().GetConsensus().GrandCentralHeight) {
+                    if (height < Params().GetConsensus().DF20GrandCentralHeight) {
                         continue;
                     }
                 }
@@ -2259,14 +2259,14 @@ void ReverseGeneralCoinbaseTx(CCustomCSView & mnview, int height, const Consensu
                 CAmount subsidy = CalculateCoinbaseReward(blockReward, kv.second);
 
                 // Remove Loan and Options balances from Unallocated
-                if ((height < Params().GetConsensus().FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
-                    (height < consensus.GrandCentralHeight && kv.first == CommunityAccountType::Options))
+                if ((height < Params().GetConsensus().DF11FortCanningHeight && kv.first == CommunityAccountType::Loan) ||
+                    (height < consensus.DF20GrandCentralHeight && kv.first == CommunityAccountType::Options))
                 {
                     mnview.SubCommunityBalance(CommunityAccountType::Unallocated, subsidy);
                 }
                 else
                 {
-                    if (height >= consensus.GrandCentralHeight)
+                    if (height >= consensus.DF20GrandCentralHeight)
                     {
                         const auto attributes = mnview.GetAttributes();
                         assert(attributes);
@@ -2451,14 +2451,14 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     // one time upgrade to convert the old CInterestRate data structure
     // we don't neeed it in undos
-    if (pindex->nHeight == chainparams.GetConsensus().FortCanningHillHeight) {
+    if (pindex->nHeight == chainparams.GetConsensus().DF14FortCanningHillHeight) {
         auto time = GetTimeMillis();
         LogPrintf("Interest rate migration ...\n");
         mnview.MigrateInterestRateToV2(mnview, static_cast<uint32_t>(pindex->nHeight));
         LogPrint(BCLog::BENCH, "    - Interest rate migration took: %dms\n", GetTimeMillis() - time);
     }
 
-    if (pindex->nHeight == chainparams.GetConsensus().FortCanningGreatWorldHeight) {
+    if (pindex->nHeight == chainparams.GetConsensus().DF18FortCanningGreatWorldHeight) {
         auto time = GetTimeMillis();
         LogPrintf("Interest rate migration ...\n");
         mnview.MigrateInterestRateToV3(mnview, static_cast<uint32_t>(pindex->nHeight));
@@ -2724,7 +2724,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
             LogApplyCustomTx(tx, applyCustomTxTime);
             if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {
-                if (pindex->nHeight >= consensus.EunosHeight) {
+                if (pindex->nHeight >= consensus.DF8EunosHeight) {
                     return state.Invalid(ValidationInvalidReason::CONSENSUS,
                                          error("%s: ApplyCustomTx on %s failed with %s",
                                                __func__, tx.GetHash().ToString(), res.msg), REJECT_CUSTOMTX, "bad-custom-tx");
@@ -2869,8 +2869,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         return accountsView.Flush(); // keeps compatibility
 
     // validates account changes as well
-    if (pindex->nHeight >= consensus.EunosHeight
-    && pindex->nHeight < consensus.EunosKampungHeight) {
+    if (pindex->nHeight >= consensus.DF8EunosHeight
+    && pindex->nHeight < consensus.DF9EunosKampungHeight) {
         bool mutated;
         uint256 hashMerkleRoot2 = BlockMerkleRoot(block, &mutated);
         if (block.hashMerkleRoot != Hash2(hashMerkleRoot2, accountsView.MerkleRoot())) {
@@ -2917,9 +2917,9 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         mnview.IncrementMintedBy(*nodeId);
 
         // Store block staker height for use in coinage
-        if (pindex->nHeight >= consensus.EunosPayaHeight) {
+        if (pindex->nHeight >= consensus.DF10EunosPayaHeight) {
             mnview.SetSubNodesBlockTime(minterKey, static_cast<uint32_t>(pindex->nHeight), ctxState.subNode, pindex->GetBlockTime());
-        } else if (pindex->nHeight >= consensus.DakotaCrescentHeight) {
+        } else if (pindex->nHeight >= consensus.DF7DakotaCrescentHeight) {
             mnview.SetMasternodeLastBlockTime(minterKey, static_cast<uint32_t>(pindex->nHeight), pindex->GetBlockTime());
         }
     }
@@ -2952,7 +2952,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             LogPrint(BCLog::BENCH, "    - Pruning undo data takes: %dms\n", GetTimeMillis() - time);
         }
         // we can safety delete old interest keys
-        if (it->first > consensus.FortCanningHillHeight) {
+        if (it->first > consensus.DF14FortCanningHillHeight) {
             CCustomCSView view(mnview);
             mnview.ForEachVaultInterest([&](const CVaultId& vaultId, DCT_ID tokenId, CInterestRate) {
                 view.EraseBy<CLoanView::LoanInterestByVault>(std::make_pair(vaultId, tokenId));
@@ -3428,7 +3428,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
     UpdateTip(pindexNew, chainparams);
 
     // Update teams every anchoringTeamChange number of blocks
-    if (pindexNew->nHeight >= Params().GetConsensus().DakotaHeight &&
+    if (pindexNew->nHeight >= Params().GetConsensus().DF6DakotaHeight &&
             pindexNew->nHeight % Params().GetConsensus().mn.anchoringTeamChange == 0) {
         pcustomcsview->CalcAnchoringTeams(blockConnecting.stakeModifier, pindexNew);
 
@@ -3605,7 +3605,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
                     fContinue = false;
                     if (state.GetRejectReason() == "high-hash"
                     || (pindexConnect == pindexMostWork
-                    && pindexConnect->nHeight >= chainparams.GetConsensus().FortCanningParkHeight
+                    && pindexConnect->nHeight >= chainparams.GetConsensus().DF13FortCanningParkHeight
                     && state.GetRejectCode() == REJECT_CUSTOMTX)) {
                         UpdateMempoolForReorg(disconnectpool, false);
                         return false;
@@ -3613,7 +3613,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
                     fInvalidFound = true;
                     InvalidChainFound(vpindexToConnect.front());
                     if (state.GetReason() == ValidationInvalidReason::BLOCK_MUTATED) {
-                        // prior EunosHeight we shoutdown node on mutated block
+                        // prior DF8EunosHeight we shoutdown node on mutated block
                         if (ShutdownRequested()) {
                             return false;
                         }
@@ -3628,7 +3628,7 @@ bool CChainState::ActivateBestChainStep(CValidationState& state, const CChainPar
                         }
                     }
                     if (pindexConnect == pindexMostWork
-                    && (pindexConnect->nHeight < chainparams.GetConsensus().EunosHeight
+                    && (pindexConnect->nHeight < chainparams.GetConsensus().DF8EunosHeight
                     || state.GetRejectCode() == REJECT_CUSTOMTX)) {
                         // NOTE: Invalidate blocks back to last checkpoint
                         auto &checkpoints = chainparams.Checkpoints().mapCheckpoints;
@@ -4202,8 +4202,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check the merkle root.
     // block merkle root is delayed to ConnectBlock to ensure account changes
-    if (fCheckMerkleRoot && (height < consensusParams.EunosHeight
-    || height >= consensusParams.EunosKampungHeight)) {
+    if (fCheckMerkleRoot && (height < consensusParams.DF8EunosHeight
+    || height >= consensusParams.DF9EunosKampungHeight)) {
         bool mutated;
         uint256 hashMerkleRoot2 = BlockMerkleRoot(block, &mutated);
         if (block.hashMerkleRoot != hashMerkleRoot2)
@@ -4235,9 +4235,9 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         TBytes dummy;
         for (unsigned int i = 1; i < block.vtx.size(); i++) {
             if (block.vtx[i]->IsCoinBase() &&
-                !IsAnchorRewardTx(*block.vtx[i], dummy, height >= consensusParams.FortCanningHeight) &&
-                !IsAnchorRewardTxPlus(*block.vtx[i], dummy, height >= consensusParams.FortCanningHeight) &&
-                !IsTokenSplitTx(*block.vtx[i], dummy, height >= consensusParams.FortCanningCrunchHeight))
+                !IsAnchorRewardTx(*block.vtx[i], dummy, height >= consensusParams.DF11FortCanningHeight) &&
+                !IsAnchorRewardTxPlus(*block.vtx[i], dummy, height >= consensusParams.DF11FortCanningHeight) &&
+                !IsTokenSplitTx(*block.vtx[i], dummy, height >= consensusParams.DF16FortCanningCrunchHeight))
                 return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-cb-multiple", "more than one coinbase");
         }
     }
@@ -4251,7 +4251,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
                                      strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
     }
 
-    if (!fIsFakeNet && fCheckPOS && height >= consensusParams.FortCanningHeight) {
+    if (!fIsFakeNet && fCheckPOS && height >= consensusParams.DF11FortCanningHeight) {
         CKeyID minter;
         // this is safe cause pos::ContextualCheckProofOfStake checked
         block.ExtractMinterKey(minter);
@@ -4259,7 +4259,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         auto node = pcustomcsview->GetMasternode(*nodeId);
         if (node->rewardAddressType != 0) {
             CTxDestination destination;
-            if (height < consensusParams.NextNetworkUpgradeHeight) {
+            if (height < consensusParams.DF22NextHeight) {
                 destination = FromOrDefaultKeyIDToDestination(node->rewardAddress, TxDestTypeToKeyType(node->rewardAddressType), KeyType::MNOwnerKeyType);
             } else {
                 destination = FromOrDefaultKeyIDToDestination(node->rewardAddress, TxDestTypeToKeyType(node->rewardAddressType), KeyType::MNRewardKeyType);
@@ -4361,7 +4361,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     assert(pindexPrev != nullptr);
     const int nHeight = pindexPrev->nHeight + 1;
 
-    if (nHeight >= params.GetConsensus().FortCanningMuseumHeight && static_cast<uint64_t>(nHeight) != block.deprecatedHeight) {
+    if (nHeight >= params.GetConsensus().DF12FortCanningMuseumHeight && static_cast<uint64_t>(nHeight) != block.deprecatedHeight) {
         return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER, false, REJECT_INVALID, "incorrect-height", "incorrect height set in block header");
     }
 
@@ -4383,7 +4383,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
         return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER, false, REJECT_INVALID, "time-too-old", strprintf("block's timestamp is too early. Block time: %d Min time: %d", block.GetBlockTime(), pindexPrev->GetMedianTimePast()));
 
     // Check timestamp
-    if (Params().NetworkIDString() != CBaseChainParams::REGTEST && nHeight >= consensusParams.EunosPayaHeight) {
+    if (Params().NetworkIDString() != CBaseChainParams::REGTEST && nHeight >= consensusParams.DF10EunosPayaHeight) {
         if (block.GetBlockTime() > GetTime() + MAX_FUTURE_BLOCK_TIME_EUNOSPAYA)
             return state.Invalid(ValidationInvalidReason::BLOCK_TIME_FUTURE, false, REJECT_INVALID, "time-too-new", strprintf("block timestamp too far in the future. Block time: %d Max time: %d", block.GetBlockTime(), GetTime() + MAX_FUTURE_BLOCK_TIME_EUNOSPAYA));
     }
@@ -4391,7 +4391,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     if (block.GetBlockTime() > nAdjustedTime + MAX_FUTURE_BLOCK_TIME)
         return state.Invalid(ValidationInvalidReason::BLOCK_TIME_FUTURE, false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
 
-    if (nHeight >= consensusParams.DakotaCrescentHeight) {
+    if (nHeight >= consensusParams.DF7DakotaCrescentHeight) {
         if (block.GetBlockTime() > GetTime() + MAX_FUTURE_BLOCK_TIME_DAKOTACRESCENT)
             return state.Invalid(ValidationInvalidReason::BLOCK_TIME_FUTURE, false, REJECT_INVALID, "time-too-new", strprintf("block timestamp too far in the future. Block time: %d Max time: %d", block.GetBlockTime(), GetTime() + MAX_FUTURE_BLOCK_TIME_DAKOTACRESCENT));
     }
@@ -4781,7 +4781,7 @@ void ProcessAuthsIfTipChanged(CBlockIndex const * oldTip, CBlockIndex const * ti
         }
 
         // Select a block further back to avoid Anchor too new error.
-        if (pindex->nHeight >= consensus.FortCanningHeight) {
+        if (pindex->nHeight >= consensus.DF11FortCanningHeight) {
             timeDepth += consensus.mn.anchoringAdditionalTimeDepth;
             while (anchorHeight > 0 && ::ChainActive()[anchorHeight]->nTime + timeDepth > pindex->nTime) {
                 --anchorHeight;
@@ -4905,7 +4905,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
     {
         ProcessAuthsIfTipChanged(oldTip, tip, chainparams.GetConsensus());
 
-        if (tip->nHeight >= chainparams.GetConsensus().DakotaHeight) {
+        if (tip->nHeight >= chainparams.GetConsensus().DF6DakotaHeight) {
             panchors->CheckPendingAnchors();
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5082,5 +5082,5 @@ CKey GetWalletsKey(const CKeyID & keyid)
 
 int32_t GetTransactionVersion(int height)
 {
-    return height >= Params().GetConsensus().AMKHeight ? CTransaction::TOKENS_MIN_VERSION : CTransaction::TX_VERSION_2;
+    return height >= Params().GetConsensus().DF1AMKHeight ? CTransaction::TOKENS_MIN_VERSION : CTransaction::TX_VERSION_2;
 }


### PR DESCRIPTION
## Summary

- Adds a numeric prefix to all network upgrades: DF<num><name>. Taken from #2292 but only the variable renames.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
