### PR TITLE
Fix calls to CreateToken

### DIFF
--- a/src/dfi/consensus/loans.cpp
+++ b/src/dfi/consensus/loans.cpp
@@ -301,7 +301,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
                                : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
     token.flags |= static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
 
-    auto tokenId = mnview.CreateToken(token, std::numeric_limits<int>::max(), &blockCtx);
+    auto tokenId = mnview.CreateToken(token, height, &blockCtx);
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/consensus/loans.cpp
+++ b/src/dfi/consensus/loans.cpp
@@ -301,7 +301,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
                                : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
     token.flags |= static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
 
-    auto tokenId = mnview.CreateToken(token, false, &blockCtx);
+    auto tokenId = mnview.CreateToken(token, std::numeric_limits<int>::max(), &blockCtx);
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/consensus/poolpairs.cpp
+++ b/src/dfi/consensus/poolpairs.cpp
@@ -80,7 +80,7 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     token.creationTx = tx.GetHash();
     token.creationHeight = height;
 
-    auto tokenId = mnview.CreateToken(token, false);
+    auto tokenId = mnview.CreateToken(token, std::numeric_limits<int>::max());
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/consensus/poolpairs.cpp
+++ b/src/dfi/consensus/poolpairs.cpp
@@ -80,7 +80,7 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     token.creationTx = tx.GetHash();
     token.creationHeight = height;
 
-    auto tokenId = mnview.CreateToken(token, std::numeric_limits<int>::max());
+    auto tokenId = mnview.CreateToken(token, height);
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1398,7 +1398,7 @@ static Res PoolSplits(CCustomCSView &view,
                 throw std::runtime_error(res.msg);
             }
 
-            auto resVal = view.CreateToken(newPoolToken, false);
+            auto resVal = view.CreateToken(newPoolToken, std::numeric_limits<int>::max());
             if (!resVal) {
                 throw std::runtime_error(resVal.msg);
             }
@@ -2018,7 +2018,7 @@ static void ProcessTokenSplits(const CBlock &block,
         }
 
         // TODO: Pass this on, once we add support for EVM splits
-        auto resVal = view.CreateToken(newToken, false);
+        auto resVal = view.CreateToken(newToken, std::numeric_limits<int>::max());
         if (!resVal) {
             LogPrintf("Token split failed on CreateToken %s\n", resVal.msg);
             continue;

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1398,7 +1398,7 @@ static Res PoolSplits(CCustomCSView &view,
                 throw std::runtime_error(res.msg);
             }
 
-            auto resVal = view.CreateToken(newPoolToken, std::numeric_limits<int>::max());
+            auto resVal = view.CreateToken(newPoolToken, pindex->nHeight);
             if (!resVal) {
                 throw std::runtime_error(resVal.msg);
             }
@@ -2018,7 +2018,7 @@ static void ProcessTokenSplits(const CBlock &block,
         }
 
         // TODO: Pass this on, once we add support for EVM splits
-        auto resVal = view.CreateToken(newToken, std::numeric_limits<int>::max());
+        auto resVal = view.CreateToken(newToken, pindex->nHeight);
         if (!resVal) {
             LogPrintf("Token split failed on CreateToken %s\n", resVal.msg);
             continue;

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -26,7 +26,7 @@ DCT_ID CreateToken(CCustomCSView &mnview, std::string const & symbol, uint8_t fl
     token.symbol = symbol;
     token.flags = flags;
 
-    auto res = mnview.CreateToken(token, false);
+    auto res = mnview.CreateToken(token, std::numeric_limits<int>::max());
     if (!res.ok) printf("%s\n", res.msg.c_str());
     BOOST_REQUIRE(res.ok);
     return *res.val;

--- a/src/test/loan_tests.cpp
+++ b/src/test/loan_tests.cpp
@@ -26,7 +26,7 @@ DCT_ID CreateToken(CCustomCSView &mnview, const std::string& symbol, const std::
     token.symbol = symbol;
     token.name = name;
 
-    auto res = mnview.CreateToken(token, false);
+    auto res = mnview.CreateToken(token, std::numeric_limits<int>::max());
     BOOST_REQUIRE(res.ok);
     return *res.val;
 }

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(tokens)
     CTokenImplementation token1;
     token1.symbol = "DCT1";
     token1.creationTx = uint256S("0x1111");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, std::numeric_limits<int>::max()).ok);
     BOOST_REQUIRE(GetTokensCount() == 2);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{128});
@@ -206,11 +206,11 @@ BOOST_AUTO_TEST_CASE(tokens)
     }
 
     // another token creation
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate symbol & tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, std::numeric_limits<int>::max()).ok == false); /// duplicate symbol & tx
     token1.symbol = "DCT2";
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, std::numeric_limits<int>::max()).ok == false); /// duplicate tx
     token1.creationTx = uint256S("0x2222");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, std::numeric_limits<int>::max()).ok);
     BOOST_REQUIRE(GetTokensCount() == 3);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{129});


### PR DESCRIPTION
## Summary

- CreateToken was updated to take a height argument but not all calls were updated at the same time. This PR updates all remaining calls which passed a bool set to false before to max int which results in the same logic as before 4.0.4.
- On mainnet creating a loan token or pool pair will fork 4.0.4 from other nodes.
- On mainnet token splits would also fail but this is a currently disabled feature.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
