### PR TITLE
icx_makeoffer do not override user set expiry

### DIFF
--- a/src/dfi/rpc_icxorderbook.cpp
+++ b/src/dfi/rpc_icxorderbook.cpp
@@ -516,10 +516,6 @@ UniValue icxmakeoffer(const JSONRPCRequest &request) {
                            strprintf("Address (%s) is not owned by the wallet", metaObj["ownerAddress"].getValStr()));
     }
 
-    if (!metaObj["expiry"].isNull()) {
-        makeoffer.expiry = metaObj["expiry"].get_int();
-    }
-
     int targetHeight;
     {
         LOCK(cs_main);
@@ -547,7 +543,11 @@ UniValue icxmakeoffer(const JSONRPCRequest &request) {
         }
 
         targetHeight = ::ChainActive().Height() + 1;
+    }
 
+    if (!metaObj["expiry"].isNull()) {
+        makeoffer.expiry = metaObj["expiry"].get_int();
+    } else {
         if (targetHeight < Params().GetConsensus().DF10EunosPayaHeight) {
             makeoffer.expiry = CICXMakeOffer::DEFAULT_EXPIRY;
         } else {


### PR DESCRIPTION
## Summary

- icx_makeoffer will always override the user set expiry. There is a check consensus side that the expiry is not less than the default amounts.

https://github.com/DeFiCh/ain/blob/73489ee2cbad6dd52f3b50465dc82f8c765ba242/src/dfi/consensus/icxorders.cpp#L132-L137

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
