### PR TITLE
Clean up error handling on debug trace transaction

### DIFF
--- a/lib/ain-grpc/src/errors.rs
+++ b/lib/ain-grpc/src/errors.rs
@@ -8,7 +8,6 @@ use jsonrpsee::{
 pub enum RPCError {
     AccountError,
     BlockNotFound,
-    DatabaseError,
     DebugNotEnabled,
     Error(Box<dyn std::error::Error>),
     EvmError(EVMError),
@@ -22,11 +21,12 @@ pub enum RPCError {
     InvalidTransactionMessage,
     InvalidTransactionType,
     NonceCacheError,
-    ReceiptNotFoundError(H256),
+    ReceiptNotFound(H256),
     RevertError(String, String),
     StateRootNotFound,
     TraceNotEnabled,
     TxExecutionFailed,
+    TxNotFound(H256),
     ValueOverflow,
 }
 
@@ -35,7 +35,6 @@ impl From<RPCError> for Error {
         match e {
             RPCError::AccountError => to_custom_err("error getting account"),
             RPCError::BlockNotFound => to_custom_err("header not found"),
-            RPCError::DatabaseError => to_custom_err("database error"),
             RPCError::DebugNotEnabled => to_custom_err("debug_* RPCs have not been enabled"),
             RPCError::Error(e) => Error::Custom(format!("{e:?}")),
             RPCError::EvmError(e) => Error::Custom(format!("error calling EVM : {e:?}")),
@@ -61,8 +60,8 @@ impl From<RPCError> for Error {
             }
             RPCError::InvalidTransactionType => to_custom_err("invalid transaction type specified"),
             RPCError::NonceCacheError => to_custom_err("could not cache account nonce"),
-            RPCError::ReceiptNotFoundError(hash) => Error::Custom(format!(
-                "could not find receipt for transaction {:#?}",
+            RPCError::ReceiptNotFound(hash) => Error::Custom(format!(
+                "could not find receipt for transaction hash {:#?}",
                 hash
             )),
             RPCError::RevertError(msg, data) => {
@@ -72,6 +71,10 @@ impl From<RPCError> for Error {
             RPCError::StateRootNotFound => to_custom_err("state root not found"),
             RPCError::TraceNotEnabled => to_custom_err("debug_trace* RPCs have not been enabled"),
             RPCError::TxExecutionFailed => to_custom_err("transaction execution failed"),
+            RPCError::TxNotFound(hash) => Error::Custom(format!(
+                "could not find transaction for transaction hash {:#?}",
+                hash
+            )),
             RPCError::ValueOverflow => to_custom_err("value overflow"),
         }
     }

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -68,19 +68,17 @@ impl MetachainDebugRPCModule {
     }
 
     fn is_enabled(&self) -> RpcResult<()> {
-        if ain_cpp_imports::is_eth_debug_rpc_enabled() {
-            Ok(())
-        } else {
-            Err(RPCError::DebugNotEnabled.into())
+        if !ain_cpp_imports::is_eth_debug_rpc_enabled() {
+            return Err(RPCError::DebugNotEnabled.into());
         }
+        Ok(())
     }
 
     fn is_trace_enabled(&self) -> RpcResult<()> {
-        if ain_cpp_imports::is_eth_debug_trace_rpc_enabled() {
-            Ok(())
-        } else {
-            Err(RPCError::TraceNotEnabled.into())
+        if !ain_cpp_imports::is_eth_debug_trace_rpc_enabled() {
+            return Err(RPCError::TraceNotEnabled.into());
         }
+        Ok(())
     }
 }
 

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -93,14 +93,14 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
             .storage
             .get_receipt(&tx_hash)
             .map_err(to_custom_err)?
-            .ok_or(RPCError::ReceiptNotFoundError(tx_hash))?;
+            .ok_or(RPCError::ReceiptNotFound(tx_hash))?;
 
         let tx = self
             .handler
             .storage
             .get_transaction_by_block_hash_and_index(&receipt.block_hash, receipt.tx_index)
             .map_err(RPCError::EvmError)?
-            .ok_or(RPCError::DatabaseError)?;
+            .ok_or(RPCError::TxNotFound(tx_hash))?;
 
         let signed_tx = SignedTx::try_from(tx).map_err(to_custom_err)?;
         let (logs, succeeded, return_data, gas_used) = self

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -12,10 +12,7 @@ use ain_evm::{
 };
 use ethereum::Account;
 use ethereum_types::{H256, U256};
-use jsonrpsee::{
-    core::{Error, RpcResult},
-    proc_macros::rpc,
-};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use log::debug;
 use rlp::{Decodable, Rlp};
 
@@ -71,23 +68,19 @@ impl MetachainDebugRPCModule {
     }
 
     fn is_enabled(&self) -> RpcResult<()> {
-        if !ain_cpp_imports::is_eth_debug_rpc_enabled() {
-            return Err(Error::Custom(
-                "debug_* RPCs have not been enabled".to_string(),
-            ));
+        if ain_cpp_imports::is_eth_debug_rpc_enabled() {
+            Ok(())
+        } else {
+            Err(RPCError::DebugNotEnabled.into())
         }
-
-        Ok(())
     }
 
     fn is_trace_enabled(&self) -> RpcResult<()> {
-        if !ain_cpp_imports::is_eth_debug_trace_rpc_enabled() {
-            return Err(Error::Custom(
-                "debug_trace* RPCs have not been enabled".to_string(),
-            ));
+        if ain_cpp_imports::is_eth_debug_trace_rpc_enabled() {
+            Ok(())
+        } else {
+            Err(RPCError::TraceNotEnabled.into())
         }
-
-        Ok(())
     }
 }
 
@@ -102,24 +95,21 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
             .storage
             .get_receipt(&tx_hash)
             .map_err(to_custom_err)?
-            .ok_or_else(|| {
-                Error::Custom(format!("Could not find receipt for transaction {tx_hash}"))
-            })?;
+            .ok_or(RPCError::ReceiptNotFoundError(tx_hash))?;
 
         let tx = self
             .handler
             .storage
             .get_transaction_by_block_hash_and_index(&receipt.block_hash, receipt.tx_index)
-            .expect("Unable to find TX hash")
-            .ok_or_else(|| Error::Custom("Error".to_string()))?;
+            .map_err(RPCError::EvmError)?
+            .ok_or(RPCError::DatabaseError)?;
 
-        let signed_tx = SignedTx::try_from(tx).expect("Unable to construct signed TX");
-
+        let signed_tx = SignedTx::try_from(tx).map_err(to_custom_err)?;
         let (logs, succeeded, return_data, gas_used) = self
             .handler
             .core
             .trace_transaction(&signed_tx, receipt.block_number)
-            .map_err(|e| Error::Custom(format!("Error calling EVM : {e:?}")))?;
+            .map_err(RPCError::EvmError)?;
         let trace_logs = logs.iter().map(|x| TraceLogs::from(x.clone())).collect();
 
         Ok(TraceTransactionResult {
@@ -141,7 +131,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         let default_limit = 100usize;
         let limit = limit
             .map_or(Ok(default_limit), |s| s.parse())
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(to_custom_err)?;
         self.handler
             .storage
             .dump_db(arg.unwrap_or(DumpArg::All), start, limit)

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -698,8 +698,7 @@ impl MetachainRPCServer for MetachainRPCModule {
     fn send_raw_transaction(&self, tx: &str) -> RpcResult<String> {
         debug!(target:"rpc", "Sending raw transaction: {:?}", tx);
         let raw_tx = tx.strip_prefix("0x").unwrap_or(tx);
-        let hex =
-            hex::decode(raw_tx).map_err(|e| Error::Custom(format!("Error decoding TX {e:?}")))?;
+        let hex = hex::decode(raw_tx).map_err(to_custom_err)?;
 
         let res_string = ain_cpp_imports::publish_eth_transaction(hex).map_err(RPCError::Error)?;
         if res_string.is_empty() {

--- a/lib/ain-grpc/src/subscription/params.rs
+++ b/lib/ain-grpc/src/subscription/params.rs
@@ -7,7 +7,7 @@ use serde_with::{serde_as, OneOrMany};
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-pub enum Kind {
+pub enum Subscription {
     /// New block headers subscription.
     NewHeads,
     /// Logs subscription.
@@ -30,7 +30,7 @@ pub struct LogsSubscriptionParams {
 
 /// Subscription kind.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
-pub enum Params {
+pub enum SubscriptionParams {
     /// No parameters passed.
     #[default]
     None,
@@ -38,19 +38,19 @@ pub enum Params {
     Logs(LogsSubscriptionParams),
 }
 
-impl<'a> Deserialize<'a> for Params {
-    fn deserialize<D>(deserializer: D) -> Result<Params, D::Error>
+impl<'a> Deserialize<'a> for SubscriptionParams {
+    fn deserialize<D>(deserializer: D) -> Result<SubscriptionParams, D::Error>
     where
         D: Deserializer<'a>,
     {
         let v: Value = Deserialize::deserialize(deserializer)?;
 
         if v.is_null() {
-            return Ok(Params::None);
+            return Ok(SubscriptionParams::None);
         }
 
         from_value(v)
-            .map(Params::Logs)
+            .map(SubscriptionParams::Logs)
             .map_err(|e| Error::custom(format!("Invalid logs parameters: {}", e)))
     }
 }


### PR DESCRIPTION
## Summary

- Clean up debug_traceTransaction error handling in the unlikely events to prevent node from panicking
- Refactor to use RPCErrors
- Cleanup subscriptions

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
