### PR TITLE
Return min fee of 1,000 Sats per KB

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -6,6 +6,7 @@
 #include <policy/fees.h>
 
 #include <clientversion.h>
+#include <consensus/tx_check.h>
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <txmempool.h>
@@ -516,6 +517,9 @@ CBlockPolicyEstimator::~CBlockPolicyEstimator()
 void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, bool validFeeEstimate)
 {
     LOCK(m_cs_fee_estimator);
+    if (IsEVMTx(entry.GetTx())) {
+        return;
+    }
     unsigned int txHeight = entry.GetHeight();
     uint256 hash = entry.GetTx().GetHash();
     if (mapMemPoolTxs.count(hash)) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -979,7 +979,11 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
     FeeCalculation feeCalc;
     CFeeRate feeRate = ::feeEstimator.estimateSmartFee(conf_target, &feeCalc, conservative);
     if (feeRate != CFeeRate(0)) {
-        result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
+        auto amount = feeRate.GetFeePerK();
+        if (amount < DEFAULT_TRANSACTION_MINFEE) {
+            amount = DEFAULT_TRANSACTION_MINFEE;
+        }
+        result.pushKV("feerate", amount);
     } else if (txOrdering == MIXED_ORDERING || txOrdering == ENTRYTIME_ORDERING) {
         result.pushKV("feerate", ValueFromAmount(DEFAULT_TRANSACTION_MINFEE));
     } else {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -983,7 +983,7 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
         if (amount < DEFAULT_TRANSACTION_MINFEE) {
             amount = DEFAULT_TRANSACTION_MINFEE;
         }
-        result.pushKV("feerate", amount);
+        result.pushKV("feerate", ValueFromAmount(amount));
     } else if (txOrdering == MIXED_ORDERING || txOrdering == ENTRYTIME_ORDERING) {
         result.pushKV("feerate", ValueFromAmount(DEFAULT_TRANSACTION_MINFEE));
     } else {


### PR DESCRIPTION
## Summary

- Return a min of 1,000 Sats per KB from estimatesmartfee

## RPCs

- estimatesmartfee will return a min of 1,000 Sats per KB

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
