### PR TITLE
EVM: Add guard against adding evm txs into genesis block

### DIFF
--- a/lib/ain-evm/src/blocktemplate.rs
+++ b/lib/ain-evm/src/blocktemplate.rs
@@ -142,6 +142,10 @@ impl BlockTemplate {
     pub fn get_block_number(&self) -> U256 {
         self.vicinity.block_number
     }
+
+    pub fn is_genesis_block(&self) -> bool {
+        self.get_block_number() == U256::zero()
+    }
 }
 
 #[derive(Debug)]

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -343,7 +343,6 @@ impl EVMServices {
                 (receipt, Some(address)),
                 logs_bloom,
             ));
-            executor.increase_tx_count();
 
             // Deploy DFIIntrinsics contract
             let DeployContractInfo {
@@ -365,7 +364,6 @@ impl EVMServices {
                 (receipt, Some(address)),
                 logs_bloom,
             ));
-            executor.increase_tx_count();
 
             // Deploy transfer domain contract on the first block
             let DeployContractInfo {
@@ -387,7 +385,6 @@ impl EVMServices {
                 (receipt, Some(address)),
                 logs_bloom,
             ));
-            executor.increase_tx_count();
 
             // Deploy transfer domain proxy
             let DeployContractInfo {
@@ -409,7 +406,6 @@ impl EVMServices {
                 (receipt, Some(address)),
                 logs_bloom,
             ));
-            executor.increase_tx_count();
 
             // Deploy DST20 implementation contract
             let DeployContractInfo {
@@ -429,7 +425,6 @@ impl EVMServices {
                 (receipt, Some(address)),
                 logs_bloom,
             ));
-            executor.increase_tx_count();
 
             // Deploy DST20 migration TX
             let migration_txs = get_dst20_migration_txs(mnview_ptr)?;
@@ -441,7 +436,6 @@ impl EVMServices {
                     apply_result.receipt,
                     logs_bloom,
                 ));
-                executor.increase_tx_count();
             }
         } else {
             let DeployContractInfo {
@@ -449,8 +443,8 @@ impl EVMServices {
             } = dfi_intrinsics_v1_deploy_info(template.dvm_block, template.vicinity.block_number)?;
 
             executor.update_storage(address, storage)?;
-            executor.increase_tx_count();
         }
+        template.backend.increase_tx_count();
         Ok(())
     }
 }

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -90,6 +90,10 @@ impl<'backend> AinExecutor<'backend> {
     pub fn get_nonce(&self, address: &H160) -> U256 {
         self.backend.get_nonce(address)
     }
+
+    pub fn increase_tx_count(&mut self) {
+        self.backend.increase_tx_count()
+    }
 }
 
 impl<'backend> AinExecutor<'backend> {

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -90,10 +90,6 @@ impl<'backend> AinExecutor<'backend> {
     pub fn get_nonce(&self, address: &H160) -> U256 {
         self.backend.get_nonce(address)
     }
-
-    pub fn increase_tx_count(&mut self) {
-        self.backend.increase_tx_count()
-    }
 }
 
 impl<'backend> AinExecutor<'backend> {

--- a/test/functional/feature_evm_genesis.py
+++ b/test/functional/feature_evm_genesis.py
@@ -9,6 +9,8 @@ import os
 from test_framework.test_framework import DefiTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
+    int_to_eth_u256,
 )
 
 TESTSDIR = os.path.dirname(os.path.realpath(__file__))
@@ -16,10 +18,111 @@ TESTSDIR = os.path.dirname(os.path.realpath(__file__))
 
 class EVMTest(DefiTestFramework):
     def set_test_params(self):
-        genesis = os.path.join(TESTSDIR, "data/evm-genesis.json")
-
         self.num_nodes = 1
         self.setup_clean_chain = True
+        self.extra_args = [
+            [
+                "-dummypos=0",
+                "-txnotokens=0",
+                "-amkheight=50",
+                "-bayfrontheight=51",
+                "-dakotaheight=51",
+                "-eunosheight=80",
+                "-fortcanningheight=82",
+                "-fortcanninghillheight=84",
+                "-fortcanningroadheight=86",
+                "-fortcanningcrunchheight=88",
+                "-fortcanningspringheight=90",
+                "-fortcanninggreatworldheight=94",
+                "-fortcanningepilogueheight=96",
+                "-grandcentralheight=101",
+                "-metachainheight=105",
+                "-subsidytest=1",
+                "-txindex=1",
+            ],
+        ]
+
+    def setup(self):
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+        self.ethAddress = "0x9b8a4af42140d8a4c153a822f02571a1dd037e89"
+        self.toAddress = "0x6c34cbb9219d8caa428835d2073e8ec88ba0a110"
+        self.ethPrivKey = (
+            "af990cc3ba17e776f7f57fcc59942a82846d75833fa17d2ba59ce6858d886e23"
+        )
+        self.nodes[0].importprivkey(self.ethPrivKey)  # ethAddress
+
+        # Generate chain
+        self.nodes[0].generate(101)
+
+        assert_raises_rpc_error(
+            -32600,
+            "called before Metachain height",
+            self.nodes[0].evmtx,
+            self.ethAddress,
+            0,
+            21,
+            21000,
+            self.toAddress,
+            0.1,
+        )
+
+        # Move to fork height
+        self.nodes[0].generate(4)
+
+        self.nodes[0].getbalance()
+        self.nodes[0].utxostoaccount({self.address: "201@DFI"})
+        self.nodes[0].setgov(
+            {
+                "ATTRIBUTES": {
+                    "v0/params/feature/evm": "true",
+                    "v0/params/feature/transferdomain": "true",
+                    "v0/transferdomain/dvm-evm/enabled": "true",
+                    "v0/transferdomain/dvm-evm/dat-enabled": "true",
+                    "v0/transferdomain/evm-dvm/dat-enabled": "true",
+                    "v0/transferdomain/dvm-evm/src-formats": ["p2pkh", "bech32"],
+                    "v0/transferdomain/dvm-evm/dest-formats": ["erc55"],
+                    "v0/transferdomain/evm-dvm/src-formats": ["erc55"],
+                    "v0/transferdomain/evm-dvm/auth-formats": ["bech32-erc55"],
+                    "v0/transferdomain/evm-dvm/dest-formats": ["p2pkh", "bech32"],
+                }
+            }
+        )
+        self.nodes[0].generate(1)
+
+    def tx_should_not_go_into_genesis_block(self):
+        # Send transferdomain tx on genesis block
+        hash = self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "dst": {
+                        "address": self.ethAddress,
+                        "amount": "100@DFI",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        # Transferdomain tx should not be minted after genesis block
+        block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)
+        assert_equal(len(block_info["tx"]), 1)
+        balance = self.nodes[0].eth_getBalance(self.ethAddress)
+        assert_equal(balance, int_to_eth_u256(0))
+        assert_equal(self.nodes[0].getrawmempool()[0], hash)
+
+        # Transferdomain tx should be minted after genesis block
+        self.nodes[0].generate(1)
+        block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 4)
+        assert_equal(len(block_info["tx"]), 2)
+        tx_info = block_info["tx"][1]
+        assert_equal(tx_info["vm"]["txtype"], "TransferDomain")
+        assert_equal(tx_info["txid"], hash)
+        balance = self.nodes[0].eth_getBalance(self.ethAddress)
+        assert_equal(balance, int_to_eth_u256(100))
+
+    def test_start_state_from_json(self):
+        genesis = os.path.join(TESTSDIR, "data/evm-genesis.json")
         self.extra_args = [
             [
                 "-ethstartstate={}".format(genesis),
@@ -41,8 +144,8 @@ class EVMTest(DefiTestFramework):
                 "-txindex=1",
             ],
         ]
-
-    def run_test(self):
+        self.stop_nodes()
+        self.start_nodes(self.extra_args)
         self.nodes[0].generate(111)
 
         ethblock0 = self.nodes[0].eth_getBlockByNumber(0)
@@ -62,6 +165,13 @@ class EVMTest(DefiTestFramework):
             "a94f5374fce5edbc8e2a8697c15331677e6ebf0b"
         )
         assert_equal(balance, "0x9184e72a000")
+
+    def run_test(self):
+        self.setup()
+
+        self.tx_should_not_go_into_genesis_block()
+
+        self.test_start_state_from_json()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Guards against adding EVM txs into genesis block
- Clean up genesis block contract deployment for consistency in indexes in overlay changeset vector and minted transactions inside blocktemplate vector


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
