### PR TITLE
Transfer domain calculate owner rewards

### DIFF
--- a/src/masternodes/consensus/xvm.cpp
+++ b/src/masternodes/consensus/xvm.cpp
@@ -262,6 +262,9 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 return DeFiErrors::TransferDomainSmartContractDestAddress();
             }
 
+            // Calculate source address rewards
+            CalculateOwnerRewards(src.address);
+
             // Subtract balance from DFI address
             res = mnview.SubBalance(src.address, src.amount);
             if (!res) {
@@ -363,6 +366,9 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             auto tokenAmount = CTokenAmount{tokenId, src.amount.nValue};
             stats.evmOut.Add(tokenAmount);
             stats.evmCurrent.Sub(tokenAmount);
+
+            // Calculate destination address rewards
+            CalculateOwnerRewards(dst.address);
 
             // Add balance to DFI address
             res = mnview.AddBalance(dst.address, dst.amount);


### PR DESCRIPTION
## Summary

- Before using an address calculate owner rewards should be called to make sure the balance is correct. This PR adds that calculation to DVM addresses used in TransferDomain.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
