### PR TITLE
RPC: Add support for RPC multiple addresses binding and add disable server config flag

### DIFF
--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -141,7 +141,10 @@ pub fn init_network_subscriptions_service(addr: &str) -> Result<()> {
     let mut methods: Methods = Methods::new();
     methods.merge(MetachainPubSubModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
 
-    runtime.websocket_handles.lock().push(server.start(methods)?);
+    runtime
+        .websocket_handles
+        .lock()
+        .push(server.start(methods)?);
     Ok(())
 }
 

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 
-use ain_evm::services::{Services, IS_SERVICES_INIT_CALL, SERVICES};
+use ain_evm::services::{IS_SERVICES_INIT_CALL, SERVICES};
 use anyhow::{format_err, Result};
 use hyper::{header::HeaderValue, Method};
 use jsonrpsee::core::server::rpc_module::Methods;
@@ -72,22 +72,12 @@ pub fn init_services() {
     let _ = &*SERVICES;
 }
 
-pub fn init_network_services(
-    json_addr: &str,
-    grpc_addr: &str,
-    websockets_addr: &str,
-) -> Result<()> {
-    init_network_json_rpc_service(&SERVICES, json_addr)?;
-    init_network_grpc_service(&SERVICES, grpc_addr)?;
-    init_network_subscriptions_service(&SERVICES, websockets_addr)?;
-    Ok(())
-}
-
-pub fn init_network_json_rpc_service(runtime: &Services, addr: &str) -> Result<()> {
+pub fn init_network_json_rpc_service(addr: &str) -> Result<()> {
     info!("Starting JSON RPC server at {}", addr);
     let addr = addr.parse::<SocketAddr>()?;
     let max_connections = ain_cpp_imports::get_max_connections();
     let max_response_size = ain_cpp_imports::get_max_response_byte_size();
+    let runtime = &SERVICES;
 
     let middleware = if !ain_cpp_imports::get_cors_allowed_origin().is_empty() {
         let origin = ain_cpp_imports::get_cors_allowed_origin();
@@ -118,24 +108,26 @@ pub fn init_network_json_rpc_service(runtime: &Services, addr: &str) -> Result<(
     methods.merge(MetachainNetRPCModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
     methods.merge(MetachainWeb3RPCModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
 
-    *runtime.json_rpc.lock() = Some(server.start(methods)?);
+    runtime.json_rpc_handle.lock().push(server.start(methods)?);
     Ok(())
 }
 
-pub fn init_network_grpc_service(_runtime: &Services, _addr: &str) -> Result<()> {
+pub fn init_network_grpc_service(_addr: &str) -> Result<()> {
     // log::info!("Starting gRPC server at {}", addr);
     // Commented out for now as nothing to serve
+    // let runtime = &SERVICES;
     // runtime
     //     .rt_handle
     // .spawn(Server::builder().serve(addr.parse()?));
     Ok(())
 }
 
-pub fn init_network_subscriptions_service(runtime: &Services, addr: &str) -> Result<()> {
+pub fn init_network_subscriptions_service(addr: &str) -> Result<()> {
     info!("Starting WebSockets server at {}", addr);
     let addr = addr.parse::<SocketAddr>()?;
     let max_connections = ain_cpp_imports::get_max_connections();
     let max_response_size = ain_cpp_imports::get_max_response_byte_size();
+    let runtime = &SERVICES;
 
     let handle = runtime.ws_rt_handle.clone();
     let server = runtime.ws_rt_handle.block_on(
@@ -149,20 +141,12 @@ pub fn init_network_subscriptions_service(runtime: &Services, addr: &str) -> Res
     let mut methods: Methods = Methods::new();
     methods.merge(MetachainPubSubModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
 
-    *runtime.ws_handle.lock() = Some(server.start(methods)?);
+    runtime.ws_handle.lock().push(server.start(methods)?);
     Ok(())
 }
 
 fn is_services_init_called() -> bool {
     IS_SERVICES_INIT_CALL.load(Ordering::SeqCst)
-}
-
-pub fn stop_network_services() -> Result<()> {
-    if is_services_init_called() {
-        info!("Shutdown rs network services");
-        SERVICES.stop_network()?;
-    }
-    Ok(())
 }
 
 pub fn stop_services() {
@@ -178,6 +162,14 @@ pub fn wipe_evm_folder() -> Result<()> {
     info!("Wiping rs storage in {}", path.display());
     if path.exists() {
         std::fs::remove_dir_all(&path).map_err(|e| format_err!("Error wiping evm dir: {e}"))?;
+    }
+    Ok(())
+}
+
+pub fn stop_network_services() -> Result<()> {
+    if is_services_init_called() {
+        info!("Shutdown rs network services");
+        SERVICES.stop_network()?;
     }
     Ok(())
 }

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -108,7 +108,7 @@ pub fn init_network_json_rpc_service(addr: &str) -> Result<()> {
     methods.merge(MetachainNetRPCModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
     methods.merge(MetachainWeb3RPCModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
 
-    runtime.json_rpc_handle.lock().push(server.start(methods)?);
+    runtime.json_rpc_handles.lock().push(server.start(methods)?);
     Ok(())
 }
 
@@ -129,8 +129,8 @@ pub fn init_network_subscriptions_service(addr: &str) -> Result<()> {
     let max_response_size = ain_cpp_imports::get_max_response_byte_size();
     let runtime = &SERVICES;
 
-    let handle = runtime.ws_rt_handle.clone();
-    let server = runtime.ws_rt_handle.block_on(
+    let handle = runtime.tokio_runtime.clone();
+    let server = runtime.tokio_runtime.block_on(
         ServerBuilder::default()
             .max_subscriptions_per_connection(max_connections)
             .max_response_body_size(max_response_size)
@@ -141,7 +141,7 @@ pub fn init_network_subscriptions_service(addr: &str) -> Result<()> {
     let mut methods: Methods = Methods::new();
     methods.merge(MetachainPubSubModule::new(Arc::clone(&runtime.evm)).into_rpc())?;
 
-    runtime.ws_handle.lock().push(server.start(methods)?);
+    runtime.websocket_handles.lock().push(server.start(methods)?);
     Ok(())
 }
 

--- a/lib/ain-rs-exports/src/core.rs
+++ b/lib/ain-rs-exports/src/core.rs
@@ -20,13 +20,22 @@ pub fn ain_rs_stop_core_services(result: &mut CrossBoundaryResult) {
     cross_boundary_success(result);
 }
 
-pub fn ain_rs_init_network_services(
-    result: &mut CrossBoundaryResult,
-    json_addr: &str,
-    grpc_addr: &str,
-    websockets_addr: &str,
-) {
-    match ain_grpc::init_network_services(json_addr, grpc_addr, websockets_addr) {
+pub fn ain_rs_init_network_json_rpc_service(result: &mut CrossBoundaryResult, addr: &str) {
+    match ain_grpc::init_network_json_rpc_service(addr) {
+        Ok(()) => cross_boundary_success(result),
+        Err(e) => cross_boundary_error_return(result, e.to_string()),
+    }
+}
+
+pub fn ain_rs_init_network_grpc_service(result: &mut CrossBoundaryResult, addr: &str) {
+    match ain_grpc::init_network_grpc_service(addr) {
+        Ok(()) => cross_boundary_success(result),
+        Err(e) => cross_boundary_error_return(result, e.to_string()),
+    }
+}
+
+pub fn ain_rs_init_network_subscriptions_service(result: &mut CrossBoundaryResult, addr: &str) {
+    match ain_grpc::init_network_subscriptions_service(addr) {
         Ok(()) => cross_boundary_success(result),
         Err(e) => cross_boundary_error_return(result, e.to_string()),
     }

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -86,12 +86,11 @@ pub mod ffi {
         fn ain_rs_init_core_services(result: &mut CrossBoundaryResult);
         fn ain_rs_wipe_evm_folder(result: &mut CrossBoundaryResult);
         fn ain_rs_stop_core_services(result: &mut CrossBoundaryResult);
-        fn ain_rs_init_network_services(
-            result: &mut CrossBoundaryResult,
-            json_addr: &str,
-            grpc_addr: &str,
-            websockets_addr: &str,
-        );
+
+        // Networking
+        fn ain_rs_init_network_json_rpc_service(result: &mut CrossBoundaryResult, addr: &str);
+        fn ain_rs_init_network_grpc_service(result: &mut CrossBoundaryResult, addr: &str);
+        fn ain_rs_init_network_subscriptions_service(result: &mut CrossBoundaryResult, addr: &str);
         fn ain_rs_stop_network_services(result: &mut CrossBoundaryResult);
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -649,11 +649,12 @@ void SetupServerArgs()
     gArgs.AddArg("-dftxworkers=<n>", strprintf("No. of parallel workers associated with the DfTx related work pool. Stock splits, parallel processing of the chain where appropriate, etc use this worker pool (default: %d)", DEFAULT_DFTX_WORKERS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxaddrratepersecond=<n>", strprintf("Sets MAX_ADDR_RATE_PER_SECOND limit for ADDR messages(default: %f)", MAX_ADDR_RATE_PER_SECOND), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-maxaddrprocessingtokenbucket=<n>", strprintf("Sets MAX_ADDR_PROCESSING_TOKEN_BUCKET limit for ADDR messages(default: %d)", MAX_ADDR_PROCESSING_TOKEN_BUCKET), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-grpcbind=<addr>[:port]", "Bind to given address to listen for JSON-gRPC connections. Do not expose the gRPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -grpcport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
-    gArgs.AddArg("-grpcport=<port>", strprintf("Start GRPC connections on <port> and <port + 1> (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), changiBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-grpcbind=<addr>[:port]", "Bind to given address to listen for gRPC connections. Do not expose the gRPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -grpcport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-grpcport=<port>", strprintf("Listen for GRPC connections on <port>. If -1 flag specified, gRPC server initialization will be disabled. (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->GRPCPort(), testnetBaseParams->GRPCPort(), changiBaseParams->GRPCPort(), devnetBaseParams->GRPCPort(), regtestBaseParams->GRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethrpcbind=<addr>[:port]", "Bind to given address to listen for ETH-JSON-RPC connections. Do not expose the ETH-RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -ethrpcport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
-    gArgs.AddArg("-ethrpcport=<port>", strprintf("Listen for ETH-JSON-RPC connections on <port>> (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->ETHRPCPort(), testnetBaseParams->ETHRPCPort(), changiBaseParams->ETHRPCPort(), devnetBaseParams->ETHRPCPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
-    gArgs.AddArg("-wsport=<port>", strprintf("Listen for ETH-WebSockets connections on <port>> (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->WSPort(), testnetBaseParams->WSPort(), changiBaseParams->WSPort(), devnetBaseParams->WSPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-ethrpcport=<port>", strprintf("Listen for ETH-JSON-RPC connections on <port>. If -1 flag specified, ETH RPC server initialization will be disabled. (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->ETHRPCPort(), testnetBaseParams->ETHRPCPort(), changiBaseParams->ETHRPCPort(), devnetBaseParams->ETHRPCPort(), regtestBaseParams->ETHRPCPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-wsbind=<addr>[:port]", "Bind to given address to listen for ETH-WebSockets connections. Do not expose the Eth-WebSockets server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -wsport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
+    gArgs.AddArg("-wsport=<port>", strprintf("Listen for ETH-WebSockets connections on <port>. If -1 flag specified, ws server initialization will be disabled. (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", defaultBaseParams->WSPort(), testnetBaseParams->WSPort(), changiBaseParams->WSPort(), devnetBaseParams->WSPort(), regtestBaseParams->WSPort()), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethmaxconnections=<connections>", strprintf("Set the maximum number of connections allowed by the ETH-RPC server (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", DEFAULT_ETH_MAX_CONNECTIONS, DEFAULT_ETH_MAX_CONNECTIONS, DEFAULT_ETH_MAX_CONNECTIONS, DEFAULT_ETH_MAX_CONNECTIONS, DEFAULT_ETH_MAX_CONNECTIONS), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethmaxresponsesize=<size>", strprintf("Set the maximum response size in MB by the ETH-RPC server (default: %u, testnet: %u, changi: %u, devnet: %u, regtest: %u)", DEFAULT_ETH_MAX_RESPONSE_SIZE_MB, DEFAULT_ETH_MAX_RESPONSE_SIZE_MB, DEFAULT_ETH_MAX_RESPONSE_SIZE_MB, DEFAULT_ETH_MAX_RESPONSE_SIZE_MB, DEFAULT_ETH_MAX_RESPONSE_SIZE_MB), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-ethdebug", strprintf("Enable debug_* ETH RPCs (default: %b)", DEFAULT_ETH_DEBUG_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
@@ -1577,50 +1578,74 @@ void SetupCacheSizes(CacheSizes& cacheSizes) {
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
 }
 
-void SetupRPCPorts(std::vector<std::pair<std::string, uint16_t>>& ethEndpoints, std::vector<std::pair<std::string, uint16_t>>& gEndpoints) {
-    // Current API only allows for one ETH RPC/gRPC server to bind to one address.
-    // By default, we will take the first address, if multiple addresses are specified.
-    int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
-    int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
-    int websockets_port = gArgs.GetArg("-wsport", BaseParams().WSPort());
-
+void SetupRPCPorts(std::vector<std::pair<std::string, uint16_t>>& ethEndpoints, std::vector<std::pair<std::string, uint16_t>>& gEndpoints, std::vector<std::pair<std::string, uint16_t>>& wsEndpoints) {
     // Determine which addresses to bind to ETH RPC server
-    if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-ethrpcbind"))) { // Default to loopback if not allowing external IPs
-        ethEndpoints.emplace_back("127.0.0.1", eth_rpc_port);
-        ethEndpoints.emplace_back("127.0.0.1", websockets_port);
-        if (gArgs.IsArgSet("-rpcallowip")) {
-            LogPrintf("WARNING: option -rpcallowip was specified without -ethrpcbind; this doesn't usually make sense\n");
-        }
-        if (gArgs.IsArgSet("-ethrpcbind")) {
-            LogPrintf("WARNING: option -ethrpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
-        }
-    } else if (gArgs.IsArgSet("-ethrpcbind")) { // Specific bind address
-        for (const std::string& strETHRPCBind : gArgs.GetArgs("-ethrpcbind")) {
-            int port = eth_rpc_port;
-            int ws_port = websockets_port;
-
-            std::string host;
-            SplitHostPort(strETHRPCBind, port, host);
-            ethEndpoints.emplace_back(host, port);
-            ethEndpoints.emplace_back(host, ws_port);
+    int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
+    
+    if (eth_rpc_port == -1) {
+            LogPrintf("ETH RPC server disabled.\n");
+    } else {
+        if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-ethrpcbind"))) { // Default to loopback if not allowing external IPs
+            ethEndpoints.emplace_back("127.0.0.1", eth_rpc_port);
+            if (gArgs.IsArgSet("-rpcallowip")) {
+                LogPrintf("WARNING: option -rpcallowip was specified without -ethrpcbind; this doesn't usually make sense\n");
+            }
+            if (gArgs.IsArgSet("-ethrpcbind")) {
+                LogPrintf("WARNING: option -ethrpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
+            }
+        } else if (gArgs.IsArgSet("-ethrpcbind")) { // Specific bind address
+            for (const std::string& strETHRPCBind : gArgs.GetArgs("-ethrpcbind")) {
+                int port = eth_rpc_port;
+                std::string host;
+                SplitHostPort(strETHRPCBind, port, host);
+                ethEndpoints.emplace_back(host, port);
+            }
         }
     }
 
     // Determine which addresses to bind to gRPC server
-    if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-grpcbind"))) { // Default to loopback if not allowing external IPs
-        gEndpoints.emplace_back("127.0.0.1", grpc_port);
-        if (gArgs.IsArgSet("-rpcallowip")) {
-            LogPrintf("WARNING: option -rpcallowip was specified without -grpcbind; this doesn't usually make sense\n");
+    int grpc_port = gArgs.GetArg("-grpcport", BaseParams().GRPCPort());
+    if (grpc_port == -1) {
+            LogPrintf("gRPC server disabled.\n");
+    } else {
+        if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-grpcbind"))) { // Default to loopback if not allowing external IPs
+            gEndpoints.emplace_back("127.0.0.1", grpc_port);
+            if (gArgs.IsArgSet("-rpcallowip")) {
+                LogPrintf("WARNING: option -rpcallowip was specified without -grpcbind; this doesn't usually make sense\n");
+            }
+            if (gArgs.IsArgSet("-grpcbind")) {
+                LogPrintf("WARNING: option -grpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
+            }
+        } else if (gArgs.IsArgSet("-grpcbind")) { // Specific bind address
+            for (const std::string& strGRPCBind : gArgs.GetArgs("-grpcbind")) {
+                int port = grpc_port;
+                std::string host;
+                SplitHostPort(strGRPCBind, port, host);
+                gEndpoints.emplace_back(host, port);
+            }
         }
-        if (gArgs.IsArgSet("-grpcbind")) {
-            LogPrintf("WARNING: option -grpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
-        }
-    } else if (gArgs.IsArgSet("-grpcbind")) { // Specific bind address
-        for (const std::string& strGRPCBind : gArgs.GetArgs("-grpcbind")) {
-            int port = grpc_port;
-            std::string host;
-            SplitHostPort(strGRPCBind, port, host);
-            gEndpoints.emplace_back(host, port);
+    }
+
+    // Determine which addresses to bind to websocket server
+    int ws_port = gArgs.GetArg("-wsport", BaseParams().WSPort());
+    if (ws_port == -1) {
+            LogPrintf("Websocket server disabled.\n");
+    }
+        if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-wscbind"))) { // Default to loopback if not allowing external IPs
+            wsEndpoints.emplace_back("127.0.0.1", ws_port);
+            if (gArgs.IsArgSet("-rpcallowip")) {
+                LogPrintf("WARNING: option -rpcallowip was specified without -wsbind; this doesn't usually make sense\n");
+            }
+            if (gArgs.IsArgSet("-wsbind")) {
+                LogPrintf("WARNING: option -wsbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
+            }
+        } else if (gArgs.IsArgSet("-wsbind")) { // Specific bind address
+            for (const std::string& strWSBind : gArgs.GetArgs("-wsbind")) {
+                int port = ws_port;
+                std::string host;
+                SplitHostPort(strWSBind, port, host);
+                wsEndpoints.emplace_back(host, port);
+            }
         }
     }
 }
@@ -2274,18 +2299,46 @@ bool AppInitMain(InitInterfaces& interfaces)
     // ********************************************************* Step 14: finished
 
     SetRPCWarmupFinished();
-    // Start the GRPC and ETH RPC servers
+    // Start the ETH RPC, gRPC and websocket servers
     // We start the evm RPC servers as late as possible.
     {
         std::vector<std::pair<std::string, uint16_t>> eth_endpoints;
         std::vector<std::pair<std::string, uint16_t>> g_endpoints;
-        SetupRPCPorts(eth_endpoints, g_endpoints);
-        // Default to using the first address passed to bind
-        auto eth_endpoint = eth_endpoints[0].first + ":" + std::to_string(eth_endpoints[0].second);
-        auto websockets_endpoint = eth_endpoints[1].first + ":" + std::to_string(eth_endpoints[1].second);
-        auto grpc_endpoint = g_endpoints[0].first + "." + std::to_string(g_endpoints[0].second);
-        auto res = XResultStatusLogged(ain_rs_init_network_services(result, eth_endpoint, grpc_endpoint, websockets_endpoint));
-        if (!res) return false;
+        std::vector<std::pair<std::string, uint16_t>> ws_endpoints;
+        SetupRPCPorts(eth_endpoints, g_endpoints, ws_endpoints);
+
+        // Bind ETH RPC addresses
+        for (auto it = eth_endpoints.begin(); it != eth_endpoints.end(); ++it) {
+            auto eth_endpoint = it->first + ":" + std::to_string(it->second);
+            LogPrint(BCLog::HTTP, "Binding ETH RPC server on address %s port %i\n", it->first, it->second);   
+            auto res =  XResultStatusLogged(ain_rs_init_network_json_rpc_service(result, eth_endpoint))
+            if (!res) {
+                LogPrintf("Binding ETH RPC server on address %s port %i failed.\n", it->first, it->second);
+                return false;
+            }
+        }
+
+        // Bind gRPC addresses
+        for (auto it = g_endpoints.begin(); it != g_endpoints.end(); ++it) {
+            auto g_endpoint = it->first + ":" + std::to_string(it->second);
+            LogPrint(BCLog::HTTP, "Binding gRPC server on address %s port %i\n", it->first, it->second);   
+            auto res =  XResultStatusLogged(ain_rs_init_network_grpc_service(result, g_endpoint))
+            if (!res) {
+                LogPrintf("Binding gRPC server on address %s port %i failed.\n", it->first, it->second);
+                return false;
+            }
+        }
+
+        // bind websocket addresses
+        for (auto it = ws_endpoints.begin(); it != ws_endpoints.end(); ++it) {
+            auto ws_endpoint = it->first + ":" + std::to_string(it->second);
+            LogPrint(BCLog::HTTP, "Binding websocket server on address %s port %i\n", it->first, it->second);   
+            auto res =  XResultStatusLogged(ain_rs_init_network_subscriptions_service(result, ws_endpoint))
+            if (!res) {
+                LogPrintf("Binding websocket server on address %s port %i failed.\n", it->first, it->second);
+                return false;
+            }
+        }
     }
     uiInterface.InitMessage(_("Done loading").translated);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1630,7 +1630,7 @@ void SetupRPCPorts(std::vector<std::pair<std::string, uint16_t>>& ethEndpoints, 
     int ws_port = gArgs.GetArg("-wsport", BaseParams().WSPort());
     if (ws_port == -1) {
             LogPrintf("Websocket server disabled.\n");
-    }
+    } else {
         if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-wscbind"))) { // Default to loopback if not allowing external IPs
             wsEndpoints.emplace_back("127.0.0.1", ws_port);
             if (gArgs.IsArgSet("-rpcallowip")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1636,7 +1636,7 @@ void SetupRPCPorts(std::vector<std::string>& ethEndpoints, std::vector<std::stri
     if (ws_port == -1) {
             LogPrintf("Websocket server disabled.\n");
     } else {
-        if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-wscbind"))) { // Default to loopback if not allowing external IPs
+        if (!(gArgs.IsArgSet("-rpcallowip") && gArgs.IsArgSet("-wsbind"))) { // Default to loopback if not allowing external IPs
             auto endpoint = default_address + ":" + std::to_string(ws_port);
             wsEndpoints.push_back(endpoint);
             if (gArgs.IsArgSet("-rpcallowip")) {


### PR DESCRIPTION
## Summary

- Add support for multiple endpoints binding for ETH RPC server (-ethrpcbind),  gRPC server (-grpcbind) and ws server (-wsbind)
- Add config flag for disabling ETH RPC, gRPC and ws servers by specifying ethrpcport/grpcport/wsport=-1


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
