### PR TITLE
Fix EVM block invalidation

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3809,7 +3809,11 @@ bool CChainState::DisconnectTip(CValidationState &state,
             mnview.GetHistoryWriters().DiscardDB();
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         }
-        XResultThrowOnErr(evm_try_disconnect_latest_block(result));
+
+        if (auto res = pcustomcsview->GetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, pindexDelete->GetBlockHash().ToString())) {
+            XResultThrowOnErr(evm_try_disconnect_latest_block(result));
+        }
+
         bool flushed = view.Flush() && mnview.Flush();
         assert(flushed);
         mnview.GetHistoryWriters().FlushDB();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3810,8 +3810,7 @@ bool CChainState::DisconnectTip(CValidationState &state,
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         }
 
-        if (auto res =
-                pcustomcsview->GetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, pindexDelete->GetBlockHash().ToString())) {
+        if (XVM::TryFrom(block.vtx[0]->vout[1].scriptPubKey)) {
             XResultThrowOnErr(evm_try_disconnect_latest_block(result));
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3810,7 +3810,8 @@ bool CChainState::DisconnectTip(CValidationState &state,
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         }
 
-        if (auto res = pcustomcsview->GetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, pindexDelete->GetBlockHash().ToString())) {
+        if (auto res =
+                pcustomcsview->GetVMDomainBlockEdge(VMDomainEdge::DVMToEVM, pindexDelete->GetBlockHash().ToString())) {
             XResultThrowOnErr(evm_try_disconnect_latest_block(result));
         }
 


### PR DESCRIPTION
## Summary

- Check if EVM block hash exists in `vmmap` index before invalidating 
