### PR TITLE
Fix mempool accounts view state mismatch

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1145,7 +1145,7 @@ void Staker::withSearchInterval(F&& f, int64_t height)
 
 void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams chainparams)
 {
-    uint32_t nClearFlag{};
+    uint32_t nPastFailures{};
     std::map<CKeyID, int32_t> nMinted;
     std::map<CKeyID, int32_t> nTried;
 
@@ -1207,14 +1207,16 @@ void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams
                 } else if (status == Staker::Status::minted) {
                     LogPrintf("ThreadStaker: (%s) minted a block!\n", operatorName);
                     nMinted[arg.operatorID]++;
-                    nClearFlag = 0;
+                    nPastFailures = 0;
                 } else if (status == Staker::Status::initWaiting) {
                     LogPrintCategoryOrThreadThrottled(BCLog::STAKING, "init_waiting", 1000 * 60 * 10, "ThreadStaker: (%s) waiting init...\n", operatorName);
                 } else if (status == Staker::Status::stakeWaiting) {
                     LogPrintCategoryOrThreadThrottled(BCLog::STAKING, "no_kernel_found", 1000 * 60 * 10, "ThreadStaker: (%s) Staked, but no kernel found yet.\n", operatorName);
                 }
             } catch (const std::runtime_error& e) {
-                if (!nClearFlag) {
+                LogPrintf("ThreadStaker: (%s) runtime error: %s failure count: %d\n", e.what(), operatorName, nPastFailures);
+
+                if (!nPastFailures) {
                     LOCK2(cs_main, mempool.cs);
                     mempool.rebuildCustomCSView();
                 } else {
@@ -1223,8 +1225,7 @@ void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams
                     mempool.clear();
                 }
 
-                ++nClearFlag;
-                LogPrintf("ThreadStaker: (%s) runtime error: %s failure count: %d\n", e.what(), operatorName, nClearFlag);
+                ++nPastFailures;
             }
 
             auto& tried = nTried[arg.operatorID];

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1214,11 +1214,11 @@ void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams
                     LogPrintCategoryOrThreadThrottled(BCLog::STAKING, "no_kernel_found", 1000 * 60 * 10, "ThreadStaker: (%s) Staked, but no kernel found yet.\n", operatorName);
                 }
             } catch (const std::runtime_error& e) {
-                LogPrintf("ThreadStaker: (%s) runtime error: %s failure count: %d\n", e.what(), operatorName, nPastFailures);
+                LogPrintf("ThreadStaker: (%s) runtime error: %s, nPastFailures: %d\n", e.what(), operatorName, nPastFailures);
 
                 if (!nPastFailures) {
                     LOCK2(cs_main, mempool.cs);
-                    mempool.rebuildCustomCSView();
+                    mempool.rebuildViews();
                 } else {
                     // Could be failed TX in mempool, wipe mempool and allow loop to continue.
                     LOCK(cs_main);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1214,18 +1214,17 @@ void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams
                     LogPrintCategoryOrThreadThrottled(BCLog::STAKING, "no_kernel_found", 1000 * 60 * 10, "ThreadStaker: (%s) Staked, but no kernel found yet.\n", operatorName);
                 }
             } catch (const std::runtime_error& e) {
-                LogPrintf("ThreadStaker: (%s) runtime error: %s\n", e.what(), operatorName);
-
                 if (!nClearFlag.count(arg.operatorID)) {
                     LOCK2(cs_main, mempool.cs);
                     mempool.rebuildCustomCSView();
-                    ++nClearFlag[arg.operatorID];
                 } else {
                     // Could be failed TX in mempool, wipe mempool and allow loop to continue.
                     LOCK(cs_main);
                     mempool.clear();
-                    ++nClearFlag[arg.operatorID];
                 }
+
+                ++nClearFlag[arg.operatorID];
+                LogPrintf("ThreadStaker: (%s) runtime error: %s failure count: %d\n", e.what(), operatorName, nClearFlag[arg.operatorID]);
             }
 
             auto& tried = nTried[arg.operatorID];

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1217,7 +1217,7 @@ void ThreadStaker::operator()(std::vector<ThreadStaker::Args> args, CChainParams
 
                 if (nClearFlag.find(arg.operatorID) == nClearFlag.end()) {
                     LOCK2(cs_main, mempool.cs);
-                    mempool.rebuildAccountsView();
+                    mempool.rebuildCustomCSView();
                     nClearFlag.insert(arg.operatorID);
                 } else {
                     // Could be failed TX in mempool, wipe mempool and allow loop to continue.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1278,7 +1278,7 @@ void CTxMemPool::AddToStaged(setEntries &staged, std::vector<CTransactionRef> &v
     const auto &hash = tx->GetHash();
     if (!mempoolIterMap.count(hash)) return;
     auto it = mempoolIterMap.at(hash);
-    LogPrintf("%s: Remove conflicting custom TX: %s\n", __func__, it->GetTx().GetHash().GetHex());
+            LogPrint(BCLog::MEMPOOL, "re-stage/add TX: %s\n", hash.GetHex());
     staged.insert(it);
     vtx.push_back(it->GetSharedTx());
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1244,22 +1244,22 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCac
     for (auto it = txsByEntryTime.begin(); it != txsByEntryTime.end(); ++it) {
         CValidationState state;
         const auto& tx = it->GetTx();
-        const auto removeTxFromPool = [&it](const indexed_transaction_set& mapTx, CTxMemPool::setEntries& staged,
+        const auto removeTxBackToStage = [&it](const indexed_transaction_set& mapTx, CTxMemPool::setEntries& staged,
                                   std::vector<CTransactionRef>& vtx, const CTransaction& tx) {
-            LogPrint(BCLog::MEMPOOL, "mempool: TX removed: %s (cause: accountsView)\n", tx.GetHash().GetHex());
+            LogPrint(BCLog::MEMPOOL, "mempool: re-stage/remove TX: %s (cause: accountsView)\n", tx.GetHash().GetHex());
             staged.insert(mapTx.project<0>(it));
             vtx.push_back(it->GetSharedTx());
         };
 
         if (!Consensus::CheckTxInputs(tx, state, coinsCache, viewDuplicate, height, txfee, Params())) {
-            removeTxFromPool(mapTx, staged, vtx, tx);
+            removeTxBackToStage(mapTx, staged, vtx, tx);
             continue;
         }
 
         std::shared_ptr<CScopedTemplate> evmTemplate{};
         auto res = ApplyCustomTx(viewDuplicate, coinsCache, tx, consensus, height, 0, nullptr, 0, evmTemplate, isEvmEnabledForBlock, true);
         if (!res && (res.code & CustomTxErrCodes::Fatal)) {
-            removeTxFromPool(mapTx, staged, vtx, tx);
+            removeTxBackToStage(mapTx, staged, vtx, tx);
         }
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1278,7 +1278,7 @@ void CTxMemPool::AddToStaged(setEntries &staged, std::vector<CTransactionRef> &v
     const auto &hash = tx->GetHash();
     if (!mempoolIterMap.count(hash)) return;
     auto it = mempoolIterMap.at(hash);
-            LogPrint(BCLog::MEMPOOL, "re-stage/add TX: %s\n", hash.GetHex());
+    LogPrint(BCLog::MEMPOOL, "re-stage/add TX: %s\n", hash.GetHex());
     staged.insert(it);
     vtx.push_back(it->GetSharedTx());
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -638,14 +638,14 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
         CCoinsViewMemPool viewMemPool(&coins_cache, *this);
         view.SetBackend(viewMemPool);
 
-        rebuildAccountsView(nBlockHeight, view);
+        rebuildCustomCSView(nBlockHeight, view);
     }
 
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = true;
 }
 
-void CTxMemPool::rebuildAccountsView() {
+void CTxMemPool::rebuildCustomCSView() {
     if (pcustomcsview) {
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);
@@ -654,7 +654,7 @@ void CTxMemPool::rebuildAccountsView() {
         view.SetBackend(viewMemPool);
 
         setAccountViewDirty();
-        rebuildAccountsView(::ChainActive().Tip()->nHeight, view);
+        rebuildCustomCSView(::ChainActive().Tip()->nHeight, view);
     }
 }
 
@@ -681,7 +681,7 @@ void CTxMemPool::clear()
     LOCK(cs);
     _clear();
     acview.reset();
-    rebuildAccountsView();
+    rebuildCustomCSView();
 }
 
 static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, CCustomCSView& mnviewDuplicate, const int64_t spendheight, const CChainParams& chainparams)
@@ -1221,7 +1221,7 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry, co
     return result;
 }
 
-void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCache)
+void CTxMemPool::rebuildCustomCSView(int height, const CCoinsViewCache& coinsCache)
 {
     if (!pcustomcsview || !accountsViewDirty) {
         return;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -646,16 +646,18 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
 }
 
 void CTxMemPool::rebuildCustomCSView() {
-    if (pcustomcsview) {
-        CCoinsView dummy;
-        CCoinsViewCache view(&dummy);
-        CCoinsViewCache& coins_cache = ::ChainstateActive().CoinsTip();
-        CCoinsViewMemPool viewMemPool(&coins_cache, *this);
-        view.SetBackend(viewMemPool);
-
-        setAccountViewDirty();
-        rebuildCustomCSView(::ChainActive().Tip()->nHeight, view);
+    if (!pcustomcsview) {
+        return;
     }
+
+    CCoinsView dummy;
+    CCoinsViewCache view(&dummy);
+    CCoinsViewCache& coins_cache = ::ChainstateActive().CoinsTip();
+    CCoinsViewMemPool viewMemPool(&coins_cache, *this);
+    view.SetBackend(viewMemPool);
+
+    setAccountViewDirty();
+    rebuildCustomCSView(::ChainActive().Tip()->nHeight, view);
 }
 
 void CTxMemPool::_clear()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -566,19 +566,6 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         CalculateDescendants(it, setAllRemoves);
     }
     RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::REORG);
-
-    if (pcustomcsview) {
-        accountsViewDirty |= forceRebuildForReorg;
-        CTransactionRef ptx{};
-
-        CCoinsView dummy;
-        CCoinsViewCache view(&dummy);
-        CCoinsViewCache& coins_cache = ::ChainstateActive().CoinsTip();
-        CCoinsViewMemPool viewMemPool(&coins_cache, *this);
-        view.SetBackend(viewMemPool);
-
-        rebuildAccountsView(nMemPoolHeight, view);
-    }
 }
 
 void CTxMemPool::removeConflicts(const CTransaction &tx)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -653,6 +653,7 @@ void CTxMemPool::rebuildAccountsView() {
         CCoinsViewMemPool viewMemPool(&coins_cache, *this);
         view.SetBackend(viewMemPool);
 
+        setAccountViewDirty();
         rebuildAccountsView(::ChainActive().Tip()->nHeight, view);
     }
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -683,7 +683,6 @@ void CTxMemPool::clear()
     LOCK(cs);
     _clear();
     acview.reset();
-    rebuildViews();
 }
 
 static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, CCustomCSView& mnviewDuplicate, const int64_t spendheight, const CChainParams& chainparams)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -638,7 +638,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
         CCoinsViewMemPool viewMemPool(&coins_cache, *this);
         view.SetBackend(viewMemPool);
 
-        rebuildCustomCSView(nBlockHeight, view);
+        rebuildAccountsView(nBlockHeight, view);
     }
 
     lastRollingFeeUpdate = GetTime();
@@ -657,7 +657,7 @@ void CTxMemPool::rebuildCustomCSView() {
     view.SetBackend(viewMemPool);
 
     setAccountViewDirty();
-    rebuildCustomCSView(::ChainActive().Tip()->nHeight, view);
+    rebuildAccountsView(::ChainActive().Tip()->nHeight, view);
 }
 
 void CTxMemPool::_clear()
@@ -1223,7 +1223,7 @@ bool CTxMemPool::checkAddressNonceAndFee(const CTxMemPoolEntry &pendingEntry, co
     return result;
 }
 
-void CTxMemPool::rebuildCustomCSView(int height, const CCoinsViewCache& coinsCache)
+void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCache)
 {
     if (!pcustomcsview || !accountsViewDirty) {
         return;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1246,7 +1246,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCac
         const auto& tx = it->GetTx();
         const auto removeTxBackToStage = [&it](const indexed_transaction_set& mapTx, CTxMemPool::setEntries& staged,
                                   std::vector<CTransactionRef>& vtx, const CTransaction& tx) {
-            LogPrint(BCLog::MEMPOOL, "mempool: re-stage/remove TX: %s (cause: accountsView)\n", tx.GetHash().GetHex());
+            LogPrint(BCLog::MEMPOOL, "re-stage/remove TX: %s (cause: accountsView)\n", tx.GetHash().GetHex());
             staged.insert(mapTx.project<0>(it));
             vtx.push_back(it->GetSharedTx());
         };

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -763,8 +763,8 @@ public:
     boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
 
     CCustomCSView& accountsView();
-    void rebuildAccountsView();
-    void rebuildAccountsView(int height, const CCoinsViewCache& coinsCache);
+    void rebuildCustomCSView();
+    void rebuildCustomCSView(int height, const CCoinsViewCache& coinsCache);
     void setAccountViewDirty();
     bool getAccountViewDirty() const;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -764,7 +764,7 @@ public:
 
     CCustomCSView& accountsView();
     void rebuildCustomCSView();
-    void rebuildCustomCSView(int height, const CCoinsViewCache& coinsCache);
+    void rebuildAccountsView(int height, const CCoinsViewCache& coinsCache);
     void setAccountViewDirty();
     bool getAccountViewDirty() const;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -763,7 +763,7 @@ public:
     boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
 
     CCustomCSView& accountsView();
-    void rebuildCustomCSView();
+    void rebuildViews();
     void rebuildAccountsView(int height, const CCoinsViewCache& coinsCache);
     void setAccountViewDirty();
     bool getAccountViewDirty() const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -763,6 +763,7 @@ public:
     boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
 
     CCustomCSView& accountsView();
+    void rebuildAccountsView();
     void rebuildAccountsView(int height, const CCoinsViewCache& coinsCache);
     void setAccountViewDirty();
     bool getAccountViewDirty() const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -633,7 +633,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         const auto height = GetSpendHeight(view);
 
         // rebuild accounts view if dirty
-        pool.rebuildAccountsView(height, view);
+        pool.rebuildCustomCSView(height, view);
 
         CAmount nFees = 0;
         if (!Consensus::CheckTxInputs(tx, state, view, mnview, height, nFees, chainparams)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -633,7 +633,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         const auto height = GetSpendHeight(view);
 
         // rebuild accounts view if dirty
-        pool.rebuildCustomCSView(height, view);
+        pool.rebuildAccountsView(height, view);
 
         CAmount nFees = 0;
         if (!Consensus::CheckTxInputs(tx, state, view, mnview, height, nFees, chainparams)) {


### PR DESCRIPTION
## Summary

- Remove accounts view rebuild pipeline on mempool reorg
- Add graceful fallbacks to create new block pipeline error failure - on first failure, mempool will do a rebuild of the accounts view state, and on second failure clear the mempool to prevent the miner from being stuck in a loop creating invalid blocks.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
