### PR TITLE
EVM: Fix transaction gas fee check

### DIFF
--- a/lib/ain-evm/src/blocktemplate.rs
+++ b/lib/ain-evm/src/blocktemplate.rs
@@ -341,6 +341,11 @@ impl BlockTemplate {
             .map_or(Bloom::default(), |tx_item| tx_item.logs_bloom)
     }
 
+    pub fn get_block_base_fee_per_gas(&self) -> U256 {
+        let data = self.data.lock();
+        data.vicinity.block_base_fee_per_gas
+    }
+
     pub fn get_block_number(&self) -> U256 {
         let data = self.data.lock();
         data.vicinity.block_number

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -218,7 +218,7 @@ fn evm_try_get_balance(address: &str) -> Result<u64> {
 ///
 /// The state update results.
 #[ffi_fallible]
-fn unsafe_update_state_in_template(template_id: u64, mnview_ptr: usize) -> Result<()> {
+fn evm_try_unsafe_update_state_in_template(template_id: u64, mnview_ptr: usize) -> Result<()> {
     unsafe {
         SERVICES
             .evm
@@ -278,7 +278,11 @@ fn evm_try_unsafe_remove_txs_above_hash_in_template(
 /// * `raw_tx` - The raw transparent transferdomain tx.
 /// * `hash` - The native hash of the transferdomain tx.
 #[ffi_fallible]
-fn evm_try_unsafe_add_balance_in_template(template_id: u64, raw_tx: &str, native_hash: &str) -> Result<()> {
+fn evm_try_unsafe_add_balance_in_template(
+    template_id: u64,
+    raw_tx: &str,
+    native_hash: &str,
+) -> Result<()> {
     let signed_tx = SERVICES
         .evm
         .core
@@ -501,7 +505,9 @@ fn evm_try_unsafe_push_tx_in_template(
 ///
 /// Returns a `FinalizeBlockResult` containing the block hash, failed transactions, burnt fees and priority fees (in satoshis) on success.
 #[ffi_fallible]
-fn evm_try_unsafe_construct_block_in_template(template_id: u64) -> Result<ffi::FinalizeBlockCompletion> {
+fn evm_try_unsafe_construct_block_in_template(
+    template_id: u64,
+) -> Result<ffi::FinalizeBlockCompletion> {
     unsafe {
         let FinalizedBlockInfo {
             block_hash,


### PR DESCRIPTION
## Summary

- Depends on PR #2574
- This PR resolves the miner crash issue on RC1 due to arithmetic overflow.
- Restores the EVM transaction fee per gas check pipeline when adding transactions into the block template.
- Only EVM transactions that are minimally of the next block base fee per gas will be included into the construction of the block.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
