### PR TITLE
gov: updateproposal bug fix

### DIFF
--- a/src/dfi/proposals.cpp
+++ b/src/dfi/proposals.cpp
@@ -112,6 +112,7 @@ Res CProposalView::UpdateProposalCycle(const CProposalId &propId,
                                        const Consensus::Params &consensus) {
     auto key = std::make_pair(uint8_t(CProposalStatusType::Voting), propId);
     auto pcycle = ReadBy<ByStatus, uint8_t>(key);
+    // TODO: Remove fork guard after update
     if (!pcycle && height >= consensus.DF22MetachainHeight) {
         return Res::Err("Proposal <%s> is not in voting period", propId.GetHex());
     }

--- a/src/dfi/proposals.cpp
+++ b/src/dfi/proposals.cpp
@@ -106,10 +106,13 @@ std::optional<CProposalObject> CProposalView::GetProposal(const CProposalId &pro
     return prop;
 }
 
-Res CProposalView::UpdateProposalCycle(const CProposalId &propId, uint8_t cycle) {
+Res CProposalView::UpdateProposalCycle(const CProposalId &propId,
+                                       uint8_t cycle,
+                                       int height,
+                                       const Consensus::Params &consensus) {
     auto key = std::make_pair(uint8_t(CProposalStatusType::Voting), propId);
     auto pcycle = ReadBy<ByStatus, uint8_t>(key);
-    if (!pcycle) {
+    if (!pcycle && height >= consensus.DF22MetachainHeight) {
         return Res::Err("Proposal <%s> is not in voting period", propId.GetHex());
     }
 

--- a/src/dfi/proposals.h
+++ b/src/dfi/proposals.h
@@ -141,7 +141,7 @@ public:
                        const CCreateProposalMessage &prop,
                        const CAmount fee);
     std::optional<CProposalObject> GetProposal(const CProposalId &propId);
-    Res UpdateProposalCycle(const CProposalId &propId, uint8_t cycle);
+    Res UpdateProposalCycle(const CProposalId &propId, uint8_t cycle, int height, const Consensus::Params &consensus);
     Res UpdateProposalStatus(const CProposalId &propId, uint32_t height, CProposalStatusType status);
     Res AddProposalVote(const CProposalId &propId, const uint256 &masternodeId, CProposalVoteType vote);
     std::optional<CProposalVoteType> GetProposalVote(const CProposalId &propId,

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2563,7 +2563,7 @@ static void ProcessProposalEvents(const CBlockIndex *pindex, CCustomCSView &cach
                 cache.UpdateProposalStatus(propId, pindex->nHeight, CProposalStatusType::Completed);
             } else {
                 assert(prop.nCycles > prop.cycle);
-                cache.UpdateProposalCycle(propId, prop.cycle + 1);
+                cache.UpdateProposalCycle(propId, prop.cycle + 1, pindex->nHeight, chainparams.GetConsensus());
             }
 
             CDataStructureV0 payoutKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::CFPPayout};


### PR DESCRIPTION
## Summary

- When removing Require usage a return was added to an error that did not return before. The missing return statement was a bug and affects consensus. This PR adds a fork guard to the added return statement.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
