### PR TITLE
Set testnet fork heights to 1.2m

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -413,11 +413,11 @@ public:
         consensus.DF15FortCanningRoadHeight = 893700;
         consensus.DF16FortCanningCrunchHeight = 1011600;
         consensus.DF17FortCanningSpringHeight = 1086000;
-        consensus.DF18FortCanningGreatWorldHeight = 1223000;
-        consensus.DF19FortCanningEpilogueHeight = 1244000;
-        consensus.DF20GrandCentralHeight = 1366000;
-        consensus.DF21GrandCentralEpilogueHeight = 1438200;
-        consensus.DF22MetachainHeight = 1949500;
+        consensus.DF18FortCanningGreatWorldHeight = 1200000;
+        consensus.DF19FortCanningEpilogueHeight = 1200000;
+        consensus.DF20GrandCentralHeight = 1200000;
+        consensus.DF21GrandCentralEpilogueHeight = 1200000;
+        consensus.DF22MetachainHeight = 1200000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -414,10 +414,10 @@ public:
         consensus.DF16FortCanningCrunchHeight = 1011600;
         consensus.DF17FortCanningSpringHeight = 1086000;
         consensus.DF18FortCanningGreatWorldHeight = 1200000;
-        consensus.DF19FortCanningEpilogueHeight = 1200000;
-        consensus.DF20GrandCentralHeight = 1200000;
-        consensus.DF21GrandCentralEpilogueHeight = 1200000;
-        consensus.DF22MetachainHeight = 1200000;
+        consensus.DF19FortCanningEpilogueHeight = 1200010;
+        consensus.DF20GrandCentralHeight = 1200020;
+        consensus.DF21GrandCentralEpilogueHeight = 1200030;
+        consensus.DF22MetachainHeight = 1200040;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 //        consensus.pos.nTargetTimespan = 14 * 24 * 60 * 60; // two weeks


### PR DESCRIPTION
## Summary

- As part of the testnet rollback set fork heights above the new fork height to the fork height.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
