### PR TITLE
Set correct path in Windows release zip

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -241,8 +241,10 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_build_dir}"
 
     if [[ "$target" == "x86_64-w64-mingw32" ]]; then
-        _ensure_enter_dir "${build_dir}"
-        zip -r "${pkg_path}" "${versioned_build_dir}/__w/ain/ain/build/"
+        _ensure_enter_dir "${versioned_build_dir}"
+        cd ..
+        local dir_to_zip=$(basename "${versioned_build_dir}")
+        zip -r "${pkg_path}" "${dir_to_zip}/"
     else
         _ensure_enter_dir "${versioned_build_dir}"
         _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*

--- a/make.sh
+++ b/make.sh
@@ -243,7 +243,8 @@ package() {
     if [[ "$target" == "x86_64-w64-mingw32" ]]; then
         _ensure_enter_dir "${versioned_build_dir}"
         cd ..
-        local dir_to_zip=$(basename "${versioned_build_dir}")
+        local dir_to_zip
+        dir_to_zip=$(basename "${versioned_build_dir}")
         zip -r "${pkg_path}" "${dir_to_zip}/"
     else
         _ensure_enter_dir "${versioned_build_dir}"

--- a/make.sh
+++ b/make.sh
@@ -242,7 +242,7 @@ package() {
 
     if [[ "$target" == "x86_64-w64-mingw32" ]]; then
         _ensure_enter_dir "${build_dir}"
-        zip -r "${pkg_path}" "${versioned_build_dir}/"
+        zip -r "${pkg_path}" "${versioned_build_dir}/__w/ain/ain/build/"
     else
         _ensure_enter_dir "${versioned_build_dir}"
         _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*


### PR DESCRIPTION
## Summary

- Set the expected path in the Windows release zip.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
