### PR TITLE
Fix eth RPC call context and fix gas estimate pipeline

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "env_logger",
  "ethereum",
  "ethereum-types",
+ "evm",
  "heck 0.4.1",
  "hex",
  "hyper",

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -127,16 +127,14 @@ pub struct EVMCoreService {
     tx_validation_cache: TxValidationCache,
 }
 pub struct EthCallArgs<'a> {
-    pub caller: Option<H160>,
+    pub caller: H160,
     pub to: Option<H160>,
     pub value: U256,
     pub data: &'a [u8],
     pub gas_limit: u64,
-    pub gas_price: Option<U256>,
-    pub max_fee_per_gas: Option<U256>,
+    pub gas_price: U256,
     pub access_list: AccessList,
     pub block_number: U256,
-    pub transaction_type: Option<U256>,
 }
 
 #[derive(Clone, Debug)]
@@ -234,10 +232,8 @@ impl EVMCoreService {
             data,
             gas_limit,
             gas_price,
-            max_fee_per_gas,
             access_list,
             block_number,
-            transaction_type,
         } = arguments;
 
         let (
@@ -269,12 +265,8 @@ impl EVMCoreService {
         );
         debug!("[call] caller: {:?}", caller);
         let vicinity = Vicinity {
-            gas_price: if transaction_type == Some(U256::from(2)) {
-                max_fee_per_gas.unwrap_or_default()
-            } else {
-                gas_price.unwrap_or_default()
-            },
-            origin: caller.unwrap_or_default(),
+            gas_price,
+            origin: caller,
             beneficiary,
             block_number,
             timestamp: U256::from(timestamp),
@@ -295,7 +287,7 @@ impl EVMCoreService {
         .map_err(|e| format_err!("------ Could not restore backend {}", e))?;
 
         Ok(AinExecutor::new(&mut backend).call(ExecutorContext {
-            caller: caller.unwrap_or_default(),
+            caller,
             to,
             value,
             data,

--- a/lib/ain-grpc/Cargo.toml
+++ b/lib/ain-grpc/Cargo.toml
@@ -9,6 +9,7 @@ ain-evm = { path = "../ain-evm" }
 ain-cpp-imports = { path = "../ain-cpp-imports" }
 cxx.workspace = true
 env_logger.workspace = true
+evm = { workspace = true, default-features = false, features = ["with-serde"] }
 jsonrpsee = { workspace = true, features = ["server", "macros", "http-client"] }
 jsonrpsee-server.workspace = true
 lazy_static.workspace = true

--- a/lib/ain-grpc/src/call_request.rs
+++ b/lib/ain-grpc/src/call_request.rs
@@ -1,7 +1,12 @@
 use ain_evm::bytes::Bytes;
 use ethereum::AccessListItem;
 use ethereum_types::{H160, U256};
+use jsonrpsee::core::Error;
 use serde::Deserialize;
+
+use crate::errors::{
+    invalid_data_err, invalid_specified_gas_price_err, invalid_transaction_type_err,
+};
 
 /// Call request
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -33,4 +38,69 @@ pub struct CallRequest {
     /// EIP-2718 type
     #[serde(rename = "type")]
     pub transaction_type: Option<U256>,
+}
+
+impl CallRequest {
+    pub fn get_effective_gas_price(&self, block_base_fee: U256) -> Result<U256, Error> {
+        if self.gas_price.is_some()
+            && (self.max_fee_per_gas.is_some() || self.max_priority_fee_per_gas.is_some())
+        {
+            return Err(invalid_specified_gas_price_err());
+        }
+
+        match self.transaction_type {
+            // Legacy
+            Some(tx_type) if tx_type == U256::zero() => {
+                if let Some(gas_price) = self.gas_price {
+                    return Ok(gas_price);
+                } else {
+                    return Ok(block_base_fee);
+                }
+            }
+            // EIP2930
+            Some(tx_type) if tx_type == U256::one() => {
+                if let Some(gas_price) = self.gas_price {
+                    return Ok(gas_price);
+                } else {
+                    return Ok(block_base_fee);
+                }
+            }
+            // EIP1559
+            Some(tx_type) if tx_type == U256::from(2) => {
+                if let Some(max_fee_per_gas) = self.max_fee_per_gas {
+                    return Ok(max_fee_per_gas);
+                } else {
+                    return Ok(block_base_fee);
+                }
+            }
+            None => (),
+            _ => return Err(invalid_transaction_type_err()),
+        }
+
+        if let Some(gas_price) = self.gas_price {
+            Ok(gas_price)
+        } else if let Some(gas_price) = self.max_fee_per_gas {
+            Ok(gas_price)
+        } else {
+            Ok(block_base_fee)
+        }
+    }
+
+    // https://github.com/ethereum/go-ethereum/blob/281e8cd5abaac86ed3f37f98250ff147b3c9fe62/internal/ethapi/transaction_args.go#L67
+    // We accept "data" and "input" for backwards-compatibility reasons.
+    //  "input" is the newer name and should be preferred by clients.
+    // 	Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+    pub fn get_data(&self) -> Result<Bytes, Error> {
+        if self.data.is_some() && self.input.is_some() {
+            return Err(invalid_data_err());
+        }
+
+        if let Some(data) = self.data.clone() {
+            Ok(data)
+        } else if let Some(data) = self.input.clone() {
+            Ok(data)
+        } else {
+            Ok(Default::default())
+        }
+    }
 }

--- a/lib/ain-grpc/src/call_request.rs
+++ b/lib/ain-grpc/src/call_request.rs
@@ -4,9 +4,7 @@ use ethereum_types::{H160, U256};
 use jsonrpsee::core::Error;
 use serde::Deserialize;
 
-use crate::errors::{
-    invalid_data_err, invalid_specified_gas_price_err, invalid_transaction_type_err,
-};
+use crate::errors::RPCError;
 
 /// Call request
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
@@ -45,7 +43,7 @@ impl CallRequest {
         if self.gas_price.is_some()
             && (self.max_fee_per_gas.is_some() || self.max_priority_fee_per_gas.is_some())
         {
-            return Err(invalid_specified_gas_price_err());
+            return Err(RPCError::InvalidGasPrice.into());
         }
 
         match self.transaction_type {
@@ -74,7 +72,7 @@ impl CallRequest {
                 }
             }
             None => (),
-            _ => return Err(invalid_transaction_type_err()),
+            _ => return Err(RPCError::InvalidTransactionType.into()),
         }
 
         if let Some(gas_price) = self.gas_price {
@@ -92,7 +90,7 @@ impl CallRequest {
     // 	Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
     pub fn get_data(&self) -> Result<Bytes, Error> {
         if self.data.is_some() && self.input.is_some() {
-            return Err(invalid_data_err());
+            return Err(RPCError::InvalidDataInput.into());
         }
 
         if let Some(data) = self.data.clone() {

--- a/lib/ain-grpc/src/errors.rs
+++ b/lib/ain-grpc/src/errors.rs
@@ -3,7 +3,6 @@ use jsonrpsee::core::Error;
 
 pub enum RPCError {
     EvmCall(EVMError),
-    NoSenderAddress,
     InsufficientFunds,
     ValueOverflow,
     InvalidGasPrice,
@@ -17,7 +16,6 @@ impl From<RPCError> for Error {
     fn from(e: RPCError) -> Self {
         match e {
             RPCError::EvmCall(e) => Error::Custom(format!("error calling EVM : {e:?}")),
-            RPCError::NoSenderAddress => to_custom_err("no from address specified"),
             RPCError::InsufficientFunds => to_custom_err("insufficient funds for transfer"),
             RPCError::ValueOverflow => to_custom_err("value overflow"),
             RPCError::InvalidGasPrice => {

--- a/lib/ain-grpc/src/errors.rs
+++ b/lib/ain-grpc/src/errors.rs
@@ -1,0 +1,44 @@
+use ain_evm::EVMError;
+use jsonrpsee::core::Error;
+
+pub fn to_custom_err<T: ToString>(e: T) -> Error {
+    jsonrpsee::core::Error::Custom(e.to_string())
+}
+
+pub fn evm_call_err(e: EVMError) -> Error {
+    Error::Custom(format!("error calling EVM : {e:?}"))
+}
+
+pub fn no_sender_address_err() -> Error {
+    Error::Custom(String::from("no from address specified"))
+}
+
+pub fn insufficient_funds_for_transfer_err() -> Error {
+    Error::Custom(String::from("insufficient funds for transfer"))
+}
+
+pub fn value_overflow_err() -> Error {
+    Error::Custom(String::from("value overflow"))
+}
+
+pub fn invalid_specified_gas_price_err() -> Error {
+    Error::Custom(String::from(
+        "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
+    ))
+}
+
+pub fn invalid_transaction_type_err() -> Error {
+    Error::Custom(String::from("invalid transaction type specified"))
+}
+
+pub fn invalid_data_err() -> Error {
+    Error::Custom(String::from("data and input fields are mutually exclusive"))
+}
+
+pub fn tx_execution_failure_err() -> Error {
+    Error::Custom(String::from("transaction execution failed"))
+}
+
+pub fn gas_cap_too_low_err(cap: u64) -> Error {
+    Error::Custom(format!("gas required exceeds allowance {:#?}", cap))
+}

--- a/lib/ain-grpc/src/errors.rs
+++ b/lib/ain-grpc/src/errors.rs
@@ -25,7 +25,7 @@ impl From<RPCError> for Error {
     fn from(e: RPCError) -> Self {
         match e {
             RPCError::AccountError => to_custom_err("error getting account"),
-            RPCError::BlockNotFound => to_custom_err("block not found"),
+            RPCError::BlockNotFound => to_custom_err("header not found"),
             RPCError::Error(e) => Error::Custom(format!("{e:?}")),
             RPCError::EvmError(e) => Error::Custom(format!("error calling EVM : {e:?}")),
             RPCError::FromBlockGreaterThanToBlock => {

--- a/lib/ain-grpc/src/errors.rs
+++ b/lib/ain-grpc/src/errors.rs
@@ -2,33 +2,57 @@ use ain_evm::EVMError;
 use jsonrpsee::core::Error;
 
 pub enum RPCError {
-    EvmCall(EVMError),
-    InsufficientFunds,
-    ValueOverflow,
-    InvalidGasPrice,
-    InvalidTransactionType,
-    InvalidDataInput,
-    TxExecutionFailed,
+    AccountError,
+    BlockNotFound,
+    Error(Box<dyn std::error::Error>),
+    EvmError(EVMError),
+    FromBlockGreaterThanToBlock,
     GasCapTooLow(u64),
+    InsufficientFunds,
+    InvalidBlockInput,
+    InvalidDataInput,
+    InvalidLogFilter,
+    InvalidGasPrice,
+    InvalidTransactionMessage,
+    InvalidTransactionType,
+    NonceCacheError,
+    StateRootNotFound,
+    TxExecutionFailed,
+    ValueOverflow,
 }
 
 impl From<RPCError> for Error {
     fn from(e: RPCError) -> Self {
         match e {
-            RPCError::EvmCall(e) => Error::Custom(format!("error calling EVM : {e:?}")),
-            RPCError::InsufficientFunds => to_custom_err("insufficient funds for transfer"),
-            RPCError::ValueOverflow => to_custom_err("value overflow"),
-            RPCError::InvalidGasPrice => {
-                to_custom_err("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+            RPCError::AccountError => to_custom_err("error getting account"),
+            RPCError::BlockNotFound => to_custom_err("block not found"),
+            RPCError::Error(e) => Error::Custom(format!("{e:?}")),
+            RPCError::EvmError(e) => Error::Custom(format!("error calling EVM : {e:?}")),
+            RPCError::FromBlockGreaterThanToBlock => {
+                to_custom_err("fromBlock is greater than toBlock")
             }
-            RPCError::InvalidTransactionType => to_custom_err("invalid transaction type specified"),
-            RPCError::InvalidDataInput => {
-                to_custom_err("data and input fields are mutually exclusive")
-            }
-            RPCError::TxExecutionFailed => to_custom_err("transaction execution failed"),
             RPCError::GasCapTooLow(cap) => {
                 Error::Custom(format!("gas required exceeds allowance {:#?}", cap))
             }
+            RPCError::InsufficientFunds => to_custom_err("insufficient funds for transfer"),
+            RPCError::InvalidBlockInput => {
+                to_custom_err("both blockHash and fromBlock/toBlock specified")
+            }
+            RPCError::InvalidDataInput => {
+                to_custom_err("data and input fields are mutually exclusive")
+            }
+            RPCError::InvalidGasPrice => {
+                to_custom_err("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+            }
+            RPCError::InvalidLogFilter => to_custom_err("invalid log filter"),
+            RPCError::InvalidTransactionMessage => {
+                to_custom_err("invalid transaction message parameters")
+            }
+            RPCError::InvalidTransactionType => to_custom_err("invalid transaction type specified"),
+            RPCError::NonceCacheError => to_custom_err("could not cache account nonce"),
+            RPCError::StateRootNotFound => to_custom_err("state root not found"),
+            RPCError::TxExecutionFailed => to_custom_err("transaction execution failed"),
+            RPCError::ValueOverflow => to_custom_err("value overflow"),
         }
     }
 }

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -5,6 +5,7 @@ extern crate serde_json;
 pub mod block;
 pub mod call_request;
 pub mod codegen;
+mod errors;
 mod filters;
 mod impls;
 pub mod logging;

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -111,7 +111,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
 
     fn fee_estimate(&self, call: CallRequest) -> RpcResult<FeeEstimate> {
         debug!(target:"rpc",  "Fee estimate");
-        let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
+        let caller = call.from.unwrap_or_default();
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
 

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -154,7 +154,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
                 access_list: call.access_list.unwrap_or_default(),
                 block_number,
             })
-            .map_err(RPCError::EvmCall)?;
+            .map_err(RPCError::EvmError)?;
 
         let used_gas = U256::from(used_gas);
         let gas_fee = used_gas

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -110,7 +110,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
     }
 
     fn fee_estimate(&self, call: CallRequest) -> RpcResult<FeeEstimate> {
-        debug!(target:"rpc",  "[RPC] Call input {:#?}", call);
+        debug!(target:"rpc",  "[RPC] Fee estimate call input {:#?}", call);
         let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -110,7 +110,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
     }
 
     fn fee_estimate(&self, call: CallRequest) -> RpcResult<FeeEstimate> {
-        debug!(target:"rpc",  "[RPC] Fee estimate call input {:#?}", call);
+        debug!(target:"rpc",  "Fee estimate");
         let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -1,4 +1,4 @@
-use std::{cmp, sync::Arc};
+use std::sync::Arc;
 
 use ain_evm::{
     core::EthCallArgs, evm::EVMServices, executor::TxResponse, storage::block_store::DumpArg,
@@ -12,8 +12,10 @@ use jsonrpsee::{
 use log::debug;
 use rlp::{Decodable, Rlp};
 
-use super::to_jsonrpsee_custom_error;
-use crate::call_request::CallRequest;
+use crate::{
+    call_request::CallRequest,
+    errors::{evm_call_err, no_sender_address_err, to_custom_err, value_overflow_err},
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct FeeEstimate {
@@ -47,7 +49,7 @@ pub trait MetachainDebugRPC {
 
     // Get transaction fee estimate
     #[method(name = "feeEstimate")]
-    fn fee_estimate(&self, input: CallRequest) -> RpcResult<FeeEstimate>;
+    fn fee_estimate(&self, call: CallRequest) -> RpcResult<FeeEstimate>;
 }
 
 pub struct MetachainDebugRPCModule {
@@ -80,7 +82,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         self.handler
             .storage
             .dump_db(arg.unwrap_or(DumpArg::All), start, limit)
-            .map_err(to_jsonrpsee_custom_error)
+            .map_err(to_custom_err)
     }
 
     fn log_account_states(&self) -> RpcResult<()> {
@@ -107,104 +109,63 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         Ok(())
     }
 
-    fn fee_estimate(&self, input: CallRequest) -> RpcResult<FeeEstimate> {
-        let CallRequest {
-            from,
-            to,
-            gas,
-            value,
-            data,
-            access_list,
-            transaction_type,
-            gas_price,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            ..
-        } = input;
+    fn fee_estimate(&self, call: CallRequest) -> RpcResult<FeeEstimate> {
+        debug!(target:"rpc",  "[RPC] Call input {:#?}", call);
+        let caller = call.from.ok_or_else(no_sender_address_err)?;
+        let byte_data = call.get_data()?;
+        let data = byte_data.0.as_slice();
 
+        // Get latest block information
         let (block_hash, block_number) = self
             .handler
             .block
             .get_latest_block_hash_and_number()
-            .map_err(to_jsonrpsee_custom_error)?
-            .ok_or(Error::Custom(
-                "Error fetching latest block hash and number".to_string(),
-            ))?;
-        let base_fee = self
+            .map_err(to_custom_err)?
+            .unwrap_or_default();
+
+        // Get gas
+        let block_gas_limit = self
+            .handler
+            .storage
+            .get_attributes_or_default()
+            .map_err(to_custom_err)?
+            .block_gas_limit;
+        let gas_limit = u64::try_from(call.gas.unwrap_or(U256::from(block_gas_limit)))
+            .map_err(to_custom_err)?;
+
+        // Get gas price
+        let block_base_fee = self
             .handler
             .block
             .calculate_base_fee(block_hash)
-            .map_err(to_jsonrpsee_custom_error)?;
-        let Ok(gas_limit) = u64::try_from(gas.ok_or(Error::Custom(
-            "Cannot get fee estimate without specifying gas limit".to_string(),
-        ))?) else {
-            return Err(Error::Custom(
-                "Cannot get fee estimate, gas value overflow".to_string(),
-            ));
-        };
+            .map_err(to_custom_err)?;
+        let gas_price = call.get_effective_gas_price(block_base_fee)?;
 
         let TxResponse { used_gas, .. } = self
             .handler
             .core
             .call(EthCallArgs {
-                caller: from,
-                to,
-                value: value.unwrap_or_default(),
-                data: &data.map(|d| d.0).unwrap_or_default(),
+                caller,
+                to: call.to,
+                value: call.value.unwrap_or_default(),
+                data,
                 gas_limit,
                 gas_price,
-                max_fee_per_gas,
-                access_list: access_list.unwrap_or_default(),
+                access_list: call.access_list.unwrap_or_default(),
                 block_number,
-                transaction_type,
             })
-            .map_err(|e| Error::Custom(format!("Error calling EVM : {e:?}")))?;
+            .map_err(evm_call_err)?;
 
         let used_gas = U256::from(used_gas);
-        let gas_fee = match transaction_type {
-            // Legacy
-            None => {
-                let Some(gas_price) = gas_price else {
-                    return Err(Error::Custom(
-                        "Cannot get Legacy TX fee estimate without gas price".to_string()
-                    ));
-                };
-                used_gas.checked_mul(gas_price)
-            }
-            // EIP2930
-            Some(typ) if typ == U256::one() => {
-                let Some(gas_price) = gas_price else {
-                    return Err(Error::Custom(
-                        "Cannot get EIP2930 TX fee estimate without gas price".to_string()
-                    ));
-                };
-                used_gas.checked_mul(gas_price)
-            }
-            // EIP1559
-            Some(typ) if typ == U256::from(2) => {
-                let (Some(max_fee_per_gas), Some(max_priority_fee_per_gas)) =
-                    (max_fee_per_gas, max_priority_fee_per_gas)
-                else {
-                    return Err(Error::Custom("Cannot get EIP1559 TX fee estimate without max_fee_per_gas and max_priority_fee_per_gas".to_string()));
-                };
-                let gas_fee = cmp::min(max_fee_per_gas, max_priority_fee_per_gas.checked_add(base_fee).ok_or_else(|| Error::Custom("max_priority_fee_per_gas overflow".to_string()))?);
-                used_gas.checked_mul(gas_fee)
-            }
-            _ => {
-                return Err(Error::Custom(
-                    "Wrong transaction type. Should be either None, 1 or 2".to_string()
-                ))
-            }
-        }.ok_or(Error::Custom(
-            "Cannot get fee estimate, fee value overflow".to_string()
-        ))?;
-
+        let gas_fee = used_gas
+            .checked_mul(used_gas)
+            .ok_or_else(value_overflow_err)?;
         let burnt_fee = used_gas
-            .checked_mul(base_fee)
-            .ok_or_else(|| Error::Custom("burnt_fee overflow".to_string()))?;
+            .checked_mul(block_base_fee)
+            .ok_or_else(value_overflow_err)?;
         let priority_fee = gas_fee
             .checked_sub(burnt_fee)
-            .ok_or_else(|| Error::Custom("priority_fee underflow".to_string()))?;
+            .ok_or_else(value_overflow_err)?;
 
         Ok(FeeEstimate {
             used_gas,

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -317,7 +317,7 @@ impl MetachainRPCModule {
 
 impl MetachainRPCServer for MetachainRPCModule {
     fn call(&self, call: CallRequest, block_number: Option<BlockNumber>) -> RpcResult<Bytes> {
-        debug!(target:"rpc",  "[RPC] Call input {:#?}", call);
+        debug!(target:"rpc",  "Call, input {:#?}", call);
         let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
@@ -397,7 +397,7 @@ impl MetachainRPCServer for MetachainRPCModule {
             .get_code(address, block_number)
             .map_err(to_custom_err)?;
 
-        debug!("code : {:?} for address {address:?}", code);
+        debug!(target:"rpc", "code : {:?} for address {address:?}", code);
         match code {
             Some(code) => Ok(format!("0x{}", hex::encode(code))),
             None => Ok(String::from("0x")),
@@ -619,7 +619,7 @@ impl MetachainRPCServer for MetachainRPCModule {
     }
 
     fn sign_transaction(&self, request: TransactionRequest) -> RpcResult<String> {
-        debug!(target:"rpc", "[sign_transaction] signing transaction: {:?}", request);
+        debug!(target:"rpc", "Signing transaction: {:?}", request);
 
         let from = match request.from {
             Some(from) => from,
@@ -632,7 +632,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 }
             }
         };
-        debug!(target:"rpc", "[send_transaction] from: {:?}", from);
+        debug!(target:"rpc", "[sign_transaction] from: {:?}", from);
 
         let chain_id = ain_cpp_imports::get_chain_id()
             .map_err(|e| Error::Custom(format!("ain_cpp_imports::get_chain_id error : {e:?}")))?;
@@ -703,7 +703,7 @@ impl MetachainRPCServer for MetachainRPCModule {
     }
 
     fn send_transaction(&self, request: TransactionRequest) -> RpcResult<String> {
-        debug!(target:"rpc", "[send_transaction] Sending transaction: {:?}", request);
+        debug!(target:"rpc", "Sending transaction: {:?}", request);
 
         let signed = self.sign_transaction(request)?;
 
@@ -714,7 +714,7 @@ impl MetachainRPCServer for MetachainRPCModule {
     }
 
     fn send_raw_transaction(&self, tx: &str) -> RpcResult<String> {
-        debug!(target:"rpc", "[send_raw_transaction] Sending raw transaction: {:?}", tx);
+        debug!(target:"rpc", "Sending raw transaction: {:?}", tx);
         let raw_tx = tx.strip_prefix("0x").unwrap_or(tx);
         let hex =
             hex::decode(raw_tx).map_err(|e| Error::Custom(format!("Eror decoding TX {e:?}")))?;
@@ -794,7 +794,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         call: CallRequest,
         block_number: Option<BlockNumber>,
     ) -> RpcResult<U256> {
-        debug!(target:"rpc",  "[RPC] Estimate gas call input {:#?}", call);
+        debug!(target:"rpc",  "Estimate gas, input {:#?}", call);
         let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
@@ -850,7 +850,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         .map_err(to_custom_err)?;
 
         if hi > allowance {
-            debug!("gas estimation capped by limited funds. original: {:#?}, balance: {:#?}, feecap: {:#?}, fundable: {:#?}", hi, balance, fee_cap, allowance);
+            debug!("[estimate_gas] gas estimation capped by limited funds. original: {:#?}, balance: {:#?}, feecap: {:#?}, fundable: {:#?}", hi, balance, fee_cap, allowance);
             hi = allowance;
         }
         let cap = hi;
@@ -906,7 +906,7 @@ impl MetachainRPCServer for MetachainRPCModule {
             }
         }
 
-        debug!(target:"rpc",  "estimateGas: {:#?} at block {:#x}", hi, block_number);
+        debug!(target:"rpc",  "[estimate_gas] estimated gas: {:#?} at block {:#x}", hi, block_number);
         Ok(U256::from(hi))
     }
 
@@ -987,7 +987,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 let starting_block = self.handler.block.get_starting_block_number();
 
                 let highest_block = current_block + (highest_native_block - current_native_height); // safe since current height cannot be higher than seen height
-                debug!("Highest native: {highest_native_block}\nCurrent native: {current_native_height}\nCurrent ETH: {current_block}\nHighest ETH: {highest_block}");
+                debug!(target:"rpc", "Highest native: {highest_native_block}\nCurrent native: {current_native_height}\nCurrent ETH: {current_block}\nHighest ETH: {highest_block}");
 
                 Ok(SyncState::Syncing(SyncInfo {
                     starting_block,
@@ -1189,7 +1189,7 @@ fn sign(
     address: H160,
     message: TransactionMessage,
 ) -> Result<TransactionV2, Box<dyn std::error::Error>> {
-    debug!("sign address {:#x}", address);
+    debug!(target:"rpc", "sign address {:#x}", address);
     let key = format!("{address:?}");
     let priv_key = get_eth_priv_key(key).unwrap();
     let secret_key = SecretKey::parse(&priv_key).unwrap();

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -318,7 +318,7 @@ impl MetachainRPCModule {
 impl MetachainRPCServer for MetachainRPCModule {
     fn call(&self, call: CallRequest, block_number: Option<BlockNumber>) -> RpcResult<Bytes> {
         debug!(target:"rpc",  "Call, input {:#?}", call);
-        let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
+        let caller = call.from.unwrap_or_default();
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
 
@@ -795,7 +795,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         block_number: Option<BlockNumber>,
     ) -> RpcResult<U256> {
         debug!(target:"rpc",  "Estimate gas, input {:#?}", call);
-        let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
+        let caller = call.from.unwrap_or_default();
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
 

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -794,7 +794,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         call: CallRequest,
         block_number: Option<BlockNumber>,
     ) -> RpcResult<U256> {
-        debug!(target:"rpc",  "[RPC] Call input {:#?}", call);
+        debug!(target:"rpc",  "[RPC] Estimate gas call input {:#?}", call);
         let caller = call.from.ok_or(RPCError::NoSenderAddress)?;
         let byte_data = call.get_data()?;
         let data = byte_data.0.as_slice();
@@ -883,7 +883,8 @@ impl MetachainRPCServer for MetachainRPCModule {
         };
 
         while lo + 1 < hi {
-            let mid = hi.checked_add(lo).ok_or(RPCError::ValueOverflow)?;
+            let sum = hi.checked_add(lo).ok_or(RPCError::ValueOverflow)?;
+            let mid = sum.checked_div(2u64).ok_or(RPCError::ValueOverflow)?;
 
             let (failed, ..) = executable(mid)?;
             if failed {

--- a/lib/ain-grpc/src/rpc/mod.rs
+++ b/lib/ain-grpc/src/rpc/mod.rs
@@ -2,7 +2,3 @@ pub mod debug;
 pub mod eth;
 pub mod net;
 pub mod web3;
-
-pub fn to_jsonrpsee_custom_error<T: ToString>(e: T) -> jsonrpsee::core::Error {
-    jsonrpsee::core::Error::Custom(e.to_string())
-}

--- a/lib/ain-grpc/src/rpc/net.rs
+++ b/lib/ain-grpc/src/rpc/net.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use ain_evm::evm::EVMServices;
-use jsonrpsee::{
-    core::RpcResult,
-    proc_macros::rpc,
-};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use crate::errors::RPCError;
 

--- a/lib/ain-grpc/src/rpc/net.rs
+++ b/lib/ain-grpc/src/rpc/net.rs
@@ -6,6 +6,8 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 
+use crate::errors::RPCError;
+
 #[rpc(server, client, namespace = "net")]
 pub trait MetachainNetRPC {
     /// Returns the current network ID as a string.
@@ -30,8 +32,7 @@ impl MetachainNetRPCModule {
 impl MetachainNetRPCServer for MetachainNetRPCModule {
     fn net_version(&self) -> RpcResult<String> {
         let chain_id = ain_cpp_imports::get_chain_id()
-            .map_err(|e| Error::Custom(format!("ain_cpp_imports::get_chain_id error : {e:?}")))?;
-
+            .map_err(RPCError::Error)?;
         Ok(format!("{chain_id}"))
     }
 

--- a/lib/ain-grpc/src/rpc/net.rs
+++ b/lib/ain-grpc/src/rpc/net.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ain_evm::evm::EVMServices;
 use jsonrpsee::{
-    core::{Error, RpcResult},
+    core::RpcResult,
     proc_macros::rpc,
 };
 

--- a/lib/ain-grpc/src/rpc/net.rs
+++ b/lib/ain-grpc/src/rpc/net.rs
@@ -31,8 +31,7 @@ impl MetachainNetRPCModule {
 
 impl MetachainNetRPCServer for MetachainNetRPCModule {
     fn net_version(&self) -> RpcResult<String> {
-        let chain_id = ain_cpp_imports::get_chain_id()
-            .map_err(RPCError::Error)?;
+        let chain_id = ain_cpp_imports::get_chain_id().map_err(RPCError::Error)?;
         Ok(format!("{chain_id}"))
     }
 

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -234,6 +234,7 @@ class EVMTest(DefiTestFramework):
                     self.evm_key_pair.address
                 ),
                 "gasPrice": 10_000_000_000,
+                "gas": 100_000,
             }
         )
         signed = self.node.w3.eth.account.sign_transaction(
@@ -303,6 +304,7 @@ class EVMTest(DefiTestFramework):
                 ),
                 "maxFeePerGas": 10_000_000_000,
                 "maxPriorityFeePerGas": 1_500_000_000,
+                "gas": 1_000_000,
             }
         )
         signed = self.node.w3.eth.account.sign_transaction(
@@ -337,6 +339,7 @@ class EVMTest(DefiTestFramework):
                 ),
                 "maxFeePerGas": 10_000_000_000,
                 "maxPriorityFeePerGas": 1_500_000_000,
+                "gas": 1_000_000,
             }
         )
         # to check the init code is larger than 49152
@@ -413,6 +416,7 @@ class EVMTest(DefiTestFramework):
                 "from": self.evm_key_pair.address,
                 "data": "0xffffffffffffffff",
                 "value": self.node.w3.to_hex(self.node.w3.to_wei("1", "ether")),
+                "gas": 100_000,
             }
         )
         self.node.generate(1)

--- a/test/functional/feature_evm_logs.py
+++ b/test/functional/feature_evm_logs.py
@@ -114,6 +114,7 @@ class EVMTestLogs(DefiTestFramework):
         tx = self.contract.functions.store(10).build_transaction(
             {
                 "chainId": node.w3.eth.chain_id,
+                "from": self.evm_key_pair.address,
                 "nonce": node.w3.eth.get_transaction_count(self.evm_key_pair.address),
                 "gasPrice": 10_000_000_000,
             }

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -107,7 +107,7 @@ class EVMRolllbackTest(DefiTestFramework):
         self.nodes[0].invalidateblock(nextblockHash)
         assert_raises_rpc_error(
             -32001,
-            "Custom error: block not found",
+            "Custom error: header not found",
             self.nodes[0].eth_getBlockByNumber,
             nextBlockNum,
         )

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -107,7 +107,7 @@ class EVMRolllbackTest(DefiTestFramework):
         self.nodes[0].invalidateblock(nextblockHash)
         assert_raises_rpc_error(
             -32001,
-            "Custom error: header not found",
+            "Custom error: block not found",
             self.nodes[0].eth_getBlockByNumber,
             nextBlockNum,
         )

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -177,9 +177,7 @@ class EVMTest(DefiTestFramework):
         assert_equal(balance, int_to_eth_u256(150))
 
         # Test querying previous block
-        balance = self.nodes[0].eth_getBalance(
-            self.ethAddress, blockNumber
-        )
+        balance = self.nodes[0].eth_getBalance(self.ethAddress, blockNumber)
         assert_equal(balance, int_to_eth_u256(100))
 
     def test_block(self):
@@ -306,7 +304,7 @@ class EVMTest(DefiTestFramework):
 
         self.test_accounts()
 
-        self.test_address_state() # TODO test smart contract
+        self.test_address_state()  # TODO test smart contract
 
         self.test_block()
 

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -88,8 +88,27 @@ class EVMTest(DefiTestFramework):
             }
         )
         self.nodes[0].generate(2)
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "dst": {
+                        "address": self.ethAddress,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        self.start_height = self.nodes[0].getblockcount()
+        self.eth_start_height = int(self.nodes[0].eth_blockNumber(), 16)
+        balance = self.nodes[0].eth_getBalance(self.ethAddress)
+        assert_equal(balance, int_to_eth_u256(100))
 
     def test_node_params(self):
+        self.rollback_to(self.start_height)
+
         is_miningA = self.nodes[0].eth_mining()
         assert_equal(is_miningA, False)
 
@@ -103,6 +122,8 @@ class EVMTest(DefiTestFramework):
         assert_equal(chainid, "0x46d")
 
     def test_gas(self):
+        self.rollback_to(self.start_height)
+
         estimate_gas = self.nodes[0].eth_estimateGas(
             {
                 "from": self.ethAddress,
@@ -116,10 +137,14 @@ class EVMTest(DefiTestFramework):
         assert_equal(gas_price, "0x2540be400")  # 10_000_000_000
 
     def test_accounts(self):
+        self.rollback_to(self.start_height)
+
         eth_accounts = self.nodes[0].eth_accounts()
         assert_equal(eth_accounts.sort(), [self.ethAddress, self.toAddress].sort())
 
-    def test_address_state(self, address):
+    def test_address_state(self):
+        self.rollback_to(self.start_height)
+
         assert_raises_rpc_error(
             -32602,
             "invalid length 7, expected a (both 0x-prefixed or not) hex string or byte array containing 20 bytes at line 1 column 9",
@@ -127,14 +152,13 @@ class EVMTest(DefiTestFramework):
             "test123",
         )
 
-        balance = self.nodes[0].eth_getBalance(address)
+        balance = self.nodes[0].eth_getBalance(self.ethAddress)
         assert_equal(balance, int_to_eth_u256(100))
 
-        code = self.nodes[0].eth_getCode(address)
+        code = self.nodes[0].eth_getCode(self.ethAddress)
         assert_equal(code, "0x")
 
         blockNumber = self.nodes[0].eth_blockNumber()
-
         self.nodes[0].transferdomain(
             [
                 {
@@ -149,17 +173,20 @@ class EVMTest(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
-        balance = self.nodes[0].eth_getBalance(address, "latest")
+        balance = self.nodes[0].eth_getBalance(self.ethAddress, "latest")
         assert_equal(balance, int_to_eth_u256(150))
 
+        # Test querying previous block
         balance = self.nodes[0].eth_getBalance(
-            address, blockNumber
-        )  # Test querying previous block
+            self.ethAddress, blockNumber
+        )
         assert_equal(balance, int_to_eth_u256(100))
 
     def test_block(self):
+        self.rollback_to(self.start_height)
+
         latest_block = self.nodes[0].eth_getBlockByNumber("latest", False)
-        assert_equal(latest_block["number"], "0x2")
+        assert_equal(latest_block["number"], hex(self.eth_start_height))
 
         # Test full transaction block
         self.nodes[0].evmtx(self.ethAddress, 0, 21, 21000, self.toAddress, 1)
@@ -180,14 +207,14 @@ class EVMTest(DefiTestFramework):
         assert_equal(res["results"]["to"].lower(), self.toAddress)
 
         latest_block = self.nodes[0].eth_getBlockByNumber("latest", False)
-        assert_equal(latest_block["number"], "0x3")
+        assert_equal(latest_block["number"], hex(self.eth_start_height + 1))
         assert_equal(
             latest_block["transactions"][0],
             "0x8c99e9f053e033078e33c2756221f38fd529b914165090a615f27961de687497",
         )
 
         latest_full_block = self.nodes[0].eth_getBlockByNumber("latest", True)
-        assert_equal(latest_full_block["number"], "0x3")
+        assert_equal(latest_full_block["number"], hex(self.eth_start_height + 1))
         assert_equal(
             latest_full_block["transactions"][0]["blockHash"], latest_full_block["hash"]
         )
@@ -279,23 +306,10 @@ class EVMTest(DefiTestFramework):
 
         self.test_accounts()
 
-        self.nodes[0].transferdomain(
-            [
-                {
-                    "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
-                    "dst": {
-                        "address": self.ethAddress,
-                        "amount": "100@DFI",
-                        "domain": 3,
-                    },
-                }
-            ]
-        )
-        self.nodes[0].generate(1)
-
-        self.test_address_state(self.ethAddress)  # TODO test smart contract
+        self.test_address_state() # TODO test smart contract
 
         self.test_block()
+
         self.test_web3_client_version()
 
 

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -103,8 +103,6 @@ class EVMTest(DefiTestFramework):
         self.nodes[0].generate(1)
         self.start_height = self.nodes[0].getblockcount()
         self.eth_start_height = int(self.nodes[0].eth_blockNumber(), 16)
-        balance = self.nodes[0].eth_getBalance(self.ethAddress)
-        assert_equal(balance, int_to_eth_u256(100))
 
     def test_node_params(self):
         self.rollback_to(self.start_height)

--- a/test/functional/feature_evm_rpc_filters.py
+++ b/test/functional/feature_evm_rpc_filters.py
@@ -197,7 +197,7 @@ class EVMTest(DefiTestFramework):
     def fail_new_filter_unavailable_block(self):
         assert_raises_rpc_error(
             -32001,
-            "Custom error: block not found",
+            "Custom error: header not found",
             self.nodes[0].eth_newFilter,
             {"fromBlock": "0x1", "toBlock": "0x999999999"},
         )

--- a/test/functional/feature_evm_rpc_filters.py
+++ b/test/functional/feature_evm_rpc_filters.py
@@ -189,7 +189,7 @@ class EVMTest(DefiTestFramework):
     def fail_new_filter_to_greater_than_from(self):
         assert_raises_rpc_error(
             -32001,
-            "Custom error: fromBlock (0x1) > toBlock (0x0)",
+            "Custom error: fromBlock is greater than toBlock",
             self.nodes[0].eth_newFilter,
             {"fromBlock": "0x1", "toBlock": "0x0"},
         )
@@ -197,7 +197,7 @@ class EVMTest(DefiTestFramework):
     def fail_new_filter_unavailable_block(self):
         assert_raises_rpc_error(
             -32001,
-            "Custom error: header not found",
+            "Custom error: block not found",
             self.nodes[0].eth_newFilter,
             {"fromBlock": "0x1", "toBlock": "0x999999999"},
         )


### PR DESCRIPTION
## Summary

- This PR fixes all eth RPC call request contexts to align with geth interface.
- Fix estimate_gas pipeline to execute the requested code and determining the highest and lowest possible gas limits to binary search between them. (ref: https://github.com/ethereum/go-ethereum/blob/master/accounts/abi/bind/backends/simulated.go#L537-L639)
- estimate_gas pipeline now aligns with geth - if the tx fails state execution, estimate_gas RPC will throw an error on the specified call context.
- Fix processing data and input fields inside all eth calls - RPCs should not allow both data and input fields to be set, and data field or input field should be used to set the transaction data. (ref: https://github.com/fjl/go-ethereum/commit/c20147392245250de1efb2122979b69ae3a5bff5)
- Fix gas price calculation inside all eth calls - RPCs should not allow if gasPrice and (maxFeePerGas or maxPriorityFeePerGas) fields are both set. Correct effective gas price calculation is now handled inside the call context.
- Cleanup eth call in core services - EthCallArgs should contain only the caller's gas price to be passed into executor to be executed on the VM.
- Refactor and clean up all eth, debug, net RPCs for better and proper return of error messages

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
