### PR TITLE
CI: Fix Dirty tag to build release workflow

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -19,7 +19,9 @@ jobs:
       TARGET: x86_64-pc-linux-gnu
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -54,7 +56,9 @@ jobs:
       TARGET: aarch64-linux-gnu
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -75,7 +79,9 @@ jobs:
       TARGET: x86_64-w64-mingw32
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -96,7 +102,9 @@ jobs:
       TARGET: x86_64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -117,7 +125,9 @@ jobs:
       TARGET: aarch64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -142,7 +152,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -14,7 +14,9 @@ jobs:
       TARGET: x86_64-pc-linux-gnu
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -34,7 +36,9 @@ jobs:
       TARGET: aarch64-linux-gnu
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -54,7 +58,9 @@ jobs:
       TARGET: x86_64-w64-mingw32
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -74,7 +80,9 @@ jobs:
       TARGET: x86_64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -94,7 +102,9 @@ jobs:
       TARGET: aarch64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -122,7 +132,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars


### PR DESCRIPTION
## Summary

- Dirty tag issue caused from upgrading github checkout action from v1 to v3, which causes the workflow to create a local working branch when checking out the reference tag
- PR fixes the issue by explicitly specifying master branch ref on the checkout action, and upgrades the version from v3 to the latest v4.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
