### PR TITLE
Replace testnet checkpoints

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -583,8 +583,7 @@ public:
                 {100000, uint256S("9896ac2c34c20771742bccda4f00f458229819947e02204022c8ff26093ac81f")},
                 {150000, uint256S("af9307f438f5c378d1a49cfd3872173a07ed4362d56155e457daffd1061742d4")},
                 {300000, uint256S("205b522772ce34206a08a635c800f99d2fc4e9696ab8c470dad7f5fa51dfea1a")},
-                {1445000, uint256S("6fd0cafbbd2262d5cecd2e07e73fe6703bac364e5d4986da3fe512b0eccf944d")},
-                {1471000, uint256S("dcf4a5fb69c004d0921710e09a09d10f275b3bc696e45ca03f6c322bb32f41bc")},
+                {1100000, uint256S("6fdfc12c273135a992a05f8eb9ec4a0f5db972c3f1d8941d1af336f99cf71f5b")},
             }
         };
 


### PR DESCRIPTION
## Summary

- Due to testnet rollback we need to remove old checkpoints and add a new one below the new height.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
