### PR TITLE
EVM: Optimize consensus to reduce unnecessary triedb commits

### DIFF
--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -212,7 +212,7 @@ impl<'backend> AinExecutor<'backend> {
         let logs = logs.into_iter().collect::<Vec<_>>();
 
         ApplyBackend::apply(self.backend, values, logs.clone(), true);
-        let mut state_root = self.backend.commit();
+        let mut state_root = self.commit();
 
         if !system_tx {
             state_root =


### PR DESCRIPTION
## Summary

- Remove unnecessary triedb commits on EVMBackend for expensive state root calculations


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
