### PR TITLE
Dev: enable rust debug

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,7 +13,7 @@ rustflags = [
 ]
 
 [profile.dev]
-debug = 1
+debug = 2
 
 [target.x86_64-apple-darwin]
 rustflags = [


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Set `debug=2` by default instead of `1`, dev friendly for debugger. Even though can remove it since debug=2 is default for dev, btw explicitly set is preferable
ref: https://doc.rust-lang.org/cargo/reference/profiles.html
