### PR TITLE
test: fix segwit test

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4963,7 +4963,6 @@ bool CWallet::GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const
     LOCK(cs_KeyStore);
     if (const auto it = mapWatchKeys.find(address); it != mapWatchKeys.end()) {
         pubkey_out = it->second;
-        ResolveKeyCompression(address.type, pubkey_out);
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary

- Remove key compression toggle from watch keys. Fixes SegWit test.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
