### PR TITLE
Disable updatetoken for DAT and splits

### DIFF
--- a/src/dfi/mn_rpc.cpp
+++ b/src/dfi/mn_rpc.cpp
@@ -632,6 +632,9 @@ UniValue setgov(const JSONRPCRequest &request) {
                                 throw JSONRPCError(RPC_INVALID_REQUEST,
                                                    "Cannot set consortium on DFI, loan tokens and non-DAT tokens");
                             }
+                        } else if (Params().NetworkIDString() != CBaseChainParams::REGTEST &&
+                                   attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits) {
+                            throw JSONRPCError(RPC_INVALID_REQUEST, "Token splits disabled");
                         }
                     }
                 }
@@ -867,6 +870,9 @@ UniValue setgovheight(const JSONRPCRequest &request) {
                             throw JSONRPCError(RPC_INVALID_REQUEST,
                                                "Cannot set consortium on DFI, loan tokens and non-DAT tokens");
                         }
+                    } else if (Params().NetworkIDString() != CBaseChainParams::REGTEST &&
+                               attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits) {
+                        throw JSONRPCError(RPC_INVALID_REQUEST, "Token splits disabled");
                     }
                 }
             }

--- a/src/dfi/mn_rpc.cpp
+++ b/src/dfi/mn_rpc.cpp
@@ -634,6 +634,7 @@ UniValue setgov(const JSONRPCRequest &request) {
                             }
                         } else if (Params().NetworkIDString() != CBaseChainParams::REGTEST &&
                                    attrV0->type == AttributeTypes::Oracles && attrV0->typeId == OracleIDs::Splits) {
+                            // Note: This is expected to be removed after DF23
                             throw JSONRPCError(RPC_INVALID_REQUEST, "Token splits disabled");
                         }
                     }

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -272,6 +272,7 @@ UniValue updatetoken(const JSONRPCRequest &request) {
         if (!token) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenStr));
         }
+        // Note: This is expected to be removed after DF23
         if (Params().NetworkIDString() != CBaseChainParams::REGTEST && token->IsDAT()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot update DAT token");
         }

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -272,6 +272,9 @@ UniValue updatetoken(const JSONRPCRequest &request) {
         if (!token) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenStr));
         }
+        if (Params().NetworkIDString() != CBaseChainParams::REGTEST && token->IsDAT()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot update DAT token");
+        }
         tokenImpl = static_cast<const CTokenImplementation &>(*token);
         if (tokenImpl.IsPoolShare()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,


### PR DESCRIPTION
## Summary

- To prevent accidental usage of updatetoken for DATs and token splits this PR will disable them on the RPC side.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
