### PR TITLE
Skip XVM check if vout missing

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3810,7 +3810,7 @@ bool CChainState::DisconnectTip(CValidationState &state,
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         }
 
-        if (XVM::TryFrom(block.vtx[0]->vout[1].scriptPubKey)) {
+        if (block.vtx[0]->vout.size() > 1 && XVM::TryFrom(block.vtx[0]->vout[1].scriptPubKey)) {
             XResultThrowOnErr(evm_try_disconnect_latest_block(result));
         }
 


### PR DESCRIPTION
## Summary

- Do not check for XVM data in coinbase if output is not present.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
