### PR TITLE
Remove legacy EVM limit

### DIFF
--- a/src/dfi/consensus/xvm.cpp
+++ b/src/dfi/consensus/xvm.cpp
@@ -430,10 +430,6 @@ Res CXVMConsensus::operator()(const CEvmTxMessage &obj) const {
         return Res::Err("Cannot create tx, EVM is not enabled");
     }
 
-    if (obj.evmTx.size() > static_cast<size_t>(EVM_TX_SIZE)) {
-        return Res::Err("evm tx size too large");
-    }
-
     CrossBoundaryResult result;
     if (evmPreValidate) {
         evm_try_unsafe_validate_raw_tx_in_template(result, evmTemplate->GetTemplate(), HexStr(obj.evmTx));

--- a/src/dfi/evm.h
+++ b/src/dfi/evm.h
@@ -10,8 +10,6 @@
 #include <serialize.h>
 #include <uint256.h>
 
-constexpr const uint16_t EVM_TX_SIZE = 32768;
-
 // EIP-2718 transaction type: legacy - 0x0, EIP2930 - 0x1, EIP1559 - 0x2
 enum CEVMTxType {
     LegacyTransaction = 0,


### PR DESCRIPTION
## Summary

- Remove legacy EVM TX limit

### Notes

- Testnet and changi are currently running with rc that have this legacy limit.
- The options are: 
  1. Fork guard (this is not helpful for anyone, as higher limits can't be tested on testnet which defeats the purpose of the removal). 
  1. Launch mainnet with 32k limit, until next fork which is disruptive for projects that have higher requirements. 
  1. Find a middle path. 
  
- A possible mid-path: In order to avoid disruption:
  - Set `MAX_OP_RETURN_EVM_ACCEPT` to < 32k (~28k). 
  - This is the network config that superseded the legacy hard limit. This ensures rc1 and rc2 will continue to follow the network until a later point.   
  - Pull MAX_OP_RETURN_EVM_ACCEPT to higher values at a later point (likely after mainnet is live to ensure everyone is on stable) 
  
### Additional Info

- The new limit defaults are https://github.com/DeFiCh/ain/blob/ab5e1365e008d7e601bdf3c399015b8abe2e277b/src/script/standard.h#L32-L34. 
- Both the legacy and new limits are derived from analyzing the Ethereum mainnet. 
- Legacy hard limit of 32k was designed to be > 99% percentile on ETH mainnet. 
- New configurable limit of 64k was designed to be > 99.9x% percentile on ETH mainnet.   


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
