### PR TITLE
CI: Fix creating / staging release

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -55,8 +55,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -78,8 +76,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -101,8 +97,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -124,8 +118,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -153,8 +153,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -133,8 +133,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -35,8 +35,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -57,8 +55,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -79,8 +75,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars
@@ -101,8 +95,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: master
 
     - name: Populate environment
       run: ./make.sh ci-export-vars

--- a/contrib/genbuild.sh
+++ b/contrib/genbuild.sh
@@ -55,7 +55,7 @@ if [ -z "$BUILD_VERSION" ] && [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$
     git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
 fi
 
-if [ -z "$BUILD_VERSION" ]; then
+if [ -n "$BUILD_VERSION" ]; then
     NEWINFO="#define BUILD_DESC \"$BUILD_VERSION\""
 elif [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""

--- a/contrib/genbuild.sh
+++ b/contrib/genbuild.sh
@@ -29,14 +29,6 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null
 
-    # if latest commit is tagged and not dirty, then override using the tag name
-    RAWDESC=$(git describe --tags --abbrev=0 2>/dev/null)
-    # shellcheck disable=SC2086
-    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
-        echo BUILD_DIRTY_CHECK: "$(git diff-index --quiet HEAD --)"
-        git diff-index --quiet HEAD -- && DESC=$RAWDESC
-    fi
-
     SUFFIX=$(git rev-parse --short HEAD)
     CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
     # Move to this after git upgrade from base images 
@@ -49,9 +41,10 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
         SUFFIX="$(echo $CURRENT_BRANCH | sed 's/\//-/g')-$SUFFIX"
     fi
 
+    # if latest commit is tagged, or if its hotfix branch, or if its master branch, we do not mark as dirty.
+    RAWDESC=$(git describe --tags --abbrev=0 2>/dev/null)
     if [ "$CURRENT_BRANCH" != "hotfix" ] && [ "$CURRENT_BRANCH" != "master" ] && [ "$(git rev-parse HEAD)" != "$(git rev-list -1 "$RAWDESC" 2>/dev/null)" ]; then
-        # if it's hotfix branch, don't mark dirty.
-        # otherwise generate suffix from git, i.e. string like "59887e8-dirty". 
+        # Otherwise generate suffix from git, i.e. string like "59887e8-dirty". 
         git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
     fi
 fi

--- a/contrib/genbuild.sh
+++ b/contrib/genbuild.sh
@@ -49,7 +49,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
         SUFFIX="$(echo $CURRENT_BRANCH | sed 's/\//-/g')-$SUFFIX"
     fi
 
-    if [ "$CURRENT_BRANCH" != "hotfix" ] && [ "$CURRENT_BRANCH" != "master" ]; then
+    if [ "$CURRENT_BRANCH" != "hotfix" ] && [ "$CURRENT_BRANCH" != "master" ] && [ "$(git rev-parse HEAD)" != "$(git rev-list -1 "$RAWDESC" 2>/dev/null)" ]; then
         # if it's hotfix branch, don't mark dirty.
         # otherwise generate suffix from git, i.e. string like "59887e8-dirty". 
         git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"

--- a/contrib/genbuild.sh
+++ b/contrib/genbuild.sh
@@ -42,8 +42,8 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
     fi
 
     # if latest commit is tagged, or if its hotfix branch, or if its master branch, we do not mark as dirty.
-    RAWDESC=$(git describe --tags --abbrev=0 2>/dev/null)
-    if [ "$CURRENT_BRANCH" != "hotfix" ] && [ "$CURRENT_BRANCH" != "master" ] && [ "$(git rev-parse HEAD)" != "$(git rev-list -1 "$RAWDESC" 2>/dev/null)" ]; then
+    TAG_DESC=$(git describe --tags --abbrev=0 2>/dev/null)
+    if [ "$CURRENT_BRANCH" != "hotfix" ] && [ "$CURRENT_BRANCH" != "master" ] && [ "$(git rev-parse HEAD)" != "$(git rev-list -1 "$TAG_DESC" 2>/dev/null)" ]; then
         # Otherwise generate suffix from git, i.e. string like "59887e8-dirty". 
         git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
     fi

--- a/contrib/genbuild.sh
+++ b/contrib/genbuild.sh
@@ -25,7 +25,7 @@ git_check_in_repo() {
 DESC=""
 SUFFIX=""
 CURRENT_BRANCH=""
-if [ -z "$GIT_VERSION" ] && [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo contrib/genbuild.sh; then
+if [ -z "$BUILD_VERSION" ] && [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo contrib/genbuild.sh; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null
 
@@ -55,8 +55,8 @@ if [ -z "$GIT_VERSION" ] && [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(c
     git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
 fi
 
-if [ -z "$GIT_VERSION" ]; then
-    NEWINFO="#define BUILD_DESC \"$GIT_VERSION\""
+if [ -z "$BUILD_VERSION" ]; then
+    NEWINFO="#define BUILD_DESC \"$BUILD_VERSION\""
 elif [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""
 elif [ -n "$SUFFIX" ]; then


### PR DESCRIPTION
## Summary

- This PR contains the more correct fixes in reference to PR #2706
- Create / staging release workflow waits for multi-arch build jobs and thus the master branch head may have changed during the workflow
- Or when setting the release, master branch may not be on the commit that the release tag is set on
- The PR removes explicit checking out of master branch ref in build-release / build-staging pipelines respectively so that we will ensure the correct git commit version in this step
- Instead when generating build.h file, we will skip git dirty check when the current git commit equals to the reference tag

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
