### PR TITLE
EVM: Prevent overriding overlay contract code

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -83,7 +83,7 @@ impl Overlay {
 
         let data = OverlayData {
             account,
-            code,
+            code: code.or(self.get_code(&address)),
             storage,
         };
         self.state.insert(address, data.clone());


### PR DESCRIPTION
## Summary

- Check if a code has been deployed on a previous changeset and keep it set if present.
- Prevent TD state injection from overriding deployed contract code in a same block