### PR TITLE
ci: Remove ethereum PPA from deps 

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -721,13 +721,6 @@ pkg_install_rust() {
     _fold_end
 }
 
-pkg_install_solc() {
-    _fold_start "pkg-install-solc"
-    add-apt-repository ppa:ethereum/ethereum -y
-    apt-get update
-    apt-get install solc -y
-}
-
 pkg_local_ensure_osx_sysroot() {
     local sdk_name="Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
     local pkg="${sdk_name}.tar.gz"
@@ -1114,7 +1107,6 @@ ci_setup_deps() {
     DEBIAN_FRONTEND=noninteractive pkg_setup_locale
     DEBIAN_FRONTEND=noninteractive pkg_install_llvm
     DEBIAN_FRONTEND=noninteractive pkg_install_rust
-    DEBIAN_FRONTEND=noninteractive pkg_install_solc
 }
 
 _ci_setup_deps_target() {


### PR DESCRIPTION
## Summary

- Fixes broken CI pipelines by remove installing solc dependency package on CI workflow with PPA ethereum repository
- solc package is already installed in build deps stage


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
