### PR TITLE
BUILD: Move shasum and windows specific in make.sh

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -87,7 +87,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip
 
   osx-x64:
     runs-on: ubuntu-latest
@@ -153,32 +153,11 @@ jobs:
     - name: Get artifacts
       uses: actions/download-artifact@v3
 
-    - name: zip package for win-x64
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        cd defichain-${ver}-x86_64-w64-mingw32
-        tar xzf defichain-${ver}-x86_64-w64-mingw32.tar.gz
-        zip -r "defichain-${ver}-x86_64-w64-mingw32.zip" defichain-${ver}/
-
     - name: Get release
       id: get_release
       uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Generate SHA256 checksum
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        (cd ./defichain-${ver}-x86_64-pc-linux-gnu
-        sha256sum ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz > ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz.SHA256)
-        (cd ./defichain-${ver}-aarch64-linux-gnu
-        sha256sum ./defichain-${ver}-aarch64-linux-gnu.tar.gz > ./defichain-${ver}-aarch64-linux-gnu.tar.gz.SHA256)
-        (cd ./defichain-${ver}-x86_64-w64-mingw32
-        sha256sum ./defichain-${ver}-x86_64-w64-mingw32.zip > ./defichain-${ver}-x86_64-w64-mingw32.zip.SHA256)
-        (cd ./defichain-${ver}-x86_64-apple-darwin
-        sha256sum ./defichain-${ver}-x86_64-apple-darwin.tar.gz > ././defichain-${ver}-x86_64-apple-darwin.tar.gz.SHA256)
-        (cd ./defichain-${ver}-aarch64-apple-darwin
-        sha256sum ./defichain-${ver}-aarch64-apple-darwin.tar.gz > ././defichain-${ver}-aarch64-apple-darwin.tar.gz.SHA256)
 
     - name: Upload release asset - linux-x64
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32
-        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.tar.gz
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-x86_64-w64-mingw32.zip
 
   osx-x64:
     runs-on: ubuntu-latest
@@ -132,24 +132,3 @@ jobs:
 
     - name: Get artifacts
       uses: actions/download-artifact@v3
-
-    - name: zip package for win-x64
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        cd defichain-${ver}-x86_64-w64-mingw32
-        tar xzf defichain-${ver}-x86_64-w64-mingw32.tar.gz
-        zip -r "defichain-${ver}-x86_64-w64-mingw32.zip" defichain-${ver}/
-
-    - name: Generate SHA256 checksum
-      run: |
-        set -e; ver=${{ env.BUILD_VERSION }}
-        (cd ./defichain-${ver}-x86_64-pc-linux-gnu
-        sha256sum ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz > ./defichain-${ver}-x86_64-pc-linux-gnu.tar.gz.SHA256)
-        (cd ./defichain-${ver}-aarch64-linux-gnu
-        sha256sum ./defichain-${ver}-aarch64-linux-gnu.tar.gz > ./defichain-${ver}-aarch64-linux-gnu.tar.gz.SHA256)
-        (cd ./defichain-${ver}-x86_64-w64-mingw32
-        sha256sum ./defichain-${ver}-x86_64-w64-mingw32.zip > ./defichain-${ver}-x86_64-w64-mingw32.zip.SHA256)
-        (cd ./defichain-${ver}-x86_64-apple-darwin
-        sha256sum ./defichain-${ver}-x86_64-apple-darwin.tar.gz > ././defichain-${ver}-x86_64-apple-darwin.tar.gz.SHA256)
-        (cd ./defichain-${ver}-aarch64-apple-darwin
-        sha256sum ./defichain-${ver}-aarch64-apple-darwin.tar.gz > ././defichain-${ver}-aarch64-apple-darwin.tar.gz.SHA256)

--- a/make.sh
+++ b/make.sh
@@ -218,10 +218,13 @@ package() {
     local build_dir="${BUILD_DIR}"
 
     local pkg_name="${img_prefix}-${img_version}-${target}"
-    local pkg_tar_file_name="${pkg_name}.tar.gz"
 
     local pkg_path
-    pkg_path="$(_canonicalize "${build_dir}/${pkg_tar_file_name}")"
+    if [[ "${TARGET}" == "x86_64-w64-mingw32" ]]; then
+        pkg_path="$(_canonicalize "${build_dir}/"${pkg_name}.zip"")"
+    else        
+        pkg_path="$(_canonicalize "${build_dir}/"${pkg_name}.tar.gz"")"
+    fi
 
     local versioned_name="${img_prefix}-${img_version}"
     local versioned_build_dir="${build_dir}/${versioned_name}"
@@ -234,8 +237,14 @@ package() {
 
     echo "> packaging: ${pkg_name} from ${versioned_build_dir}"
 
-    _ensure_enter_dir "${versioned_build_dir}"
-    _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
+    
+    if [[ "${TARGET}" == "x86_64-w64-mingw32" ]]; then
+        _ensure_enter_dir "${build_dir}"
+        zip -r "${pkg_path}" "${versioned_build_dir}/"
+    else
+        _ensure_enter_dir "${versioned_build_dir}"
+        _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
+    fi
     sha256sum "${pkg_path}" > "${pkg_path}.SHA256"
     _exit_dir
 

--- a/make.sh
+++ b/make.sh
@@ -236,6 +236,7 @@ package() {
 
     _ensure_enter_dir "${versioned_build_dir}"
     _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*
+    sha256sum "${pkg_path}" > "${pkg_path}.SHA256"
     _exit_dir
 
     echo "> package: ${pkg_path}"
@@ -1165,7 +1166,7 @@ get_rust_triplet() {
 }
 
 _sign() {
-    # TODO: generate sha sums and sign
+    # TODO: sign
     :
 }
 


### PR DESCRIPTION
## Summary

- Added shasum file generation into make.sh
- Added windows zip package building into make.sh
- Removed shasum stage from build-release and build-staging pipeline
- Removed windows zip package building stage from build-release and build-staging pipeline



## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
