### PR TITLE
Remove BlockTemplateMap

### DIFF
--- a/lib/ain-evm/src/blocktemplate.rs
+++ b/lib/ain-evm/src/blocktemplate.rs
@@ -1,9 +1,5 @@
-use std::{collections::HashMap, sync::Arc};
-
 use ethereum::{Block, ReceiptV3, TransactionV2};
 use ethereum_types::{Bloom, H160, H256, U256};
-use parking_lot::{Mutex, RwLock};
-use rand::Rng;
 
 use crate::{
     backend::Vicinity, core::XHash, evm::ExecTxState, receipt::Receipt, transaction::SignedTx,
@@ -12,184 +8,6 @@ use crate::{
 type Result<T> = std::result::Result<T, BlockTemplateError>;
 
 pub type ReceiptAndOptionalContractAddress = (ReceiptV3, Option<H160>);
-
-#[derive(Debug)]
-pub struct BlockTemplateMap {
-    templates: RwLock<HashMap<u64, Arc<BlockTemplate>>>,
-}
-
-impl Default for BlockTemplateMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Holds multiple `BlockTemplate`s, each associated with a unique template ID.
-///
-/// Template IDs are randomly generated and used to access distinct transaction templates.
-impl BlockTemplateMap {
-    pub fn new() -> Self {
-        BlockTemplateMap {
-            templates: RwLock::new(HashMap::new()),
-        }
-    }
-
-    /// `create` generates a unique random ID, creates a new `BlockTemplate` for that ID,
-    /// and then returns the ID.
-    ///
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn create(&self, block_data: BlockTemplateData) -> u64 {
-        let mut rng = rand::thread_rng();
-        loop {
-            let template_id = rng.gen();
-            // Safety check to disallow 0 as it's equivalent to no template_id
-            if template_id == 0 {
-                continue;
-            };
-            let mut write_guard = self.templates.write();
-
-            if let std::collections::hash_map::Entry::Vacant(e) = write_guard.entry(template_id) {
-                e.insert(Arc::new(BlockTemplate::new(block_data)));
-                return template_id;
-            }
-        }
-    }
-
-    /// Try to remove and return the `BlockTemplate` associated with the provided
-    /// template ID.
-    ///
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn remove(&self, template_id: u64) -> Option<Arc<BlockTemplate>> {
-        self.templates.write().remove(&template_id)
-    }
-
-    /// Returns an atomic reference counting pointer of the `BlockTemplate` associated with the provided template ID.
-    /// Note that the `BlockTemplate` instance contains the mutex of the `BlockTemplateData`, and this method
-    /// should be used if multiple read/write operations on the block template is required within the pipeline. This is
-    /// to ensure the atomicity and functionality of the client, and to maintain the integrity of the block template.
-    ///
-    /// # Errors
-    ///
-    /// Returns `BlockTemplateError::NoSuchTemplate` if no block template is associated with the given template ID.
-    ///
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless cs_main lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn get(&self, template_id: u64) -> Result<Arc<BlockTemplate>> {
-        Ok(Arc::clone(
-            self.templates
-                .read()
-                .get(&template_id)
-                .ok_or(BlockTemplateError::NoSuchTemplate)?,
-        ))
-    }
-
-    /// Attempts to add a new transaction to the `BlockTemplate` associated with the provided template ID.
-    /// Nonces for each account must be in strictly increasing order. This means that if the last added transaction
-    /// for an account has nonce 3, the next one should have nonce 4. If a `SignedTx` with a nonce that is not one
-    /// more than the previous nonce is added, an error is returned. This helps to ensure the integrity of the block
-    /// template and enforce correct nonce usage.
-    ///
-    /// # Errors
-    ///
-    /// Returns `BlockTemplateError::NoSuchTemplate` if no block template is associated with the given template ID.
-    ///
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn push_in(
-        &self,
-        template_id: u64,
-        tx_update: ExecTxState,
-        hash: XHash,
-    ) -> Result<()> {
-        self.with_block_template(template_id, |template| template.add_tx(tx_update, hash))
-            .and_then(|res| res)
-    }
-
-    /// Removes all transactions in the block template whose sender matches the provided sender address.
-    /// # Errors
-    ///
-    /// Returns `BlockTemplateError::NoSuchTemplate` if no template is associated with the given template ID.
-    ///
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn remove_txs_above_hash_in(
-        &self,
-        template_id: u64,
-        target_hash: XHash,
-    ) -> Result<Vec<XHash>> {
-        self.with_block_template(template_id, |template| {
-            template.remove_txs_above_hash(target_hash)
-        })
-        .and_then(|res| res)
-    }
-
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn get_total_gas_used_in(&self, template_id: u64) -> Result<U256> {
-        self.with_block_template(template_id, BlockTemplate::get_total_gas_used)
-    }
-
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn get_target_block_in(&self, template_id: u64) -> Result<U256> {
-        self.with_block_template(template_id, BlockTemplate::get_target_block)
-    }
-
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn get_timestamp_in(&self, template_id: u64) -> Result<u64> {
-        self.with_block_template(template_id, BlockTemplate::get_timestamp)
-    }
-
-    /// # Safety
-    ///
-    /// Result cannot be used safety unless `cs_main` lock is taken on C++ side
-    /// across all usages. Note: To be replaced with a proper lock flow later.
-    ///
-    pub unsafe fn get_latest_state_root_in(&self, template_id: u64) -> Result<H256> {
-        self.with_block_template(template_id, BlockTemplate::get_latest_state_root)
-    }
-
-    /// Apply the closure to the template associated with the template ID.
-    /// # Errors
-    ///
-    /// Returns `BlockTemplateError::NoSuchTemplate` if no block template is associated with the given template ID.
-    unsafe fn with_block_template<T, F>(&self, template_id: u64, f: F) -> Result<T>
-    where
-        F: FnOnce(&BlockTemplate) -> T,
-    {
-        match self.templates.read().get(&template_id) {
-            Some(template) => Ok(f(template)),
-            None => Err(BlockTemplateError::NoSuchTemplate),
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TemplateTxItem {
@@ -239,7 +57,7 @@ pub struct BlockData {
 /// The template is used to construct a valid EVM block.
 ///
 #[derive(Clone, Debug, Default)]
-pub struct BlockTemplateData {
+pub struct BlockTemplate {
     pub transactions: Vec<TemplateTxItem>,
     pub block_data: Option<BlockData>,
     pub total_gas_used: U256,
@@ -250,27 +68,33 @@ pub struct BlockTemplateData {
     pub initial_state_root: H256,
 }
 
-#[derive(Debug, Default)]
-pub struct BlockTemplate {
-    pub data: Mutex<BlockTemplateData>,
-}
-
 impl BlockTemplate {
-    fn new(block_data: BlockTemplateData) -> Self {
+    pub fn new(
+        vicinity: Vicinity,
+        parent_hash: H256,
+        dvm_block: u64,
+        timestamp: u64,
+        initial_state_root: H256,
+    ) -> Self {
         Self {
-            data: Mutex::new(block_data),
+            transactions: Vec::new(),
+            block_data: None,
+            total_gas_used: U256::zero(),
+            vicinity,
+            parent_hash,
+            dvm_block,
+            timestamp,
+            initial_state_root,
         }
     }
 
-    pub fn add_tx(&self, tx_update: ExecTxState, tx_hash: XHash) -> Result<()> {
-        let mut data = self.data.lock();
-
-        data.total_gas_used = data
+    pub fn add_tx(&mut self, tx_update: ExecTxState, tx_hash: XHash) -> Result<()> {
+        self.total_gas_used = self
             .total_gas_used
             .checked_add(tx_update.gas_used)
             .ok_or(BlockTemplateError::ValueOverflow)?;
 
-        data.transactions.push(TemplateTxItem {
+        self.transactions.push(TemplateTxItem {
             tx: tx_update.tx,
             tx_hash,
             gas_used: tx_update.gas_used,
@@ -282,22 +106,21 @@ impl BlockTemplate {
         Ok(())
     }
 
-    pub fn remove_txs_above_hash(&self, target_hash: XHash) -> Result<Vec<XHash>> {
-        let mut data = self.data.lock();
+    pub fn remove_txs_above_hash(&mut self, target_hash: XHash) -> Result<Vec<XHash>> {
         let mut removed_txs = Vec::new();
 
-        if let Some(index) = data
+        if let Some(index) = self
             .transactions
             .iter()
             .position(|item| item.tx_hash == target_hash)
         {
-            removed_txs = data
+            removed_txs = self
                 .transactions
                 .drain(index..)
                 .map(|tx_item| tx_item.tx_hash)
                 .collect();
 
-            data.total_gas_used = data.transactions.iter().try_fold(U256::zero(), |acc, tx| {
+            self.total_gas_used = self.transactions.iter().try_fold(U256::zero(), |acc, tx| {
                 acc.checked_add(tx.gas_used)
                     .ok_or(BlockTemplateError::ValueOverflow)
             })?
@@ -306,49 +129,31 @@ impl BlockTemplate {
         Ok(removed_txs)
     }
 
-    pub fn get_total_gas_used(&self) -> U256 {
-        self.data.lock().total_gas_used
-    }
-
-    pub fn get_target_block(&self) -> U256 {
-        self.data.lock().vicinity.block_number
-    }
-
-    pub fn get_timestamp(&self) -> u64 {
-        self.data.lock().timestamp
-    }
-
     pub fn get_state_root_from_native_hash(&self, hash: XHash) -> Option<H256> {
-        self.data
-            .lock()
-            .transactions
+        self.transactions
             .iter()
             .find(|tx_item| tx_item.tx_hash == hash)
             .map(|tx_item| tx_item.state_root)
     }
 
     pub fn get_latest_state_root(&self) -> H256 {
-        let data = self.data.lock();
-        data.transactions
+        self.transactions
             .last()
-            .map_or(data.initial_state_root, |tx_item| tx_item.state_root)
+            .map_or(self.initial_state_root, |tx_item| tx_item.state_root)
     }
 
     pub fn get_latest_logs_bloom(&self) -> Bloom {
-        let data = self.data.lock();
-        data.transactions
+        self.transactions
             .last()
             .map_or(Bloom::default(), |tx_item| tx_item.logs_bloom)
     }
 
     pub fn get_block_base_fee_per_gas(&self) -> U256 {
-        let data = self.data.lock();
-        data.vicinity.block_base_fee_per_gas
+        self.vicinity.block_base_fee_per_gas
     }
 
     pub fn get_block_number(&self) -> U256 {
-        let data = self.data.lock();
-        data.vicinity.block_number
+        self.vicinity.block_number
     }
 }
 

--- a/lib/ain-evm/src/log.rs
+++ b/lib/ain-evm/src/log.rs
@@ -1,6 +1,6 @@
-use anyhow::format_err;
 use std::{collections::HashMap, sync::Arc};
 
+use anyhow::format_err;
 use ethereum::ReceiptV3;
 use ethereum_types::{H160, H256, U256};
 use log::debug;

--- a/lib/ain-evm/src/receipt.rs
+++ b/lib/ain-evm/src/receipt.rs
@@ -1,6 +1,6 @@
-use anyhow::format_err;
 use std::sync::Arc;
 
+use anyhow::format_err;
 use ethereum::{util::ordered_trie_root, EnvelopedEncodable, ReceiptV3};
 use ethereum_types::{H160, H256, U256};
 use keccak_hash::keccak;

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -1,6 +1,5 @@
 pub mod system;
 
-use crate::EVMError;
 use anyhow::format_err;
 use ethereum::{
     AccessList, EnvelopedDecoderError, EnvelopedEncodable, LegacyTransaction, TransactionAction,
@@ -10,7 +9,10 @@ use ethereum_types::{H160, H256, U256};
 use rlp::RlpStream;
 use sha3::Digest;
 
-use crate::ecrecover::{public_key_to_address, recover_public_key};
+use crate::{
+    ecrecover::{public_key_to_address, recover_public_key},
+    EVMError,
+};
 
 // Lowest acceptable value for r and s in sig.
 pub const LOWER_H256: H256 = H256([

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -215,8 +215,8 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
     }
 
     fn log_block_templates(&self) -> RpcResult<()> {
-        let templates = &self.handler.core.block_templates;
-        debug!("templates : {:#?}", templates);
+        // let templates = &self.handler.core.block_templates;
+        // debug!("templates : {:#?}", templates);
         Ok(())
     }
 }

--- a/lib/ain-macros/src/lib.rs
+++ b/lib/ain-macros/src/lib.rs
@@ -39,13 +39,14 @@ pub fn ffi_fallible(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let expanded = quote! {
         pub fn #name(result: &mut ffi::CrossBoundaryResult, #inputs) -> #inner_type {
             #input
-
-            match #name(#(#param_names),*) {
-                Ok(success_value) => {
-                    cross_boundary_success_return(result, success_value)
-                }
-                Err(err_msg) => {
-                    cross_boundary_error_return(result, err_msg.to_string())
+            unsafe {
+                match #name(#(#param_names),*) {
+                    Ok(success_value) => {
+                        cross_boundary_success_return(result, success_value)
+                    }
+                    Err(err_msg) => {
+                        cross_boundary_error_return(result, err_msg.to_string())
+                    }
                 }
             }
         }

--- a/lib/ain-macros/src/lib.rs
+++ b/lib/ain-macros/src/lib.rs
@@ -39,14 +39,13 @@ pub fn ffi_fallible(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let expanded = quote! {
         pub fn #name(result: &mut ffi::CrossBoundaryResult, #inputs) -> #inner_type {
             #input
-            unsafe {
-                match #name(#(#param_names),*) {
-                    Ok(success_value) => {
-                        cross_boundary_success_return(result, success_value)
-                    }
-                    Err(err_msg) => {
-                        cross_boundary_error_return(result, err_msg.to_string())
-                    }
+
+            match #name(#(#param_names),*) {
+                Ok(success_value) => {
+                    cross_boundary_success_return(result, success_value)
+                }
+                Err(err_msg) => {
+                    cross_boundary_error_return(result, err_msg.to_string())
                 }
             }
         }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -372,7 +372,7 @@ fn evm_try_unsafe_validate_raw_tx_in_template(
 ) -> Result<()> {
     debug!("[unsafe_validate_raw_tx_in_template]");
     unsafe {
-        let _ = SERVICES.evm.core.validate_raw_tx(raw_tx, &mut template.0)?;
+        let _ = SERVICES.evm.core.validate_raw_tx(raw_tx, &template.0)?;
         Ok(())
     }
 }
@@ -409,7 +409,7 @@ fn evm_try_unsafe_validate_transferdomain_tx_in_template(
     unsafe {
         let _ = SERVICES.evm.core.validate_raw_transferdomain_tx(
             raw_tx,
-            &mut template.0,
+            &template.0,
             TransferDomainTxInfo {
                 from: context.from,
                 to: context.to,

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -450,7 +450,7 @@ pub unsafe fn evm_try_unsafe_create_template(
             }
         };
 
-    Box::into_raw(Box::new(BlockTemplate(template)))
+    cross_boundary_success_return(result, Box::into_raw(Box::new(BlockTemplate(template))))
 }
 
 /// /// Discards an EVM block template.

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -426,14 +426,18 @@ fn evm_try_unsafe_validate_transferdomain_tx_in_template(
 }
 
 fn block_template_err_wrapper() -> &'static mut BlockTemplateWrapper {
-    static CELL: std::sync::OnceLock<std::sync::Mutex<BlockTemplateWrapper>> = std::sync::OnceLock::new();
-    let mut val = CELL.get_or_init(|| {
-        std::sync::Mutex::new(BlockTemplateWrapper(BlockTemplate::default()))
-    }).lock().unwrap();
-    
+    static CELL: std::sync::OnceLock<std::sync::Mutex<BlockTemplateWrapper>> =
+        std::sync::OnceLock::new();
+    let mut val = CELL
+        .get_or_init(|| std::sync::Mutex::new(BlockTemplateWrapper(BlockTemplate::default())))
+        .lock()
+        .unwrap();
+
     unsafe {
         #[allow(mutable_transmutes)]
-        std::mem::transmute::<&mut BlockTemplateWrapper, &'static mut BlockTemplateWrapper>(val.deref_mut())
+        std::mem::transmute::<&mut BlockTemplateWrapper, &'static mut BlockTemplateWrapper>(
+            val.deref_mut(),
+        )
     }
 }
 

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -423,6 +423,15 @@ fn evm_try_unsafe_validate_transferdomain_tx_in_template(
     Ok(())
 }
 
+fn block_template_err_wrapper() -> &'static mut BlockTemplateWrapper {
+    let cell = std::cell::OnceCell::new();
+    let val = cell.get_or_init(|| BlockTemplateWrapper(BlockTemplate::default()));
+    unsafe {
+        #[allow(mutable_transmutes)]
+        std::mem::transmute::<&BlockTemplateWrapper, &'static mut BlockTemplateWrapper>(val)
+    }
+}
+
 /// Creates an EVM block template.
 ///
 /// # Returns
@@ -442,7 +451,7 @@ pub fn evm_try_unsafe_create_template(
             Ok(a) => a,
             Err(_) => {
                 cross_boundary_error(result, "Invalid address");
-                return Box::leak(Box::new(BlockTemplateWrapper(BlockTemplate::default())));
+                return block_template_err_wrapper();
             }
         }
     };
@@ -458,7 +467,7 @@ pub fn evm_try_unsafe_create_template(
             ),
             Err(e) => {
                 cross_boundary_error(result, e.to_string());
-                return Box::leak(Box::new(BlockTemplateWrapper(BlockTemplate::default())));
+                return block_template_err_wrapper();
             }
         }
     }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -429,8 +429,9 @@ fn block_template_err_wrapper() -> &'static mut BlockTemplateWrapper {
     // to never be used
     static mut CELL: std::cell::OnceCell<BlockTemplateWrapper> = std::cell::OnceCell::new();
     unsafe {
-        let _ = CELL.get_or_init(|| BlockTemplateWrapper(BlockTemplate::default()));
-        CELL.get_mut().unwrap()
+        let v = CELL.get_or_init(|| BlockTemplateWrapper(BlockTemplate::default()));
+        #[allow(mutable_transmutes)]
+        std::mem::transmute(v)
     }
 }
 

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -3,6 +3,9 @@ mod evm;
 mod prelude;
 
 use crate::{core::*, evm::*};
+use ain_evm::blocktemplate::BlockTemplate;
+
+pub struct BlockTemplateWrapper(BlockTemplate);
 
 #[cxx::bridge]
 pub mod ffi {
@@ -134,108 +137,128 @@ pub mod ffi {
     }
 
     extern "Rust" {
-        type BlockTemplate;
+        type BlockTemplateWrapper;
         // In-fallible functions
         //
         // If they are fallible, it's a TODO to changed and move later
         // so errors are propogated up properly.
         fn evm_try_get_balance(result: &mut CrossBoundaryResult, address: &str) -> u64;
-        unsafe fn evm_try_unsafe_create_template(
+
+        fn evm_try_unsafe_create_template(
             result: &mut CrossBoundaryResult,
             dvm_block: u64,
             miner_address: &str,
             difficulty: u32,
             timestamp: u64,
-        ) -> *mut BlockTemplate;
-        unsafe fn evm_try_unsafe_remove_template(
+        ) -> &'static mut BlockTemplateWrapper;
+
+        fn evm_try_unsafe_remove_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
         );
+
         fn evm_try_disconnect_latest_block(result: &mut CrossBoundaryResult);
 
         // Failible functions
         // Has to take CrossBoundaryResult as first param
         // Has to start with try_ / evm_try
-        unsafe fn evm_try_unsafe_update_state_in_template(
+        fn evm_try_unsafe_update_state_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             mnview_ptr: usize,
         );
-        unsafe fn evm_try_unsafe_get_next_valid_nonce_in_template(
+
+        fn evm_try_unsafe_get_next_valid_nonce_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             address: &str,
         ) -> u64;
-        unsafe fn evm_try_unsafe_remove_txs_above_hash_in_template(
+
+        fn evm_try_unsafe_remove_txs_above_hash_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             target_hash: String,
         ) -> Vec<String>;
-        unsafe fn evm_try_unsafe_add_balance_in_template(
+
+        fn evm_try_unsafe_add_balance_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
             native_hash: &str,
         );
-        unsafe fn evm_try_unsafe_sub_balance_in_template(
+
+        fn evm_try_unsafe_sub_balance_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
             native_hash: &str,
         ) -> bool;
-        unsafe fn evm_try_unsafe_validate_raw_tx_in_template(
+
+        fn evm_try_unsafe_validate_raw_tx_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
         );
-        unsafe fn evm_try_unsafe_validate_transferdomain_tx_in_template(
+
+        fn evm_try_unsafe_validate_transferdomain_tx_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
             context: TransferDomainInfo,
         );
-        unsafe fn evm_try_unsafe_push_tx_in_template(
+
+        fn evm_try_unsafe_push_tx_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
             native_hash: &str,
         ) -> ValidateTxCompletion;
-        unsafe fn evm_try_unsafe_construct_block_in_template(
+
+        fn evm_try_unsafe_construct_block_in_template(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
         ) -> FinalizeBlockCompletion;
-        unsafe fn evm_try_unsafe_commit_block(
+
+        fn evm_try_unsafe_commit_block(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
         );
-        unsafe fn evm_try_unsafe_handle_attribute_apply(
+
+        fn evm_try_unsafe_handle_attribute_apply(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             attribute_type: GovVarKeyDataStructure,
             value: Vec<u8>,
         ) -> bool;
+
         fn evm_try_create_and_sign_tx(
             result: &mut CrossBoundaryResult,
             ctx: CreateTransactionContext,
         ) -> CreateTxResult;
+
         fn evm_try_create_and_sign_transfer_domain_tx(
             result: &mut CrossBoundaryResult,
             ctx: CreateTransferDomainContext,
         ) -> CreateTxResult;
+
         fn evm_try_store_account_nonce(
             result: &mut CrossBoundaryResult,
             from_address: &str,
             nonce: u64,
         );
+
         fn evm_try_get_block_hash_by_number(
             result: &mut CrossBoundaryResult,
             height: u64,
         ) -> String;
+
         fn evm_try_get_block_number_by_hash(result: &mut CrossBoundaryResult, hash: &str) -> u64;
+
         fn evm_try_get_block_header_by_hash(
             result: &mut CrossBoundaryResult,
             hash: &str,
         ) -> EVMBlockHeader;
+
         fn evm_try_get_tx_by_hash(
             result: &mut CrossBoundaryResult,
             tx_hash: &str,
@@ -243,31 +266,35 @@ pub mod ffi {
 
         fn evm_try_get_tx_hash(result: &mut CrossBoundaryResult, raw_tx: &str) -> String;
 
-        unsafe fn evm_try_unsafe_create_dst20(
+        fn evm_try_unsafe_create_dst20(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             native_hash: &str,
             name: &str,
             symbol: &str,
             token_id: u64,
         );
-        unsafe fn evm_try_unsafe_bridge_dst20(
+
+        fn evm_try_unsafe_bridge_dst20(
             result: &mut CrossBoundaryResult,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
             raw_tx: &str,
             native_hash: &str,
             token_id: u64,
             out: bool,
         );
-        unsafe fn evm_try_unsafe_is_smart_contract_in_template(
+        
+        fn evm_try_unsafe_is_smart_contract_in_template(
             result: &mut CrossBoundaryResult,
             address: &str,
-            block_template: *mut BlockTemplate,
+            block_template: &mut BlockTemplateWrapper,
         ) -> bool;
+
         fn evm_try_get_tx_miner_info_from_raw_tx(
             result: &mut CrossBoundaryResult,
             raw_tx: &str,
         ) -> TxMinerInfo;
+
         fn evm_try_dispatch_pending_transactions_event(
             result: &mut CrossBoundaryResult,
             raw_tx: &str,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -283,7 +283,7 @@ pub mod ffi {
             token_id: u64,
             out: bool,
         );
-        
+
         fn evm_try_unsafe_is_smart_contract_in_template(
             result: &mut CrossBoundaryResult,
             address: &str,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -5,6 +5,7 @@ mod prelude;
 use crate::{core::*, evm::*};
 use ain_evm::blocktemplate::BlockTemplate;
 
+#[derive(Debug)]
 pub struct BlockTemplateWrapper(BlockTemplate);
 
 #[cxx::bridge]

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -134,76 +134,83 @@ pub mod ffi {
     }
 
     extern "Rust" {
+        type BlockTemplate;
         // In-fallible functions
         //
         // If they are fallible, it's a TODO to changed and move later
         // so errors are propogated up properly.
         fn evm_try_get_balance(result: &mut CrossBoundaryResult, address: &str) -> u64;
-        fn evm_try_unsafe_create_template(
+        unsafe fn evm_try_unsafe_create_template(
             result: &mut CrossBoundaryResult,
             dvm_block: u64,
             miner_address: &str,
             difficulty: u32,
             timestamp: u64,
-        ) -> u64;
-        fn evm_try_unsafe_remove_template(result: &mut CrossBoundaryResult, template_id: u64);
+        ) -> *mut BlockTemplate;
+        unsafe fn evm_try_unsafe_remove_template(
+            result: &mut CrossBoundaryResult,
+            block_template: *mut BlockTemplate,
+        );
         fn evm_try_disconnect_latest_block(result: &mut CrossBoundaryResult);
 
         // Failible functions
         // Has to take CrossBoundaryResult as first param
         // Has to start with try_ / evm_try
-        fn evm_try_unsafe_update_state_in_template(
+        unsafe fn evm_try_unsafe_update_state_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             mnview_ptr: usize,
         );
-        fn evm_try_unsafe_get_next_valid_nonce_in_template(
+        unsafe fn evm_try_unsafe_get_next_valid_nonce_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             address: &str,
         ) -> u64;
-        fn evm_try_unsafe_remove_txs_above_hash_in_template(
+        unsafe fn evm_try_unsafe_remove_txs_above_hash_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             target_hash: String,
         ) -> Vec<String>;
-        fn evm_try_unsafe_add_balance_in_template(
+        unsafe fn evm_try_unsafe_add_balance_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
             native_hash: &str,
         );
-        fn evm_try_unsafe_sub_balance_in_template(
+        unsafe fn evm_try_unsafe_sub_balance_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
             native_hash: &str,
         ) -> bool;
-        fn evm_try_unsafe_validate_raw_tx_in_template(
+        unsafe fn evm_try_unsafe_validate_raw_tx_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
         );
-        fn evm_try_unsafe_validate_transferdomain_tx_in_template(
+        unsafe fn evm_try_unsafe_validate_transferdomain_tx_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
             context: TransferDomainInfo,
         );
-        fn evm_try_unsafe_push_tx_in_template(
+        unsafe fn evm_try_unsafe_push_tx_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
             native_hash: &str,
         ) -> ValidateTxCompletion;
-        fn evm_try_unsafe_construct_block_in_template(
+        unsafe fn evm_try_unsafe_construct_block_in_template(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
         ) -> FinalizeBlockCompletion;
-        fn evm_try_unsafe_commit_block(result: &mut CrossBoundaryResult, template_id: u64);
-        fn evm_try_handle_attribute_apply(
+        unsafe fn evm_try_unsafe_commit_block(
             result: &mut CrossBoundaryResult,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
+        );
+        unsafe fn evm_try_unsafe_handle_attribute_apply(
+            result: &mut CrossBoundaryResult,
+            block_template: *mut BlockTemplate,
             attribute_type: GovVarKeyDataStructure,
             value: Vec<u8>,
         ) -> bool;
@@ -236,26 +243,26 @@ pub mod ffi {
 
         fn evm_try_get_tx_hash(result: &mut CrossBoundaryResult, raw_tx: &str) -> String;
 
-        fn evm_try_create_dst20(
+        unsafe fn evm_try_unsafe_create_dst20(
             result: &mut CrossBoundaryResult,
-            context: u64,
+            block_template: *mut BlockTemplate,
             native_hash: &str,
             name: &str,
             symbol: &str,
             token_id: u64,
         );
-        fn evm_try_unsafe_bridge_dst20(
+        unsafe fn evm_try_unsafe_bridge_dst20(
             result: &mut CrossBoundaryResult,
-            context: u64,
+            block_template: *mut BlockTemplate,
             raw_tx: &str,
             native_hash: &str,
             token_id: u64,
             out: bool,
         );
-        fn evm_try_unsafe_is_smart_contract_in_template(
+        unsafe fn evm_try_unsafe_is_smart_contract_in_template(
             result: &mut CrossBoundaryResult,
             address: &str,
-            template_id: u64,
+            block_template: *mut BlockTemplate,
         ) -> bool;
         fn evm_try_get_tx_miner_info_from_raw_tx(
             result: &mut CrossBoundaryResult,

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -180,10 +180,10 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
 
     if (IsBelowDakotaMintTokenOrAccountToUtxos(txType, nSpendHeight) || (nSpendHeight >= chainparams.GetConsensus().DF20GrandCentralHeight && txType == CustomTxType::UpdateMasternode)) {
         CCustomCSView discardCache(mnview, nullptr, nullptr, nullptr);
-        // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough, 
+        // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough,
         // that it's propagated.
-        std::shared_ptr<CScopedTemplateID> evmTemplateId{};
-        auto res = ApplyCustomTx(discardCache, inputs, tx, chainparams.GetConsensus(), nSpendHeight, 0, &canSpend, 0, evmTemplateId, false, false);
+        std::shared_ptr<CScopedTemplate> evmTemplate{};
+        auto res = ApplyCustomTx(discardCache, inputs, tx, chainparams.GetConsensus(), nSpendHeight, 0, &canSpend, 0, evmTemplate, false, false);
         if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {
             return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-txns-customtx", res.msg);
         }

--- a/src/dfi/consensus/governance.cpp
+++ b/src/dfi/consensus/governance.cpp
@@ -28,7 +28,7 @@ Res CGovernanceConsensus::operator()(const CGovernanceMessage &obj) const {
             }
 
             govVar->time = time;
-            govVar->evmTemplateId = evmTemplateId;
+            govVar->evmTemplate = evmTemplate;
 
             auto newVar = std::dynamic_pointer_cast<ATTRIBUTES>(var);
             if (!newVar) {

--- a/src/dfi/consensus/loans.cpp
+++ b/src/dfi/consensus/loans.cpp
@@ -290,7 +290,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
                                : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
     token.flags |= static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
 
-    auto tokenId = mnview.CreateToken(token, false, isEvmEnabledForBlock, evmTemplateId);
+    auto tokenId = mnview.CreateToken(token, false, isEvmEnabledForBlock, evmTemplate);
     if (!tokenId) {
         return tokenId;
     }
@@ -300,7 +300,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
 
         auto attributes = mnview.GetAttributes();
         attributes->time = time;
-        attributes->evmTemplateId = evmTemplateId;
+        attributes->evmTemplate = evmTemplate;
 
         CDataStructureV0 mintEnabled{AttributeTypes::Token, id, TokenKeys::LoanMintingEnabled};
         CDataStructureV0 mintInterest{AttributeTypes::Token, id, TokenKeys::LoanMintingInterest};

--- a/src/dfi/consensus/tokens.cpp
+++ b/src/dfi/consensus/tokens.cpp
@@ -104,7 +104,7 @@ Res CTokensConsensus::operator()(const CCreateTokenMessage &obj) const {
     }
 
     auto tokenId = mnview.CreateToken(
-        token, static_cast<int>(height) < consensus.DF2BayfrontHeight, isEvmEnabledForBlock, evmTemplateId);
+        token, static_cast<int>(height) < consensus.DF2BayfrontHeight, isEvmEnabledForBlock, evmTemplate);
     return tokenId;
 }
 

--- a/src/dfi/consensus/txvisitor.cpp
+++ b/src/dfi/consensus/txvisitor.cpp
@@ -96,7 +96,7 @@ CCustomTxVisitor::CCustomTxVisitor(const CTransaction &tx,
                                    const Consensus::Params &consensus,
                                    const uint64_t time,
                                    const uint32_t txn,
-                                   const std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                                   const std::shared_ptr<CScopedTemplate> &evmTemplate,
                                    const bool isEvmEnabledForBlock,
                                    const bool evmPreValidate)
     : height(height),
@@ -106,7 +106,7 @@ CCustomTxVisitor::CCustomTxVisitor(const CTransaction &tx,
       consensus(consensus),
       time(time),
       txn(txn),
-      evmTemplateId(evmTemplateId),
+      evmTemplate(evmTemplate),
       isEvmEnabledForBlock(isEvmEnabledForBlock),
       evmPreValidate(evmPreValidate) {}
 

--- a/src/dfi/consensus/txvisitor.h
+++ b/src/dfi/consensus/txvisitor.h
@@ -18,7 +18,7 @@ class CCustomCSView;
 struct CLoanSchemeData;
 class CPoolPair;
 class CScript;
-class CScopedTemplateID;
+class CScopedTemplate;
 class CTokenImplementation;
 class CTransaction;
 class CVaultAssets;
@@ -56,7 +56,7 @@ protected:
     const Consensus::Params &consensus;
     const uint64_t time;
     const uint32_t txn;
-    const std::shared_ptr<CScopedTemplateID> &evmTemplateId;
+    const std::shared_ptr<CScopedTemplate> &evmTemplate;
     bool isEvmEnabledForBlock;
     bool evmPreValidate;
 
@@ -68,7 +68,7 @@ public:
                      const Consensus::Params &consensus,
                      const uint64_t time,
                      const uint32_t txn,
-                     const std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                     const std::shared_ptr<CScopedTemplate> &evmTemplate,
                      const bool isEvmEnabledForBlock,
                      const bool evmPreValidate);
 

--- a/src/dfi/consensus/xvm.cpp
+++ b/src/dfi/consensus/xvm.cpp
@@ -253,8 +253,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
 
             // Check if destination address is a contract
-            auto isSmartContract = evm_try_unsafe_is_smart_contract_in_template(
-                result, toAddress->GetHex(), evmTemplateId->GetTemplateID());
+            auto isSmartContract =
+                evm_try_unsafe_is_smart_contract_in_template(result, toAddress->GetHex(), evmTemplate->GetTemplate());
             if (!result.ok) {
                 return Res::Err("Error checking contract address: %s", result.reason);
             }
@@ -283,7 +283,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
             const auto evmTx = HexStr(dst.data);
             evm_try_unsafe_validate_transferdomain_tx_in_template(
-                result, evmTemplateId->GetTemplateID(), evmTx, contexts[idx]);
+                result, evmTemplate->GetTemplate(), evmTx, contexts[idx]);
             if (!result.ok) {
                 return Res::Err("transferdomain evm tx failed to pre-validate : %s", result.reason);
             }
@@ -300,13 +300,13 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             auto tokenId = dst.amount.nTokenId;
             if (tokenId == DCT_ID{0}) {
                 evm_try_unsafe_add_balance_in_template(
-                    result, evmTemplateId->GetTemplateID(), evmTx, tx.GetHash().GetHex());
+                    result, evmTemplate->GetTemplate(), evmTx, tx.GetHash().GetHex());
                 if (!result.ok) {
                     return Res::Err("Error bridging DFI: %s", result.reason);
                 }
             } else {
                 evm_try_unsafe_bridge_dst20(
-                    result, evmTemplateId->GetTemplateID(), evmTx, tx.GetHash().GetHex(), tokenId.v, true);
+                    result, evmTemplate->GetTemplate(), evmTx, tx.GetHash().GetHex(), tokenId.v, true);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }
@@ -326,8 +326,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
 
             // Check if source address is a contract
-            auto isSmartContract = evm_try_unsafe_is_smart_contract_in_template(
-                result, fromAddress->GetHex(), evmTemplateId->GetTemplateID());
+            auto isSmartContract =
+                evm_try_unsafe_is_smart_contract_in_template(result, fromAddress->GetHex(), evmTemplate->GetTemplate());
             if (!result.ok) {
                 return Res::Err("Error checking contract address: %s", result.reason);
             }
@@ -340,7 +340,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             }
             const auto evmTx = HexStr(src.data);
             evm_try_unsafe_validate_transferdomain_tx_in_template(
-                result, evmTemplateId->GetTemplateID(), evmTx, contexts[idx]);
+                result, evmTemplate->GetTemplate(), evmTx, contexts[idx]);
             if (!result.ok) {
                 return Res::Err("transferdomain evm tx failed to pre-validate %s", result.reason);
             }
@@ -358,7 +358,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             auto tokenId = dst.amount.nTokenId;
             if (tokenId == DCT_ID{0}) {
                 if (!evm_try_unsafe_sub_balance_in_template(
-                        result, evmTemplateId->GetTemplateID(), evmTx, tx.GetHash().GetHex())) {
+                        result, evmTemplate->GetTemplate(), evmTx, tx.GetHash().GetHex())) {
                     return DeFiErrors::TransferDomainNotEnoughBalance(EncodeDestination(dest));
                 }
                 if (!result.ok) {
@@ -366,7 +366,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
                 }
             } else {
                 evm_try_unsafe_bridge_dst20(
-                    result, evmTemplateId->GetTemplateID(), evmTx, tx.GetHash().GetHex(), tokenId.v, false);
+                    result, evmTemplate->GetTemplate(), evmTx, tx.GetHash().GetHex(), tokenId.v, false);
                 if (!result.ok) {
                     return Res::Err("Error bridging DST20: %s", result.reason);
                 }
@@ -379,7 +379,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
             res = mnview.AddBalance(dst.address, dst.amount);
             if (!res) {
                 evm_try_unsafe_remove_txs_above_hash_in_template(
-                    result, evmTemplateId->GetTemplateID(), tx.GetHash().GetHex());
+                    result, evmTemplate->GetTemplate(), tx.GetHash().GetHex());
                 return res;
             }
             stats.evmDvmTotal.Add(dst.amount);
@@ -405,7 +405,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
     attributes->SetValue(CTransferDomainStatsLive::Key, stats);
     res = mnview.SetVariable(*attributes);
     if (!res) {
-        evm_try_unsafe_remove_txs_above_hash_in_template(result, evmTemplateId->GetTemplateID(), tx.GetHash().GetHex());
+        evm_try_unsafe_remove_txs_above_hash_in_template(result, evmTemplate->GetTemplate(), tx.GetHash().GetHex());
         return res;
     }
     return Res::Ok();
@@ -422,7 +422,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
 
     CrossBoundaryResult result;
     if (evmPreValidate) {
-        evm_try_unsafe_validate_raw_tx_in_template(result, evmTemplateId->GetTemplateID(), HexStr(obj.evmTx));
+        evm_try_unsafe_validate_raw_tx_in_template(result, evmTemplate->GetTemplate(), HexStr(obj.evmTx));
         if (!result.ok) {
             return Res::Err("evm tx failed to pre-validate %s", result.reason);
         }
@@ -430,7 +430,7 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
     }
 
     const auto validateResults = evm_try_unsafe_push_tx_in_template(
-        result, evmTemplateId->GetTemplateID(), HexStr(obj.evmTx), tx.GetHash().GetHex());
+        result, evmTemplate->GetTemplate(), HexStr(obj.evmTx), tx.GetHash().GetHex());
     if (!result.ok) {
         LogPrintf("[evm_try_push_tx_in_template] failed, reason : %s\n", result.reason);
         return Res::Err("evm tx failed to queue %s\n", result.reason);

--- a/src/dfi/evm.cpp
+++ b/src/dfi/evm.cpp
@@ -54,7 +54,7 @@ void CVMDomainGraphView::ForEachVMDomainTxEdges(
         std::make_pair(static_cast<uint8_t>(start.first), start.second));
 }
 
-CScopedTemplate::CScopedTemplate(BlockTemplate *evmTemplate)
+CScopedTemplate::CScopedTemplate(BlockTemplateWrapper& evmTemplate)
     : evmTemplate(evmTemplate) {}
 
 std::shared_ptr<CScopedTemplate> CScopedTemplate::Create(const uint64_t dvmBlockNumber,
@@ -62,7 +62,7 @@ std::shared_ptr<CScopedTemplate> CScopedTemplate::Create(const uint64_t dvmBlock
                                                          const unsigned int difficulty,
                                                          const uint64_t timestamp) {
     CrossBoundaryResult result;
-    BlockTemplate *evmTemplate =
+    BlockTemplateWrapper &evmTemplate =
         evm_try_unsafe_create_template(result, dvmBlockNumber, minerAddress, difficulty, timestamp);
     if (result.ok) {
         return std::shared_ptr<CScopedTemplate>(new CScopedTemplate(evmTemplate));
@@ -74,10 +74,10 @@ CScopedTemplate::~CScopedTemplate() {
     CrossBoundaryResult result;
     evm_try_unsafe_remove_template(result, evmTemplate);
     if (!result.ok) {
-        LogPrintf("Failed to destroy queue %d\n", evmTemplate);
+        LogPrintf("Failed to destroy queue\n");
     }
 }
 
-BlockTemplate *CScopedTemplate::GetTemplate() const {
+BlockTemplateWrapper& CScopedTemplate::GetTemplate() const {
     return evmTemplate;
 }

--- a/src/dfi/evm.cpp
+++ b/src/dfi/evm.cpp
@@ -2,6 +2,7 @@
 #include <dfi/errors.h>
 #include <dfi/evm.h>
 #include <dfi/res.h>
+#include <ffi/ffihelpers.h>
 #include <uint256.h>
 
 Res CVMDomainGraphView::SetVMDomainBlockEdge(VMDomainEdge type, std::string blockHashKey, std::string blockHash) {
@@ -54,7 +55,7 @@ void CVMDomainGraphView::ForEachVMDomainTxEdges(
         std::make_pair(static_cast<uint8_t>(start.first), start.second));
 }
 
-CScopedTemplate::CScopedTemplate(BlockTemplateWrapper& evmTemplate)
+CScopedTemplate::CScopedTemplate(BlockTemplateWrapper &evmTemplate)
     : evmTemplate(evmTemplate) {}
 
 std::shared_ptr<CScopedTemplate> CScopedTemplate::Create(const uint64_t dvmBlockNumber,
@@ -71,13 +72,9 @@ std::shared_ptr<CScopedTemplate> CScopedTemplate::Create(const uint64_t dvmBlock
 }
 
 CScopedTemplate::~CScopedTemplate() {
-    CrossBoundaryResult result;
-    evm_try_unsafe_remove_template(result, evmTemplate);
-    if (!result.ok) {
-        LogPrintf("Failed to destroy queue\n");
-    }
+    XResultStatusLogged(evm_try_unsafe_remove_template(result, evmTemplate));
 }
 
-BlockTemplateWrapper& CScopedTemplate::GetTemplate() const {
+BlockTemplateWrapper &CScopedTemplate::GetTemplate() const {
     return evmTemplate;
 }

--- a/src/dfi/evm.cpp
+++ b/src/dfi/evm.cpp
@@ -54,29 +54,30 @@ void CVMDomainGraphView::ForEachVMDomainTxEdges(
         std::make_pair(static_cast<uint8_t>(start.first), start.second));
 }
 
-CScopedTemplateID::CScopedTemplateID(uint64_t id)
-    : evmTemplateId(id) {}
+CScopedTemplate::CScopedTemplate(BlockTemplate *evmTemplate)
+    : evmTemplate(evmTemplate) {}
 
-std::shared_ptr<CScopedTemplateID> CScopedTemplateID::Create(const uint64_t dvmBlockNumber,
-                                                             const std::string minerAddress,
-                                                             const unsigned int difficulty,
-                                                             const uint64_t timestamp) {
+std::shared_ptr<CScopedTemplate> CScopedTemplate::Create(const uint64_t dvmBlockNumber,
+                                                         const std::string minerAddress,
+                                                         const unsigned int difficulty,
+                                                         const uint64_t timestamp) {
     CrossBoundaryResult result;
-    uint64_t templateId = evm_try_unsafe_create_template(result, dvmBlockNumber, minerAddress, difficulty, timestamp);
+    BlockTemplate *evmTemplate =
+        evm_try_unsafe_create_template(result, dvmBlockNumber, minerAddress, difficulty, timestamp);
     if (result.ok) {
-        return std::shared_ptr<CScopedTemplateID>(new CScopedTemplateID(templateId));
+        return std::shared_ptr<CScopedTemplate>(new CScopedTemplate(evmTemplate));
     }
     return nullptr;
 }
 
-CScopedTemplateID::~CScopedTemplateID() {
+CScopedTemplate::~CScopedTemplate() {
     CrossBoundaryResult result;
-    evm_try_unsafe_remove_template(result, evmTemplateId);
+    evm_try_unsafe_remove_template(result, evmTemplate);
     if (!result.ok) {
-        LogPrintf("Failed to destroy queue %d\n", evmTemplateId);
+        LogPrintf("Failed to destroy queue %d\n", evmTemplate);
     }
 }
 
-uint64_t CScopedTemplateID::GetTemplateID() const {
-    return evmTemplateId;
+BlockTemplate *CScopedTemplate::GetTemplate() const {
+    return evmTemplate;
 }

--- a/src/dfi/evm.h
+++ b/src/dfi/evm.h
@@ -58,7 +58,7 @@ public:
 };
 
 class CScopedTemplate {
-    explicit CScopedTemplate(BlockTemplateWrapper& blockTemplate);
+    explicit CScopedTemplate(BlockTemplateWrapper &blockTemplate);
 
     BlockTemplateWrapper &evmTemplate;
 
@@ -69,7 +69,7 @@ public:
                                                    const uint64_t timestamp);
     ~CScopedTemplate();
 
-    BlockTemplateWrapper& GetTemplate() const;
+    BlockTemplateWrapper &GetTemplate() const;
 };
 
 #endif  // DEFI_DFI_EVM_H

--- a/src/dfi/evm.h
+++ b/src/dfi/evm.h
@@ -1,6 +1,7 @@
 #ifndef DEFI_DFI_EVM_H
 #define DEFI_DFI_EVM_H
 
+#include <ain_rs_exports.h>
 #include <amount.h>
 #include <dfi/consensus/xvm.h>
 #include <dfi/res.h>
@@ -56,19 +57,19 @@ public:
     };
 };
 
-class CScopedTemplateID {
-    explicit CScopedTemplateID(uint64_t id);
+class CScopedTemplate {
+    explicit CScopedTemplate(BlockTemplate *blockTemplate);
 
-    uint64_t evmTemplateId;
+    BlockTemplate *evmTemplate;
 
 public:
-    static std::shared_ptr<CScopedTemplateID> Create(const uint64_t dvmBlockNumber,
-                                                     std::string minerAddress,
-                                                     unsigned int difficulty,
-                                                     const uint64_t timestamp);
-    ~CScopedTemplateID();
+    static std::shared_ptr<CScopedTemplate> Create(const uint64_t dvmBlockNumber,
+                                                   std::string minerAddress,
+                                                   unsigned int difficulty,
+                                                   const uint64_t timestamp);
+    ~CScopedTemplate();
 
-    uint64_t GetTemplateID() const;
+    BlockTemplate *GetTemplate() const;
 };
 
 #endif  // DEFI_DFI_EVM_H

--- a/src/dfi/evm.h
+++ b/src/dfi/evm.h
@@ -58,9 +58,9 @@ public:
 };
 
 class CScopedTemplate {
-    explicit CScopedTemplate(BlockTemplate *blockTemplate);
+    explicit CScopedTemplate(BlockTemplateWrapper& blockTemplate);
 
-    BlockTemplate *evmTemplate;
+    BlockTemplateWrapper &evmTemplate;
 
 public:
     static std::shared_ptr<CScopedTemplate> Create(const uint64_t dvmBlockNumber,
@@ -69,7 +69,7 @@ public:
                                                    const uint64_t timestamp);
     ~CScopedTemplate();
 
-    BlockTemplate *GetTemplate() const;
+    BlockTemplateWrapper& GetTemplate() const;
 };
 
 #endif  // DEFI_DFI_EVM_H

--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -2423,10 +2423,10 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
         govVarValue.reserve(govVarVec.size());
         std::copy(govVarVec.begin(), govVarVec.end(), govVarValue.begin());
 
-        if (evmTemplateId) {
+        if (evmTemplate) {
             CrossBoundaryResult result;
             const auto rustKey = GovVarKeyDataStructure{attrV0->type, attrV0->typeId, attrV0->key, attrV0->keyId};
-            if (!evm_try_handle_attribute_apply(result, evmTemplateId->GetTemplateID(), rustKey, govVarValue)) {
+            if (!evm_try_unsafe_handle_attribute_apply(result, evmTemplate->GetTemplate(), rustKey, govVarValue)) {
                 return DeFiErrors::SettingEVMAttributeFailure();
             }
             if (!result.ok) {

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -548,7 +548,7 @@ public:
     }
 
     uint32_t time{0};
-    std::shared_ptr<CScopedTemplateID> evmTemplateId{};
+    std::shared_ptr<CScopedTemplate> evmTemplate{};
 
     // For formatting in export
     static const std::map<uint8_t, std::string> &displayVersions();

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -326,7 +326,7 @@ class CCustomTxApplyVisitor {
     const Consensus::Params &consensus;
     uint64_t time;
     uint32_t txn;
-    const std::shared_ptr<CScopedTemplateID> &evmTemplateId;
+    const std::shared_ptr<CScopedTemplate> &evmTemplate;
     bool isEvmEnabledForBlock;
     bool evmPreValidate;
 
@@ -336,7 +336,7 @@ class CCustomTxApplyVisitor {
 
         if constexpr (std::is_invocable_v<T1, T>) {
             return T1{
-                tx, height, coins, mnview, consensus, time, txn, evmTemplateId, isEvmEnabledForBlock, evmPreValidate}(
+                tx, height, coins, mnview, consensus, time, txn, evmTemplate, isEvmEnabledForBlock, evmPreValidate}(
                 obj);
         } else if constexpr (sizeof...(Args) != 0) {
             return ConsensusHandler<T, Args...>(obj);
@@ -355,7 +355,7 @@ public:
                           const Consensus::Params &consensus,
                           uint64_t time,
                           uint32_t txn,
-                          const std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                          const std::shared_ptr<CScopedTemplate> &evmTemplate,
                           const bool isEvmEnabledForBlock,
                           const bool evmPreValidate)
 
@@ -366,7 +366,7 @@ public:
           consensus(consensus),
           time(time),
           txn(txn),
-          evmTemplateId(evmTemplateId),
+          evmTemplate(evmTemplate),
           isEvmEnabledForBlock(isEvmEnabledForBlock),
           evmPreValidate(evmPreValidate) {}
 
@@ -443,17 +443,17 @@ Res CustomTxVisit(CCustomCSView &mnview,
                   const CCustomTxMessage &txMessage,
                   const uint64_t time,
                   const uint32_t txn,
-                  std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                  std::shared_ptr<CScopedTemplate> &evmTemplate,
                   const bool isEvmEnabledForBlock,
                   const bool evmPreValidate) {
     if (IsDisabledTx(height, tx, consensus)) {
         return Res::ErrCode(CustomTxErrCodes::Fatal, "Disabled custom transaction");
     }
 
-    if (!evmTemplateId && isEvmEnabledForBlock) {
+    if (!evmTemplate && isEvmEnabledForBlock) {
         std::string minerAddress{};
-        evmTemplateId = CScopedTemplateID::Create(height, minerAddress, 0u, time);
-        if (!evmTemplateId) {
+        evmTemplate = CScopedTemplate::Create(height, minerAddress, 0u, time);
+        if (!evmTemplate) {
             return Res::Err("Failed to create queue");
         }
     }
@@ -461,7 +461,7 @@ Res CustomTxVisit(CCustomCSView &mnview,
     try {
         auto res = std::visit(
             CCustomTxApplyVisitor(
-                tx, height, coins, mnview, consensus, time, txn, evmTemplateId, isEvmEnabledForBlock, evmPreValidate),
+                tx, height, coins, mnview, consensus, time, txn, evmTemplate, isEvmEnabledForBlock, evmPreValidate),
             txMessage);
         return res;
     } catch (const std::bad_variant_access &e) {
@@ -549,7 +549,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                   uint64_t time,
                   uint256 *canSpend,
                   uint32_t txn,
-                  std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                  std::shared_ptr<CScopedTemplate> &evmTemplate,
                   const bool isEvmEnabledForBlock,
                   const bool evmPreValidate) {
     auto res = Res::Ok();
@@ -598,7 +598,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                             txMessage,
                             time,
                             txn,
-                            evmTemplateId,
+                            evmTemplate,
                             isEvmEnabledForBlock,
                             evmPreValidate);
 

--- a/src/dfi/mn_checks.h
+++ b/src/dfi/mn_checks.h
@@ -170,7 +170,7 @@ Res ApplyCustomTx(CCustomCSView &mnview,
                   uint64_t time,
                   uint256 *canSpend,
                   uint32_t txn,
-                  std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                  std::shared_ptr<CScopedTemplate> &evmTemplate,
                   const bool isEvmEnabledForBlock,
                   const bool evmPreValidate);
 
@@ -182,7 +182,7 @@ Res CustomTxVisit(CCustomCSView &mnview,
                   const CCustomTxMessage &txMessage,
                   const uint64_t time,
                   const uint32_t txn,
-                  std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                  std::shared_ptr<CScopedTemplate> &evmTemplate,
                   const bool isEvmEnabledForBlock,
                   const bool evmPreValidate);
 

--- a/src/dfi/mn_rpc.cpp
+++ b/src/dfi/mn_rpc.cpp
@@ -485,7 +485,7 @@ void execTestTx(const CTransaction &tx, uint32_t height, CTransactionRef optAuth
         CCustomCSView view(*pcustomcsview);
         auto consensus = Params().GetConsensus();
         const auto isEvmEnabledForBlock = IsEVMEnabled(view, consensus);
-        std::shared_ptr<CScopedTemplateID> evmTemplateId{};
+        std::shared_ptr<CScopedTemplate> evmTemplate{};
         res = CustomTxVisit(view,
                             coins,
                             tx,
@@ -494,7 +494,7 @@ void execTestTx(const CTransaction &tx, uint32_t height, CTransactionRef optAuth
                             txMessage,
                             ::ChainActive().Tip()->nTime,
                             0,
-                            evmTemplateId,
+                            evmTemplate,
                             isEvmEnabledForBlock,
                             true);
     }

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -670,7 +670,7 @@ UniValue getcustomtx(const JSONRPCRequest &request) {
         const auto &consensus = Params().GetConsensus();
         const auto isEvmEnabledForBlock = IsEVMEnabled(mnview, consensus);
 
-        std::shared_ptr<CScopedTemplateID> evmTemplateId{};
+        std::shared_ptr<CScopedTemplate> evmTemplate{};
         auto res = ApplyCustomTx(mnview,
                                  view,
                                  *tx,
@@ -679,7 +679,7 @@ UniValue getcustomtx(const JSONRPCRequest &request) {
                                  0,
                                  nullptr,
                                  0,
-                                 evmTemplateId,
+                                 evmTemplate,
                                  isEvmEnabledForBlock,
                                  false);
 

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -71,7 +71,7 @@ Res CTokensView::CreateDFIToken() {
 ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
                                         bool isPreBayfront,
                                         bool shouldCreateDst20,
-                                        const std::shared_ptr<CScopedTemplateID> &evmTemplateId) {
+                                        const std::shared_ptr<CScopedTemplate> &evmTemplate) {
     if (GetTokenByCreationTx(token.creationTx)) {
         return Res::Err("token with creation tx %s already exists!", token.creationTx.ToString());
     }
@@ -105,12 +105,12 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
 
         if (shouldCreateDst20) {
             CrossBoundaryResult result;
-            evm_try_create_dst20(result,
-                                 evmTemplateId->GetTemplateID(),
-                                 token.creationTx.GetHex(),
-                                 rust::string(token.name.c_str()),
-                                 rust::string(token.symbol.c_str()),
-                                 id.v);
+            evm_try_unsafe_create_dst20(result,
+                                        evmTemplate->GetTemplate(),
+                                        token.creationTx.GetHex(),
+                                        rust::string(token.name.c_str()),
+                                        rust::string(token.symbol.c_str()),
+                                        id.v);
             if (!result.ok) {
                 return Res::Err("Error creating DST20 token: %s", result.reason);
             }

--- a/src/dfi/tokens.h
+++ b/src/dfi/tokens.h
@@ -197,7 +197,7 @@ public:
     ResVal<DCT_ID> CreateToken(const CTokenImpl &token,
                                bool isPreBayfront = false,
                                bool shouldCreateDst20 = false,
-                               const std::shared_ptr<CScopedTemplateID> &evmTemplateId = {});
+                               const std::shared_ptr<CScopedTemplate> &evmTemplate = {});
     Res UpdateToken(const CTokenImpl &newToken, bool isPreBayfront = false, const bool tokenSplitUpdate = false);
 
     Res BayfrontFlagsCleanup();

--- a/src/dfi/validation.h
+++ b/src/dfi/validation.h
@@ -23,13 +23,13 @@ void ProcessDeFiEvent(const CBlock &block,
                       const CCoinsViewCache &view,
                       const CChainParams &chainparams,
                       const CreationTxs &creationTxs,
-                      const std::shared_ptr<CScopedTemplateID> &evmTemplateId);
+                      const std::shared_ptr<CScopedTemplate> &evmTemplate);
 
 Res ProcessDeFiEventFallible(const CBlock &block,
                              const CBlockIndex *pindex,
                              CCustomCSView &mnview,
                              const CChainParams &chainparams,
-                             const std::shared_ptr<CScopedTemplateID> &evmTemplateId,
+                             const std::shared_ptr<CScopedTemplate> &evmTemplate,
                              const bool isEvmEnabledForBlock);
 
 std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets &vaultAssets,

--- a/src/miner.h
+++ b/src/miner.h
@@ -22,7 +22,7 @@
 
 class CBlockIndex;
 class CChainParams;
-class CScopedTemplateID;
+class CScopedTemplate;
 class CScript;
 class CAnchor;
 struct EvmTxPreApplyContext;
@@ -201,7 +201,7 @@ private:
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
     template<class T>
-    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, int nHeight, CCustomCSView &view, std::shared_ptr<CScopedTemplateID> &evmTemplateId, std::map<uint256, CAmount> &txFees, const bool isEvmEnabledForBlock) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, int nHeight, CCustomCSView &view, std::shared_ptr<CScopedTemplate> &evmTemplate, std::map<uint256, CAmount> &txFees, const bool isEvmEnabledForBlock) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
     rawTx.vout = { CTxOut(0, CScript()) };
     rawTx.vin = { CTxIn(auth_out) };
 
-    std::shared_ptr<CScopedTemplateID> evmTemplateId{};
+    std::shared_ptr<CScopedTemplate> evmTemplate{};
 
     // try to send "A:-1@DFI"
     {
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplateId, false, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplate, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplateId, false, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplate, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_EQUAL(res.code, (uint32_t) CustomTxErrCodes::NotEnoughBalance);
         // check that nothing changes:
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplateId, false, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplate, false, false);
         BOOST_CHECK(!res.ok);
         BOOST_CHECK_NE(res.msg.find("negative amount"), std::string::npos);
         // check that nothing changes:
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
         rawTx.vout[0].scriptPubKey = CreateMetaA2A(msg);
 
-        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplateId, false, false);
+        res = ApplyCustomTx(mnview, coinview, CTransaction(rawTx), amkCheated, 1, 0, nullptr, 0, evmTemplate, false, false);
         BOOST_CHECK(res.ok);
         // check result balances:
         auto const dfi90 = CTokenAmount{DFI, 90};

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1247,8 +1247,8 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache& coinsCac
             vtx.push_back(it->GetSharedTx());
             continue;
         }
-        std::shared_ptr<CScopedTemplateID> evmTemplateId{};
-        auto res = ApplyCustomTx(viewDuplicate, coinsCache, tx, consensus, height, 0, nullptr, 0, evmTemplateId, isEvmEnabledForBlock, true);
+        std::shared_ptr<CScopedTemplate> evmTemplate{};
+        auto res = ApplyCustomTx(viewDuplicate, coinsCache, tx, consensus, height, 0, nullptr, 0, evmTemplate, isEvmEnabledForBlock, true);
         if (!res && (res.code & CustomTxErrCodes::Fatal)) {
             LogPrintf("%s: Remove conflicting custom TX: %s\n", __func__, tx.GetHash().GetHex());
             staged.insert(mapTx.project<0>(it));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -652,8 +652,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         const auto& consensus = chainparams.GetConsensus();
         const auto isEvmEnabledForBlock = IsEVMEnabled(mnview, consensus);
 
-        std::shared_ptr<CScopedTemplateID> evmTemplateId{};
-        auto res = ApplyCustomTx(mnview, view, tx, consensus, height, nAcceptTime, nullptr, 0, evmTemplateId, isEvmEnabledForBlock, true);
+        std::shared_ptr<CScopedTemplate> evmTemplate{};
+        auto res = ApplyCustomTx(mnview, view, tx, consensus, height, nAcceptTime, nullptr, 0, evmTemplate, isEvmEnabledForBlock, true);
         if (!res.ok || (res.code & CustomTxErrCodes::Fatal)) {
             return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_INVALID, res.msg);
         }
@@ -2448,8 +2448,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             // Do not track burns in genesis
             mnview.GetHistoryWriters().GetBurnView() = nullptr;
             for (size_t i = 0; i < block.vtx.size(); ++i) {
-                std::shared_ptr<CScopedTemplateID> evmTemplateId{};
-                const auto res = ApplyCustomTx(mnview, view, *block.vtx[i], chainparams.GetConsensus(), pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmTemplateId, false, false);
+                std::shared_ptr<CScopedTemplate> evmTemplate{};
+                const auto res = ApplyCustomTx(mnview, view, *block.vtx[i], chainparams.GetConsensus(), pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmTemplate, false, false);
                 if (!res.ok) {
                     return error("%s: Genesis block ApplyCustomTx failed. TX: %s Error: %s",
                                  __func__, block.vtx[i]->GetHash().ToString(), res.msg);
@@ -2660,18 +2660,18 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     const auto& consensus = chainparams.GetConsensus();
     const auto isEvmEnabledForBlock = IsEVMEnabled(attributes);
-    std::shared_ptr<CScopedTemplateID> evmTemplateId{};
+    std::shared_ptr<CScopedTemplate> evmTemplate{};
 
     if (isEvmEnabledForBlock) {
         auto xvmRes = XVM::TryFrom(block.vtx[0]->vout[1].scriptPubKey);
         if (!xvmRes) {
             return Res::Err("Failed to process XVM in coinbase");
         }
-        evmTemplateId = CScopedTemplateID::Create(pindex->nHeight, xvmRes->evm.beneficiary, block.nBits, pindex->GetBlockTime());
-        if (!evmTemplateId) {
+        evmTemplate = CScopedTemplate::Create(pindex->nHeight, xvmRes->evm.beneficiary, block.nBits, pindex->GetBlockTime());
+        if (!evmTemplate) {
             return Res::Err("Failed to create block template");
         }
-        XResultThrowOnErr(evm_try_unsafe_update_state_in_template(result, evmTemplateId->GetTemplateID(), static_cast<std::size_t>(reinterpret_cast<uintptr_t>(&mnview))));
+        XResultThrowOnErr(evm_try_unsafe_update_state_in_template(result, evmTemplate->GetTemplate(), static_cast<std::size_t>(reinterpret_cast<uintptr_t>(&mnview))));
     }
 
     // Execute TXs
@@ -2744,7 +2744,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
             }
 
             const auto applyCustomTxTime = GetTimeMicros();
-            const auto res = ApplyCustomTx(accountsView, view, tx, consensus, pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmTemplateId, isEvmEnabledForBlock, false);
+            const auto res = ApplyCustomTx(accountsView, view, tx, consensus, pindex->nHeight, pindex->GetBlockTime(), nullptr, i, evmTemplate, isEvmEnabledForBlock, false);
 
             LogApplyCustomTx(tx, applyCustomTxTime);
             if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {
@@ -2912,7 +2912,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     accountsView.Flush();
 
     // Execute EVM Queue
-    res = ProcessDeFiEventFallible(block, pindex, mnview, chainparams, evmTemplateId, isEvmEnabledForBlock);
+    res = ProcessDeFiEventFallible(block, pindex, mnview, chainparams, evmTemplate, isEvmEnabledForBlock);
     if (!res.ok) {
         return state.Invalid(ValidationInvalidReason::CONSENSUS, error("%s: %s", __func__, res.msg), REJECT_INVALID, res.dbgMsg);
     }
@@ -2929,7 +2929,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 
-    ProcessDeFiEvent(block, pindex, mnview, view, chainparams, creationTxs, evmTemplateId);
+    ProcessDeFiEvent(block, pindex, mnview, view, chainparams, creationTxs, evmTemplate);
 
     // Write any UTXO burns
     for (const auto& [key, value] : writeBurnEntries)
@@ -2992,7 +2992,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     // Finalize items
     if (isEvmEnabledForBlock) {
-        XResultThrowOnErr(evm_try_unsafe_commit_block(result, evmTemplateId->GetTemplateID()));
+        XResultThrowOnErr(evm_try_unsafe_commit_block(result, evmTemplate->GetTemplate()));
     }
 
     int64_t nTime5 = GetTimeMicros(); nTimeIndex += nTime5 - nTime4;


### PR DESCRIPTION
## Summary

- Remove blockTemplateId and return a ptr to the template itself.
- Remove need for locks and sync primitives
