### PR TITLE
Get correct compression for encrypted wallet

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -2196,6 +2196,8 @@ UniValue transferdomain(const JSONRPCRequest &request) {
 
     pwallet->BlockUntilSyncedToCurrentChain();
 
+    EnsureWalletIsUnlocked(pwallet);
+
     RPCTypeCheck(request.params, {UniValue::VARR}, false);
 
     UniValue srcDstArray(UniValue::VARR);

--- a/src/dfi/rpc_evm.cpp
+++ b/src/dfi/rpc_evm.cpp
@@ -68,6 +68,8 @@ UniValue evmtx(const JSONRPCRequest &request) {
     }
     pwallet->BlockUntilSyncedToCurrentChain();
 
+    EnsureWalletIsUnlocked(pwallet);
+
     const auto fromDest = DecodeDestination(request.params[0].get_str());
     if (fromDest.index() != WitV16KeyEthHashType) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "from address not an Ethereum address");

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -98,13 +98,8 @@ bool FillableSigningProvider::GetPubKey(const CKeyID &address, CPubKey &vchPubKe
     if (!GetKey(address, key)) {
         return false;
     }
-    auto pubkey = key.GetPubKey();
-    if (!pubkey.IsCompressed() && address.type == KeyAddressType::COMPRESSED) {
-        pubkey.Compress();
-    } else if (pubkey.IsCompressed() && address.type == KeyAddressType::UNCOMPRESSED) {
-        pubkey.Decompress();
-    }
-    vchPubKeyOut = pubkey;
+    vchPubKeyOut = key.GetPubKey();
+    ResolveKeyCompression(address.type, vchPubKeyOut);
     return true;
 }
 

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -89,4 +89,12 @@ public:
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
 CKeyID GetKeyOrDefaultFromDestination(const SigningProvider& store, const CTxDestination& dest);
 
+inline void ResolveKeyCompression(const KeyAddressType type, CPubKey &pubkey) {
+    if (!pubkey.IsCompressed() && type == KeyAddressType::COMPRESSED) {
+        pubkey.Compress();
+    } else if (pubkey.IsCompressed() && type == KeyAddressType::UNCOMPRESSED) {
+        pubkey.Decompress();
+    }
+}
+
 #endif // DEFI_SCRIPT_SIGNINGPROVIDER_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4322,12 +4322,7 @@ UniValue addressmap(const JSONRPCRequest &request) {
             if (key.IsCompressed()) {
                 key.Decompress();
             }
-            const auto erc55 = EncodeDestination(WitnessV16EthHash(key));
-            // Check if it's in the wallet. 
-            // Note: Can be removed if the full wallet is migrated.
-            // Ref: https://github.com/DeFiCh/ain/issues/2604
-            AddrToPubKey(pwallet, erc55);
-            format.pushKV("erc55", erc55);
+            format.pushKV("erc55", EncodeDestination(WitnessV16EthHash(key)));
             break;
         }
         case AddressConversionType::EVMToDVMAddress: {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4979,10 +4979,14 @@ bool CWallet::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
         return true;
     }
 
-    CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
-    if (mi != mapCryptedKeys.end())
+    if (const auto mi = mapCryptedKeys.find(address); mi != mapCryptedKeys.end())
     {
         vchPubKeyOut = (*mi).second.first;
+        if (!vchPubKeyOut.IsCompressed() && address.type == KeyAddressType::COMPRESSED) {
+            vchPubKeyOut.Compress();
+        } else if (vchPubKeyOut.IsCompressed() && address.type == KeyAddressType::UNCOMPRESSED) {
+            vchPubKeyOut.Decompress();
+        }
         return true;
     }
     // Check for watch-only pubkeys

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4961,9 +4961,9 @@ bool CWallet::GetKey(const CKeyID &address, CKey& keyOut) const
 bool CWallet::GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const
 {
     LOCK(cs_KeyStore);
-    WatchKeyMap::const_iterator it = mapWatchKeys.find(address);
-    if (it != mapWatchKeys.end()) {
+    if (const auto it = mapWatchKeys.find(address); it != mapWatchKeys.end()) {
         pubkey_out = it->second;
+        ResolveKeyCompression(address.type, pubkey_out);
         return true;
     }
     return false;
@@ -4982,11 +4982,7 @@ bool CWallet::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
     if (const auto mi = mapCryptedKeys.find(address); mi != mapCryptedKeys.end())
     {
         vchPubKeyOut = (*mi).second.first;
-        if (!vchPubKeyOut.IsCompressed() && address.type == KeyAddressType::COMPRESSED) {
-            vchPubKeyOut.Compress();
-        } else if (vchPubKeyOut.IsCompressed() && address.type == KeyAddressType::UNCOMPRESSED) {
-            vchPubKeyOut.Decompress();
-        }
+        ResolveKeyCompression(address.type, vchPubKeyOut);
         return true;
     }
     // Check for watch-only pubkeys

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -1363,6 +1363,12 @@ class EVMTest(DefiTestFramework):
         # Check pubkey
         assert_equal(pub_key, self.nodes[0].getaddressinfo(address)["pubkey"])
 
+        # Check equivalent DVM address
+        assert_equal(
+            "bcrt1qkhd438yhrvnleflep3xlxj4xvnm4q7r0wsxzya",
+            self.nodes[0].addressmap(address, 2)["format"]["bech32"],
+        )
+
         # Fund EVM address
         self.nodes[0].transferdomain(
             [


### PR DESCRIPTION
## Summary

- Ensure that the correct ERC55 public key compression is returned for encrypted wallets.
- Resolves https://github.com/DeFiCh/ain/issues/2604
- Adds locked wallet check to evmtx and transferdomain RPC calls.
- Adds test to check transferdomain works in both directions and that the correct public key is shown in getaddressinfo.

## RPC

- If evmtx or transferdomain on a locked wallet then the user is informed that they need to unlock the wallet first.
- ERC55 public keys now show in uncompressed form in getaddressinfo.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
