### PR TITLE
RPC: Add single key check for source and destination addresses in transferdomain RPC

### DIFF
--- a/ci/ethlibs_test/main.sh
+++ b/ci/ethlibs_test/main.sh
@@ -79,7 +79,7 @@ setup_fixtures() {
                     "v0/params/feature/transferdomain": "true"}}'
     $DEFI_CLI_BIN -regtest generatetoaddress 2 "$OWNERAUTHADDR"
 
-    $DEFI_CLI_BIN -regtest transferdomain '[{"src":{"address":"'"$OWNERAUTHADDR"'", "amount":"200@DFI", "domain":2}, "dst":{"address":"'"$ALICE"'", "amount":"200@DFI", "domain":3}}]'
+    $DEFI_CLI_BIN -regtest transferdomain '[{"src":{"address":"'"$OWNERAUTHADDR"'", "amount":"200@DFI", "domain":2}, "dst":{"address":"'"$ALICE"'", "amount":"200@DFI", "domain":3}, "singlekeycheck": False}]'
     $DEFI_CLI_BIN -regtest generatetoaddress 1 "$OWNERAUTHADDR"
 
     $DEFI_CLI_BIN -regtest eth_sendTransaction '{"from":"'"$ALICE"'", "data":"'"$CONTRACT_COUNTER"'", "value":"0x00", "gas":"0x7a120", "gasPrice": "0x22ecb25c00"}'

--- a/ci/ethlibs_test/main.sh
+++ b/ci/ethlibs_test/main.sh
@@ -79,7 +79,7 @@ setup_fixtures() {
                     "v0/params/feature/transferdomain": "true"}}'
     $DEFI_CLI_BIN -regtest generatetoaddress 2 "$OWNERAUTHADDR"
 
-    $DEFI_CLI_BIN -regtest transferdomain '[{"src":{"address":"'"$OWNERAUTHADDR"'", "amount":"200@DFI", "domain":2}, "dst":{"address":"'"$ALICE"'", "amount":"200@DFI", "domain":3}, "singlekeycheck": False}]'
+    $DEFI_CLI_BIN -regtest transferdomain '[{"src":{"address":"'"$OWNERAUTHADDR"'", "amount":"200@DFI", "domain":2}, "dst":{"address":"'"$ALICE"'", "amount":"200@DFI", "domain":3}, "singlekeycheck": false}]'
     $DEFI_CLI_BIN -regtest generatetoaddress 1 "$OWNERAUTHADDR"
 
     $DEFI_CLI_BIN -regtest eth_sendTransaction '{"from":"'"$ALICE"'", "data":"'"$CONTRACT_COUNTER"'", "value":"0x00", "gas":"0x7a120", "gasPrice": "0x22ecb25c00"}'

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -2124,7 +2124,7 @@ UniValue transferdomain(const JSONRPCRequest &request) {
         "DVM, etc.\n" +
             HelpRequiringPassphrase(pwallet) + "\n",
         {
-            {
+                          {
                 "array",
                 RPCArg::Type::ARR,
                 RPCArg::Optional::NO,
@@ -2188,8 +2188,7 @@ UniValue transferdomain(const JSONRPCRequest &request) {
                         },
                     },
                 },
-            },
-        },
+            }, },
         RPCResult{"\"hash\"                  (string) The hex-encoded hash of broadcasted transaction\n"},
         RPCExamples{
                           HelpExampleCli(
@@ -2223,9 +2222,9 @@ UniValue transferdomain(const JSONRPCRequest &request) {
         const UniValue &elem = srcDstArray[i].get_obj();
         RPCTypeCheckObj(elem,
                         {
-                            {"src", UniValueType(UniValue::VOBJ)},
-                            {"dst", UniValueType(UniValue::VOBJ)},
-                            {"nonce", UniValueType(UniValue::VNUM)},
+                            {"src",            UniValueType(UniValue::VOBJ) },
+                            {"dst",            UniValueType(UniValue::VOBJ) },
+                            {"nonce",          UniValueType(UniValue::VNUM) },
                             {"singlekeycheck", UniValueType(UniValue::VBOOL)},
         },
                         true,

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -2314,35 +2314,10 @@ UniValue transferdomain(const JSONRPCRequest &request) {
             singlekeycheck = singlekeycheckObj.getBool();
         }
         if (singlekeycheck) {
-            auto [uncomp, comp] = GetBothPubkeyCompressions(srcKey);
-
-            std::vector<CTxDestination> dests;
-            const auto dstIndex = DecodeDestination(dstObj["address"].getValStr()).index();
-            switch (dstIndex) {
-                case PKHashType:
-                    dests.push_back(GetDestinationForKey(comp, OutputType::LEGACY));
-                    dests.push_back(GetDestinationForKey(uncomp, OutputType::LEGACY));
-                    break;
-                case WitV0KeyHashType:
-                    dests.push_back(GetDestinationForKey(comp, OutputType::BECH32));
-                    break;
-                case WitV16KeyEthHashType:
-                    dests.push_back(GetDestinationForKey(uncomp, OutputType::ERC55));
-                    break;
-                default:
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid dst address provided");
-            }
-
-            bool found = false;
-            for (const auto dest : dests) {
-                auto script = GetScriptForDestination(dest);
-                if (dst.address == script) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found) {
+            auto dstKey = AddrToPubKey(pwallet, ScriptToString(dst.address));
+            auto [uncompSrcKey, compSrcKey] = GetBothPubkeyCompressions(srcKey);
+            auto [uncompDstKey, compDstKey] = GetBothPubkeyCompressions(dstKey);
+            if (uncompSrcKey != uncompDstKey || compSrcKey != compDstKey) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Dst address does not match source key");
             }
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4330,10 +4330,9 @@ UniValue addressmap(const JSONRPCRequest &request) {
                 throwInvalidAddressFmt();
             }
             CPubKey key = AddrToPubKey(pwallet, input);
-            if (!key.IsCompressed()) {
-                key.Compress();
-            }
-            format.pushKV("bech32", EncodeDestination(WitnessV0KeyHash(key)));
+            auto [uncomp, comp] = GetBothPubkeyCompressions(key);
+            format.pushKV("bech32", EncodeDestination(WitnessV0KeyHash(comp)));
+            format.pushKV("legacy", EncodeDestination(PKHash(uncomp)));
             break;
         }
         default:

--- a/test/functional/feature_address_map.py
+++ b/test/functional/feature_address_map.py
@@ -127,14 +127,17 @@ class addressmapTests(DefiTestFramework):
         ]
         addr_maps = [
             [
+                "n32jT7A5sv6t9Hm2NAYK6juuwsCdsWe1SF",
                 "bcrt1qmhpq9hxgdglwja6uruc92yne8ekxljgykrfta5",
                 "0xfD0766e7aBe123A25c73c95f6dc3eDe26D0b7263",
             ],
             [
+                "n4VvfBJBTQpDf8ooyjgehiq9mTjeKhcwEc",
                 "bcrt1qtqggfdte5jp8duffzmt54aqtqwlv3l8xsjdrhf",
                 "0x4d07A76Db2a281a348d5A5a1833F4322D77799d5",
             ],
             [
+                "n1HUChzN3RR89jhtehNBNboLUnt4QNAJ8E",
                 "bcrt1qdw7fqrq9n2d530uh05vdm2yvpag2ydm0z67yc5",
                 "0x816a4DDbC26B80602767B13Fb17B2e1785125BE7",
             ],
@@ -151,44 +154,58 @@ class addressmapTests(DefiTestFramework):
             #
             # self.nodes[0].importprivkey(wif)
             self.nodes[0].importprivkey(rawkey)
-        for [dfi_addr, eth_addr] in addr_maps:
+        for [legacy_address, bech32_address, erc55_address] in addr_maps:
             # dvm -> evm
             res = self.nodes[0].addressmap(
-                dfi_addr, AddressConversionType.DVMToEVMAddress
+                legacy_address, AddressConversionType.DVMToEVMAddress
             )
-            assert_equal(res["input"], dfi_addr)
+            assert_equal(res["input"], legacy_address)
             assert_equal(res["type"], 1)
-            assert_equal(res["format"]["erc55"], eth_addr)
+            assert_equal(res["format"]["erc55"], erc55_address)
+
+            res = self.nodes[0].addressmap(
+                bech32_address, AddressConversionType.DVMToEVMAddress
+            )
+            assert_equal(res["input"], bech32_address)
+            assert_equal(res["type"], 1)
+            assert_equal(res["format"]["erc55"], erc55_address)
 
             # evm -> dvm
             res = self.nodes[0].addressmap(
-                eth_addr, AddressConversionType.EVMToDVMAddress
+                erc55_address, AddressConversionType.EVMToDVMAddress
             )
-            assert_equal(res["input"], eth_addr)
+            assert_equal(res["input"], erc55_address)
             assert_equal(res["type"], 2)
-            assert_equal(res["format"]["bech32"], dfi_addr)
+            assert_equal(res["format"]["legacy"], legacy_address)
+            assert_equal(res["format"]["bech32"], bech32_address)
 
             # auto (dvm -> evm)
-            res = self.nodes[0].addressmap(dfi_addr, AddressConversionType.Auto)
-            assert_equal(res["input"], dfi_addr)
+            res = self.nodes[0].addressmap(legacy_address, AddressConversionType.Auto)
+            assert_equal(res["input"], legacy_address)
             assert_equal(res["type"], 1)
-            assert_equal(res["format"]["erc55"], eth_addr)
+            assert_equal(res["format"]["erc55"], erc55_address)
+
+            res = self.nodes[0].addressmap(bech32_address, AddressConversionType.Auto)
+            assert_equal(res["input"], bech32_address)
+            assert_equal(res["type"], 1)
+            assert_equal(res["format"]["erc55"], erc55_address)
 
             # auto (evm -> dvm)
-            res = self.nodes[0].addressmap(eth_addr, AddressConversionType.Auto)
-            assert_equal(res["input"], eth_addr)
+            res = self.nodes[0].addressmap(erc55_address, AddressConversionType.Auto)
+            assert_equal(res["input"], erc55_address)
             assert_equal(res["type"], 2)
-            assert_equal(res["format"]["bech32"], dfi_addr)
+            assert_equal(res["format"]["legacy"], legacy_address)
+            assert_equal(res["format"]["bech32"], bech32_address)
 
     def addressmap_valid_address_not_present_should_fail(self):
         self.rollback_to(self.start_block_height)
         # Give an address that is not own by the node. THis should fail since we don't have the public key of the address.
-        eth_address = self.nodes[1].getnewaddress("", "erc55")
+        erc55_addressess = self.nodes[1].getnewaddress("", "erc55")
         assert_raises_rpc_error(
             -5,
-            "no full public key for address " + eth_address,
+            "no full public key for address " + erc55_addressess,
             self.nodes[0].addressmap,
-            eth_address,
+            erc55_addressess,
             AddressConversionType.EVMToDVMAddress,
         )
 
@@ -196,7 +213,7 @@ class addressmapTests(DefiTestFramework):
         self.rollback_to(self.start_block_height)
         address = self.nodes[0].getnewaddress("", "legacy")
         p2sh_address = self.nodes[0].getnewaddress("", "p2sh-segwit")
-        eth_address = self.nodes[0].getnewaddress("", "erc55")
+        erc55_addressess = self.nodes[0].getnewaddress("", "erc55")
         assert_invalid_parameter = lambda *args: assert_raises_rpc_error(
             -8, "Invalid type parameter", self.nodes[0].addressmap, *args
         )
@@ -205,7 +222,7 @@ class addressmapTests(DefiTestFramework):
         )
         assert_invalid_parameter(address, 9)
         assert_invalid_parameter(address, -1)
-        assert_invalid_format(eth_address, AddressConversionType.DVMToEVMAddress)
+        assert_invalid_format(erc55_addressess, AddressConversionType.DVMToEVMAddress)
         assert_invalid_format(address, AddressConversionType.EVMToDVMAddress)
         assert_invalid_format(p2sh_address, AddressConversionType.DVMToEVMAddress)
         assert_invalid_format(p2sh_address, AddressConversionType.DVMToEVMAddress)
@@ -213,19 +230,19 @@ class addressmapTests(DefiTestFramework):
     def addressmap_invalid_address_should_fail(self):
         self.rollback_to(self.start_block_height)
         # Check that addressmap is failing on wrong input
-        eth_address = "0x0000000000000000000000000000000000000000"
+        erc55_addressess = "0x0000000000000000000000000000000000000000"
         assert_raises_rpc_error(
             -5,
-            eth_address + " does not refer to a key",
+            erc55_addressess + " does not refer to a key",
             self.nodes[0].addressmap,
-            eth_address,
+            erc55_addressess,
             AddressConversionType.EVMToDVMAddress,
         )
         assert_raises_rpc_error(
             -8,
             "Invalid address format",
             self.nodes[0].addressmap,
-            eth_address,
+            erc55_addressess,
             AddressConversionType.DVMToEVMAddress,
         )
         assert_raises_rpc_error(

--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -63,6 +63,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -361,6 +362,7 @@ class EVMTest(DefiTestFramework):
                             "amount": "100@DFI",
                             "domain": 3,
                         },
+                        "singlekeycheck": False,
                     }
                 ],
             )
@@ -383,6 +385,7 @@ class EVMTest(DefiTestFramework):
                             "amount": "100@DFI",
                             "domain": 3,
                         },
+                        "singlekeycheck": False,
                     }
                 ],
             )
@@ -418,6 +421,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -447,6 +451,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -581,6 +586,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -610,6 +616,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -639,6 +646,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -738,6 +746,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "200@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -1362,6 +1371,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "0.1@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -1377,6 +1387,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "0.1@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -1396,6 +1407,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "2@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -1416,6 +1428,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "20@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_contract_env_vars.py
+++ b/test/functional/feature_evm_contract_env_vars.py
@@ -73,6 +73,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -75,6 +75,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_dfi_intrinsics.py
+++ b/test/functional/feature_evm_dfi_intrinsics.py
@@ -147,6 +147,7 @@ class DFIIntrinsicsTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -230,6 +230,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@USDT",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -253,6 +254,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "1@USDT", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -370,6 +372,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -401,6 +404,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -429,6 +433,7 @@ class DST20(DefiTestFramework):
                         "amount": "1.5@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -459,6 +464,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "nonce": nonce,
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -472,6 +478,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "nonce": nonce + 1,
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -503,6 +510,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -515,6 +523,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "1@BTC", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -548,6 +557,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "1@BTC", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -583,6 +593,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@XYZ",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -617,6 +628,7 @@ class DST20(DefiTestFramework):
                         "amount": "-1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -634,6 +646,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@ETH",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -708,6 +721,7 @@ class DST20(DefiTestFramework):
                         "amount": "2@TSLA",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -735,6 +749,7 @@ class DST20(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "1@TSLA", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -764,6 +779,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -801,6 +817,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -840,6 +857,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -879,6 +897,7 @@ class DST20(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_eip1559_fees.py
+++ b/test/functional/feature_evm_eip1559_fees.py
@@ -77,6 +77,7 @@ class EIP1559Fees(DefiTestFramework):
                         "amount": "10@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_fee.py
+++ b/test/functional/feature_evm_fee.py
@@ -324,6 +324,7 @@ class EVMFeeTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_gas.py
+++ b/test/functional/feature_evm_gas.py
@@ -96,6 +96,7 @@ class EVMGasTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_genesis.py
+++ b/test/functional/feature_evm_genesis.py
@@ -99,6 +99,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_logs.py
+++ b/test/functional/feature_evm_logs.py
@@ -77,6 +77,7 @@ class EVMTestLogs(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -153,6 +154,7 @@ class EVMTestLogs(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_mempool.py
+++ b/test/functional/feature_evm_mempool.py
@@ -99,6 +99,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -120,6 +121,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 2,
                     },
                     "nonce": nonce,
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -420,6 +422,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 2,
                     },
                     "nonce": nonce,
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -103,6 +103,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -327,6 +328,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ]
             )
@@ -440,6 +442,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ]
             )
@@ -534,6 +537,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ]
             )
@@ -1025,6 +1029,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ]
             )
@@ -1051,6 +1056,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ]
             )
@@ -1076,6 +1082,7 @@ class EVMTest(DefiTestFramework):
                             "domain": 3,
                         },
                         "nonce": start_nonce_erc55 + i,
+                        "singlekeycheck": False,
                     }
                 ],
             )

--- a/test/functional/feature_evm_proxy.py
+++ b/test/functional/feature_evm_proxy.py
@@ -73,6 +73,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_rollback.py
+++ b/test/functional/feature_evm_rollback.py
@@ -84,6 +84,7 @@ class EVMRolllbackTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -242,6 +243,7 @@ class EVMRolllbackTest(DefiTestFramework):
                             "amount": "10@DFI",
                             "domain": 3,
                         },
+                        "singlekeycheck": False,
                     }
                 ]
             )

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -101,6 +101,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -334,6 +335,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -86,6 +86,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_rpc_filters.py
+++ b/test/functional/feature_evm_rpc_filters.py
@@ -74,6 +74,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_rpc_transaction.py
+++ b/test/functional/feature_evm_rpc_transaction.py
@@ -105,6 +105,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -502,6 +503,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 2,
                     },
                     "nonce": nonce + 2,
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -537,6 +539,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "1@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_smart_contract.py
+++ b/test/functional/feature_evm_smart_contract.py
@@ -124,6 +124,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "10@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -162,6 +163,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_transaction_replacement.py
+++ b/test/functional/feature_evm_transaction_replacement.py
@@ -100,6 +100,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -14,6 +14,8 @@ from test_framework.util import (
 from test_framework.evm_contract import EVMContract
 from test_framework.evm_key_pair import EvmKeyPair
 
+import json
+import math
 from decimal import Decimal
 
 
@@ -27,6 +29,7 @@ def transfer_domain(node, fromAddr, toAddr, amount, fromDomain, toDomain):
                     "amount": amount,
                     "domain": toDomain,
                 },
+                "singlekeycheck": False,
             }
         ]
     )
@@ -264,7 +267,7 @@ class EVMTest(DefiTestFramework):
 
         self.start_height = self.nodes[0].getblockcount()
 
-    def check_initial_balance(self):
+    def setup_after_evm_activation(self):
         self.rollback_to(self.start_height)
 
         # Check initial balances
@@ -273,6 +276,43 @@ class EVMTest(DefiTestFramework):
         assert_equal(self.dfi_balance, Decimal("101"))
         assert_equal(self.eth_balance, int_to_eth_u256(0))
         assert_equal(len(self.nodes[0].getaccount(self.eth_address, {}, True)), 0)
+
+        self.contract_address_btc = self.nodes[0].w3.to_checksum_address(
+            "0xff00000000000000000000000000000000000001"
+        )
+        self.btc = self.nodes[0].w3.eth.contract(
+            address=self.contract_address_btc, abi=self.abi
+        )
+        self.bytecode = json.loads(
+            open(
+                get_solc_artifact_path("dst20", "deployed_bytecode.json"),
+                "r",
+                encoding="utf8",
+            ).read()
+        )["object"]
+        assert_equal(self.btc.functions.name().call(), "BTC token")
+        assert_equal(self.btc.functions.symbol().call(), "BTC")
+
+        # check BTC migration
+        genesis_block = self.nodes[0].eth_getBlockByNumber("0x0")
+        btc_tx = genesis_block["transactions"][5]
+        receipt = self.nodes[0].eth_getTransactionReceipt(btc_tx)
+        tx = self.nodes[0].eth_getTransactionByHash(btc_tx)
+        assert_equal(
+            self.nodes[0].w3.to_checksum_address(receipt["contractAddress"]),
+            self.contract_address_btc,
+        )
+        assert_equal(receipt["from"], tx["from"])
+        assert_equal(receipt["gasUsed"], "0x0")
+        assert_equal(receipt["logs"], [])
+        assert_equal(receipt["status"], "0x1")
+        assert_equal(receipt["to"], None)
+        assert_equal(
+            self.nodes[0].w3.to_hex(
+                self.nodes[0].w3.eth.get_code(self.contract_address_btc)
+            ),
+            self.bytecode,
+        )
 
     def invalid_parameters(self):
         self.rollback_to(self.start_height)
@@ -290,6 +330,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -305,6 +346,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -320,6 +362,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -339,6 +382,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -354,6 +398,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": "evm",
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -369,6 +414,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -384,6 +430,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 4,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -399,6 +446,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -410,6 +458,7 @@ class EVMTest(DefiTestFramework):
                 {
                     "src": {"address": self.address, "amount": "100@DFI", "domain": 2},
                     "dst": {"address": "blablabla", "amount": "100@DFI", "domain": 3},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -443,6 +492,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "101@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -539,6 +589,7 @@ class EVMTest(DefiTestFramework):
                 {
                     "src": {"address": self.address, "amount": "100@DFI", "domain": 3},
                     "dst": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -558,6 +609,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -573,6 +625,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "100@DFI", "domain": 3},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -588,6 +641,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "101@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -603,6 +657,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "10@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 },
                 {
                     "src": {
@@ -615,6 +670,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "10@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 },
             ],
         )
@@ -634,6 +690,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "1@" + self.symbolUSER,
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -653,6 +710,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "1@" + self.symbolBTCDFI,
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -727,6 +785,170 @@ class EVMTest(DefiTestFramework):
             attributes["v0/live/economy/evm/block/fee_priority"], Decimal("0E-8")
         )
 
+    def single_key_transfer(self):
+        self.rollback_to(self.start_height)
+
+        # Valid DVM legacy address to EVM address with same key transfer
+        legacy_address = self.nodes[0].getnewaddress("", "legacy")
+        self.nodes[0].accounttoaccount(self.address, {legacy_address: "1@DFI"})
+        self.nodes[0].accounttoaccount(self.address, {legacy_address: "1@BTC"})
+        self.nodes[0].generate(1)
+
+        # Native transfer
+        legacy_erc55_address = self.nodes[0].addressmap(legacy_address, 1)["format"]["erc55"]
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": legacy_address, "amount": "1@DFI", "domain": 2},
+                    "dst": {
+                        "address": legacy_erc55_address,
+                        "amount": "1@DFI",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        balance = self.nodes[0].eth_getBalance(legacy_erc55_address)
+        assert_equal(balance, int_to_eth_u256(1))
+
+        # Token transfer
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": legacy_address, "amount": "1@BTC", "domain": 2},
+                    "dst": {
+                        "address": legacy_erc55_address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        assert_equal(
+            self.btc.functions.balanceOf(legacy_erc55_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+
+        # Valid DVM bech32 address to EVM address with same key transfer
+        bech32_address = self.nodes[0].getnewaddress("", "bech32")
+        self.nodes[0].accounttoaccount(self.address, {bech32_address: "1@DFI"})
+        self.nodes[0].accounttoaccount(self.address, {bech32_address: "1@BTC"})
+        self.nodes[0].generate(1)
+
+        # Native transfer
+        bech32_erc55_address = self.nodes[0].addressmap(bech32_address, 1)["format"]["erc55"]
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": bech32_address, "amount": "1@DFI", "domain": 2},
+                    "dst": {
+                        "address": bech32_erc55_address,
+                        "amount": "1@DFI",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        balance = self.nodes[0].eth_getBalance(bech32_erc55_address)
+        assert_equal(balance, int_to_eth_u256(1))
+
+        # Token transfer
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": bech32_address, "amount": "1@BTC", "domain": 2},
+                    "dst": {
+                        "address": bech32_erc55_address,
+                        "amount": "1@BTC",
+                        "domain": 3,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        assert_equal(
+            self.btc.functions.balanceOf(bech32_erc55_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(2),
+        )
+
+        # Valid ERC55 address to DVM bech32/legacy address with same key transfer
+        erc55_address = self.nodes[0].getnewaddress("", "erc55")
+        transfer_domain(self.nodes[0], self.address, erc55_address, "1@DFI", 2, 3)
+        transfer_domain(self.nodes[0], self.address, erc55_address, "1@BTC", 2, 3)
+        self.nodes[0].generate(1)
+        assert_equal(
+            self.btc.functions.balanceOf(erc55_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(1),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(3),
+        )
+
+        # Native transfer
+        erc55_bech32_address = self.nodes[0].addressmap(erc55_address, 2)["format"]["bech32"]
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": erc55_address, "amount": "1@DFI", "domain": 3},
+                    "dst": {
+                        "address": erc55_bech32_address,
+                        "amount": "1@DFI",
+                        "domain": 2,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        balance = self.nodes[0].eth_getBalance(erc55_address)
+        assert_equal(balance, int_to_eth_u256(0))
+        balance = self.nodes[0].getaccount(erc55_bech32_address, {}, True)["0"]
+        assert_equal(balance, Decimal("1"))
+
+        # Token transfer
+        self.nodes[0].transferdomain(
+            [
+                {
+                    "src": {"address": erc55_address, "amount": "1@BTC", "domain": 3},
+                    "dst": {
+                        "address": erc55_bech32_address,
+                        "amount": "1@BTC",
+                        "domain": 2,
+                    },
+                }
+            ]
+        )
+        self.nodes[0].generate(1)
+        assert_equal(
+            self.btc.functions.balanceOf(erc55_address).call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(0),
+        )
+        assert_equal(
+            self.btc.functions.totalSupply().call()
+            / math.pow(10, self.btc.functions.decimals().call()),
+            Decimal(2),
+        )
+        balance = self.nodes[0].getaccount(erc55_bech32_address, {}, True)["1"]
+        assert_equal(balance, Decimal("1"))
+
     def invalid_transfer_sc(self):
         self.rollback_to(self.start_height)
 
@@ -740,6 +962,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "50@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -784,6 +1007,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "1@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -803,6 +1027,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "1@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -818,6 +1043,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "1@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ],
         )
@@ -863,6 +1089,7 @@ class EVMTest(DefiTestFramework):
                         "amount": "101@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -965,6 +1192,7 @@ class EVMTest(DefiTestFramework):
                         "domain": 3,
                     },
                     "dst": {"address": self.address, "amount": "100@DFI", "domain": 2},
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -1259,7 +1487,7 @@ class EVMTest(DefiTestFramework):
         self.setup()
         self.invalid_before_fork_and_disabled()
 
-        self.check_initial_balance()
+        self.setup_after_evm_activation()
         self.invalid_parameters()
 
         # Transfer DVM->EVM
@@ -1269,6 +1497,9 @@ class EVMTest(DefiTestFramework):
         # Transfer EVM->DVM
         self.invalid_values_evm_dvm()
         self.valid_transfer_evm_dvm()
+
+        # Single key transfer
+        self.single_key_transfer()
 
         # Transfer to smart contract
         self.invalid_transfer_sc()

--- a/test/functional/feature_evm_vmmap_rpc.py
+++ b/test/functional/feature_evm_vmmap_rpc.py
@@ -103,6 +103,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -189,6 +190,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -242,6 +244,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -324,6 +327,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -360,6 +364,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -415,6 +420,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -440,6 +446,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "100@DFI",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -488,6 +495,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 3,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )
@@ -509,6 +517,7 @@ class VMMapTests(DefiTestFramework):
                         "amount": "1@BTC",
                         "domain": 2,
                     },
+                    "singlekeycheck": False,
                 }
             ]
         )


### PR DESCRIPTION
## Summary

- Add optional parameter for single key check (singlekeycheck) that run on default in transferdomain RPC
- Single key check pipeline will check that the source and destination addresses specified in the transferdomain RPC matches the same pubkey
- Guards against unplanned loss in funds to ensure destination address specified in the call is to the correct corresponding address
- To do a transferdomain to a different destination address that does not correspond to the same key, the RPC will need to explicitly set the singlekeycheck parameter to false
- Fix all functional tests with the new parameter, and add single key check tests in feature_evm_transferdomain
- Add legacy addresses into addressmap RPC


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
