### PR TITLE
Fix CI sync runs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,8 +54,8 @@ jobs:
     - name: Setup dependencies
       run: ./make.sh ci-setup-deps
 
-    - name: Setup dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/tests-ethlibs.yaml
+++ b/.github/workflows/tests-ethlibs.yaml
@@ -31,8 +31,8 @@ jobs:
     - name: Setup dependencies
       run: ./make.sh ci-setup-deps
 
-    - name: Setup dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/tests-frontier.yml
+++ b/.github/workflows/tests-frontier.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Setup dependencies
       run: sudo ./make.sh ci-setup-deps
 
-    - name: Setup dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/tests-sync.yml
+++ b/.github/workflows/tests-sync.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       block_ranges:
-        description: 'Optionally restrict to specific block ranges. Should be
-          formatted as multiple start block, such as "350000 50000 750000".
-          Defaults to all block ranges'
+        description: 'Block ranges: Format: "<start-block-1> <start-block-2>" 
+          Eg: "350000 50000 750000".
+          Default: All available ranges when empty'
         required: false
       name:
-        description: 'Workflow run custom name'
+        description: 'Custom name for the workflow run'
         required: false
   pull_request:
     branches:
@@ -34,7 +34,7 @@ jobs:
       run: ./make.sh ci-export-vars
 
     - name: Setup dependencies
-      run: sudo ./make.sh ci-setup-deps
+      run: ./make.sh ci-setup-deps
 
     - name: Setup dependencies for target
       run: ./make.sh ci-setup-deps-target

--- a/.github/workflows/tests-sync.yml
+++ b/.github/workflows/tests-sync.yml
@@ -34,10 +34,10 @@ jobs:
       run: ./make.sh ci-export-vars
 
     - name: Setup dependencies
-      run: ./make.sh ci-setup-deps
+      run: sudo ./make.sh ci-setup-deps
 
-    - name: Setup dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,8 +41,8 @@ jobs:
     - name: Install dependencies
       run: ./make.sh ci-setup-deps
     
-    - name: Install dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:
@@ -71,9 +71,9 @@ jobs:
 
     - name: Setup dependencies
       run: ./make.sh ci-setup-deps
-
-    - name: Setup dependencies for target
-      run: ./make.sh ci-setup-deps-target
+    
+    - name: Setup dependencies for user
+      run: ./make.sh ci-setup-user-deps
 
     - uses: Swatinem/rust-cache@v2
       with:

--- a/contrib/dockerfiles/draft/aarch64-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/draft/aarch64-linux-gnu.dockerfile
@@ -13,7 +13,7 @@ COPY ./make.sh .
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN ./make.sh ci-setup-deps
-RUN ./make.sh ci-setup-deps-target
+RUN ./make.sh ci-setup-user-deps
 
 COPY . .
 RUN ./make.sh build-deps

--- a/contrib/dockerfiles/draft/arm-linux-gnueabihf.dockerfile
+++ b/contrib/dockerfiles/draft/arm-linux-gnueabihf.dockerfile
@@ -13,7 +13,7 @@ COPY ./make.sh .
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN ./make.sh ci-setup-deps
-RUN ./make.sh ci-setup-deps-target
+RUN ./make.sh ci-setup-user-deps
 
 COPY . .
 RUN ./make.sh build-deps

--- a/contrib/dockerfiles/noarch.dockerfile
+++ b/contrib/dockerfiles/noarch.dockerfile
@@ -15,7 +15,7 @@ COPY ./make.sh .
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN ./make.sh ci-setup-deps
-RUN ./make.sh ci-setup-deps-target
+RUN ./make.sh ci-setup-user-deps
 
 COPY . .
 RUN ./make.sh build-deps

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -13,7 +13,7 @@ COPY ./make.sh .
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN ./make.sh ci-setup-deps
-RUN ./make.sh ci-setup-deps-target
+RUN ./make.sh ci-setup-user-deps
 
 COPY . .
 RUN ./make.sh build-deps

--- a/make.sh
+++ b/make.sh
@@ -1122,7 +1122,7 @@ ci_setup_deps() {
     ci_setup_deps_target
 }
 
-_ci_setup_deps_target() {
+ci_setup_deps_target() {
     local target=${TARGET}
     case $target in
         # Nothing to do on host

--- a/make.sh
+++ b/make.sh
@@ -726,14 +726,6 @@ pkg_user_install_rust() {
     _fold_end
 }
 
-pkg_user_ensure_rust() {
-    if command -v cargo &> /dev/null; then
-        return
-    fi
-    pkg_user_install_rust
-    pkg_user_setup_rust
-}
-
 pkg_local_ensure_osx_sysroot() {
     local sdk_name="Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
     local pkg="${sdk_name}.tar.gz"

--- a/make.sh
+++ b/make.sh
@@ -719,11 +719,19 @@ pkg_install_llvm() {
     _fold_end
 }
 
-pkg_install_rust() {
+pkg_user_install_rust() {
     _fold_start "pkg-install-rust"
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         --default-toolchain="${RUST_DEFAULT_VERSION}" -y
     _fold_end
+}
+
+pkg_user_ensure_rust() {
+    if command -v cargo &> /dev/null; then
+        return
+    fi
+    pkg_user_install_rust
+    pkg_user_setup_rust
 }
 
 pkg_local_ensure_osx_sysroot() {
@@ -782,7 +790,7 @@ clean_pkg_local_py_deps() {
   _safe_rm_rf "${python_venv}"
 }
 
-pkg_setup_rust() {
+pkg_user_setup_rust() {
     local rust_target
     # shellcheck disable=SC2119
     rust_target=$(get_rust_triplet)
@@ -1111,7 +1119,7 @@ ci_setup_deps() {
     DEBIAN_FRONTEND=noninteractive pkg_install_deps
     DEBIAN_FRONTEND=noninteractive pkg_setup_locale
     DEBIAN_FRONTEND=noninteractive pkg_install_llvm
-    DEBIAN_FRONTEND=noninteractive pkg_install_rust
+    ci_setup_deps_target
 }
 
 _ci_setup_deps_target() {
@@ -1134,9 +1142,9 @@ _ci_setup_deps_target() {
     esac
 }
 
-ci_setup_deps_target() {
-    _ci_setup_deps_target
-    pkg_setup_rust
+ci_setup_user_deps() {
+    pkg_user_install_rust
+    pkg_user_setup_rust
 }
 
 # Public helpers


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- CI runs on GCP runners fail due to mismatch of env installs due to deps with `sudo`. 
- Either all dep installs need elevated permissions or all run as user. 
- This separates out the user level dependencies so it can be easier to manage them separately
- In order to keep maintenance low, target deps which was a separate step is now included in ci-setup-deps

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
