### PR TITLE
CI: Add CPP and rust caching into CI workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .code
 .cache
+.ccache
 .idea
 
 # Editors.

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -46,11 +46,24 @@ jobs:
       
     - name: Setup user dependencies
       run: ./make.sh ci-setup-user-deps
+    
+    - name: Restore cpp build cache
+      id: cpp-cache-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ./build/depends
+          ./build/src
+          ./build/.ccache
+        key: cpp-${{ env.TARGET }}-${{ env.BUILD_TYPE }}
 
-    - uses: Swatinem/rust-cache@v2
+    - name: Restore rust build cache
+      uses: Swatinem/rust-cache@v2
+      id: rust-cache-restore
       with:
         workspaces: lib -> ../build/lib/target
         save-if: ${{ github.ref == 'refs/heads/master' }}
+        shared-key: rust-${{ env.TARGET }}-${{ env.BUILD_TYPE }}
 
     - name: Build and package
       run: ./make.sh release
@@ -60,6 +73,37 @@ jobs:
       with:
         name: defichain-${{ env.BUILD_VERSION }}-${{ env.TARGET }}
         path: ./build/defichain-${{ env.BUILD_VERSION }}-${{ env.TARGET }}.${{ env.PKG_TYPE }}
+
+    - name: Add debugging log to find ccache
+      run: ls -lahR ~
+
+    - name: Delete previous cpp cache
+      if: ${{ steps.cpp-cache-restore.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "${{ cpp-${{ env.TARGET }}-${{ env.BUILD_TYPE }} }}" --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Delete previous rust cache
+      if: ${{ steps.rust-cache-restore.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "${{ rust-${{ env.TARGET }}-${{ env.BUILD_TYPE }} }}" --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save cpp cache
+      # if: ${{ github.ref == 'refs/heads/master' }}
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ./build/depends
+          ./build/src
+          ./build/.ccache
+        key: cpp-${{ env.TARGET }}-${{ env.BUILD_TYPE }}
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .code
 .cache
+.ccache
 .idea
 
 # Editors.

--- a/make.sh
+++ b/make.sh
@@ -689,7 +689,7 @@ pkg_install_deps() {
         software-properties-common build-essential git libtool autotools-dev automake \
         pkg-config bsdmainutils python3 python3-pip python3-venv libssl-dev libevent-dev libboost-system-dev \
         libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev \
-        libminiupnpc-dev libzmq3-dev libqrencode-dev wget \
+        libminiupnpc-dev libzmq3-dev libqrencode-dev wget ccache \
         libdb-dev libdb++-dev libdb5.3 libdb5.3-dev libdb5.3++ libdb5.3++-dev \
         curl cmake zip unzip libc6-dev gcc-multilib locales locales-all
 
@@ -1140,10 +1140,13 @@ _nproc() {
 
 # shellcheck disable=SC2129
 ci_export_vars() {
+    local build_dir="${BUILD_DIR}"
+
     if [[ -n "${GITHUB_ACTIONS-}" ]]; then
         # GitHub Actions
         echo "BUILD_VERSION=${IMAGE_VERSION}" >> "$GITHUB_ENV"
         echo "PATH=$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"
+        echo "CCACHE_DIR=${build_dir}/.ccache"
         echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
         if [[ "${TARGET}" == "x86_64-w64-mingw32" ]]; then
             echo "PKG_TYPE=zip" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Part 2 of CI workflow development, continuation of PR #2717. Requires #2717 be merged first.
- Implements ccache into all defi binaries build workflows
- Adds caching of build dependencies
- Adds caching of cpp build tree of defi binaries

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
