### PR TITLE
util: Remove obsolete check in addr conversions 

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -158,9 +158,6 @@ CPubKey AddrToPubKey(FillableSigningProvider* const keystore, const std::string&
     if (!keystore->GetPubKey(key, vchPubKey)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("no full public key for address %s", addr_in));
     }
-    if (dest.index() == WitV16KeyEthHashType && vchPubKey.IsCompressed()) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("no valid public key for address %s", addr_in));
-    }
     if (!vchPubKey.IsFullyValid()) {
        throw JSONRPCError(RPC_INTERNAL_ERROR, "Wallet contains an invalid public key");
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4283,13 +4283,14 @@ UniValue addressmap(const JSONRPCRequest &request) {
     }
         .Check(request);
 
-    auto throwInvalidParam = []() { throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid type parameter")); };
+    auto throwInvalidParamType = []() { throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid type parameter")); };
+    auto throwInvalidAddressFmt = []() { throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid address format")); };
 
     const std::string input = request.params[0].get_str();
 
     int typeInt = request.params[1].get_int();
     if (typeInt < 0 || typeInt >= AddressConversionTypeCount) {
-        throwInvalidParam();
+        throwInvalidParamType();
     }
 
     CTxDestination dest = DecodeDestination(input);
@@ -4315,7 +4316,7 @@ UniValue addressmap(const JSONRPCRequest &request) {
     switch (type) {
         case AddressConversionType::DVMToEVMAddress: {
             if (dest.index() != WitV0KeyHashType && dest.index() != PKHashType) {
-                throwInvalidParam();
+                throwInvalidAddressFmt();
             }
             CPubKey key = AddrToPubKey(pwallet, input);
             if (key.IsCompressed()) {
@@ -4326,7 +4327,7 @@ UniValue addressmap(const JSONRPCRequest &request) {
         }
         case AddressConversionType::EVMToDVMAddress: {
             if (dest.index() != WitV16KeyEthHashType) {
-                throwInvalidParam();
+                throwInvalidAddressFmt();
             }
             CPubKey key = AddrToPubKey(pwallet, input);
             if (!key.IsCompressed()) {
@@ -4336,7 +4337,7 @@ UniValue addressmap(const JSONRPCRequest &request) {
             break;
         }
         default:
-            throwInvalidParam();
+            throwInvalidParamType();
     }
 
     ret.pushKV("format", format);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4322,7 +4322,12 @@ UniValue addressmap(const JSONRPCRequest &request) {
             if (key.IsCompressed()) {
                 key.Decompress();
             }
-            format.pushKV("erc55", EncodeDestination(WitnessV16EthHash(key)));
+            auto erc55 = EncodeDestination(WitnessV16EthHash(key));
+            // Check if it's in the wallet. 
+            // Note: Can be removed if the full wallet is migrated.
+            // Ref: https://github.com/DeFiCh/ain/issues/2604
+            AddrToPubKey(pwallet, erc55);
+            format.pushKV("erc55", erc55);
             break;
         }
         case AddressConversionType::EVMToDVMAddress: {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4322,7 +4322,7 @@ UniValue addressmap(const JSONRPCRequest &request) {
             if (key.IsCompressed()) {
                 key.Decompress();
             }
-            auto erc55 = EncodeDestination(WitnessV16EthHash(key));
+            const auto erc55 = EncodeDestination(WitnessV16EthHash(key));
             // Check if it's in the wallet. 
             // Note: Can be removed if the full wallet is migrated.
             // Ref: https://github.com/DeFiCh/ain/issues/2604


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Remove the obsolete check which was a part of previous address generation logic.
- This util function affects only RPCs

- Depends on: https://github.com/DeFiCh/ain/pull/2607/files

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
