### PR TITLE
Restore debug_dumpdb RPC call

### DIFF
--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -8,8 +8,11 @@ use anyhow::format_err;
 use ethereum::{Block, PartialHeader, ReceiptV3};
 use ethereum_types::{Bloom, H160, H256, H64, U256};
 use log::{debug, trace};
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    RwLock,
+};
 
-use crate::log::Notification;
 use crate::{
     backend::{EVMBackend, Vicinity},
     block::BlockService,
@@ -22,7 +25,7 @@ use crate::{
     core::{EVMCoreService, XHash},
     executor::AinExecutor,
     filters::FilterService,
-    log::LogService,
+    log::{LogService, Notification},
     receipt::ReceiptService,
     storage::{traits::BlockStorage, Storage},
     transaction::{
@@ -33,8 +36,6 @@ use crate::{
     txqueue::{BlockData, QueueTx},
     EVMError, Result,
 };
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::sync::RwLock;
 
 pub struct NotificationChannel<T> {
     pub sender: UnboundedSender<T>,

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -226,6 +226,7 @@ impl Rollback for BlockStore {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DumpArg {
     All,
     Blocks,

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -1,12 +1,13 @@
-use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
+use std::{collections::HashMap, fs, marker::PhantomData, path::Path, str::FromStr, sync::Arc};
 
 use anyhow::format_err;
 use ethereum::{BlockAny, TransactionV2};
 use ethereum_types::{H160, H256, U256};
 use log::debug;
+use serde::{Deserialize, Serialize};
 
 use super::{
-    db::{Column, ColumnName, LedgerColumn, Rocks},
+    db::{Column, ColumnName, LedgerColumn, Rocks, TypedColumn},
     traits::{BlockStorage, FlushableStorage, ReceiptStorage, Rollback, TransactionStorage},
 };
 use crate::{
@@ -127,7 +128,7 @@ impl BlockStorage for BlockStore {
     fn get_latest_block(&self) -> Result<Option<BlockAny>> {
         let latest_block_cf = self.column::<columns::LatestBlockNumber>();
 
-        match latest_block_cf.get(&()) {
+        match latest_block_cf.get(&"") {
             Ok(Some(block_number)) => self.get_block_by_number(&block_number),
             Ok(None) => Ok(None),
             Err(e) => Err(e),
@@ -138,7 +139,7 @@ impl BlockStorage for BlockStore {
         if let Some(block) = block {
             let latest_block_cf = self.column::<columns::LatestBlockNumber>();
             let block_number = block.header.number;
-            latest_block_cf.put(&(), &block_number)?;
+            latest_block_cf.put(&"latest_block", &block_number)?;
         }
         Ok(())
     }
@@ -217,9 +218,63 @@ impl Rollback for BlockStore {
 
             if let Some(block) = self.get_block_by_hash(&block.header.parent_hash)? {
                 let latest_block_cf = self.column::<columns::LatestBlockNumber>();
-                latest_block_cf.put(&(), &block.header.number)?;
+                latest_block_cf.put(&"latest_block", &block.header.number)?;
             }
         }
         Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum DumpArg {
+    All,
+    Blocks,
+    Txs,
+    Receipts,
+    BlockMap,
+    Logs,
+}
+
+impl BlockStore {
+    pub fn dump(&self, arg: &DumpArg, from: Option<&str>, limit: usize) {
+        let s_to_u256 = |s| {
+            U256::from_str_radix(s, 10)
+                .or(U256::from_str_radix(s, 16))
+                .unwrap_or_else(|_| U256::zero())
+        };
+        let s_to_h256 = |s: &str| H256::from_str(&s).unwrap_or(H256::zero());
+
+        match arg {
+            DumpArg::All => {
+                self.dump_all(limit);
+            }
+            DumpArg::Blocks => self.dump_column(columns::Blocks, from.map(s_to_u256), limit),
+            DumpArg::Txs => self.dump_column(columns::Transactions, from.map(s_to_h256), limit),
+            DumpArg::Receipts => self.dump_column(columns::Receipts, from.map(s_to_h256), limit),
+            DumpArg::BlockMap => self.dump_column(columns::BlockMap, from.map(s_to_h256), limit),
+            DumpArg::Logs => self.dump_column(columns::AddressLogsMap, from.map(s_to_u256), limit),
+        }
+    }
+
+    fn dump_all(&self, limit: usize) {
+        for arg in &[
+            DumpArg::Blocks,
+            DumpArg::Txs,
+            DumpArg::Receipts,
+            DumpArg::BlockMap,
+            DumpArg::Logs,
+        ] {
+            self.dump(arg, None, limit);
+        }
+    }
+
+    fn dump_column<C>(&self, _: C, from: Option<C::Index>, limit: usize)
+    where
+        C: TypedColumn + ColumnName,
+    {
+        println!("{}", C::NAME);
+        for (k, v) in self.column::<C>().iter(from, limit) {
+            println!("{:?}: {:#?}", k, v);
+        }
     }
 }

--- a/lib/ain-evm/src/storage/db.rs
+++ b/lib/ain-evm/src/storage/db.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::HashMap,
+    fmt::Debug,
+    iter::Iterator,
     marker::PhantomData,
     path::{Path, PathBuf},
     sync::Arc,
@@ -8,7 +10,10 @@ use std::{
 use bincode;
 use ethereum::{BlockAny, TransactionV2};
 use ethereum_types::{H160, H256, U256};
-use rocksdb::{BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor, Options, DB};
+use rocksdb::{
+    BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor, DBIterator, IteratorMode,
+    Options, DB,
+};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{log::LogIndex, receipt::Receipt, Result};
@@ -95,6 +100,13 @@ impl Rocks {
     fn delete_cf(&self, cf: &ColumnFamily, key: &[u8]) -> Result<()> {
         self.0.delete_cf(cf, key)?;
         Ok(())
+    }
+
+    pub fn iterator_cf<C>(&self, cf: &ColumnFamily, iterator_mode: IteratorMode) -> DBIterator
+    where
+        C: Column,
+    {
+        self.0.iterator_cf(cf, iterator_mode)
     }
 
     pub fn flush(&self) -> Result<()> {
@@ -209,9 +221,11 @@ impl ColumnName for columns::CodeMap {
 // Column trait. Define associated index type
 //
 pub trait Column {
-    type Index;
+    type Index: Debug;
 
     fn key(index: &Self::Index) -> Vec<u8>;
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index;
 }
 
 //
@@ -224,6 +238,10 @@ impl Column for columns::Transactions {
     fn key(index: &Self::Index) -> Vec<u8> {
         index.as_bytes().to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        Self::Index::from_slice(&raw_key)
+    }
 }
 
 impl Column for columns::Blocks {
@@ -234,6 +252,10 @@ impl Column for columns::Blocks {
         index.to_big_endian(&mut bytes);
         bytes.to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        Self::Index::from(&*raw_key)
+    }
 }
 
 impl Column for columns::Receipts {
@@ -242,6 +264,10 @@ impl Column for columns::Receipts {
     fn key(index: &Self::Index) -> Vec<u8> {
         index.to_fixed_bytes().to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        Self::Index::from_slice(&raw_key)
+    }
 }
 impl Column for columns::BlockMap {
     type Index = H256;
@@ -249,13 +275,21 @@ impl Column for columns::BlockMap {
     fn key(index: &Self::Index) -> Vec<u8> {
         index.to_fixed_bytes().to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        Self::Index::from_slice(&raw_key)
+    }
 }
 
 impl Column for columns::LatestBlockNumber {
-    type Index = ();
+    type Index = &'static str;
 
     fn key(_index: &Self::Index) -> Vec<u8> {
         b"latest".to_vec()
+    }
+
+    fn get_key(_raw_key: Box<[u8]>) -> Self::Index {
+        "latest"
     }
 }
 
@@ -267,6 +301,10 @@ impl Column for columns::AddressLogsMap {
         index.to_big_endian(&mut bytes);
         bytes.to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        Self::Index::from(&*raw_key)
+    }
 }
 
 impl Column for columns::CodeMap {
@@ -275,13 +313,17 @@ impl Column for columns::CodeMap {
     fn key(index: &Self::Index) -> Vec<u8> {
         index.to_fixed_bytes().to_vec()
     }
+
+    fn get_key(raw_key: Box<[u8]>) -> Self::Index {
+        H256::from_slice(&raw_key)
+    }
 }
 
 //
 // TypedColumn trait. Define associated value type
 //
 pub trait TypedColumn: Column {
-    type Type: Serialize + DeserializeOwned;
+    type Type: Serialize + DeserializeOwned + Debug;
 }
 
 //
@@ -333,5 +375,27 @@ where
 
     pub fn delete(&self, key: &C::Index) -> Result<()> {
         self.backend.delete_cf(self.handle(), &C::key(key))
+    }
+
+    pub fn iter(
+        &self,
+        from: Option<C::Index>,
+        limit: usize,
+    ) -> impl Iterator<Item = (C::Index, C::Type)> + '_ {
+        let index = from.as_ref().map(|i| C::key(i)).unwrap_or_default();
+        let iterator_mode = from.map_or(IteratorMode::Start, |_| {
+            IteratorMode::From(&index, rocksdb::Direction::Forward)
+        });
+        self.backend
+            .iterator_cf::<C>(self.handle(), iterator_mode)
+            .into_iter()
+            .filter_map(|k| {
+                k.ok().and_then(|(k, v)| {
+                    let value = bincode::deserialize(&v).ok()?;
+                    let key = C::get_key(k);
+                    Some((key, value))
+                })
+            })
+            .take(limit)
     }
 }

--- a/lib/ain-evm/src/storage/mod.rs
+++ b/lib/ain-evm/src/storage/mod.rs
@@ -1,4 +1,4 @@
-mod block_store;
+pub mod block_store;
 mod cache;
 mod db;
 pub mod traits;
@@ -10,7 +10,7 @@ use ethereum::{BlockAny, TransactionV2};
 use ethereum_types::{H160, H256, U256};
 
 use self::{
-    block_store::BlockStore,
+    block_store::{BlockStore, DumpArg},
     cache::Cache,
     traits::{
         AttributesStorage, BlockStorage, FlushableStorage, ReceiptStorage, Rollback,
@@ -206,8 +206,9 @@ impl Storage {
 }
 
 impl Storage {
-    pub fn dump_db(&self) {
-        // println!("self.block_data_handler : {:#?}", self.blockstore);
+    pub fn dump_db(&self, arg: DumpArg, from: Option<&str>, limit: usize) {
+        println!("[dump_db]");
+        self.blockstore.dump(&arg, from, limit)
     }
 }
 

--- a/lib/ain-evm/src/weiamount.rs
+++ b/lib/ain-evm/src/weiamount.rs
@@ -69,11 +69,13 @@ pub fn try_from_satoshi(satoshi: U256) -> Result<WeiAmount> {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
+    use ethereum_types::U256;
+
     use crate::weiamount::{
         try_from_satoshi, WeiAmount, MAX_MONEY_SATS, MAX_MONEY_SATS_DOUBLE, WEI_TO_SATS,
     };
-    use ethereum_types::U256;
-    use std::error::Error;
 
     #[test]
     fn test_satoshi_double_conversion() -> Result<(), Box<dyn Error>> {

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -51,7 +51,7 @@ use crate::{
 
 // TODO: Ideally most of the below and SERVICES needs to go into its own core crate now,
 // and this crate be dedicated to network services.
-// Note: This cannot just move to rs-exports, since rs-exports cannot cannot have reverse
+// Note: This cannot just move to rs-exports, since rs-exports cannot have reverse
 // deps that depend on it.
 
 pub fn preinit() {}

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -29,23 +29,24 @@ use std::{
 
 use ain_evm::services::{Services, IS_SERVICES_INIT_CALL, SERVICES};
 use anyhow::{format_err, Result};
-use hyper::header::HeaderValue;
-use hyper::Method;
+use hyper::{header::HeaderValue, Method};
 use jsonrpsee::core::server::rpc_module::Methods;
 use jsonrpsee_server::ServerBuilder;
 use log::info;
 use logging::CppLogTarget;
 use tower_http::cors::CorsLayer;
 
-use crate::rpc::{
-    debug::{MetachainDebugRPCModule, MetachainDebugRPCServer},
-    eth::{MetachainRPCModule, MetachainRPCServer},
-    net::{MetachainNetRPCModule, MetachainNetRPCServer},
-    web3::{MetachainWeb3RPCModule, MetachainWeb3RPCServer},
-};
-use crate::subscription::{
-    eth::{MetachainPubSubModule, MetachainPubSubServer},
-    MetachainSubIdProvider,
+use crate::{
+    rpc::{
+        debug::{MetachainDebugRPCModule, MetachainDebugRPCServer},
+        eth::{MetachainRPCModule, MetachainRPCServer},
+        net::{MetachainNetRPCModule, MetachainNetRPCServer},
+        web3::{MetachainWeb3RPCModule, MetachainWeb3RPCServer},
+    },
+    subscription::{
+        eth::{MetachainPubSubModule, MetachainPubSubServer},
+        MetachainSubIdProvider,
+    },
 };
 
 // TODO: Ideally most of the below and SERVICES needs to go into its own core crate now,

--- a/lib/ain-grpc/src/receipt.rs
+++ b/lib/ain-grpc/src/receipt.rs
@@ -1,5 +1,4 @@
-use ain_evm::log::LogIndex;
-use ain_evm::receipt::Receipt;
+use ain_evm::{log::LogIndex, receipt::Receipt};
 use ethereum::{EIP658ReceiptData, Log};
 use ethereum_types::{H160, H256, U256};
 

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -73,8 +73,9 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         start: Option<&str>,
         limit: Option<&str>,
     ) -> RpcResult<()> {
+        let default_limit = 100usize;
         let limit = limit
-            .map_or(Ok(usize::MAX), |s| s.parse())
+            .map_or(Ok(default_limit), |s| s.parse())
             .map_err(|e| Error::Custom(e.to_string()))?;
         self.handler
             .storage

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -1,6 +1,8 @@
 use std::{cmp, sync::Arc};
 
-use ain_evm::{core::EthCallArgs, evm::EVMServices, executor::TxResponse};
+use ain_evm::{
+    core::EthCallArgs, evm::EVMServices, executor::TxResponse, storage::block_store::DumpArg,
+};
 use ethereum::Account;
 use ethereum_types::U256;
 use jsonrpsee::{
@@ -28,7 +30,12 @@ pub trait MetachainDebugRPC {
 
     // Dump full db
     #[method(name = "dumpdb")]
-    fn dump_db(&self) -> RpcResult<()>;
+    fn dump_db(
+        &self,
+        arg: Option<DumpArg>,
+        from: Option<&str>,
+        limit: Option<&str>,
+    ) -> RpcResult<()>;
 
     // Log accounts state
     #[method(name = "logaccountstates")]
@@ -60,8 +67,18 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         Ok(())
     }
 
-    fn dump_db(&self) -> RpcResult<()> {
-        self.handler.storage.dump_db();
+    fn dump_db(
+        &self,
+        arg: Option<DumpArg>,
+        start: Option<&str>,
+        limit: Option<&str>,
+    ) -> RpcResult<()> {
+        let limit = limit
+            .map_or(Ok(usize::MAX), |s| s.parse())
+            .map_err(|e| Error::Custom(format!("{e}")))?;
+        self.handler
+            .storage
+            .dump_db(arg.unwrap_or(DumpArg::All), start, limit);
         Ok(())
     }
 

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -75,7 +75,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
     ) -> RpcResult<()> {
         let limit = limit
             .map_or(Ok(usize::MAX), |s| s.parse())
-            .map_err(|e| Error::Custom(format!("{e}")))?;
+            .map_err(|e| Error::Custom(e.to_string()))?;
         self.handler
             .storage
             .dump_db(arg.unwrap_or(DumpArg::All), start, limit);

--- a/lib/ain-grpc/src/subscription/eth.rs
+++ b/lib/ain-grpc/src/subscription/eth.rs
@@ -1,12 +1,15 @@
-use crate::subscription::params::{Kind, Params};
-use crate::subscription::sync_status::{PubSubSyncStatus, SyncStatusMetadata};
-use crate::subscription::PubSubResult;
-use ain_evm::log::Notification;
-use ain_evm::{evm::EVMServices, storage::traits::BlockStorage};
+use std::sync::Arc;
+
+use ain_evm::{evm::EVMServices, log::Notification, storage::traits::BlockStorage};
 use anyhow::format_err;
 use jsonrpsee::{proc_macros::rpc, types::SubscriptionEmptyError, SubscriptionSink};
 use log::debug;
-use std::sync::Arc;
+
+use crate::subscription::{
+    params::{Kind, Params},
+    sync_status::{PubSubSyncStatus, SyncStatusMetadata},
+    PubSubResult,
+};
 
 /// Metachain WebSockets interface.
 #[rpc(server)]

--- a/lib/ain-grpc/src/subscription/mod.rs
+++ b/lib/ain-grpc/src/subscription/mod.rs
@@ -2,13 +2,13 @@ pub mod eth;
 pub mod params;
 pub mod sync_status;
 
-use crate::block::RpcBlockHeader;
 use ethereum_types::H256;
 use jsonrpsee::core::traits::IdProvider;
 use serde::{Serialize, Serializer};
 
-use crate::receipt::LogResult;
-use crate::subscription::sync_status::PubSubSyncStatus;
+use crate::{
+    block::RpcBlockHeader, receipt::LogResult, subscription::sync_status::PubSubSyncStatus,
+};
 
 /// Subscription result.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/lib/ain-grpc/src/subscription/params.rs
+++ b/lib/ain-grpc/src/subscription/params.rs
@@ -1,6 +1,5 @@
 use ethereum_types::{H160, H256};
-use serde::de::Error;
-use serde::{Deserialize, Deserializer};
+use serde::{de::Error, Deserialize, Deserializer};
 use serde_json::{from_value, Value};
 use serde_with::{serde_as, OneOrMany};
 

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -2,11 +2,11 @@ use ain_contracts::{
     get_transfer_domain_contract, get_transferdomain_dst20_transfer_function,
     get_transferdomain_native_transfer_function, FixedContract,
 };
-use ain_evm::log::Notification;
 use ain_evm::{
     core::{TransferDomainTxInfo, XHash},
     evm::FinalizedBlockInfo,
     fee::{calculate_max_tip_gas_fee, calculate_min_rbf_tip_gas_fee},
+    log::Notification,
     services::SERVICES,
     storage::traits::{BlockStorage, Rollback, TransactionStorage},
     transaction::{

--- a/src/defi-cli.cpp
+++ b/src/defi-cli.cpp
@@ -327,7 +327,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
 
     // Check if DVM or EVM RPC
     int port = dvmport;
-    if (strMethod.rfind("eth_", 0 || strMethod == "net_version") == 0)
+    if (strMethod.rfind("eth_", 0) == 0 || strMethod.rfind("debug_", 0) == 0 || strMethod.rfind("net_", 0) == 0)
         port = evmport;
 
     // Obtain event base


### PR DESCRIPTION
## Summary

- Restore debug RPC call to dump db data

## RPCs

- Takes optional `type` (default `all`), `from` (default `None`) and `limit` (default 100) parameters. 
- Available type params : One of `all`, `blocks`, `txs`, `receipts`, `blockmap`, `logs`
