### PR TITLE
CI: Clean up win-x64 package pipeline

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -225,7 +225,7 @@ package() {
     local pkg_path
     if [[ "$target" == "x86_64-w64-mingw32" ]]; then
         pkg_path="$(_canonicalize "${build_dir}/${pkg_name}.zip")"
-    else        
+    else
         pkg_path="$(_canonicalize "${build_dir}/${pkg_name}.tar.gz")"
     fi
 

--- a/make.sh
+++ b/make.sh
@@ -241,11 +241,8 @@ package() {
     echo "> packaging: ${pkg_name} from ${versioned_build_dir}"
 
     if [[ "$target" == "x86_64-w64-mingw32" ]]; then
-        _ensure_enter_dir "${versioned_build_dir}"
-        cd ..
-        local dir_to_zip
-        dir_to_zip=$(basename "${versioned_build_dir}")
-        zip -r "${pkg_path}" "${dir_to_zip}/"
+        _ensure_enter_dir "${build_dir}"
+        zip -r "${pkg_path}" "$(basename "${versioned_build_dir}")"
     else
         _ensure_enter_dir "${versioned_build_dir}"
         _tar --transform "s,^./,${versioned_name}/," -czf "${pkg_path}" ./*


### PR DESCRIPTION
## Summary

- Remove relative path directory in make.sh package command.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
