### PR TITLE
Remove usage of Discard() from codebase

### DIFF
--- a/src/dfi/historywriter.cpp
+++ b/src/dfi/historywriter.cpp
@@ -216,15 +216,3 @@ void CHistoryWriters::FlushDB() {
         vaultView->Flush();
     }
 }
-
-void CHistoryWriters::DiscardDB() {
-    if (historyView) {
-        historyView->Discard();
-    }
-    if (burnView) {
-        burnView->Discard();
-    }
-    if (vaultView) {
-        vaultView->Discard();
-    }
-}

--- a/src/dfi/historywriter.h
+++ b/src/dfi/historywriter.h
@@ -114,7 +114,6 @@ public:
 
     void ClearState();
     void FlushDB();
-    void DiscardDB();
     void Flush(const uint32_t height,
                const uint256 &txid,
                const uint32_t txn,

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -1415,7 +1415,6 @@ UniValue listaccounthistory(const JSONRPCRequest &request) {
 
             // starting new account
             if (account.empty() && lastOwner != key.owner) {
-                view.Discard();
                 lastOwner = key.owner;
                 lastHeight = maxBlockHeight;
             }
@@ -1884,7 +1883,6 @@ UniValue accounthistorycount(const JSONRPCRequest &request) {
             if (!noRewards) {
                 // starting new account
                 if (lastOwner != key.owner) {
-                    view.Discard();
                     lastOwner = key.owner;
                     lastHeight = currentHeight;
                 }

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -110,7 +110,7 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
                 CrossBoundaryResult result;
                 rust::string token_name{};
                 rust::string token_symbol{};
-                if (height >= Params().GetConsensus().DF23Height) {
+                if (height >= static_cast<uint32_t>(Params().GetConsensus().DF23Height)) {
                     if (token.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
                         return Res::Err("Error creating DST20 token, token name is larger than max bytes\n");
                     }

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1564,7 +1564,6 @@ static Res PoolSplits(CCustomCSView &view,
 
                 res = addView.AddBalance(owner, {newPoolId, liquidity});
                 if (!res) {
-                    addView.Discard();
                     refundBalances();
                     continue;
                 }

--- a/src/flushablestorage.h
+++ b/src/flushablestorage.h
@@ -312,7 +312,10 @@ public:
         return true;
     }
     void Discard() override {
-        changed.clear();
+        // A cache copy of CCustomCSView or a snapshot will have a copy of the flushable
+        // storage. This should not be discarded as this flushable storage may have data
+        // not yet written to disk.
+        throw std::runtime_error("Discard should not be called on flushable storage");
     }
     size_t SizeEstimate() const override {
         return memusage::DynamicUsage(changed);

--- a/src/flushablestorage.h
+++ b/src/flushablestorage.h
@@ -72,7 +72,6 @@ public:
     virtual bool Read(const TBytes& key, TBytes& value) const = 0;
     virtual std::unique_ptr<CStorageKVIterator> NewIterator() = 0;
     virtual size_t SizeEstimate() const = 0;
-    virtual void Discard() = 0;
     virtual bool Flush() = 0;
 };
 
@@ -159,9 +158,6 @@ public:
         auto result = db.WriteBatch(batch);
         batch.Clear();
         return result;
-    }
-    void Discard() override {
-        batch.Clear();
     }
     size_t SizeEstimate() const override {
         return batch.SizeEstimate();
@@ -310,12 +306,6 @@ public:
         }
         changed.clear();
         return true;
-    }
-    void Discard() override {
-        // A cache copy of CCustomCSView or a snapshot will have a copy of the flushable
-        // storage. This should not be discarded as this flushable storage may have data
-        // not yet written to disk.
-        throw std::runtime_error("Discard should not be called on flushable storage");
     }
     size_t SizeEstimate() const override {
         return memusage::DynamicUsage(changed);
@@ -508,7 +498,6 @@ public:
     }
 
     virtual bool Flush() { return DB().Flush(); }
-    void Discard() { DB().Discard(); }
     size_t SizeEstimate() const { return DB().SizeEstimate(); }
 
 protected:

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -612,10 +612,16 @@ CTxMemPool::~CTxMemPool() {}
 
 CCustomCSView &CTxMemPool::accountsView() {
     if (!acview) {
+        LOCK(cs_main);
         assert(pcustomcsview);
         acview = std::make_unique<CCustomCSView>(*pcustomcsview);
     }
     return *acview;
+}
+
+void CTxMemPool::resetAccountsView() {
+    LOCK(cs_main);
+    acview = std::make_unique<CCustomCSView>(*pcustomcsview);
 }
 
 /**
@@ -1260,7 +1266,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
     }
 
     CAmount txfee{};
-    accountsView().Discard();
+    resetAccountsView();
     CCustomCSView viewDuplicate(accountsView());
 
     setEntries staged;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -747,6 +747,7 @@ public:
     CCustomCSView &accountsView();
     void rebuildViews();
     void rebuildAccountsView(int height, const CCoinsViewCache &coinsCache);
+    void resetAccountsView();
     void setAccountViewDirty();
     bool getAccountViewDirty() const;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -644,7 +644,6 @@ static bool AcceptToMemoryPoolWorker(const CChainParams &chainparams,
     {
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);
-        CCustomCSView mnview(pool.accountsView());
 
         LockPoints lp;
         CCoinsViewCache &coins_cache = ::ChainstateActive().CoinsTip();
@@ -698,6 +697,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams &chainparams,
 
         // rebuild accounts view if dirty
         pool.rebuildAccountsView(height, view);
+
+        // Get view after we rebuild account view
+        CCustomCSView mnview(pool.accountsView());
 
         CAmount nFees = 0;
         if (!Consensus::CheckTxInputs(tx, state, view, mnview, height, nFees, chainparams)) {
@@ -3802,7 +3804,6 @@ bool CChainState::DisconnectTip(CValidationState &state,
         std::vector<CAnchorConfirmMessage> disconnectedConfirms;
         if (DisconnectBlock(block, pindexDelete, view, mnview, disconnectedConfirms) != DISCONNECT_OK) {
             m_disconnectTip = false;
-            mnview.GetHistoryWriters().DiscardDB();
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         }
 
@@ -3969,7 +3970,6 @@ bool CChainState::ConnectTip(CValidationState &state,
             if (s.IsInvalid()) {
                 InvalidBlockFound(p, s);
             }
-            m.GetHistoryWriters().DiscardDB();
             return error("ConnectBlock %s failed, %s", p->GetBlockHash().ToString(), FormatStateMessage(s));
         };
 
@@ -6445,7 +6445,6 @@ bool CChainState::ReplayBlocks(const CChainParams &params, CCoinsView *view, CCu
             std::vector<CAnchorConfirmMessage> disconnectedConfirms;  // dummy
             DisconnectResult res = DisconnectBlock(block, pindexOld, cache, mncache, disconnectedConfirms);
             if (res == DISCONNECT_FAILED) {
-                mncache.GetHistoryWriters().DiscardDB();
                 return error("RollbackBlock(): DisconnectBlock failed at %d, hash=%s",
                              pindexOld->nHeight,
                              pindexOld->GetBlockHash().ToString());
@@ -6467,7 +6466,6 @@ bool CChainState::ReplayBlocks(const CChainParams &params, CCoinsView *view, CCu
                                  (int)((nHeight - nForkHeight) * 100.0 / (pindexNew->nHeight - nForkHeight)),
                                  false);
         if (!RollforwardBlock(pindex, cache, mncache, params)) {
-            mncache.GetHistoryWriters().DiscardDB();
             return false;
         }
     }


### PR DESCRIPTION
## Summary

- Prevent usage of Discard on flushable storage. A cache copy of CCustomCSView or a snapshot will have a copy of the flushable storage. This should not be discarded as this flushable storage may have data not yet written to disk.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
