### PR TITLE
EVM: Clean up backend vicinity

### DIFF
--- a/lib/ain-cpp-imports/src/bridge.rs
+++ b/lib/ain-cpp-imports/src/bridge.rs
@@ -50,7 +50,7 @@ pub mod ffi {
         fn getNumCores() -> i32;
         fn getCORSAllowedOrigin() -> String;
         fn getNumConnections() -> i32;
-        fn isDebugEnabled() -> bool;
-        fn isDebugTraceEnabled() -> bool;
+        fn isEthDebugRPCEnabled() -> bool;
+        fn isEthDebugTraceRPCEnabled() -> bool;
     }
 }

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -100,10 +100,10 @@ mod ffi {
     pub fn getNumConnections() -> i32 {
         unimplemented!("{}", UNIMPL_MSG)
     }
-    pub fn isDebugEnabled() -> bool {
+    pub fn isEthDebugRPCEnabled() -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
-    pub fn isDebugTraceEnabled() -> bool {
+    pub fn isEthDebugTraceRPCEnabled() -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
 }
@@ -217,12 +217,12 @@ pub fn get_num_connections() -> i32 {
     ffi::getNumConnections()
 }
 
-pub fn is_debug_enabled() -> bool {
-    ffi::isDebugEnabled()
+pub fn is_eth_debug_rpc_enabled() -> bool {
+    ffi::isEthDebugRPCEnabled()
 }
 
-pub fn is_debug_trace_enabled() -> bool {
-    ffi::isDebugTraceEnabled()
+pub fn is_eth_debug_trace_rpc_enabled() -> bool {
+    ffi::isEthDebugTraceRPCEnabled()
 }
 
 #[cfg(test)]

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -252,51 +252,25 @@ impl EVMCoreService {
             access_list,
             block_number,
         } = arguments;
+        debug!("[call] caller: {:?}", caller);
 
-        let (
-            state_root,
-            block_number,
-            beneficiary,
-            base_fee,
-            timestamp,
-            block_difficulty,
-            block_gas_limit,
-        ) = self
+        let block_header = self
             .storage
             .get_block_by_number(&block_number)?
-            .map(|block| {
-                (
-                    block.header.state_root,
-                    block.header.number,
-                    block.header.beneficiary,
-                    block.header.base_fee,
-                    block.header.timestamp,
-                    block.header.difficulty,
-                    block.header.gas_limit,
-                )
-            })
+            .map(|block| block.header)
             .ok_or(format_err!(
                 "[call] Block number {:x?} not found",
                 block_number
             ))?;
-
+        let state_root = block_header.state_root;
         debug!(
             "Calling EVM at block number : {:#x}, state_root : {:#x}",
             block_number, state_root
         );
-        debug!("[call] caller: {:?}", caller);
-        let vicinity = Vicinity {
-            gas_price,
-            origin: caller,
-            beneficiary,
-            block_number,
-            timestamp: U256::from(timestamp),
-            total_gas_used: U256::zero(),
-            block_difficulty,
-            block_gas_limit,
-            block_base_fee_per_gas: base_fee,
-            block_randomness: None,
-        };
+
+        let mut vicinity = Vicinity::from(block_header);
+        vicinity.gas_price = gas_price;
+        vicinity.origin = caller;
         debug!("[call] vicinity: {:?}", vicinity);
 
         let mut backend = EVMBackend::from_root(
@@ -765,63 +739,38 @@ impl EVMCoreService {
     #[allow(clippy::too_many_arguments)]
     pub fn trace_transaction(
         &self,
-        caller: H160,
-        to: H160,
-        value: U256,
-        data: &[u8],
-        gas_limit: u64,
-        access_list: AccessList,
+        tx: &SignedTx,
         block_number: U256,
     ) -> Result<(Vec<ExecutionStep>, bool, Vec<u8>, u64)> {
-        let (
-            state_root,
-            block_number,
-            beneficiary,
-            base_fee,
-            timestamp,
-            block_difficulty,
-            block_gas_limit,
-        ) = self
+        let caller = tx.sender;
+        let to = tx.to().ok_or(format_err!(
+            "debug_traceTransaction does not support contract creation transactions",
+        ))?;
+        let value = tx.value();
+        let data = tx.data();
+        let gas_limit = u64::try_from(tx.gas_limit())?;
+        let access_list = tx.access_list();
+
+        let block_header = self
             .storage
             .get_block_by_number(&block_number)?
-            .ok_or_else(|| format_err!("Cannot find block"))
-            .map(|block| {
-                (
-                    block.header.state_root,
-                    block.header.number,
-                    block.header.beneficiary,
-                    block.header.base_fee,
-                    block.header.timestamp,
-                    block.header.difficulty,
-                    block.header.gas_limit,
-                )
-            })?;
-
+            .ok_or_else(|| format_err!("Block not found"))
+            .map(|block| block.header)?;
+        let state_root = block_header.state_root;
         debug!(
             "Calling EVM at block number : {:#x}, state_root : {:#x}",
             block_number, state_root
         );
 
-        let vicinity = Vicinity {
-            gas_price: base_fee,
-            origin: caller,
-            beneficiary,
-            block_number,
-            timestamp: U256::from(timestamp),
-            total_gas_used: U256::zero(),
-            block_difficulty,
-            block_gas_limit,
-            block_base_fee_per_gas: base_fee,
-            block_randomness: None,
-        };
-
-        let backend = EVMBackend::from_root(
+        let vicinity = Vicinity::from(block_header);
+        let mut backend = EVMBackend::from_root(
             state_root,
             Arc::clone(&self.trie_store),
             Arc::clone(&self.storage),
             vicinity,
         )
         .map_err(|e| format_err!("Could not restore backend {}", e))?;
+        backend.update_vicinity_from_tx(tx)?;
 
         static CONFIG: Config = Config::shanghai();
         let metadata = StackSubstateMetadata::new(gas_limit, &CONFIG);
@@ -835,7 +784,6 @@ impl EVMCoreService {
         let mut gas_listener = crate::eventlistener::GasListener::new();
 
         let al = access_list.clone();
-
         gas_using(&mut gas_listener, move || {
             let access_list = al
                 .into_iter()
@@ -952,51 +900,21 @@ impl EVMCoreService {
     }
 
     pub fn get_latest_block_backend(&self) -> Result<EVMBackend> {
-        let (
-            state_root,
-            block_number,
-            beneficiary,
-            base_fee,
-            timestamp,
-            block_difficulty,
-            block_gas_limit,
-        ) = self
+        let block_header = self
             .storage
             .get_latest_block()?
-            .map(|block| {
-                (
-                    block.header.state_root,
-                    block.header.number,
-                    block.header.beneficiary,
-                    block.header.base_fee,
-                    block.header.timestamp,
-                    block.header.difficulty,
-                    block.header.gas_limit,
-                )
-            })
+            .map(|block| block.header)
             .ok_or(format_err!(
                 "[get_latest_block_backend] Latest block not found",
             ))?;
-
+        let state_root = block_header.state_root;
         trace!(
             "[get_latest_block_backend] At block number : {:#x}, state_root : {:#x}",
-            block_number,
+            block_header.number,
             state_root,
         );
 
-        let vicinity = Vicinity {
-            gas_price: base_fee,
-            beneficiary,
-            block_number,
-            timestamp: U256::from(timestamp),
-            total_gas_used: U256::zero(),
-            block_difficulty,
-            block_gas_limit,
-            block_base_fee_per_gas: base_fee,
-            block_randomness: None,
-            ..Vicinity::default()
-        };
-
+        let vicinity = Vicinity::from(block_header);
         EVMBackend::from_root(
             state_root,
             Arc::clone(&self.trie_store),

--- a/lib/ain-evm/src/eventlistener.rs
+++ b/lib/ain-evm/src/eventlistener.rs
@@ -1,10 +1,11 @@
-use crate::core::ExecutionStep;
-use crate::opcode;
-use evm::gasometer::tracing::{Event as GasEvent, EventListener as GasEventListener};
-use evm_runtime::tracing::{Event as RuntimeEvent, EventListener as RuntimeEventListener};
-use evm_runtime::Opcode;
 use std::collections::VecDeque;
 
+use crate::{core::ExecutionStep, opcode};
+use evm::gasometer::tracing::{Event as GasEvent, EventListener as GasEventListener};
+use evm_runtime::{
+    tracing::{Event as RuntimeEvent, EventListener as RuntimeEventListener},
+    Opcode,
+};
 use log::debug;
 
 pub struct Listener {

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -147,7 +147,7 @@ impl<'backend> AinExecutor<'backend> {
         base_fee: U256,
         system_tx: bool,
     ) -> Result<(TxResponse, ReceiptV3)> {
-        self.backend.update_vicinity_from_tx(signed_tx);
+        self.backend.update_vicinity_from_tx(signed_tx)?;
         trace!(
             "[Executor] Executing EVM TX with vicinity : {:?}",
             self.backend.vicinity

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -1,10 +1,15 @@
 use anyhow::format_err;
 use std::sync::Arc;
 
-use ain_evm::storage::traits::{ReceiptStorage, TransactionStorage};
-use ain_evm::transaction::SignedTx;
 use ain_evm::{
-    core::EthCallArgs, evm::EVMServices, executor::TxResponse, storage::block_store::DumpArg,
+    core::EthCallArgs,
+    evm::EVMServices,
+    executor::TxResponse,
+    storage::{
+        block_store::DumpArg,
+        traits::{ReceiptStorage, TransactionStorage},
+    },
+    transaction::SignedTx,
 };
 use ethereum::Account;
 use ethereum_types::{H256, U256};
@@ -15,10 +20,10 @@ use jsonrpsee::{
 use log::debug;
 use rlp::{Decodable, Rlp};
 
-use crate::transaction::{TraceLogs, TraceTransactionResult};
 use crate::{
     call_request::CallRequest,
     errors::{to_custom_err, RPCError},
+    transaction::{TraceLogs, TraceTransactionResult},
 };
 
 #[derive(Serialize, Deserialize)]

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -72,7 +72,7 @@ impl MetachainDebugRPCModule {
     }
 
     fn is_enabled(&self) -> RpcResult<()> {
-        if !ain_cpp_imports::is_debug_enabled() {
+        if !ain_cpp_imports::is_eth_debug_rpc_enabled() {
             return Err(Error::Custom(
                 "debug_* RPCs have not been enabled".to_string(),
             ));
@@ -82,7 +82,7 @@ impl MetachainDebugRPCModule {
     }
 
     fn is_trace_enabled(&self) -> RpcResult<()> {
-        if !ain_cpp_imports::is_debug_trace_enabled() {
+        if !ain_cpp_imports::is_eth_debug_trace_rpc_enabled() {
             return Err(Error::Custom(
                 "debug_trace* RPCs have not been enabled".to_string(),
             ));

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -1,4 +1,3 @@
-use anyhow::format_err;
 use std::sync::Arc;
 
 use ain_evm::{
@@ -119,21 +118,8 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         let (logs, succeeded, return_data, gas_used) = self
             .handler
             .core
-            .trace_transaction(
-                signed_tx.sender,
-                signed_tx.to().ok_or_else(|| {
-                    format_err!(
-                        "debug_traceTransaction does not support contract creation transactions"
-                    )
-                })?,
-                signed_tx.value(),
-                signed_tx.data(),
-                signed_tx.gas_limit().as_u64(),
-                signed_tx.access_list(),
-                receipt.block_number,
-            )
+            .trace_transaction(&signed_tx, receipt.block_number)
             .map_err(|e| Error::Custom(format!("Error calling EVM : {e:?}")))?;
-
         let trace_logs = logs.iter().map(|x| TraceLogs::from(x.clone())).collect();
 
         Ok(TraceTransactionResult {

--- a/lib/ain-grpc/src/transaction.rs
+++ b/lib/ain-grpc/src/transaction.rs
@@ -1,5 +1,7 @@
-use ain_evm::core::ExecutionStep;
-use ain_evm::transaction::{SignedTx, TransactionError};
+use ain_evm::{
+    core::ExecutionStep,
+    transaction::{SignedTx, TransactionError},
+};
 use ethereum::{AccessListItem, BlockAny, EnvelopedEncodable, TransactionV2};
 use ethereum_types::{H256, U256};
 

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -301,10 +301,10 @@ int32_t getNumConnections() {
     return (int32_t)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
 }
 
-bool isDebugEnabled() {
+bool isEthDebugRPCEnabled() {
     return gArgs.GetBoolArg("-ethdebug", false);
 }
 
-bool isDebugTraceEnabled() {
+bool isEthDebugTraceRPCEnabled() {
     return gArgs.GetBoolArg("-ethdebugtrace", true);
 }

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -74,7 +74,7 @@ rust::string getClientVersion();
 int32_t getNumCores();
 rust::string getCORSAllowedOrigin();
 int32_t getNumConnections();
-bool isDebugEnabled();
-bool isDebugTraceEnabled();
+bool isEthDebugRPCEnabled();
+bool isEthDebugTraceRPCEnabled();
 
 #endif  // DEFI_FFI_FFIEXPORTS_H


### PR DESCRIPTION
## Summary

- Clean up RPCs when creating backend instances
- Resolves https://github.com/DeFiCh/ain/pull/2634
- Backend instance should propagate error if block query fails instead of returning a default
- Passing full block state into backend vicinity to ensure EVM state execution is correct
- Rename to eth_debug_rpc for ffi cpp exports

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
