### PR TITLE
CI: Pass BUILD_VERSION into docker builds

### DIFF
--- a/contrib/dockerfiles/noarch.dockerfile
+++ b/contrib/dockerfiles/noarch.dockerfile
@@ -7,6 +7,7 @@ ARG TARGET=unknown
 FROM ubuntu:latest as builder
 ARG TARGET
 ARG MAKE_DEBUG
+ARG BUILD_VERSION
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}
 

--- a/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
+++ b/contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile
@@ -5,6 +5,7 @@ ARG TARGET=x86_64-pc-linux-gnu
 FROM --platform=linux/amd64 docker.io/defi/ain-builder as builder
 ARG TARGET
 ARG MAKE_DEBUG
+ARG BUILD_VERSION
 LABEL org.defichain.name="defichain-builder"
 LABEL org.defichain.arch=${TARGET}
 

--- a/make.sh
+++ b/make.sh
@@ -268,6 +268,7 @@ docker_build() {
     docker build -f "${docker_file}" \
         --build-arg TARGET="${target}" \
         --build-arg MAKE_DEBUG="${MAKE_DEBUG}" \
+        --build-arg BUILD_VERSION="${img_version}" \
         -t "${img}" "${docker_context}"
 }
 


### PR DESCRIPTION
## Summary

- Pass BUILD_VERSION into docker build as build arg to set defi client version with tag correctly


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
