### PR TITLE
EVM: Fix atomicity of apply operations with backend overlay

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -195,6 +195,10 @@ impl EVMBackend {
         self.overlay.state.clear()
     }
 
+    pub fn reset(&mut self) {
+        self.overlay.state = self.overlay.changeset.last().cloned().unwrap_or_default();
+    }
+
     pub fn reset_from_tx(&mut self, index: usize) {
         self.overlay.state = self
             .overlay

--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -195,7 +195,7 @@ impl EVMBackend {
         self.overlay.state.clear()
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset_to_last_changeset(&mut self) {
         self.overlay.state = self.overlay.changeset.last().cloned().unwrap_or_default();
     }
 

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -289,7 +289,7 @@ impl EVMServices {
                 })
             }
             Err(e) => {
-                template.backend.reset();
+                template.backend.reset_to_last_changeset();
                 Err(e)
             }
         }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -275,17 +275,24 @@ impl EVMServices {
         let mut executor = AinExecutor::new(&mut template.backend);
 
         executor.update_total_gas_used(template.total_gas_used);
-        let apply_tx = executor.execute_tx(tx, base_fee)?;
-        EVMCoreService::logs_bloom(apply_tx.logs, &mut logs_bloom);
-        template.backend.increase_tx_count();
+        match executor.execute_tx(tx, base_fee) {
+            Ok(apply_tx) => {
+                EVMCoreService::logs_bloom(apply_tx.logs, &mut logs_bloom);
+                template.backend.increase_tx_count();
 
-        Ok(ExecTxState {
-            tx: apply_tx.tx,
-            receipt: apply_tx.receipt,
-            logs_bloom,
-            gas_used: apply_tx.used_gas,
-            gas_fees: apply_tx.gas_fee,
-        })
+                Ok(ExecTxState {
+                    tx: apply_tx.tx,
+                    receipt: apply_tx.receipt,
+                    logs_bloom,
+                    gas_used: apply_tx.used_gas,
+                    gas_fees: apply_tx.gas_fee,
+                })
+            }
+            Err(e) => {
+                template.backend.reset();
+                Err(e)
+            }
+        }
     }
 
     ///

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -472,7 +472,7 @@ pub fn evm_try_unsafe_create_template(
             ),
             Err(e) => {
                 cross_boundary_error(result, e.to_string());
-                return block_template_err_wrapper();
+                block_template_err_wrapper()
             }
         }
     }


### PR DESCRIPTION
## Summary

- Make execution of txs on the executor atomic - all states will be reverted if tx execution fails to be added into the block template


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
