### PR TITLE
Add time, height, consensus to block context

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -183,13 +183,11 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         CCustomCSView discardCache(mnview, nullptr, nullptr, nullptr);
         // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough,
         // that it's propagated.
-        BlockContext blockCtx(nSpendHeight, {}, &discardCache);
+        BlockContext blockCtx(nSpendHeight, {}, chainparams.GetConsensus(), &discardCache);
         auto txCtx = TransactionContext{
                 inputs,
                 tx,
-                chainparams.GetConsensus(),
-                blockCtx.GetHeight(),
-                blockCtx.GetTime(),
+                blockCtx,
         };
         auto res = ApplyCustomTx(blockCtx, txCtx, &canSpend);
         if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -183,12 +183,13 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         CCustomCSView discardCache(mnview, nullptr, nullptr, nullptr);
         // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough,
         // that it's propagated.
-        BlockContext blockCtx{&discardCache};
+        BlockContext blockCtx(nSpendHeight, {}, &discardCache);
         auto txCtx = TransactionContext{
                 inputs,
                 tx,
                 chainparams.GetConsensus(),
-                static_cast<uint32_t>(nSpendHeight),
+                blockCtx.GetHeight(),
+                blockCtx.GetTime(),
         };
         auto res = ApplyCustomTx(blockCtx, txCtx, &canSpend);
         if (!res.ok && (res.code & CustomTxErrCodes::Fatal)) {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -183,6 +183,9 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
         CCustomCSView discardCache(mnview, nullptr, nullptr, nullptr);
         // Note: TXs are already filtered. So we pass isEVMEnabled to false, but for future proof, refactor this enough,
         // that it's propagated.
+        // 
+        // Note: We set time to 0 here. Take care not to use time
+        // in Apply for MintToken or AccountToUtxos path.
         BlockContext blockCtx(nSpendHeight, {}, chainparams.GetConsensus(), &discardCache);
         auto txCtx = TransactionContext{
                 inputs,

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -1511,8 +1511,8 @@ void TransferDomainConfig::SetToAttributesIfNotExists(ATTRIBUTES &attrs) const {
 TransactionContext::TransactionContext(const CCoinsViewCache &coins,
                                        const CTransaction &tx,
                                        const Consensus::Params &consensus,
-                                       const uint32_t height,
-                                       const uint64_t time,
+                                       const uint32_t &height,
+                                       const uint64_t &time,
                                        const uint32_t txn)
     : coins(coins),
       tx(tx),

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -1510,15 +1510,13 @@ void TransferDomainConfig::SetToAttributesIfNotExists(ATTRIBUTES &attrs) const {
 
 TransactionContext::TransactionContext(const CCoinsViewCache &coins,
                                        const CTransaction &tx,
-                                       const Consensus::Params &consensus,
-                                       const uint32_t &height,
-                                       const uint64_t &time,
+                                       const BlockContext &blockCtx,
                                        const uint32_t txn)
     : coins(coins),
       tx(tx),
-      consensus(consensus),
-      height(height),
-      time(time),
+      consensus(blockCtx.GetConsensus()),
+      height(blockCtx.GetHeight()),
+      time(blockCtx.GetTime()),
       txn(txn) {
     metadataValidation = height >= static_cast<uint32_t>(consensus.DF11FortCanningHeight);
 }

--- a/src/dfi/mn_checks.h
+++ b/src/dfi/mn_checks.h
@@ -161,21 +161,29 @@ class BlockContext {
     std::optional<bool> isEvmEnabledForBlock;
     std::shared_ptr<CScopedTemplate> evmTemplate{};
     bool evmPreValidate{};
+    const uint32_t height{};
+    const uint64_t time{};
 
 public:
-    explicit BlockContext(CCustomCSView *view = {},
+    explicit BlockContext(const uint32_t height,
+                          const uint64_t time,
+                          CCustomCSView *view = {},
                           const std::optional<bool> enabled = {},
                           const std::shared_ptr<CScopedTemplate> &evmTemplate = {},
                           const bool prevalidate = {})
         : view(view),
           isEvmEnabledForBlock(enabled),
           evmTemplate(evmTemplate),
-          evmPreValidate(prevalidate) {}
+          evmPreValidate(prevalidate),
+          height(height),
+          time(time) {}
 
     [[nodiscard]] CCustomCSView &GetView();
     [[nodiscard]] bool GetEVMEnabledForBlock();
     [[nodiscard]] bool GetEVMPreValidate() const;
     [[nodiscard]] const std::shared_ptr<CScopedTemplate> &GetEVMTemplate() const;
+    [[nodiscard]] uint32_t GetHeight() const;
+    [[nodiscard]] uint64_t GetTime() const;
 
     void SetView(CCustomCSView &other);
     void SetEVMPreValidate(const bool other);
@@ -186,8 +194,8 @@ class TransactionContext {
     const CCoinsViewCache &coins;
     const CTransaction &tx;
     const Consensus::Params &consensus;
-    const uint32_t height{};
-    const uint64_t time{};
+    const uint32_t &height;
+    const uint64_t &time;
     const uint32_t txn{};
 
     std::vector<unsigned char> metadata;
@@ -199,8 +207,8 @@ public:
     TransactionContext(const CCoinsViewCache &coins,
                        const CTransaction &tx,
                        const Consensus::Params &consensus,
-                       const uint32_t height = {},
-                       const uint64_t time = {},
+                       const uint32_t &height,
+                       const uint64_t &time,
                        const uint32_t txn = {});
 
     [[nodiscard]] const CCoinsViewCache &GetCoins() const;

--- a/src/dfi/mn_checks.h
+++ b/src/dfi/mn_checks.h
@@ -163,10 +163,12 @@ class BlockContext {
     bool evmPreValidate{};
     const uint32_t height{};
     const uint64_t time{};
+    const Consensus::Params &consensus;
 
 public:
     explicit BlockContext(const uint32_t height,
                           const uint64_t time,
+                          const Consensus::Params &consensus,
                           CCustomCSView *view = {},
                           const std::optional<bool> enabled = {},
                           const std::shared_ptr<CScopedTemplate> &evmTemplate = {},
@@ -176,14 +178,16 @@ public:
           evmTemplate(evmTemplate),
           evmPreValidate(prevalidate),
           height(height),
-          time(time) {}
+          time(time),
+          consensus(consensus) {}
 
     [[nodiscard]] CCustomCSView &GetView();
     [[nodiscard]] bool GetEVMEnabledForBlock();
     [[nodiscard]] bool GetEVMPreValidate() const;
     [[nodiscard]] const std::shared_ptr<CScopedTemplate> &GetEVMTemplate() const;
-    [[nodiscard]] uint32_t GetHeight() const;
-    [[nodiscard]] uint64_t GetTime() const;
+    [[nodiscard]] const uint32_t &GetHeight() const;
+    [[nodiscard]] const uint64_t &GetTime() const;
+    [[nodiscard]] const Consensus::Params &GetConsensus() const;
 
     void SetView(CCustomCSView &other);
     void SetEVMPreValidate(const bool other);
@@ -206,9 +210,7 @@ class TransactionContext {
 public:
     TransactionContext(const CCoinsViewCache &coins,
                        const CTransaction &tx,
-                       const Consensus::Params &consensus,
-                       const uint32_t &height,
-                       const uint64_t &time,
+                       const BlockContext &blockCtx,
                        const uint32_t txn = {});
 
     [[nodiscard]] const CCoinsViewCache &GetCoins() const;

--- a/src/dfi/mn_rpc.cpp
+++ b/src/dfi/mn_rpc.cpp
@@ -480,15 +480,15 @@ void execTestTx(const CTransaction &tx, const uint32_t height, const CTransactio
         if (optAuthTx) {
             AddCoins(coins, *optAuthTx, height);
         }
-        BlockContext blockCtx;
+        BlockContext blockCtx(height, ::ChainActive().Tip()->nTime);
         blockCtx.SetEVMPreValidate(true);
 
         const auto txCtx = TransactionContext{
             coins,
             tx,
             Params().GetConsensus(),
-            height,
-            ::ChainActive().Tip()->nTime,
+            blockCtx.GetHeight(),
+            blockCtx.GetTime(),
         };
         res = CustomTxVisit(txMessage, blockCtx, txCtx);
     }

--- a/src/dfi/mn_rpc.cpp
+++ b/src/dfi/mn_rpc.cpp
@@ -480,15 +480,13 @@ void execTestTx(const CTransaction &tx, const uint32_t height, const CTransactio
         if (optAuthTx) {
             AddCoins(coins, *optAuthTx, height);
         }
-        BlockContext blockCtx(height, ::ChainActive().Tip()->nTime);
+        BlockContext blockCtx(height, ::ChainActive().Tip()->nTime, Params().GetConsensus());
         blockCtx.SetEVMPreValidate(true);
 
         const auto txCtx = TransactionContext{
             coins,
             tx,
-            Params().GetConsensus(),
-            blockCtx.GetHeight(),
-            blockCtx.GetTime(),
+            blockCtx,
         };
         res = CustomTxVisit(txMessage, blockCtx, txCtx);
     }

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -666,15 +666,13 @@ UniValue getcustomtx(const JSONRPCRequest &request) {
     result.pushKV("type", ToString(guess));
     if (!actualHeight) {
         LOCK(cs_main);
-        BlockContext blockCtx(nHeight, ::ChainActive().Tip()->nTime);
+        BlockContext blockCtx(nHeight, ::ChainActive().Tip()->nTime, Params().GetConsensus());
         CCoinsViewCache view(&::ChainstateActive().CoinsTip());
 
         auto txCtx = TransactionContext{
             view,
             *tx,
-            Params().GetConsensus(),
-            blockCtx.GetHeight(),
-            blockCtx.GetTime(),
+            blockCtx,
         };
 
         auto res = ApplyCustomTx(blockCtx, txCtx);

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -666,14 +666,15 @@ UniValue getcustomtx(const JSONRPCRequest &request) {
     result.pushKV("type", ToString(guess));
     if (!actualHeight) {
         LOCK(cs_main);
-        BlockContext blockCtx;
+        BlockContext blockCtx(nHeight, ::ChainActive().Tip()->nTime);
         CCoinsViewCache view(&::ChainstateActive().CoinsTip());
 
         auto txCtx = TransactionContext{
             view,
             *tx,
             Params().GetConsensus(),
-            static_cast<uint32_t>(nHeight),
+            blockCtx.GetHeight(),
+            blockCtx.GetTime(),
         };
 
         auto res = ApplyCustomTx(blockCtx, txCtx);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -237,7 +237,7 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;
-    BlockContext blockCtx(nHeight, pblock->nTime);
+    BlockContext blockCtx(nHeight, pblock->nTime, chainparams.GetConsensus());
     auto &mnview = blockCtx.GetView();
     if (!blockTime) {
         UpdateTime(pblock, consensus, pindexPrev);  // update time before tx packaging
@@ -879,9 +879,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected,
                 auto txCtx = TransactionContext{
                     coins,
                     tx,
-                    chainparams.GetConsensus(),
-                    blockCtx.GetHeight(),
-                    blockCtx.GetTime(),
+                    blockCtx,
                 };
 
                 // Copy block context and update to cache view

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -237,7 +237,7 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;
-    BlockContext blockCtx;
+    BlockContext blockCtx(nHeight, pblock->nTime);
     auto &mnview = blockCtx.GetView();
     if (!blockTime) {
         UpdateTime(pblock, consensus, pindexPrev);  // update time before tx packaging
@@ -880,8 +880,8 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected,
                     coins,
                     tx,
                     chainparams.GetConsensus(),
-                    static_cast<uint32_t>(nHeight),
-                    pblock->nTime,
+                    blockCtx.GetHeight(),
+                    blockCtx.GetTime(),
                 };
 
                 // Copy block context and update to cache view

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
     LOCK(cs_main);
 
-    BlockContext blockCtx{{}, {}};
+    BlockContext blockCtx{{}, {}, amkCheated};
     auto &mnview = blockCtx.GetView();
     CCoinsViewCache coinview(&::ChainstateActive().CoinsTip());
 
@@ -124,9 +124,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
         auto txCtx = TransactionContext{
             coinview,
             tx,
-            amkCheated,
-            blockCtx.GetHeight(),
-            blockCtx.GetTime(),
+            blockCtx,
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -150,9 +148,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
         auto txCtx = TransactionContext{
                 coinview,
                 tx,
-                amkCheated,
-                blockCtx.GetHeight(),
-                blockCtx.GetTime(),
+                blockCtx,
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -176,9 +172,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
         auto txCtx = TransactionContext{
                 coinview,
                 tx,
-                amkCheated,
-                blockCtx.GetHeight(),
-                blockCtx.GetTime(),
+                blockCtx,
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -202,9 +196,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
         auto txCtx = TransactionContext{
                 coinview,
                 tx,
-                amkCheated,
-                blockCtx.GetHeight(),
-                blockCtx.GetTime(),
+                blockCtx,
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);

--- a/src/test/applytx_tests.cpp
+++ b/src/test/applytx_tests.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
 
     LOCK(cs_main);
 
-    BlockContext blockCtx;
+    BlockContext blockCtx{{}, {}};
     auto &mnview = blockCtx.GetView();
     CCoinsViewCache coinview(&::ChainstateActive().CoinsTip());
 
@@ -125,6 +125,8 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
             coinview,
             tx,
             amkCheated,
+            blockCtx.GetHeight(),
+            blockCtx.GetTime(),
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -149,6 +151,8 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
                 coinview,
                 tx,
                 amkCheated,
+                blockCtx.GetHeight(),
+                blockCtx.GetTime(),
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -173,6 +177,8 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
                 coinview,
                 tx,
                 amkCheated,
+                blockCtx.GetHeight(),
+                blockCtx.GetTime(),
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);
@@ -197,6 +203,8 @@ BOOST_AUTO_TEST_CASE(apply_a2a_neg)
                 coinview,
                 tx,
                 amkCheated,
+                blockCtx.GetHeight(),
+                blockCtx.GetTime(),
         };
 
         res = ApplyCustomTx(blockCtx, txCtx);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1290,6 +1290,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
         auto blockCtx = BlockContext{
             static_cast<uint32_t>(height),
             static_cast<uint64_t>(it->GetTime()),
+            consensus,
             &viewDuplicate,
             isEvmEnabledForBlock,
             {},
@@ -1298,9 +1299,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
         auto txCtx = TransactionContext{
             coinsCache,
             tx,
-            consensus,
-            blockCtx.GetHeight(),
-            blockCtx.GetTime(),
+            blockCtx,
         };
         auto res = ApplyCustomTx(blockCtx, txCtx);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1288,6 +1288,8 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
             continue;
         }
         auto blockCtx = BlockContext{
+            static_cast<uint32_t>(height),
+            static_cast<uint64_t>(it->GetTime()),
             &viewDuplicate,
             isEvmEnabledForBlock,
             {},
@@ -1297,7 +1299,8 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
             coinsCache,
             tx,
             consensus,
-            static_cast<uint32_t>(height),
+            blockCtx.GetHeight(),
+            blockCtx.GetTime(),
         };
         auto res = ApplyCustomTx(blockCtx, txCtx);
 


### PR DESCRIPTION
## Summary

- Time and height should have been defined in block context instead of transaction context. This PR starts moving them to from transaction context to block context. To keep changes to a minimum this PR adds them to the block context and retains them in transaction context as aliases. This prevents a large changeset in one go which is then safer to implement and easier to review.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
