### PR TITLE
 Move attributes into CCustomCSView

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,6 +184,7 @@ DEFI_CORE_H = \
   dfi/evm.h \
   dfi/factory.h \
   dfi/govvariables/attributes.h \
+  dfi/govvariables/attributetypes.h \
   dfi/govvariables/icx_takerfee_per_btc.h \
   dfi/govvariables/loan_daily_reward.h \
   dfi/govvariables/loan_liquidation_penalty.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -8,7 +8,8 @@
 #include <chainparams.h>
 #include <chainparamsseeds.h>
 #include <consensus/merkle.h>
-#include <dfi/mn_checks.h>
+#include <consensus/tx_check.h>
+#include <dfi/customtx.h>
 #include <streams.h>
 #include <tinyformat.h>
 #include <util/system.h>

--- a/src/dfi/accountshistory.cpp
+++ b/src/dfi/accountshistory.cpp
@@ -102,7 +102,12 @@ CAccountsHistoryWriter::CAccountsHistoryWriter(CCustomCSView &storage,
       txn(txn),
       txid(txid),
       type(type),
-      writers(storage.GetHistoryWriters()) {}
+      writers(storage.GetHistoryWriters()) {
+    if (storage.HasAttributes()) {
+        attributes = storage.GetAttributes();
+    }
+    persistentAttributes = true;
+}
 
 CAccountsHistoryWriter::~CAccountsHistoryWriter() {
     writers.ClearState();

--- a/src/dfi/consensus/icxorders.cpp
+++ b/src/dfi/consensus/icxorders.cpp
@@ -8,11 +8,10 @@
 #include <dfi/masternodes.h>
 #include <dfi/mn_checks.h>
 
-bool IsICXEnabled(const int height, const CCustomCSView &view, const Consensus::Params &consensus) {
+bool IsICXEnabled(const int height, CCustomCSView &view, const Consensus::Params &consensus) {
     if (height >= consensus.DF22MetachainHeight) {
         const CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::ICXEnabled};
-        auto attributes = view.GetAttributes();
-        return attributes->GetValue(enabledKey, false);
+        return view.GetValue(enabledKey, false);
     }
     // ICX transactions allowed before NextNetwrokUpgrade and some of these conditions
     else if (height < consensus.DF13FortCanningParkHeight || IsRegtestNetwork() ||

--- a/src/dfi/consensus/masternodes.cpp
+++ b/src/dfi/consensus/masternodes.cpp
@@ -163,14 +163,12 @@ Res CMasternodesConsensus::operator()(const CUpdateMasterNodeMessage &obj) const
         return DeFiErrors::MNStateNotEnabled(obj.mnId.ToString());
     }
 
-    const auto attributes = mnview.GetAttributes();
-
     bool ownerType{}, operatorType{}, rewardType{};
     for (const auto &[type, addressPair] : obj.updates) {
         const auto &[addressType, rawAddress] = addressPair;
         if (type == static_cast<uint8_t>(UpdateMasternodeType::OwnerAddress)) {
             CDataStructureV0 key{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::MNSetOwnerAddress};
-            if (!attributes->GetValue(key, false)) {
+            if (!mnview.GetValue(key, false)) {
                 return Res::Err("Updating masternode owner address not currently enabled in attributes.");
             }
             if (ownerType) {
@@ -230,7 +228,7 @@ Res CMasternodesConsensus::operator()(const CUpdateMasterNodeMessage &obj) const
             mnview.UpdateMasternodeCollateral(obj.mnId, *node, tx.GetHash(), height);
         } else if (type == static_cast<uint8_t>(UpdateMasternodeType::OperatorAddress)) {
             CDataStructureV0 key{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::MNSetOperatorAddress};
-            if (!attributes->GetValue(key, false)) {
+            if (!mnview.GetValue(key, false)) {
                 return Res::Err("Updating masternode operator address not currently enabled in attributes.");
             }
             if (operatorType) {
@@ -255,7 +253,7 @@ Res CMasternodesConsensus::operator()(const CUpdateMasterNodeMessage &obj) const
             mnview.UpdateMasternodeOperator(obj.mnId, *node, addressType, keyID, height);
         } else if (type == static_cast<uint8_t>(UpdateMasternodeType::SetRewardAddress)) {
             CDataStructureV0 key{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::MNSetRewardAddress};
-            if (!attributes->GetValue(key, false)) {
+            if (!mnview.GetValue(key, false)) {
                 return Res::Err("Updating masternode reward address not currently enabled in attributes.");
             }
             if (rewardType) {
@@ -294,7 +292,7 @@ Res CMasternodesConsensus::operator()(const CUpdateMasterNodeMessage &obj) const
             }
         } else if (type == static_cast<uint8_t>(UpdateMasternodeType::RemRewardAddress)) {
             CDataStructureV0 key{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::MNSetRewardAddress};
-            if (!attributes->GetValue(key, false)) {
+            if (!mnview.GetValue(key, false)) {
                 return Res::Err("Updating masternode reward address not currently enabled in attributes.");
             }
             if (rewardType) {

--- a/src/dfi/consensus/poolpairs.cpp
+++ b/src/dfi/consensus/poolpairs.cpp
@@ -80,7 +80,9 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     token.creationTx = tx.GetHash();
     token.creationHeight = height;
 
-    auto tokenId = mnview.CreateToken(token, false);
+    // EVM Template will be null so no DST20 will be created
+    BlockContext dummyContext;
+    auto tokenId = mnview.CreateToken(token, dummyContext);
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/consensus/proposals.cpp
+++ b/src/dfi/consensus/proposals.cpp
@@ -23,9 +23,8 @@ Res CProposalsConsensus::IsOnChainGovernanceEnabled() const {
     CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovernanceEnabled};
 
     auto &mnview = blockCtx.GetView();
-    auto attributes = mnview.GetAttributes();
 
-    if (!attributes->GetValue(enabledKey, false)) {
+    if (!mnview.GetValue(enabledKey, false)) {
         return Res::Err("Cannot create tx, on-chain governance is not enabled");
     }
 
@@ -96,9 +95,8 @@ Res CProposalsConsensus::operator()(const CCreateProposalMessage &obj) const {
     const auto &tx = txCtx.GetTransaction();
     auto &mnview = blockCtx.GetView();
 
-    auto attributes = mnview.GetAttributes();
     CDataStructureV0 cfpMaxCycles{AttributeTypes::Governance, GovernanceIDs::Proposals, GovernanceKeys::CFPMaxCycles};
-    auto maxCycles = attributes->GetValue(cfpMaxCycles, static_cast<uint32_t>(MAX_CYCLES));
+    auto maxCycles = mnview.GetValue(cfpMaxCycles, static_cast<uint32_t>(MAX_CYCLES));
 
     if (obj.nCycles < 1 || obj.nCycles > maxCycles) {
         return Res::Err("proposal cycles can be between 1 and %d", maxCycles);

--- a/src/dfi/consensus/txvisitor.cpp
+++ b/src/dfi/consensus/txvisitor.cpp
@@ -117,11 +117,9 @@ Res CCustomTxVisitor::HasFoundationAuth() const {
     const auto &tx = txCtx.GetTransaction();
 
     auto members = consensus.foundationMembers;
-    const auto attributes = mnview.GetAttributes();
 
-    if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation},
-                             false)) {
-        if (const auto databaseMembers = attributes->GetValue(
+    if (mnview.GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation}, false)) {
+        if (const auto databaseMembers = mnview.GetValue(
                 CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
             !databaseMembers.empty()) {
             members = databaseMembers;
@@ -316,9 +314,7 @@ Res CCustomTxVisitor::CollateralPctCheck(const bool hasDUSDLoans,
 
     if (isPostNext) {
         const CDataStructureV0 enabledKey{AttributeTypes::Vaults, VaultIDs::DUSDVault, VaultKeys::DUSDVaultEnabled};
-        auto attributes = mnview.GetAttributes();
-
-        auto DUSDVaultsAllowed = attributes->GetValue(enabledKey, false);
+        auto DUSDVaultsAllowed = mnview.GetValue(enabledKey, false);
         if (DUSDVaultsAllowed && hasDUSDColl && !hasOtherColl) {
             return Res::Ok();  // every loan ok when DUSD loops allowed and 100% DUSD collateral
         }

--- a/src/dfi/consensus/vaults.cpp
+++ b/src/dfi/consensus/vaults.cpp
@@ -220,8 +220,7 @@ Res CVaultsConsensus::operator()(const CDepositToVaultMessage &obj) const {
     // If collateral token exist make sure it is enabled.
     if (mnview.GetCollateralTokenFromAttributes(obj.amount.nTokenId)) {
         CDataStructureV0 collateralKey{AttributeTypes::Token, obj.amount.nTokenId.v, TokenKeys::LoanCollateralEnabled};
-        const auto attributes = mnview.GetAttributes();
-        if (!attributes->GetValue(collateralKey, false)) {
+        if (!mnview.GetValue(collateralKey, false)) {
             return Res::Err("Collateral token (%d) is disabled", obj.amount.nTokenId.v);
         }
     }

--- a/src/dfi/consensus/xvm.cpp
+++ b/src/dfi/consensus/xvm.cpp
@@ -15,14 +15,13 @@
 
 constexpr uint32_t MAX_TRANSFERDOMAIN_EVM_DATA_LEN = 1024;
 
-static bool IsTransferDomainEnabled(const int height, const CCustomCSView &view, const Consensus::Params &consensus) {
+static bool IsTransferDomainEnabled(const int height, CCustomCSView &view, const Consensus::Params &consensus) {
     if (height < consensus.DF22MetachainHeight) {
         return false;
     }
 
     const CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::TransferDomain};
-    auto attributes = view.GetAttributes();
-    return attributes->GetValue(enabledKey, false);
+    return view.GetValue(enabledKey, false);
 }
 
 static XVmAddressFormatTypes FromTxDestType(const size_t index) {
@@ -190,7 +189,7 @@ static Res ValidateTransferDomainEdge(const CTransaction &tx,
 static Res ValidateTransferDomain(const CTransaction &tx,
                                   uint32_t height,
                                   const CCoinsViewCache &coins,
-                                  const CCustomCSView &mnview,
+                                  CCustomCSView &mnview,
                                   const Consensus::Params &consensus,
                                   const CTransferDomainMessage &obj,
                                   const bool isEvmEnabledForBlock,
@@ -241,8 +240,7 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
         return res;
     }
 
-    auto attributes = mnview.GetAttributes();
-    auto stats = attributes->GetValue(CTransferDomainStatsLive::Key, CTransferDomainStatsLive{});
+    auto stats = mnview.GetValue(CTransferDomainStatsLive::Key, CTransferDomainStatsLive{});
     std::string evmTxHash;
     CrossBoundaryResult result;
 
@@ -409,12 +407,8 @@ Res CXVMConsensus::operator()(const CTransferDomainMessage &obj) const {
         LogPrintf("Failed to store EVMToDVM TX hash for DFI TX %s\n", txHash);
     }
 
-    attributes->SetValue(CTransferDomainStatsLive::Key, stats);
-    res = mnview.SetVariable(*attributes);
-    if (!res) {
-        evm_try_unsafe_remove_txs_above_hash_in_template(result, evmTemplate->GetTemplate(), tx.GetHash().GetHex());
-        return res;
-    }
+    mnview.SetValue(CTransferDomainStatsLive::Key, stats);
+
     return Res::Ok();
 }
 

--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -894,10 +894,8 @@ static void TrackLiveBalance(CCustomCSView &mnview,
                              const CTokenAmount &amount,
                              const EconomyKeys dataKey,
                              const bool add) {
-    auto attributes = mnview.GetAttributes();
-
     CDataStructureV0 key{AttributeTypes::Live, ParamIDs::Economy, dataKey};
-    auto balances = attributes->GetValue(key, CBalances{});
+    auto balances = mnview.GetValue(key, CBalances{});
     Res res{};
     if (add) {
         res = balances.Add(amount);
@@ -905,8 +903,7 @@ static void TrackLiveBalance(CCustomCSView &mnview,
         res = balances.Sub(amount);
     }
     if (res) {
-        attributes->SetValue(key, balances);
-        mnview.SetVariable(*attributes);
+        mnview.SetValue(key, balances);
     }
 }
 
@@ -926,30 +923,17 @@ void TrackDUSDSub(CCustomCSView &mnview, const CTokenAmount &amount) {
 }
 
 void TrackLiveBalances(CCustomCSView &mnview, const CBalances &balances, const uint8_t key) {
-    auto attributes = mnview.GetAttributes();
-
     const CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Auction, key};
-    auto storedBalances = attributes->GetValue(liveKey, CBalances{});
+    auto storedBalances = mnview.GetValue(liveKey, CBalances{});
     for (const auto &[tokenID, amount] : balances.balances) {
         storedBalances.balances[tokenID] += amount;
     }
-    attributes->SetValue(liveKey, storedBalances);
-    mnview.SetVariable(*attributes);
+    mnview.SetValue(liveKey, storedBalances);
 }
 
-bool IsEVMEnabled(const std::shared_ptr<ATTRIBUTES> attributes) {
-    if (!attributes) {
-        return false;
-    }
-
+bool IsEVMEnabled(CCustomCSView &view) {
     const CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::EVMEnabled};
-    return attributes->GetValue(enabledKey, false);
-}
-
-bool IsEVMEnabled(const CCustomCSView &view, const Consensus::Params &consensus) {
-    auto attributes = view.GetAttributes();
-
-    return IsEVMEnabled(attributes);
+    return view.GetValue(enabledKey, false);
 }
 
 Res StoreGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view) {
@@ -1479,6 +1463,25 @@ Res ATTRIBUTES::Import(const UniValue &val) {
                     return Res::Ok();
                 } else if (attrV0->type == AttributeTypes::Token && attrV0->key == TokenKeys::LoanMintingInterest) {
                     interestTokens.insert(attrV0->typeId);
+                } else if (attrV0->type == AttributeTypes::Consortium && attrV0->key == ConsortiumKeys::MemberValues) {
+                    if (const auto newMembers = std::get_if<CConsortiumMembers>(&value)) {
+                        auto existingMembers = GetValue(*attrV0, CConsortiumMembers{});
+
+                        for (auto const &[newName, newMember] : *newMembers) {
+                            for (auto const &[oldName, oldMember] : existingMembers) {
+                                if (oldName != newName && oldMember.ownerAddress == newMember.ownerAddress) {
+                                    return Res::Err(
+                                        "Cannot add a member with an owner address of a existing consortium member!");
+                                }
+                            }
+
+                            existingMembers[newName] = newMember;
+                        }
+                        SetValue(attribute, existingMembers);
+                        return Res::Ok();
+                    } else {
+                        return Res::Err("Invalid member data");
+                    }
                 }
 
                 // apply DFI via old keys
@@ -1491,26 +1494,6 @@ Res ATTRIBUTES::Import(const UniValue &val) {
                     }
                     SetValue(newAttr, value);
                     return Res::Ok();
-                } else if (attrV0->type == AttributeTypes::Consortium && attrV0->key == ConsortiumKeys::MemberValues) {
-                    if (auto attrValue = std::get_if<CConsortiumMembers>(&value)) {
-                        auto members = GetValue(*attrV0, CConsortiumMembers{});
-
-                        for (auto const &member : *attrValue) {
-                            for (auto const &tmp : members) {
-                                if (tmp.first != member.first &&
-                                    tmp.second.ownerAddress == member.second.ownerAddress) {
-                                    return Res::Err(
-                                        "Cannot add a member with an owner address of a existing consortium member!");
-                                }
-                            }
-
-                            members[member.first] = member.second;
-                        }
-                        SetValue(*attrV0, members);
-                        return Res::Ok();
-                    } else {
-                        return Res::Err("Invalid member data");
-                    }
                 }
             }
             SetValue(attribute, value);
@@ -1859,7 +1842,8 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         [[fallthrough]];
                     case TokenKeys::PaybackDFI:
                     case TokenKeys::PaybackDFIFeePCT:
-                        if (!view.GetLoanTokenByID({attrV0->typeId})) {
+                        if (!view.GetLoanTokenByIDFromStore({attrV0->typeId}) &&
+                            !GetLoanTokenByID(view, {attrV0->typeId})) {
                             return DeFiErrors::GovVarValidateLoanToken(attrV0->typeId);
                         }
                         break;
@@ -1868,7 +1852,8 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                             return DeFiErrors::GovVarValidateFortCanningRoad();
                         }
-                        if (!view.GetLoanTokenByID({attrV0->typeId})) {
+                        if (!view.GetLoanTokenByIDFromStore({attrV0->typeId}) &&
+                            !GetLoanTokenByID(view, {attrV0->typeId})) {
                             return DeFiErrors::GovVarValidateLoanToken(attrV0->typeId);
                         }
                         if (!view.GetToken(DCT_ID{attrV0->keyId})) {
@@ -1961,7 +1946,8 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         if (view.GetLastHeight() < Params().GetConsensus().DF15FortCanningRoadHeight) {
                             return DeFiErrors::GovVarValidateFortCanningRoad();
                         }
-                        if (!view.GetLoanTokenByID({attrV0->typeId})) {
+                        if (!view.GetLoanTokenByIDFromStore({attrV0->typeId}) &&
+                            !GetLoanTokenByID(view, {attrV0->typeId})) {
                             return DeFiErrors::GovVarValidateLoanToken(attrV0->typeId);
                         }
                         break;
@@ -1985,7 +1971,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
 
                         if (!view.GetToken(DCT_ID{attrV0->typeId})) {
-                            return Res::Err("No such token (%d)", attrV0->typeId);
+                            return DeFiErrors::GovVarValidateToken(attrV0->typeId);
                         }
 
                         const auto members = std::get_if<CConsortiumMembers>(&value);
@@ -2019,7 +2005,7 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         }
 
                         if (!view.GetToken(DCT_ID{attrV0->typeId})) {
-                            return Res::Err("No such token (%d)", attrV0->typeId);
+                            return DeFiErrors::GovVarValidateToken(attrV0->typeId);
                         }
                         break;
                     default:
@@ -2037,22 +2023,23 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         return DeFiErrors::GovVarUnsupportedValue();
                     }
 
-                    for (const auto &[tokenId, multipler] : *splitMap) {
-                        if (tokenId == 0) {
+                    for (const auto &[tokenNum, multipler] : *splitMap) {
+                        if (tokenNum == 0) {
                             return DeFiErrors::GovVarValidateSplitDFI();
                         }
-                        if (view.HasPoolPair({tokenId})) {
+                        const DCT_ID tokenId{tokenNum};
+                        if (view.HasPoolPair(tokenId)) {
                             return DeFiErrors::GovVarValidateSplitPool();
                         }
-                        const auto token = view.GetToken(DCT_ID{tokenId});
+                        const auto token = view.GetToken(tokenId);
                         if (!token) {
-                            return DeFiErrors::GovVarValidateTokenExist(tokenId);
+                            return DeFiErrors::GovVarValidateTokenExist(tokenNum);
                         }
                         if (!token->IsDAT()) {
                             return DeFiErrors::GovVarValidateSplitDAT();
                         }
-                        if (!view.GetLoanTokenByID({tokenId})) {
-                            return DeFiErrors::GovVarValidateLoanTokenID(tokenId);
+                        if (!view.GetLoanTokenByIDFromStore(tokenId) && !GetLoanTokenByID(view, tokenId)) {
+                            return DeFiErrors::GovVarValidateLoanTokenID(tokenNum);
                         }
                     }
                 } else {
@@ -2127,17 +2114,19 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
             case AttributeTypes::Live:
                 break;
 
-            case AttributeTypes::Locks:
+            case AttributeTypes::Locks: {
                 if (view.GetLastHeight() < Params().GetConsensus().DF16FortCanningCrunchHeight) {
                     return Res::Err("Cannot be set before FortCanningCrunch");
                 }
                 if (attrV0->typeId != ParamIDs::TokenID) {
                     return Res::Err("Unrecognised locks id");
                 }
-                if (!view.GetLoanTokenByID(DCT_ID{attrV0->key}).has_value()) {
-                    return Res::Err("No loan token with id (%d)", attrV0->key);
+                const DCT_ID tokenId{attrV0->key};
+                if (!view.GetLoanTokenByIDFromStore(tokenId) && !GetLoanTokenByID(view, tokenId)) {
+                    return DeFiErrors::GovVarValidateLoanTokenID(attrV0->key);
                 }
                 break;
+            }
 
             case AttributeTypes::Governance:
                 if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight) {
@@ -2458,7 +2447,7 @@ Res ATTRIBUTES::Apply(CCustomCSView &mnview, const uint32_t height) {
     return Res::Ok();
 }
 
-Res ATTRIBUTES::Erase(CCustomCSView &mnview, uint32_t, const std::vector<std::string> &keys) {
+Res ATTRIBUTES::Erase(CCustomCSView &mnview, uint32_t height, const std::vector<std::string> &keys) {
     for (const auto &key : keys) {
         auto res = ProcessVariable(key, {}, [&](const CAttributeType &attribute, const CAttributeValue &) {
             auto attrV0 = std::get_if<CDataStructureV0>(&attribute);
@@ -2497,4 +2486,29 @@ Res ATTRIBUTES::Erase(CCustomCSView &mnview, uint32_t, const std::vector<std::st
     }
 
     return Res::Ok();
+}
+
+void ATTRIBUTES::SetAttributesMembers(const int64_t setTime, const std::shared_ptr<CScopedTemplate> &setEvmTemplate) {
+    time = setTime;
+    evmTemplate = setEvmTemplate;
+}
+
+std::optional<CLoanView::CLoanSetLoanTokenImpl> ATTRIBUTES::GetLoanTokenByID(const CCustomCSView &view,
+                                                                             const DCT_ID &id) const {
+    CDataStructureV0 pairKey{AttributeTypes::Token, id.v, TokenKeys::FixedIntervalPriceId};
+    CDataStructureV0 interestKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingInterest};
+    CDataStructureV0 mintableKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingEnabled};
+
+    if (const auto token = view.GetToken(id);
+        token && CheckKey(pairKey) && CheckKey(interestKey) && CheckKey(mintableKey)) {
+        CLoanView::CLoanSetLoanTokenImpl loanToken;
+        loanToken.fixedIntervalPriceId = GetValue(pairKey, CTokenCurrencyPair{});
+        loanToken.interest = GetValue(interestKey, CAmount{});
+        loanToken.mintable = GetValue(mintableKey, false);
+        loanToken.symbol = token->symbol;
+        loanToken.name = token->name;
+        return loanToken;
+    }
+
+    return {};
 }

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -5,449 +5,22 @@
 #ifndef DEFI_DFI_GOVVARIABLES_ATTRIBUTES_H
 #define DEFI_DFI_GOVVARIABLES_ATTRIBUTES_H
 
-#include <amount.h>
-#include <dfi/balances.h>
-#include <dfi/evm.h>
+#include <dfi/govvariables/attributetypes.h>
 #include <dfi/gv.h>
-#include <dfi/oracles.h>
 
+class CBlockIndex;
 namespace Consensus {
     struct Params;
 }
-
-enum VersionTypes : uint8_t {
-    v0 = 0,
-};
-
-enum AttributeTypes : uint8_t {
-    Live = 'l',
-    Oracles = 'o',
-    Param = 'a',
-    Token = 't',
-    Poolpairs = 'p',
-    Locks = 'L',
-    Governance = 'g',
-    Consortium = 'c',
-    Transfer = 'b',
-    EVMType = 'e',
-    Vaults = 'v',
-    Rules = 'r',
-};
-
-enum ParamIDs : uint8_t {
-    DFIP2201 = 'a',
-    DFIP2203 = 'b',
-    TokenID = 'c',
-    Economy = 'e',
-    DFIP2206A = 'f',
-    DFIP2206F = 'g',
-    Feature = 'h',
-    Auction = 'i',
-    Foundation = 'j',
-};
-
-enum OracleIDs : uint8_t {
-    Splits = 'a',
-};
-
-enum EVMIDs : uint8_t {
-    Block = 'a',
-};
-
-enum EVMKeys : uint8_t {
-    Finalized = 'a',
-    GasLimit = 'b',
-    GasTargetFactor = 'c',
-    RbfIncrementMinPct = 'd',
-};
-
-enum GovernanceIDs : uint8_t {
-    Global = 'a',
-    Proposals = 'b',
-};
-
-enum TransferIDs : uint8_t {
-    DVMToEVM = 'a',
-    EVMToDVM = 'b',
-};
-
-enum VaultIDs : uint8_t {
-    DUSDVault = 'a',
-};
-
-enum RulesIDs : uint8_t {
-    TXRules = 'a',
-};
-
-enum EconomyKeys : uint8_t {
-    PaybackDFITokens = 'a',
-    PaybackTokens = 'b',
-    DFIP2203Current = 'c',
-    DFIP2203Burned = 'd',
-    DFIP2203Minted = 'e',
-    DFIP2206FCurrent = 'f',
-    DFIP2206FBurned = 'g',
-    DFIP2206FMinted = 'h',
-    DexTokens = 'i',
-    NegativeInt = 'j',
-    NegativeIntCurrent = 'k',
-    ConsortiumMinted = 'l',
-    ConsortiumMembersMinted = 'm',
-    BatchRoundingExcess = 'n',        // Extra added to loan amounts on auction creation due to round errors.
-    ConsolidatedInterest = 'o',       // Amount added to loan amounts after auction with no bids.
-    PaybackDFITokensPrincipal = 'p',  // Same as PaybackDFITokens but without interest.
-    Loans = 'q',
-    TransferDomainStatsLive = 'r',
-    EVMBlockStatsLive = 's',
-};
-
-enum DFIPKeys : uint8_t {
-    Active = 'a',
-    Premium = 'b',
-    MinSwap = 'c',
-    RewardPct = 'd',
-    BlockPeriod = 'e',
-    DUSDInterestBurn = 'g',
-    DUSDLoanBurn = 'h',
-    StartBlock = 'i',
-    GovUnset = 'j',
-    GovFoundation = 'k',
-    MNSetRewardAddress = 'l',
-    MNSetOperatorAddress = 'm',
-    MNSetOwnerAddress = 'n',
-    ConsortiumEnabled = 'o',
-    Members = 'p',
-    GovernanceEnabled = 'q',
-    CFPPayout = 'r',
-    EmissionUnusedFund = 's',
-    MintTokens = 't',
-    EVMEnabled = 'u',
-    ICXEnabled = 'v',
-    TransferDomain = 'w',
-};
-
-enum GovernanceKeys : uint8_t {
-    FeeRedistribution = 'a',
-    FeeBurnPct = 'b',
-    CFPFee = 'd',
-    CFPApprovalThreshold = 'e',
-    VOCFee = 'f',
-    VOCEmergencyFee = 'g',
-    VOCEmergencyPeriod = 'h',
-    VOCApprovalThreshold = 'i',
-    Quorum = 'j',
-    VotingPeriod = 'k',
-    VOCEmergencyQuorum = 'l',
-    CFPMaxCycles = 'm',
-};
-
-enum TokenKeys : uint8_t {
-    PaybackDFI = 'a',
-    PaybackDFIFeePCT = 'b',
-    LoanPayback = 'c',
-    LoanPaybackFeePCT = 'd',
-    DexInFeePct = 'e',
-    DexOutFeePct = 'f',
-    DFIP2203Enabled = 'g',
-    FixedIntervalPriceId = 'h',
-    LoanCollateralEnabled = 'i',
-    LoanCollateralFactor = 'j',
-    LoanMintingEnabled = 'k',
-    LoanMintingInterest = 'l',
-    Ascendant = 'm',
-    Descendant = 'n',
-    Epitaph = 'o',
-    LoanPaybackCollateral = 'p',
-};
-
-enum ConsortiumKeys : uint8_t {
-    MemberValues = 'a',
-    MintLimit = 'b',
-    DailyMintLimit = 'c',
-};
-
-enum PoolKeys : uint8_t {
-    TokenAFeePCT = 'a',
-    TokenBFeePCT = 'b',
-    TokenAFeeDir = 'c',
-    TokenBFeeDir = 'd',
-};
-
-enum TransferKeys : uint8_t {
-    TransferEnabled = 'a',
-    SrcFormats = 'b',
-    DestFormats = 'c',
-    AuthFormats = 'd',
-    NativeEnabled = 'e',
-    DATEnabled = 'f',
-    Disallowed = 'g',
-};
-
-enum VaultKeys : uint8_t {
-    DUSDVaultEnabled = 'w',
-};
-
-enum RulesKeys : uint8_t {
-    CoreOPReturn = 'a',
-    DVMOPReturn = 'b',
-    EVMOPReturn = 'c',
-};
-
-struct CDataStructureV0 {
-    uint8_t type;
-    uint32_t typeId;
-    uint32_t key;
-    uint32_t keyId;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(type);
-        READWRITE(typeId);
-        READWRITE(VARINT(key));
-        if (IsExtendedSize()) {
-            READWRITE(keyId);
-        } else {
-            keyId = 0;
-        }
-    }
-
-    bool IsExtendedSize() const {
-        return type == AttributeTypes::Token && (key == TokenKeys::LoanPayback || key == TokenKeys::LoanPaybackFeePCT);
-    }
-
-    bool operator<(const CDataStructureV0 &o) const {
-        return std::tie(type, typeId, key, keyId) < std::tie(o.type, o.typeId, o.key, o.keyId);
-    }
-};
-
-// for future use
-struct CDataStructureV1 {
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {}
-
-    bool operator<(const CDataStructureV1 &o) const { return false; }
-};
-
-struct CTokenPayback {
-    CBalances tokensFee;
-    CBalances tokensPayback;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(tokensFee);
-        READWRITE(tokensPayback);
-    }
-};
-
-struct CFeeDir {
-    uint8_t feeDir;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(feeDir);
-    }
-};
-
-ResVal<CScript> GetFutureSwapContractAddress(const std::string &contract);
-
-struct CDexTokenInfo {
-    struct CTokenInfo {
-        uint64_t swaps;
-        uint64_t feeburn;
-        uint64_t commissions;
-
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream &s, Operation ser_action) {
-            READWRITE(swaps);
-            READWRITE(feeburn);
-            READWRITE(commissions);
-        }
-    };
-
-    CTokenInfo totalTokenA;
-    CTokenInfo totalTokenB;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(totalTokenA);
-        READWRITE(totalTokenB);
-    }
-};
-
-enum FeeDirValues : uint8_t { Both, In, Out };
-
-struct CTransferDomainStatsLive {
-    CStatsTokenBalances dvmEvmTotal;
-    CStatsTokenBalances evmDvmTotal;
-    CStatsTokenBalances dvmIn;
-    CStatsTokenBalances evmIn;
-    CStatsTokenBalances dvmOut;
-    CStatsTokenBalances evmOut;
-    CStatsTokenBalances dvmCurrent;
-    CStatsTokenBalances evmCurrent;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(dvmEvmTotal);
-        READWRITE(evmDvmTotal);
-        READWRITE(dvmIn);
-        READWRITE(evmIn);
-        READWRITE(dvmOut);
-        READWRITE(evmOut);
-        READWRITE(dvmCurrent);
-        READWRITE(evmCurrent);
-    }
-
-    static constexpr CDataStructureV0 Key = {AttributeTypes::Live,
-                                             ParamIDs::Economy,
-                                             EconomyKeys::TransferDomainStatsLive};
-};
-
-struct CConsortiumMember {
-    static const uint16_t MAX_CONSORTIUM_MEMBERS_STRING_LENGTH = 512;
-    static const uint16_t MIN_CONSORTIUM_MEMBERS_STRING_LENGTH = 3;
-    enum Status : uint8_t {
-        Active = 0,
-        Disabled = 0x01,
-    };
-
-    std::string name;
-    CScript ownerAddress;
-    std::string backingId;
-    CAmount mintLimit;
-    CAmount dailyMintLimit;
-    uint8_t status;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(name);
-        READWRITE(ownerAddress);
-        READWRITE(backingId);
-        READWRITE(mintLimit);
-        READWRITE(dailyMintLimit);
-        READWRITE(status);
-    }
-};
-
-struct CConsortiumMinted {
-    CAmount minted;
-    CAmount burnt;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(minted);
-        READWRITE(burnt);
-    }
-};
-
-struct CConsortiumDailyMinted : public CConsortiumMinted {
-    std::pair<uint32_t, CAmount> dailyMinted;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITEAS(CConsortiumMinted, *this);
-        READWRITE(dailyMinted);
-    }
-};
-
-enum XVmAddressFormatTypes : uint8_t {
-    None,
-    Bech32,
-    Bech32ProxyErc55,
-    PkHash,
-    PkHashProxyErc55,
-    Erc55,
-};
-
-struct CEvmBlockStatsLive {
-    CAmount feeBurnt;
-    CAmount feeBurntMin = std::numeric_limits<CAmount>::max();
-    uint256 feeBurntMinHash;
-    CAmount feeBurntMax = std::numeric_limits<CAmount>::min();
-    uint256 feeBurntMaxHash;
-    CAmount feePriority;
-    CAmount feePriorityMin = std::numeric_limits<CAmount>::max();
-    uint256 feePriorityMinHash;
-    CAmount feePriorityMax = std::numeric_limits<CAmount>::min();
-    uint256 feePriorityMaxHash;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(feeBurnt);
-        READWRITE(feeBurntMin);
-        READWRITE(feeBurntMinHash);
-        READWRITE(feeBurntMax);
-        READWRITE(feeBurntMaxHash);
-        READWRITE(feePriority);
-        READWRITE(feePriorityMin);
-        READWRITE(feePriorityMinHash);
-        READWRITE(feePriorityMax);
-        READWRITE(feePriorityMaxHash);
-    }
-
-    static constexpr CDataStructureV0 Key = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::EVMBlockStatsLive};
-};
-
-using CDexBalances = std::map<DCT_ID, CDexTokenInfo>;
-using OracleSplits = std::map<uint32_t, int32_t>;
-using DescendantValue = std::pair<uint32_t, int32_t>;
-using AscendantValue = std::pair<uint32_t, std::string>;
-using CConsortiumMembers = std::map<std::string, CConsortiumMember>;
-using CConsortiumMembersMinted = std::map<DCT_ID, std::map<std::string, CConsortiumDailyMinted>>;
-using CConsortiumGlobalMinted = std::map<DCT_ID, CConsortiumMinted>;
-using CAttributeType = std::variant<CDataStructureV0, CDataStructureV1>;
-using CAttributeValue = std::variant<bool,
-                                     CAmount,
-                                     CBalances,
-                                     CTokenPayback,
-                                     CTokenCurrencyPair,
-                                     OracleSplits,
-                                     DescendantValue,
-                                     AscendantValue,
-                                     CFeeDir,
-                                     CDexBalances,
-                                     std::set<CScript>,
-                                     std::set<std::string>,
-                                     CConsortiumMembers,
-                                     CConsortiumMembersMinted,
-                                     CConsortiumGlobalMinted,
-                                     int32_t,
-                                     uint32_t,
-                                     uint64_t,
-                                     XVmAddressFormatItems,
-                                     CTransferDomainStatsLive,
-                                     CEvmBlockStatsLive>;
 
 void TrackNegativeInterest(CCustomCSView &mnview, const CTokenAmount &amount);
 void TrackLiveBalances(CCustomCSView &mnview, const CBalances &balances, const uint8_t key);
 void TrackDUSDAdd(CCustomCSView &mnview, const CTokenAmount &amount);
 void TrackDUSDSub(CCustomCSView &mnview, const CTokenAmount &amount);
 
-bool IsEVMEnabled(const std::shared_ptr<ATTRIBUTES> attributes);
-bool IsEVMEnabled(const CCustomCSView &view, const Consensus::Params &consensus);
+bool IsEVMEnabled(CCustomCSView &view);
 Res StoreGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view);
+ResVal<CScript> GetFutureSwapContractAddress(const std::string &contract);
 
 enum GovVarsFilter {
     All,
@@ -477,6 +50,7 @@ public:
     static constexpr const char *TypeName() { return "ATTRIBUTES"; }
     static GovVariable *Create() { return new ATTRIBUTES(); }
 
+private:
     template <typename T>
     static void GetIf(std::optional<T> &opt, const CAttributeValue &var) {
         if (auto value = std::get_if<T>(&var)) {
@@ -491,6 +65,10 @@ public:
         }
     }
 
+    uint32_t time{};
+    std::shared_ptr<CScopedTemplate> evmTemplate{};
+
+public:
     template <typename K, typename T>
     [[nodiscard]] T GetValue(const K &key, T value) const {
         static_assert(std::is_convertible_v<K, CAttributeType>);
@@ -538,8 +116,6 @@ public:
         }
     }
 
-    [[nodiscard]] const std::map<CAttributeType, CAttributeValue> &GetAttributesMap() const { return attributes; }
-
     ADD_OVERRIDE_VECTOR_SERIALIZE_METHODS
     ADD_OVERRIDE_SERIALIZE_METHODS(CDataStream)
 
@@ -547,9 +123,6 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action) {
         READWRITE(attributes);
     }
-
-    uint32_t time{0};
-    std::shared_ptr<CScopedTemplate> evmTemplate{};
 
     // For formatting in export
     static const std::map<uint8_t, std::string> &displayVersions();
@@ -565,12 +138,9 @@ public:
     static const std::map<uint8_t, std::string> &displayRulesIDs();
     static const std::map<uint8_t, std::map<uint8_t, std::string>> &displayKeys();
 
-    Res RefundFuturesContracts(CCustomCSView &mnview,
-                               const uint32_t height,
-                               const uint32_t tokenID = std::numeric_limits<uint32_t>::max());
-
 private:
     friend class CGovView;
+    friend class CCustomCSView;
     bool futureUpdated{};
     bool futureDUSDUpdated{};
     std::set<uint32_t> tokenSplits{};
@@ -597,6 +167,13 @@ private:
                         const std::optional<UniValue> &value,
                         std::function<Res(const CAttributeType &, const CAttributeValue &)> applyVariable);
     Res RefundFuturesDUSD(CCustomCSView &mnview, const uint32_t height);
+    Res RefundFuturesContracts(CCustomCSView &mnview,
+                               const uint32_t height,
+                               const uint32_t tokenID = std::numeric_limits<uint32_t>::max());
+    void SetAttributesMembers(const int64_t setTime, const std::shared_ptr<CScopedTemplate> &setEvmTemplate);
+    [[nodiscard]] std::optional<CLoanView::CLoanSetLoanTokenImpl> GetLoanTokenByID(const CCustomCSView &view,
+                                                                                   const DCT_ID &id) const;
+    [[nodiscard]] bool IsChanged() const { return !changed.empty(); }
 };
 
 #endif  // DEFI_DFI_GOVVARIABLES_ATTRIBUTES_H

--- a/src/dfi/govvariables/attributetypes.h
+++ b/src/dfi/govvariables/attributetypes.h
@@ -1,0 +1,439 @@
+// Copyright (c) 2020 The DeFi Foundation
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFI_DFI_GOVVARIABLES_ATTRIBUTETYPES_H
+#define DEFI_DFI_GOVVARIABLES_ATTRIBUTETYPES_H
+
+#include <amount.h>
+#include <dfi/balances.h>
+#include <dfi/evm.h>
+#include <dfi/loan.h>
+#include <dfi/oracles.h>
+
+enum VersionTypes : uint8_t {
+    v0 = 0,
+};
+
+enum AttributeTypes : uint8_t {
+    Live = 'l',
+    Oracles = 'o',
+    Param = 'a',
+    Token = 't',
+    Poolpairs = 'p',
+    Locks = 'L',
+    Governance = 'g',
+    Consortium = 'c',
+    Transfer = 'b',
+    EVMType = 'e',
+    Vaults = 'v',
+    Rules = 'r',
+};
+
+enum ParamIDs : uint8_t {
+    DFIP2201 = 'a',
+    DFIP2203 = 'b',
+    TokenID = 'c',
+    Economy = 'e',
+    DFIP2206A = 'f',
+    DFIP2206F = 'g',
+    Feature = 'h',
+    Auction = 'i',
+    Foundation = 'j',
+};
+
+enum OracleIDs : uint8_t {
+    Splits = 'a',
+};
+
+enum EVMIDs : uint8_t {
+    Block = 'a',
+};
+
+enum EVMKeys : uint8_t {
+    Finalized = 'a',
+    GasLimit = 'b',
+    GasTargetFactor = 'c',
+    RbfIncrementMinPct = 'd',
+};
+
+enum GovernanceIDs : uint8_t {
+    Global = 'a',
+    Proposals = 'b',
+};
+
+enum TransferIDs : uint8_t {
+    DVMToEVM = 'a',
+    EVMToDVM = 'b',
+};
+
+enum VaultIDs : uint8_t {
+    DUSDVault = 'a',
+};
+
+enum RulesIDs : uint8_t {
+    TXRules = 'a',
+};
+
+enum EconomyKeys : uint8_t {
+    PaybackDFITokens = 'a',
+    PaybackTokens = 'b',
+    DFIP2203Current = 'c',
+    DFIP2203Burned = 'd',
+    DFIP2203Minted = 'e',
+    DFIP2206FCurrent = 'f',
+    DFIP2206FBurned = 'g',
+    DFIP2206FMinted = 'h',
+    DexTokens = 'i',
+    NegativeInt = 'j',
+    NegativeIntCurrent = 'k',
+    ConsortiumMinted = 'l',
+    ConsortiumMembersMinted = 'm',
+    BatchRoundingExcess = 'n',        // Extra added to loan amounts on auction creation due to round errors.
+    ConsolidatedInterest = 'o',       // Amount added to loan amounts after auction with no bids.
+    PaybackDFITokensPrincipal = 'p',  // Same as PaybackDFITokens but without interest.
+    Loans = 'q',
+    TransferDomainStatsLive = 'r',
+    EVMBlockStatsLive = 's',
+};
+
+enum DFIPKeys : uint8_t {
+    Active = 'a',
+    Premium = 'b',
+    MinSwap = 'c',
+    RewardPct = 'd',
+    BlockPeriod = 'e',
+    DUSDInterestBurn = 'g',
+    DUSDLoanBurn = 'h',
+    StartBlock = 'i',
+    GovUnset = 'j',
+    GovFoundation = 'k',
+    MNSetRewardAddress = 'l',
+    MNSetOperatorAddress = 'm',
+    MNSetOwnerAddress = 'n',
+    ConsortiumEnabled = 'o',
+    Members = 'p',
+    GovernanceEnabled = 'q',
+    CFPPayout = 'r',
+    EmissionUnusedFund = 's',
+    MintTokens = 't',
+    EVMEnabled = 'u',
+    ICXEnabled = 'v',
+    TransferDomain = 'w',
+};
+
+enum GovernanceKeys : uint8_t {
+    FeeRedistribution = 'a',
+    FeeBurnPct = 'b',
+    CFPFee = 'd',
+    CFPApprovalThreshold = 'e',
+    VOCFee = 'f',
+    VOCEmergencyFee = 'g',
+    VOCEmergencyPeriod = 'h',
+    VOCApprovalThreshold = 'i',
+    Quorum = 'j',
+    VotingPeriod = 'k',
+    VOCEmergencyQuorum = 'l',
+    CFPMaxCycles = 'm',
+};
+
+enum TokenKeys : uint8_t {
+    PaybackDFI = 'a',
+    PaybackDFIFeePCT = 'b',
+    LoanPayback = 'c',
+    LoanPaybackFeePCT = 'd',
+    DexInFeePct = 'e',
+    DexOutFeePct = 'f',
+    DFIP2203Enabled = 'g',
+    FixedIntervalPriceId = 'h',
+    LoanCollateralEnabled = 'i',
+    LoanCollateralFactor = 'j',
+    LoanMintingEnabled = 'k',
+    LoanMintingInterest = 'l',
+    Ascendant = 'm',
+    Descendant = 'n',
+    Epitaph = 'o',
+    LoanPaybackCollateral = 'p',
+};
+
+enum ConsortiumKeys : uint8_t {
+    MemberValues = 'a',
+    MintLimit = 'b',
+    DailyMintLimit = 'c',
+};
+
+enum PoolKeys : uint8_t {
+    TokenAFeePCT = 'a',
+    TokenBFeePCT = 'b',
+    TokenAFeeDir = 'c',
+    TokenBFeeDir = 'd',
+};
+
+enum TransferKeys : uint8_t {
+    TransferEnabled = 'a',
+    SrcFormats = 'b',
+    DestFormats = 'c',
+    AuthFormats = 'd',
+    NativeEnabled = 'e',
+    DATEnabled = 'f',
+    Disallowed = 'g',
+};
+
+enum VaultKeys : uint8_t {
+    DUSDVaultEnabled = 'w',
+};
+
+enum RulesKeys : uint8_t {
+    CoreOPReturn = 'a',
+    DVMOPReturn = 'b',
+    EVMOPReturn = 'c',
+};
+
+struct CDataStructureV0 {
+    uint8_t type;
+    uint32_t typeId;
+    uint32_t key;
+    uint32_t keyId;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(type);
+        READWRITE(typeId);
+        READWRITE(VARINT(key));
+        if (IsExtendedSize()) {
+            READWRITE(keyId);
+        } else {
+            keyId = 0;
+        }
+    }
+
+    bool IsExtendedSize() const {
+        return type == AttributeTypes::Token && (key == TokenKeys::LoanPayback || key == TokenKeys::LoanPaybackFeePCT);
+    }
+
+    bool operator<(const CDataStructureV0 &o) const {
+        return std::tie(type, typeId, key, keyId) < std::tie(o.type, o.typeId, o.key, o.keyId);
+    }
+};
+
+// for future use
+struct CDataStructureV1 {
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {}
+
+    bool operator<(const CDataStructureV1 &o) const { return false; }
+};
+
+struct CTokenPayback {
+    CBalances tokensFee;
+    CBalances tokensPayback;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(tokensFee);
+        READWRITE(tokensPayback);
+    }
+};
+
+struct CFeeDir {
+    uint8_t feeDir;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(feeDir);
+    }
+};
+
+struct CDexTokenInfo {
+    struct CTokenInfo {
+        uint64_t swaps;
+        uint64_t feeburn;
+        uint64_t commissions;
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream &s, Operation ser_action) {
+            READWRITE(swaps);
+            READWRITE(feeburn);
+            READWRITE(commissions);
+        }
+    };
+
+    CTokenInfo totalTokenA;
+    CTokenInfo totalTokenB;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(totalTokenA);
+        READWRITE(totalTokenB);
+    }
+};
+
+enum FeeDirValues : uint8_t { Both, In, Out };
+
+struct CTransferDomainStatsLive {
+    CStatsTokenBalances dvmEvmTotal;
+    CStatsTokenBalances evmDvmTotal;
+    CStatsTokenBalances dvmIn;
+    CStatsTokenBalances evmIn;
+    CStatsTokenBalances dvmOut;
+    CStatsTokenBalances evmOut;
+    CStatsTokenBalances dvmCurrent;
+    CStatsTokenBalances evmCurrent;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(dvmEvmTotal);
+        READWRITE(evmDvmTotal);
+        READWRITE(dvmIn);
+        READWRITE(evmIn);
+        READWRITE(dvmOut);
+        READWRITE(evmOut);
+        READWRITE(dvmCurrent);
+        READWRITE(evmCurrent);
+    }
+
+    static constexpr CDataStructureV0 Key = {AttributeTypes::Live,
+                                             ParamIDs::Economy,
+                                             EconomyKeys::TransferDomainStatsLive};
+};
+
+struct CConsortiumMember {
+    static const uint16_t MAX_CONSORTIUM_MEMBERS_STRING_LENGTH = 512;
+    static const uint16_t MIN_CONSORTIUM_MEMBERS_STRING_LENGTH = 3;
+    enum Status : uint8_t {
+        Active = 0,
+        Disabled = 0x01,
+    };
+
+    std::string name;
+    CScript ownerAddress;
+    std::string backingId;
+    CAmount mintLimit;
+    CAmount dailyMintLimit;
+    uint8_t status;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(name);
+        READWRITE(ownerAddress);
+        READWRITE(backingId);
+        READWRITE(mintLimit);
+        READWRITE(dailyMintLimit);
+        READWRITE(status);
+    }
+};
+
+struct CConsortiumMinted {
+    CAmount minted;
+    CAmount burnt;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(minted);
+        READWRITE(burnt);
+    }
+};
+
+struct CConsortiumDailyMinted : public CConsortiumMinted {
+    std::pair<uint32_t, CAmount> dailyMinted;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITEAS(CConsortiumMinted, *this);
+        READWRITE(dailyMinted);
+    }
+};
+
+enum XVmAddressFormatTypes : uint8_t {
+    None,
+    Bech32,
+    Bech32ProxyErc55,
+    PkHash,
+    PkHashProxyErc55,
+    Erc55,
+};
+
+struct CEvmBlockStatsLive {
+    CAmount feeBurnt;
+    CAmount feeBurntMin = std::numeric_limits<CAmount>::max();
+    uint256 feeBurntMinHash;
+    CAmount feeBurntMax = std::numeric_limits<CAmount>::min();
+    uint256 feeBurntMaxHash;
+    CAmount feePriority;
+    CAmount feePriorityMin = std::numeric_limits<CAmount>::max();
+    uint256 feePriorityMinHash;
+    CAmount feePriorityMax = std::numeric_limits<CAmount>::min();
+    uint256 feePriorityMaxHash;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(feeBurnt);
+        READWRITE(feeBurntMin);
+        READWRITE(feeBurntMinHash);
+        READWRITE(feeBurntMax);
+        READWRITE(feeBurntMaxHash);
+        READWRITE(feePriority);
+        READWRITE(feePriorityMin);
+        READWRITE(feePriorityMinHash);
+        READWRITE(feePriorityMax);
+        READWRITE(feePriorityMaxHash);
+    }
+
+    static constexpr CDataStructureV0 Key = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::EVMBlockStatsLive};
+};
+
+using CDexBalances = std::map<DCT_ID, CDexTokenInfo>;
+using OracleSplits = std::map<uint32_t, int32_t>;
+using DescendantValue = std::pair<uint32_t, int32_t>;
+using AscendantValue = std::pair<uint32_t, std::string>;
+using CConsortiumMembers = std::map<std::string, CConsortiumMember>;
+using CConsortiumMembersMinted = std::map<DCT_ID, std::map<std::string, CConsortiumDailyMinted>>;
+using CConsortiumGlobalMinted = std::map<DCT_ID, CConsortiumMinted>;
+using CAttributeType = std::variant<CDataStructureV0, CDataStructureV1>;
+using XVmAddressFormatItems = std::set<uint8_t>;
+
+using CAttributeValue = std::variant<bool,
+                                     CAmount,
+                                     CBalances,
+                                     CTokenPayback,
+                                     CTokenCurrencyPair,
+                                     OracleSplits,
+                                     DescendantValue,
+                                     AscendantValue,
+                                     CFeeDir,
+                                     CDexBalances,
+                                     std::set<CScript>,
+                                     std::set<std::string>,
+                                     CConsortiumMembers,
+                                     CConsortiumMembersMinted,
+                                     CConsortiumGlobalMinted,
+                                     int32_t,
+                                     uint32_t,
+                                     uint64_t,
+                                     XVmAddressFormatItems,
+                                     CTransferDomainStatsLive,
+                                     CEvmBlockStatsLive>;
+
+#endif  // DEFI_DFI_GOVVARIABLES_ATTRIBUTETYPES_H

--- a/src/dfi/gv.h
+++ b/src/dfi/gv.h
@@ -13,8 +13,6 @@
 class ATTRIBUTES;
 class CCustomCSView;
 
-using XVmAddressFormatItems = std::set<uint8_t>;
-
 template <typename T>
 class GvOptional : public std::optional<T> {
 public:
@@ -106,9 +104,12 @@ struct CGovernanceUnsetMessage {
 };
 
 class CGovView : public virtual CStorageView {
+protected:
+    [[nodiscard]] std::shared_ptr<ATTRIBUTES> GetAttributesFromStore() const;
+
 public:
-    Res SetVariable(const GovVariable &var);
-    std::shared_ptr<GovVariable> GetVariable(const std::string &govKey) const;
+    Res SetVariable(GovVariable &var);
+    [[nodiscard]] std::shared_ptr<GovVariable> GetVariable(const std::string &govKey) const;
 
     Res SetStoredVariables(const std::set<std::shared_ptr<GovVariable>> &govVars, const uint32_t height);
     std::set<std::shared_ptr<GovVariable>> GetStoredVariables(const uint32_t height);
@@ -117,9 +118,7 @@ public:
     std::map<std::string, std::map<uint64_t, std::shared_ptr<GovVariable>>> GetAllStoredVariables();
     void EraseStoredVariables(const uint32_t height);
 
-    std::shared_ptr<ATTRIBUTES> GetAttributes() const;
-
-    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) const = 0;
+    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) = 0;
 
     struct ByHeightVars {
         static constexpr uint8_t prefix() { return 'G'; }

--- a/src/dfi/loan.cpp
+++ b/src/dfi/loan.cpp
@@ -55,14 +55,14 @@ std::optional<CLoanView::CLoanSetCollateralTokenImpl> CLoanView::HasLoanCollater
 std::optional<CLoanView::CLoanSetLoanTokenImpl> CLoanView::GetLoanToken(const uint256 &txid) const {
     auto id = ReadBy<LoanSetLoanTokenCreationTx, DCT_ID>(txid);
     if (id) {
-        return GetLoanTokenByID(*id);
+        return GetLoanTokenByIDFromStore(*id);
     }
     return {};
 }
 
 Res CLoanView::SetLoanToken(const CLoanSetLoanTokenImpl &loanToken, DCT_ID const &id) {
     // this should not happen, but for sure
-    if (GetLoanTokenByID(id)) {
+    if (GetLoanTokenByIDFromStore(id)) {
         return Res::Err("setLoanToken with creation tx %s already exists!", loanToken.creationTx.GetHex());
     }
 

--- a/src/dfi/loan.h
+++ b/src/dfi/loan.h
@@ -412,8 +412,9 @@ public:
                                     const CollateralTokenKey &start = {DCT_ID{0}, UINT_MAX});
     std::optional<CLoanSetCollateralTokenImpl> HasLoanCollateralToken(const CollateralTokenKey &key);
 
-    std::optional<CLoanSetLoanTokenImpl> GetLoanToken(const uint256 &txid) const;
-    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(DCT_ID const &id) const = 0;
+    [[nodiscard]] std::optional<CLoanSetLoanTokenImpl> GetLoanToken(const uint256 &txid) const;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByIDFromStore(const DCT_ID &id) const = 0;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImpl> GetLoanTokenByID(const DCT_ID &id) = 0;
     Res SetLoanToken(const CLoanSetLoanTokenImpl &loanToken, DCT_ID const &id);
     Res UpdateLoanToken(const CLoanSetLoanTokenImpl &loanToken, DCT_ID const &id);
     Res EraseLoanToken(const DCT_ID &id);
@@ -479,9 +480,9 @@ public:
     CAmount GetLoanLiquidationPenalty();
 
     [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenFromAttributes(
-        const DCT_ID &id) const = 0;
+        const DCT_ID &id) = 0;
     [[nodiscard]] virtual std::optional<CLoanSetCollateralTokenImpl> GetCollateralTokenFromAttributes(
-        const DCT_ID &id) const = 0;
+        const DCT_ID &id) = 0;
 
     struct LoanSetCollateralTokenCreationTx {
         static constexpr uint8_t prefix() { return 0x10; }

--- a/src/dfi/mn_checks.h
+++ b/src/dfi/mn_checks.h
@@ -69,9 +69,9 @@ struct OpReturnLimits {
     uint64_t evmSizeBytes{};
 
     static OpReturnLimits Default();
-    static OpReturnLimits From(const uint64_t height, const Consensus::Params &consensus, const ATTRIBUTES &attributes);
+    static OpReturnLimits From(const uint64_t height, const Consensus::Params &consensus, CCustomCSView &mnview);
 
-    void SetToAttributesIfNotExists(ATTRIBUTES &attrs) const;
+    void SetToAttributesIfNotExists(CCustomCSView &mnviews) const;
     Res Validate(const CTransaction &tx, const CustomTxType txType) const;
     uint64_t MaxSize() { return std::max({coreSizeBytes, dvmSizeBytes, evmSizeBytes}); }
 };
@@ -92,9 +92,9 @@ struct TransferDomainConfig {
     std::set<uint32_t> evmToDvmDisallowedTokens;
 
     static TransferDomainConfig Default();
-    static TransferDomainConfig From(const CCustomCSView &mnview);
+    static TransferDomainConfig From(CCustomCSView &mnview);
 
-    void SetToAttributesIfNotExists(ATTRIBUTES &attrs) const;
+    void SetToAttributesIfNotExists(CCustomCSView &mnview) const;
 };
 
 struct CCustomTxMessageNone {};

--- a/src/dfi/oracles.h
+++ b/src/dfi/oracles.h
@@ -156,10 +156,10 @@ public:
     Res EraseIntervalBlock();
     uint32_t GetIntervalBlock() const;
 
-    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) const = 0;
+    [[nodiscard]] virtual bool AreTokensLocked(const std::set<uint32_t> &tokenIds) = 0;
     [[nodiscard]] virtual std::optional<CTokenImplementation> GetTokenGuessId(const std::string &str,
                                                                               DCT_ID &id) const = 0;
-    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenByID(DCT_ID const &id) const = 0;
+    [[nodiscard]] virtual std::optional<CLoanSetLoanTokenImplementation> GetLoanTokenByID(DCT_ID const &id) = 0;
 
     struct ByName {
         static constexpr uint8_t prefix() { return 'O'; }

--- a/src/dfi/proposals.h
+++ b/src/dfi/proposals.h
@@ -157,11 +157,11 @@ public:
     void ForEachCycleProposal(std::function<bool(const CProposalId &, const CProposalObject &)> callback,
                               uint32_t height);
 
-    virtual uint32_t GetVotingPeriodFromAttributes() const = 0;
-    virtual uint32_t GetEmergencyPeriodFromAttributes(const CProposalType &type) const = 0;
-    virtual CAmount GetApprovalThresholdFromAttributes(const CProposalType &type) const = 0;
-    virtual CAmount GetQuorumFromAttributes(const CProposalType &type, bool emergency = false) const = 0;
-    virtual CAmount GetFeeBurnPctFromAttributes() const = 0;
+    virtual uint32_t GetVotingPeriodFromAttributes() = 0;
+    virtual uint32_t GetEmergencyPeriodFromAttributes(const CProposalType &type) = 0;
+    virtual CAmount GetApprovalThresholdFromAttributes(const CProposalType &type) = 0;
+    virtual CAmount GetQuorumFromAttributes(const CProposalType &type, bool emergency = false) = 0;
+    virtual CAmount GetFeeBurnPctFromAttributes() = 0;
 
     struct ByType {
         static constexpr uint8_t prefix() { return 0x2B; }

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -2433,11 +2433,9 @@ UniValue getburninfo(const JSONRPCRequest &request) {
     auto hash = ::ChainActive().Tip()->GetBlockHash();
     auto fortCanningHeight = Params().GetConsensus().DF11FortCanningHeight;
     auto burnAddress = Params().GetConsensus().burnAddress;
-    auto view = *pcustomcsview;
-    const auto attributes = view.GetAttributes();
 
     CDataStructureV0 liveKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackDFITokens};
-    auto tokenBalances = attributes->GetValue(liveKey, CBalances{});
+    auto tokenBalances = pcustomcsview->GetValue(liveKey, CBalances{});
     for (const auto &balance : tokenBalances.balances) {
         if (balance.first == DCT_ID{0}) {
             dfiPaybackFee = balance.second;
@@ -2446,20 +2444,20 @@ UniValue getburninfo(const JSONRPCRequest &request) {
         }
     }
     liveKey = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::PaybackTokens};
-    auto paybacks = attributes->GetValue(liveKey, CTokenPayback{});
+    auto paybacks = pcustomcsview->GetValue(liveKey, CTokenPayback{});
     paybackfees = std::move(paybacks.tokensFee);
     paybacktokens = std::move(paybacks.tokensPayback);
 
     liveKey = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::DFIP2203Burned};
-    dfi2203Tokens = attributes->GetValue(liveKey, CBalances{});
+    dfi2203Tokens = pcustomcsview->GetValue(liveKey, CBalances{});
 
     liveKey = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::DFIP2206FBurned};
-    dfiToDUSDTokens = attributes->GetValue(liveKey, CBalances{});
+    dfiToDUSDTokens = pcustomcsview->GetValue(liveKey, CBalances{});
 
     for (const auto &kv : Params().GetConsensus().blockTokenRewards) {
         if (kv.first == CommunityAccountType::Unallocated || kv.first == CommunityAccountType::IncentiveFunding ||
             (height >= fortCanningHeight && kv.first == CommunityAccountType::Loan)) {
-            burnt += view.GetCommunityBalance(kv.first);
+            burnt += pcustomcsview->GetCommunityBalance(kv.first);
         }
     }
 
@@ -2581,7 +2579,7 @@ UniValue getburninfo(const JSONRPCRequest &request) {
     GetMemoizedResultCache().Set(request, {height, hash, *totalResult});
 
     liveKey = {AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::ConsortiumMinted};
-    auto balances = attributes->GetValue(liveKey, CConsortiumGlobalMinted{});
+    auto balances = pcustomcsview->GetValue(liveKey, CConsortiumGlobalMinted{});
 
     for (const auto &token : totalResult->nonConsortiumTokens.balances) {
         TAmounts amount;

--- a/src/dfi/rpc_loan.cpp
+++ b/src/dfi/rpc_loan.cpp
@@ -281,9 +281,7 @@ UniValue listcollateraltokens(const JSONRPCRequest &request) {
         return ret;
     }
 
-    auto attributes = view.GetAttributes();
-
-    attributes->ForEach(
+    view.ForEachAttribute(
         [&](const CDataStructureV0 &attr, const CAttributeValue &) {
             if (attr.type != AttributeTypes::Token) {
                 return false;
@@ -618,9 +616,7 @@ UniValue listloantokens(const JSONRPCRequest &request) {
         return ret;
     }
 
-    auto attributes = view.GetAttributes();
-
-    attributes->ForEach(
+    view.ForEachAttribute(
         [&](const CDataStructureV0 &attr, const CAttributeValue &) {
             if (attr.type != AttributeTypes::Token) {
                 return false;
@@ -1541,9 +1537,7 @@ UniValue getloaninfo(const JSONRPCRequest &request) {
         });
 
         // Now, let's go over attributes. If it's on attributes, the above calls would have done nothing.
-        auto attributes = view.GetAttributes();
-
-        attributes->ForEach(
+        view.ForEachAttribute(
             [&](const CDataStructureV0 &attr, const CAttributeValue &) {
                 if (attr.type != AttributeTypes::Token) {
                     return false;

--- a/src/dfi/rpc_poolpair.cpp
+++ b/src/dfi/rpc_poolpair.cpp
@@ -2,11 +2,7 @@
 
 #include <dfi/govvariables/attributes.h>
 
-UniValue poolToJSON(const CCustomCSView view,
-                    DCT_ID const &id,
-                    const CPoolPair &pool,
-                    const CToken &token,
-                    bool verbose) {
+UniValue poolToJSON(CCustomCSView &view, DCT_ID const &id, const CPoolPair &pool, const CToken &token, bool verbose) {
     UniValue poolObj(UniValue::VOBJ);
     poolObj.pushKV("symbol", token.symbol);
     poolObj.pushKV("name", token.name);
@@ -15,31 +11,29 @@ UniValue poolToJSON(const CCustomCSView view,
     poolObj.pushKV("idTokenB", pool.idTokenB.ToString());
 
     if (verbose) {
-        const auto attributes = view.GetAttributes();
-
         CDataStructureV0 dirAKey{AttributeTypes::Poolpairs, id.v, PoolKeys::TokenAFeeDir};
         CDataStructureV0 dirBKey{AttributeTypes::Poolpairs, id.v, PoolKeys::TokenBFeeDir};
-        const auto dirA = attributes->GetValue(dirAKey, CFeeDir{FeeDirValues::Both});
-        const auto dirB = attributes->GetValue(dirBKey, CFeeDir{FeeDirValues::Both});
+        const auto dirA = view.GetValue(dirAKey, CFeeDir{FeeDirValues::Both});
+        const auto dirB = view.GetValue(dirBKey, CFeeDir{FeeDirValues::Both});
 
-        if (const auto dexFee = pcustomcsview->GetDexFeeInPct(id, pool.idTokenA)) {
+        if (const auto dexFee = view.GetDexFeeInPct(id, pool.idTokenA)) {
             poolObj.pushKV("dexFeePctTokenA", ValueFromAmount(dexFee));
             if (dirA.feeDir == FeeDirValues::In || dirA.feeDir == FeeDirValues::Both) {
                 poolObj.pushKV("dexFeeInPctTokenA", ValueFromAmount(dexFee));
             }
         }
-        if (const auto dexFee = pcustomcsview->GetDexFeeOutPct(id, pool.idTokenB)) {
+        if (const auto dexFee = view.GetDexFeeOutPct(id, pool.idTokenB)) {
             poolObj.pushKV("dexFeePctTokenB", ValueFromAmount(dexFee));
             if (dirB.feeDir == FeeDirValues::Out || dirB.feeDir == FeeDirValues::Both) {
                 poolObj.pushKV("dexFeeOutPctTokenB", ValueFromAmount(dexFee));
             }
         }
-        if (const auto dexFee = pcustomcsview->GetDexFeeInPct(id, pool.idTokenB)) {
+        if (const auto dexFee = view.GetDexFeeInPct(id, pool.idTokenB)) {
             if (dirB.feeDir == FeeDirValues::In || dirB.feeDir == FeeDirValues::Both) {
                 poolObj.pushKV("dexFeeInPctTokenB", ValueFromAmount(dexFee));
             }
         }
-        if (const auto dexFee = pcustomcsview->GetDexFeeOutPct(id, pool.idTokenA)) {
+        if (const auto dexFee = view.GetDexFeeOutPct(id, pool.idTokenA)) {
             if (dirA.feeDir == FeeDirValues::Out || dirA.feeDir == FeeDirValues::Both) {
                 poolObj.pushKV("dexFeeOutPctTokenA", ValueFromAmount(dexFee));
             }
@@ -82,7 +76,7 @@ UniValue poolToJSON(const CCustomCSView view,
                 ++next_it;
 
                 // Get token balance
-                const auto balance = pcustomcsview->GetBalance(pool.ownerAddress, it->first).nValue;
+                const auto balance = view.GetBalance(pool.ownerAddress, it->first).nValue;
 
                 // Make there's enough to pay reward otherwise remove it
                 if (balance < it->second) {

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -331,11 +331,10 @@ UniValue updatetoken(const JSONRPCRequest &request) {
         rawTx.vin = GetAuthInputsSmart(
             pwallet, rawTx.nVersion, auths, true, optAuthTx, txInputs, request.metadata.coinSelectOpts);
     } else {  // post-bayfront auth
-        const auto attributes = pcustomcsview->GetAttributes();
         std::set<CScript> databaseMembers;
-        if (attributes->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation},
-                                 false)) {
-            databaseMembers = attributes->GetValue(
+        if (pcustomcsview->GetValue(CDataStructureV0{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::GovFoundation},
+                                    false)) {
+            databaseMembers = pcustomcsview->GetValue(
                 CDataStructureV0{AttributeTypes::Param, ParamIDs::Foundation, DFIPKeys::Members}, std::set<CScript>{});
         }
         bool isFoundersToken = !databaseMembers.empty() ? databaseMembers.find(owner) != databaseMembers.end()
@@ -401,10 +400,9 @@ UniValue tokenToJSON(CCustomCSView &view, DCT_ID const &id, const CTokenImplemen
         tokenObj.pushKV("finalized", token.IsFinalized());
         auto loanToken{token.IsLoanToken()};
         if (!loanToken) {
-            auto attributes = view.GetAttributes();
             CDataStructureV0 mintingKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingEnabled};
             CDataStructureV0 interestKey{AttributeTypes::Token, id.v, TokenKeys::LoanMintingInterest};
-            loanToken = attributes->GetValue(mintingKey, false) && attributes->CheckKey(interestKey);
+            loanToken = view.GetValue(mintingKey, false) && view.CheckKey(interestKey);
         }
         tokenObj.pushKV("isLoanToken", loanToken);
 
@@ -811,12 +809,11 @@ UniValue minttokens(const JSONRPCRequest &request) {
 
             if (token->IsDAT()) {
                 auto found{false};
-                auto attributes = pcustomcsview->GetAttributes();
 
                 CDataStructureV0 enableKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::ConsortiumEnabled};
-                if (attributes->GetValue(enableKey, false)) {
+                if (pcustomcsview->GetValue(enableKey, false)) {
                     CDataStructureV0 membersKey{AttributeTypes::Consortium, id.v, ConsortiumKeys::MemberValues};
-                    auto members = attributes->GetValue(membersKey, CConsortiumMembers{});
+                    auto members = pcustomcsview->GetValue(membersKey, CConsortiumMembers{});
 
                     for (const auto &member : members) {
                         if (IsMineCached(*pwallet, member.second.ownerAddress)) {
@@ -943,14 +940,12 @@ UniValue burntokens(const JSONRPCRequest &request) {
     }
 
     if (burnedTokens.amounts.balances.size() == 1 && metaObj["from"].isNull() && metaObj["context"].isNull()) {
-        auto attributes = pcustomcsview->GetAttributes();
-
         CDataStructureV0 enableKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::ConsortiumEnabled};
-        if (attributes->GetValue(enableKey, false)) {
+        if (pcustomcsview->GetValue(enableKey, false)) {
             CDataStructureV0 membersKey{AttributeTypes::Consortium,
                                         burnedTokens.amounts.balances.begin()->first.v,
                                         ConsortiumKeys::MemberValues};
-            auto members = attributes->GetValue(membersKey, CConsortiumMembers{});
+            auto members = pcustomcsview->GetValue(membersKey, CConsortiumMembers{});
 
             for (const auto &member : members) {
                 if (IsMineCached(*pwallet, member.second.ownerAddress)) {

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -69,8 +69,8 @@ Res CTokensView::CreateDFIToken() {
 }
 
 ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
-                                        bool isPreBayfront,
-                                        BlockContext *blockCtx) {
+                                        BlockContext &blockCtx,
+                                        bool isPreBayfront) {
     if (GetTokenByCreationTx(token.creationTx)) {
         return Res::Err("token with creation tx %s already exists!", token.creationTx.ToString());
     }
@@ -102,20 +102,17 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
                       id.ToString().c_str());
         }
 
-        if (blockCtx) {
-            const auto shouldCreateDst20 = blockCtx->GetEVMEnabledForBlock();
-            const auto &evmTemplate = blockCtx->GetEVMTemplate();
-            if (shouldCreateDst20 && evmTemplate) {
-                CrossBoundaryResult result;
-                evm_try_unsafe_create_dst20(result,
-                                            evmTemplate->GetTemplate(),
-                                            token.creationTx.GetHex(),
-                                            rust::string(token.name.c_str()),
-                                            rust::string(token.symbol.c_str()),
-                                            id.v);
-                if (!result.ok) {
-                    return Res::Err("Error creating DST20 token: %s", result.reason);
-                }
+        const auto &evmTemplate = blockCtx.GetEVMTemplate();
+        if (evmTemplate) {
+            CrossBoundaryResult result;
+            evm_try_unsafe_create_dst20(result,
+                                        evmTemplate->GetTemplate(),
+                                        token.creationTx.GetHex(),
+                                        rust::string(token.name.c_str()),
+                                        rust::string(token.symbol.c_str()),
+                                        id.v);
+            if (!result.ok) {
+                return Res::Err("Error creating DST20 token: %s", result.reason);
             }
         }
     } else {

--- a/src/dfi/tokens.h
+++ b/src/dfi/tokens.h
@@ -197,7 +197,7 @@ public:
                       DCT_ID const &start = DCT_ID{0});
 
     Res CreateDFIToken();
-    ResVal<DCT_ID> CreateToken(const CTokenImpl &token, bool isPreBayfront = false, BlockContext *blockCtx = nullptr);
+    ResVal<DCT_ID> CreateToken(const CTokenImpl &token, BlockContext &blockCtx, bool isPreBayfront = false);
     Res UpdateToken(const CTokenImpl &newToken, bool isPreBayfront = false, const bool tokenSplitUpdate = false);
 
     Res BayfrontFlagsCleanup();

--- a/src/dfi/validation.h
+++ b/src/dfi/validation.h
@@ -23,7 +23,7 @@ void ProcessDeFiEvent(const CBlock &block,
                       const CCoinsViewCache &view,
                       const CChainParams &chainparams,
                       const CreationTxs &creationTxs,
-                      const std::shared_ptr<CScopedTemplate> &evmTemplate);
+                      BlockContext &blockCtx);
 
 Res ProcessDeFiEventFallible(const CBlock &block,
                              const CBlockIndex *pindex,
@@ -31,6 +31,11 @@ Res ProcessDeFiEventFallible(const CBlock &block,
                              const CChainParams &chainparams,
                              const std::shared_ptr<CScopedTemplate> &evmTemplate,
                              const bool isEvmEnabledForBlock);
+
+void ProcessGovEvents(const CBlockIndex *pindex,
+                      CCustomCSView &cache,
+                      const CChainParams &chainparams,
+                      const std::shared_ptr<CScopedTemplate> &evmTemplate);
 
 std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets &vaultAssets,
                                                  const TAmounts &collBalances,

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -281,24 +281,22 @@ Attributes getAttributeValues(std::size_t mnview_ptr) {
         view = pcustomcsview.get();
     }
 
-    const auto attributes = view->GetAttributes();
-
     CDataStructureV0 blockGasTargetFactorKey{AttributeTypes::EVMType, EVMIDs::Block, EVMKeys::GasTargetFactor};
     CDataStructureV0 blockGasLimitKey{AttributeTypes::EVMType, EVMIDs::Block, EVMKeys::GasLimit};
     CDataStructureV0 finalityCountKey{AttributeTypes::EVMType, EVMIDs::Block, EVMKeys::Finalized};
     CDataStructureV0 rbfIncrementMinPctKey{AttributeTypes::EVMType, EVMIDs::Block, EVMKeys::RbfIncrementMinPct};
 
-    if (attributes->CheckKey(blockGasTargetFactorKey)) {
-        val.blockGasTargetFactor = attributes->GetValue(blockGasTargetFactorKey, DEFAULT_EVM_BLOCK_GAS_TARGET_FACTOR);
+    if (view->CheckKey(blockGasTargetFactorKey)) {
+        val.blockGasTargetFactor = view->GetValue(blockGasTargetFactorKey, DEFAULT_EVM_BLOCK_GAS_TARGET_FACTOR);
     }
-    if (attributes->CheckKey(blockGasLimitKey)) {
-        val.blockGasLimit = attributes->GetValue(blockGasLimitKey, DEFAULT_EVM_BLOCK_GAS_LIMIT);
+    if (view->CheckKey(blockGasLimitKey)) {
+        val.blockGasLimit = view->GetValue(blockGasLimitKey, DEFAULT_EVM_BLOCK_GAS_LIMIT);
     }
-    if (attributes->CheckKey(finalityCountKey)) {
-        val.finalityCount = attributes->GetValue(finalityCountKey, DEFAULT_EVM_FINALITY_COUNT);
+    if (view->CheckKey(finalityCountKey)) {
+        val.finalityCount = view->GetValue(finalityCountKey, DEFAULT_EVM_FINALITY_COUNT);
     }
-    if (attributes->CheckKey(rbfIncrementMinPctKey)) {
-        val.rbfIncrementMinPct = attributes->GetValue(rbfIncrementMinPctKey, DEFAULT_EVM_RBF_FEE_INCREMENT);
+    if (view->CheckKey(rbfIncrementMinPctKey)) {
+        val.rbfIncrementMinPct = view->GetValue(rbfIncrementMinPctKey, DEFAULT_EVM_RBF_FEE_INCREMENT);
     }
 
     return val;
@@ -317,7 +315,7 @@ rust::vec<DST20Token> getDST20Tokens(std::size_t mnview_ptr) {
     LOCK(cs_main);
 
     rust::vec<DST20Token> tokens;
-    CCustomCSView *cache = reinterpret_cast<CCustomCSView *>(static_cast<uintptr_t>(mnview_ptr));
+    auto *cache = reinterpret_cast<CCustomCSView *>(static_cast<uintptr_t>(mnview_ptr));
     cache->ForEachToken(
         [&](DCT_ID const &id, CTokensView::CTokenImpl token) {
             if (!token.IsDAT() || token.IsPoolShare()) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -233,6 +233,7 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;
+
     BlockContext blockCtx;
     auto &mnview = blockCtx.GetView();
     if (!blockTime) {
@@ -256,7 +257,6 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
         timeOrdering = false;
     }
 
-    const auto attributes = mnview.GetAttributes();
     const auto isEvmEnabledForBlock = blockCtx.GetEVMEnabledForBlock();
     const auto &evmTemplate = blockCtx.GetEVMTemplate();
 
@@ -301,42 +301,40 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
 
     // TXs for the creationTx field in new tokens created via token split
     if (nHeight >= chainparams.GetConsensus().DF16FortCanningCrunchHeight) {
-        if (attributes) {
-            CDataStructureV0 splitKey{AttributeTypes::Oracles, OracleIDs::Splits, static_cast<uint32_t>(nHeight)};
-            const auto splits = attributes->GetValue(splitKey, OracleSplits{});
+        CDataStructureV0 splitKey{AttributeTypes::Oracles, OracleIDs::Splits, static_cast<uint32_t>(nHeight)};
+        const auto splits = mnview.GetValue(splitKey, OracleSplits{});
 
-            for (const auto &[id, multiplier] : splits) {
-                uint32_t entries{1};
-                mnview.ForEachPoolPair([&, id = id](DCT_ID const &poolId, const CPoolPair &pool) {
-                    if (pool.idTokenA.v == id || pool.idTokenB.v == id) {
-                        const auto tokenA = mnview.GetToken(pool.idTokenA);
-                        const auto tokenB = mnview.GetToken(pool.idTokenB);
-                        assert(tokenA);
-                        assert(tokenB);
-                        if ((tokenA->destructionHeight == -1 && tokenA->destructionTx == uint256{}) &&
-                            (tokenB->destructionHeight == -1 && tokenB->destructionTx == uint256{})) {
-                            ++entries;
-                        }
+        for (const auto &[id, multiplier] : splits) {
+            uint32_t entries{1};
+            mnview.ForEachPoolPair([&, id = id](DCT_ID const &poolId, const CPoolPair &pool) {
+                if (pool.idTokenA.v == id || pool.idTokenB.v == id) {
+                    const auto tokenA = mnview.GetToken(pool.idTokenA);
+                    const auto tokenB = mnview.GetToken(pool.idTokenB);
+                    assert(tokenA);
+                    assert(tokenB);
+                    if ((tokenA->destructionHeight == -1 && tokenA->destructionTx == uint256{}) &&
+                        (tokenB->destructionHeight == -1 && tokenB->destructionTx == uint256{})) {
+                        ++entries;
                     }
-                    return true;
-                });
-
-                for (uint32_t i{0}; i < entries; ++i) {
-                    CDataStream metadata(DfTokenSplitMarker, SER_NETWORK, PROTOCOL_VERSION);
-                    metadata << i << id << multiplier;
-
-                    CMutableTransaction mTx(txVersion);
-                    mTx.vin.resize(1);
-                    mTx.vin[0].prevout.SetNull();
-                    mTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
-                    mTx.vout.resize(1);
-                    mTx.vout[0].scriptPubKey = CScript() << OP_RETURN << ToByteVector(metadata);
-                    mTx.vout[0].nValue = 0;
-                    pblock->vtx.push_back(MakeTransactionRef(std::move(mTx)));
-                    pblocktemplate->vTxFees.push_back(0);
-                    pblocktemplate->vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR *
-                                                            GetLegacySigOpCount(*pblock->vtx.back()));
                 }
+                return true;
+            });
+
+            for (uint32_t i{0}; i < entries; ++i) {
+                CDataStream metadata(DfTokenSplitMarker, SER_NETWORK, PROTOCOL_VERSION);
+                metadata << i << id << multiplier;
+
+                CMutableTransaction mTx(txVersion);
+                mTx.vin.resize(1);
+                mTx.vin[0].prevout.SetNull();
+                mTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+                mTx.vout.resize(1);
+                mTx.vout[0].scriptPubKey = CScript() << OP_RETURN << ToByteVector(metadata);
+                mTx.vout[0].nValue = 0;
+                pblock->vtx.push_back(MakeTransactionRef(std::move(mTx)));
+                pblocktemplate->vTxFees.push_back(0);
+                pblocktemplate->vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR *
+                                                        GetLegacySigOpCount(*pblock->vtx.back()));
             }
         }
     }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -4,6 +4,7 @@
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <dfi/masternodes.h>
 #include <net.h>
 #include <net_processing.h>
 #include <txmempool.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -348,7 +348,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     // Serialize passed information without accessing chain state of the active chain!
     AssertLockNotHeld(cs_main); // For performance reasons
     const auto consensus = Params().GetConsensus();
-    const auto isEvmEnabledForBlock = IsEVMEnabled(*pcustomcsview, consensus);
+    const auto isEvmEnabledForBlock = IsEVMEnabled(*pcustomcsview);
 
     auto txsToUniValue = [&isEvmEnabledForBlock](const CBlock& block, bool txDetails, int version) {
         UniValue txs(UniValue::VARR);

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -1,8 +1,7 @@
 #include <chainparams.h>
 #include <dfi/govvariables/attributes.h>
 #include <dfi/masternodes.h>
-#include <dfi/poolpairs.h>
-#include <validation.h>
+#include <dfi/mn_checks.h>
 
 #include <test/setup_common.h>
 
@@ -26,7 +25,8 @@ DCT_ID CreateToken(CCustomCSView &mnview, std::string const & symbol, uint8_t fl
     token.symbol = symbol;
     token.flags = flags;
 
-    auto res = mnview.CreateToken(token, false);
+    BlockContext dummyContext;
+    auto res = mnview.CreateToken(token, dummyContext);
     if (!res.ok) printf("%s\n", res.msg.c_str());
     BOOST_REQUIRE(res.ok);
     return *res.val;

--- a/src/test/loan_tests.cpp
+++ b/src/test/loan_tests.cpp
@@ -1,11 +1,10 @@
 #include <chainparams.h>
 #include <dfi/loan.h>
 #include <dfi/masternodes.h>
-#include <validation.h>
+#include <dfi/mn_checks.h>
 
 #include <test/setup_common.h>
 #include <boost/test/unit_test.hpp>
-#include <algorithm>
 
 inline uint256 NextTx()
 {
@@ -26,7 +25,8 @@ DCT_ID CreateToken(CCustomCSView &mnview, const std::string& symbol, const std::
     token.symbol = symbol;
     token.name = name;
 
-    auto res = mnview.CreateToken(token, false);
+    BlockContext dummyContext;
+    auto res = mnview.CreateToken(token, dummyContext);
     BOOST_REQUIRE(res.ok);
     return *res.val;
 }

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -4,6 +4,7 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <dfi/masternodes.h>
+#include <dfi/mn_checks.h>
 #include <rpc/rawtransaction_util.h>
 #include <test/setup_common.h>
 
@@ -180,11 +181,13 @@ BOOST_AUTO_TEST_CASE(tokens)
         BOOST_REQUIRE(pair->second->symbol == "DFI");
     }
 
+    BlockContext dummyContext;
+
     // token creation
     CTokenImplementation token1;
     token1.symbol = "DCT1";
     token1.creationTx = uint256S("0x1111");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok);
     BOOST_REQUIRE(GetTokensCount() == 2);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{128});
@@ -206,11 +209,11 @@ BOOST_AUTO_TEST_CASE(tokens)
     }
 
     // another token creation
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate symbol & tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok == false); /// duplicate symbol & tx
     token1.symbol = "DCT2";
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok == false); /// duplicate tx
     token1.creationTx = uint256S("0x2222");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok);
     BOOST_REQUIRE(GetTokensCount() == 3);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{129});

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1267,7 +1267,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
     std::vector<CTransactionRef> vtx;
 
     const auto &consensus = Params().GetConsensus();
-    const auto isEvmEnabledForBlock = IsEVMEnabled(viewDuplicate, consensus);
+    const auto isEvmEnabledForBlock = IsEVMEnabled(viewDuplicate);
 
     // Check custom TX consensus types are now not in conflict with account layer
     auto &txsByEntryTime = mapTx.get<entry_time>();


### PR DESCRIPTION
## Summary

- Moves attributes into CCustomCSView
- Removes the need to load ATTRIBUTES from the view as keys and values can be checked, retrieved, set, erased or looped through via the view itself.
- Attributes are loaded into CCustomCSView on demand and are passed on to copies of CCustomCSView. On Flush or before Flush if an undo is to be created the changes in the attribute copy is applied.
- Note that after Flush the copy in the parent is cleared with ClearAttributes(), this happen outside of SetAttributes(), but should be moved into it to avoid having to add these additional calls or update the parent copy.
- Change BlockContext argument to CreateToken to a reference.
- Move attribute types to its own file. Not needed but tidier.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [x] Includes consensus refactors
  - [ ] None
