### PR TITLE
Token ID must be numeric

### DIFF
--- a/src/dfi/errors.h
+++ b/src/dfi/errors.h
@@ -260,6 +260,8 @@ public:
 
     static Res GovVarValidateExcessAmount() { return Res::Err("Percentage exceeds 100%%"); }
 
+    static Res GovVarTokenAsString() { return Res::Err("Token should be defined as numeric ID"); }
+
     static Res GovVarValidateNegativeAmount() { return Res::Err("Amount must be a positive value"); }
 
     static Res GovVarValidateCurrencyPair() { return Res::Err("Fixed interval price currency pair must be set first"); }

--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -1145,11 +1145,15 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
         typeKey = ParamIDs::TokenID;
         if (const auto keyValue = VerifyInt32(keys[3])) {
             attrV0 = CDataStructureV0{type, typeId, static_cast<uint32_t>(*keyValue)};
+        } else {
+            return DeFiErrors::GovVarTokenAsString();
         }
     } else if (type == AttributeTypes::Oracles) {
         typeKey = OracleIDs::Splits;
         if (const auto keyValue = VerifyPositiveInt32(keys[3])) {
             attrV0 = CDataStructureV0{type, typeId, static_cast<uint32_t>(*keyValue)};
+        } else {
+            return DeFiErrors::GovVarTokenAsString();
         }
     } else {
         auto ikey = allowedKeys().find(type);

--- a/test/functional/feature_setgov.py
+++ b/test/functional/feature_setgov.py
@@ -1428,6 +1428,12 @@ class GovsetTest(DefiTestFramework):
             {"ATTRIBUTES": {"v0/oracles/splits/4000": "4/2"}},
         )
         assert_raises_rpc_error(
+            -5,
+            "Token should be defined as numeric ID",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/oracles/splits/abc": "4/2"}},
+        )
+        assert_raises_rpc_error(
             -32600,
             "ATTRIBUTES: Price feed DUFF/USD does not belong to any oracle",
             self.nodes[0].setgov,
@@ -1558,6 +1564,12 @@ class GovsetTest(DefiTestFramework):
             "Fixed interval price currency pair must be set first",
             self.nodes[0].setgov,
             {"ATTRIBUTES": {"v0/token/5/loan_minting_interest": "1"}},
+        )
+        assert_raises_rpc_error(
+            -5,
+            "Token should be defined as numeric ID",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/locks/token/abc": "true"}},
         )
 
         # Set locks


### PR DESCRIPTION
## Summary

- Prevent Gov var TXs being created with incorrect token IDs for splits and locks. This resulted in a TX being added to the chain which had no impact on Gov vars. The key would be set as 0, 0, 0, 0, when parsing the TX the Export function would skip over this key.

## RPCs

- setgov RPC will now fail on `v0/locks/token/` and `v0/oracles/splits/` if the final part of the key is not numerical.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
