### PR TITLE
Improve ETH RPC pipeline

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -818,7 +818,7 @@ impl EVMCoreService {
 
 // State methods
 impl EVMCoreService {
-    pub fn get_state_root(&self) -> Result<H256> {
+    pub fn get_latest_state_root(&self) -> Result<H256> {
         let state_root = self
             .storage
             .get_latest_block()?

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -825,16 +825,8 @@ impl EVMCoreService {
             .map_or(H256::default(), |block| block.header.state_root);
         Ok(state_root)
     }
-    pub fn get_account(&self, address: H160, block_number: U256) -> Result<Option<Account>> {
-        let state_root = self
-            .storage
-            .get_block_by_number(&block_number)?
-            .map(|block| block.header.state_root)
-            .ok_or(format_err!(
-                "[get_account] Block number {:x?} not found",
-                block_number
-            ))?;
 
+    pub fn get_account(&self, address: H160, state_root: H256) -> Result<Option<Account>> {
         let backend = EVMBackend::from_root(
             state_root,
             Arc::clone(&self.trie_store),
@@ -844,8 +836,8 @@ impl EVMCoreService {
         Ok(backend.get_account(&address))
     }
 
-    pub fn get_code(&self, address: H160, block_number: U256) -> Result<Option<Vec<u8>>> {
-        self.get_account(address, block_number)?
+    pub fn get_code(&self, address: H160, state_root: H256) -> Result<Option<Vec<u8>>> {
+        self.get_account(address, state_root)?
             .map_or(Ok(None), |account| {
                 self.storage.get_code_by_hash(address, account.code_hash)
             })
@@ -855,9 +847,9 @@ impl EVMCoreService {
         &self,
         address: H160,
         position: U256,
-        block_number: U256,
+        state_root: H256,
     ) -> Result<Option<Vec<u8>>> {
-        self.get_account(address, block_number)?
+        self.get_account(address, state_root)?
             .map_or(Ok(None), |account| {
                 let storage_trie = self
                     .trie_store
@@ -873,25 +865,16 @@ impl EVMCoreService {
             })
     }
 
-    pub fn get_balance(&self, address: H160, block_number: U256) -> Result<U256> {
+    pub fn get_balance(&self, address: H160, state_root: H256) -> Result<U256> {
         let balance = self
-            .get_account(address, block_number)?
+            .get_account(address, state_root)?
             .map_or(U256::zero(), |account| account.balance);
 
         debug!("Account {:x?} balance {:x?}", address, balance);
         Ok(balance)
     }
 
-    pub fn get_nonce_from_block_number(&self, address: H160, block_number: U256) -> Result<U256> {
-        let nonce = self
-            .get_account(address, block_number)?
-            .map_or(U256::zero(), |account| account.nonce);
-
-        debug!("Account {:x?} nonce {:x?}", address, nonce);
-        Ok(nonce)
-    }
-
-    pub fn get_nonce_from_state_root(&self, address: H160, state_root: H256) -> Result<U256> {
+    pub fn get_nonce(&self, address: H160, state_root: H256) -> Result<U256> {
         let backend = self.get_backend(state_root)?;
         let nonce = backend.get_nonce(&address);
         Ok(nonce)
@@ -939,7 +922,7 @@ impl EVMCoreService {
     }
 
     pub fn get_next_account_nonce(&self, address: H160, state_root: H256) -> Result<U256> {
-        let state_root_nonce = self.get_nonce_from_state_root(address, state_root)?;
+        let state_root_nonce = self.get_nonce(address, state_root)?;
         let mut nonce_store = self.nonce_store.lock();
         match nonce_store.entry(address) {
             std::collections::hash_map::Entry::Vacant(_) => Ok(state_root_nonce),

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -569,10 +569,4 @@ impl EVMServices {
             Some(account) => account.code_hash != H256::zero(),
         })
     }
-
-    pub fn get_nonce(&self, address: H160, state_root: H256) -> Result<U256> {
-        let backend = self.core.get_backend(state_root)?;
-        let nonce = backend.get_nonce(&address);
-        Ok(nonce)
-    }
 }

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -464,10 +464,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         block_number: BlockNumber,
         full_transactions: Option<bool>,
     ) -> RpcResult<Option<RpcBlock>> {
-        let block_number = self
-            .get_block(Some(block_number))?
-            .header
-            .number;
+        let block_number = self.get_block(Some(block_number))?.header.number;
         debug!(target:"rpc", "Getting block by number : {}", block_number);
         self.handler
             .storage
@@ -605,10 +602,7 @@ impl MetachainRPCServer for MetachainRPCModule {
     }
 
     fn get_block_transaction_count_by_number(&self, block_number: BlockNumber) -> RpcResult<usize> {
-        let block_number = self
-            .get_block(Some(block_number))?
-            .header
-            .number;
+        let block_number = self.get_block(Some(block_number))?.header.number;
         self.handler
             .storage
             .get_block_by_number(&block_number)

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -633,7 +633,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         debug!(target:"rpc", "[sign_transaction] from: {:?}", from);
 
         let chain_id = ain_cpp_imports::get_chain_id().map_err(RPCError::Error)?;
-        let Ok(state_root) = self.handler.core.get_state_root() else {
+        let Ok(state_root) = self.handler.core.get_latest_state_root() else {
             return Err(RPCError::StateRootNotFound.into());
         };
         let nonce = match request.nonce {

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -138,7 +138,7 @@ fn evm_try_create_and_sign_transfer_domain_tx(
         }
     }?;
 
-    let state_root = SERVICES.evm.core.get_state_root()?;
+    let state_root = SERVICES.evm.core.get_latest_state_root()?;
     let nonce = if ctx.use_nonce {
         U256::from(ctx.nonce)
     } else {

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -194,16 +194,9 @@ fn evm_try_store_account_nonce(from_address: &str, nonce: u64) -> Result<()> {
 #[ffi_fallible]
 fn evm_try_get_balance(address: &str) -> Result<u64> {
     let address = address.parse::<H160>().map_err(|_| "Invalid address")?;
-    let (_, latest_block_number) = SERVICES
-        .evm
-        .block
-        .get_latest_block_hash_and_number()?
-        .unwrap_or_default();
+    let state_root = SERVICES.evm.block.get_latest_state_root()?;
 
-    let balance = SERVICES
-        .evm
-        .core
-        .get_balance(address, latest_block_number)?;
+    let balance = SERVICES.evm.core.get_balance(address, state_root)?;
     let amount = WeiAmount(balance).to_satoshi()?.try_into()?;
 
     Ok(amount)


### PR DESCRIPTION
## Summary

- Return whole block and rename to `block_number_to_block`
- This is done in order not to have to re-fetch state root from storage when restoring backend.
- Change all state methods used by RPC to use state root directly
