### PR TITLE
EVM: Fix create token

### DIFF
--- a/lib/ain-cpp-imports/src/bridge.rs
+++ b/lib/ain-cpp-imports/src/bridge.rs
@@ -46,7 +46,7 @@ pub mod ffi {
         fn getEthSyncStatus() -> [i64; 2];
         fn getAttributeValues(mnview_ptr: usize) -> Attributes;
         fn CppLogPrintf(message: String);
-        fn getDST20Tokens(mnview_ptr: usize) -> Vec<DST20Token>;
+        fn getDST20Tokens(mnview_ptr: usize, tokens: &mut Vec<DST20Token>) -> bool;
         fn getClientVersion() -> String;
         fn getNumCores() -> i32;
         fn getCORSAllowedOrigin() -> String;

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -86,7 +86,7 @@ mod ffi {
         // Just the logs are skipped.
     }
 
-    pub fn getDST20Tokens(_mnview_ptr: usize) -> Vec<DST20Token> {
+    pub fn getDST20Tokens(mnview_ptr: usize, tokens: &mut Vec<DST20Token>) -> bool {
         unimplemented!("{}", UNIMPL_MSG)
     }
     pub fn getClientVersion() -> String {
@@ -211,8 +211,8 @@ pub fn log_print(message: &str) {
     ffi::CppLogPrintf(message.to_owned());
 }
 
-pub fn get_dst20_tokens(mnview_ptr: usize) -> Vec<ffi::DST20Token> {
-    ffi::getDST20Tokens(mnview_ptr)
+pub fn get_dst20_tokens(mnview_ptr: usize, tokens: &mut Vec<ffi::DST20Token>) -> bool {
+    ffi::getDST20Tokens(mnview_ptr, tokens)
 }
 
 pub fn get_num_cores() -> i32 {

--- a/lib/ain-evm/src/contract.rs
+++ b/lib/ain-evm/src/contract.rs
@@ -412,7 +412,11 @@ fn get_default_successful_receipt() -> ReceiptV3 {
 
 pub fn get_dst20_migration_txs(mnview_ptr: usize) -> Result<Vec<ExecuteTx>> {
     let mut txs = Vec::new();
-    for token in ain_cpp_imports::get_dst20_tokens(mnview_ptr) {
+    let mut tokens = vec![];
+    if !ain_cpp_imports::get_dst20_tokens(mnview_ptr, &mut tokens) {
+        return Err(format_err!("DST20 token migration failed, invalid UTF-8 encoding.").into());
+    }
+    for token in tokens {
         let address = ain_contracts::dst20_address_from_token_id(token.id)?;
         trace!(
             "[get_dst20_migration_txs] Deploying to address {:#?}",

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -154,6 +154,7 @@ DEFI_TESTS =\
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
+  test/utf8_string_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \
   test/versionbits_tests.cpp \

--- a/src/dfi/tokens.h
+++ b/src/dfi/tokens.h
@@ -22,6 +22,7 @@ class UniValue;
 class CToken {
 public:
     static const uint8_t MAX_TOKEN_NAME_LENGTH = 128;
+    static const uint8_t MAX_DST20_TOKEN_NAME_LENGTH = 30;
     static const uint8_t MAX_TOKEN_SYMBOL_LENGTH = 8;
     static const uint8_t MAX_TOKEN_POOLPAIR_LENGTH = 16;
     enum class TokenFlags : uint8_t {

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -314,7 +314,7 @@ uint32_t getEthMaxResponseByteSize() {
     return max_response_size_mb * 1024 * 1024;
 }
 
-bool getDST20Tokens(std::size_t mnview_ptr, rust::vec<DST20Token>& tokens) {
+bool getDST20Tokens(std::size_t mnview_ptr, rust::vec<DST20Token> &tokens) {
     LOCK(cs_main);
 
     bool res = true;

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -78,7 +78,7 @@ rust::string getStateInputJSON();
 std::array<int64_t, 2> getEthSyncStatus();
 Attributes getAttributeValues(std::size_t mnview_ptr);
 void CppLogPrintf(rust::string message);
-rust::vec<DST20Token> getDST20Tokens(std::size_t mnview_ptr);
+bool getDST20Tokens(std::size_t mnview_ptr, rust::vec<DST20Token>& tokens);
 rust::string getClientVersion();
 int32_t getNumCores();
 rust::string getCORSAllowedOrigin();

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -78,7 +78,7 @@ rust::string getStateInputJSON();
 std::array<int64_t, 2> getEthSyncStatus();
 Attributes getAttributeValues(std::size_t mnview_ptr);
 void CppLogPrintf(rust::string message);
-bool getDST20Tokens(std::size_t mnview_ptr, rust::vec<DST20Token>& tokens);
+bool getDST20Tokens(std::size_t mnview_ptr, rust::vec<DST20Token> &tokens);
 rust::string getClientVersion();
 int32_t getNumCores();
 rust::string getCORSAllowedOrigin();

--- a/src/test/utf8_string_tests.cpp
+++ b/src/test/utf8_string_tests.cpp
@@ -18,6 +18,10 @@ BOOST_AUTO_TEST_CASE(check_for_valid_utf8_strings)
     std::string test4 = "Slightly Smiling Face 🙂";
     std::string test5 = "🤣🤣🤣 Rolling on the Floor Laughing";
     std::string test6 = "🤩🤩🤩 Star-🤩Struck 🤩🤩";
+    std::string test7 = "Left till here away at to whom past. Feelings laughing at no wondered repeated provided finished."
+        " It acceptance thoroughly my advantages everything as. Are projecting inquietude affronting preference saw who."
+        " Marry of am do avoid ample as. Old disposal followed she ignorant desirous two has. Called played entire roused"
+        " though for one too. He into walk roof made tall cold he. Feelings way likewise addition wandered contempt bed indulged.";
 
     BOOST_CHECK(check_is_valid_utf8(test1));
     BOOST_CHECK(check_is_valid_utf8(test2));
@@ -25,6 +29,7 @@ BOOST_AUTO_TEST_CASE(check_for_valid_utf8_strings)
     BOOST_CHECK(check_is_valid_utf8(test4));
     BOOST_CHECK(check_is_valid_utf8(test5));
     BOOST_CHECK(check_is_valid_utf8(test6));
+    BOOST_CHECK(check_is_valid_utf8(test7));
 }
 
 BOOST_AUTO_TEST_CASE(check_for_invalid_utf8_strings)

--- a/src/test/utf8_string_tests.cpp
+++ b/src/test/utf8_string_tests.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <util/strencodings.h>
+#include <test/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(utf8_string_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(check_for_valid_utf8_strings)
+{
+    std::string test1 = "abcdefghijklmnopqrstuvwxyz1234567890~_= ^+%]{}";
+    std::string test2 = "abcdeàèéìòù";
+    std::string test3 = "😁 Beaming Face With Smiling Eyes";
+    std::string test4 = "Slightly Smiling Face 🙂";
+    std::string test5 = "🤣🤣🤣 Rolling on the Floor Laughing";
+    std::string test6 = "🤩🤩🤩 Star-🤩Struck 🤩🤩";
+
+    BOOST_CHECK(check_is_valid_utf8(test1));
+    BOOST_CHECK(check_is_valid_utf8(test2));
+    BOOST_CHECK(check_is_valid_utf8(test3));
+    BOOST_CHECK(check_is_valid_utf8(test4));
+    BOOST_CHECK(check_is_valid_utf8(test5));
+    BOOST_CHECK(check_is_valid_utf8(test6));
+}
+
+BOOST_AUTO_TEST_CASE(check_for_invalid_utf8_strings)
+{
+    std::string smiling_face = "😁";
+    std::string laughing_face = "🤣";
+    std::string star_struck_face = "🤩";
+    std::string test1 = smiling_face.substr(0, 1) +  " Beaming Face With Smiling Eyes";
+    std::string test2 = laughing_face.substr(0, 3) + laughing_face.substr(0, 2) + laughing_face.substr(0, 1) + " Rolling on the Floor Laughing";
+    std::string test3 = star_struck_face.substr(0, 1) + "🤩🤩 Star-🤩Struck 🤩🤩";
+
+    BOOST_CHECK(!check_is_valid_utf8(test1));
+    BOOST_CHECK(!check_is_valid_utf8(test2));
+    BOOST_CHECK(!check_is_valid_utf8(test3));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -578,3 +578,62 @@ std::string trim_ws(std::string const & str)
     size_t last = str.find_last_not_of(ws);
     return str.substr(first, (last - first + 1));
 }
+
+bool check_is_valid_utf8(const std::string& str)
+{
+    if (!str.data())
+        return true;
+
+    const unsigned char *bytes = (const unsigned char *)str.data();
+    unsigned int cp;
+    int num;
+
+    while (*bytes != 0x00)
+    {
+        if ((*bytes & 0x80) == 0x00)
+        {
+            // U+0000 to U+007F 
+            cp = (*bytes & 0x7F);
+            num = 1;
+        }
+        else if ((*bytes & 0xE0) == 0xC0)
+        {
+            // U+0080 to U+07FF 
+            cp = (*bytes & 0x1F);
+            num = 2;
+        }
+        else if ((*bytes & 0xF0) == 0xE0)
+        {
+            // U+0800 to U+FFFF 
+            cp = (*bytes & 0x0F);
+            num = 3;
+        }
+        else if ((*bytes & 0xF8) == 0xF0)
+        {
+            // U+10000 to U+10FFFF 
+            cp = (*bytes & 0x07);
+            num = 4;
+        }
+        else
+            return false;
+
+        bytes += 1;
+        for (int i = 1; i < num; ++i)
+        {
+            if ((*bytes & 0xC0) != 0x80)
+                return false;
+            cp = (cp << 6) | (*bytes & 0x3F);
+            bytes += 1;
+        }
+
+        if ((cp > 0x10FFFF) ||
+            ((cp >= 0xD800) && (cp <= 0xDFFF)) ||
+            ((cp <= 0x007F) && (num != 1)) ||
+            ((cp >= 0x0080) && (cp <= 0x07FF) && (num != 2)) ||
+            ((cp >= 0x0800) && (cp <= 0xFFFF) && (num != 3)) ||
+            ((cp >= 0x10000) && (cp <= 0x1FFFFF) && (num != 4)))
+            return false;
+    }
+
+    return true;
+}

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -40,6 +40,7 @@ std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);
 std::string trim_ws(std::string const & str);
+bool check_is_valid_utf8(const std::string& str);
 /* Returns true if each character in str is a hex character, and has an even
  * number of hex digits.*/
 bool IsHex(const std::string& str);


### PR DESCRIPTION
## Summary

- Add UTF-8 encoding check on cpp string to rust string conversions
- Limit token name length
- Add additional layer of UTF-8 encoding check on genesis block DST20 migration
- Add unit test for UTF-8 validity checks

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [x] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
