### PR TITLE
CI: Fix broken win-x64 binary

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -31,12 +31,9 @@ jobs:
       matrix:
         target: [x86_64-pc-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin]
         include:
-        - target: x86_64-pc-linux-gnu
-          container: defi/ain-builder:latest
+        - container: defi/ain-builder:latest
         - target: x86_64-w64-mingw32
           container: defi/ain-win-builder:latest
-        - target: x86_64-apple-darwin
-          container: defi/ain-builder:latest
     container:
       image: ${{ matrix.container }}
     env:

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -37,6 +37,8 @@ jobs:
           container: defi/ain-win-builder:latest
         - target: x86_64-apple-darwin
           container: defi/ain-builder:latest
+    container:
+      image: ${{ matrix.container }}
     env:
       TARGET: ${{matrix.target}}
 

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -27,10 +27,16 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: defi/ain-builder:latest
     strategy:
       matrix:
         target: [x86_64-pc-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin]
+        include:
+        - target: x86_64-pc-linux-gnu
+          container: defi/ain-builder:latest
+        - target: x86_64-w64-mingw32
+          container: defi/ain-win-builder:latest
+        - target: x86_64-apple-darwin
+          container: defi/ain-builder:latest
     env:
       TARGET: ${{matrix.target}}
 

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -19,6 +19,17 @@ jobs:
     strategy:
       matrix:
         target: [x86_64-pc-linux-gnu, aarch64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+        - target: x86_64-pc-linux-gnu
+          container: defi/ain-builder:latest
+        - target: aarch64-linux-gnu
+          container: defi/ain-builder:latest
+        - target: x86_64-w64-mingw32
+          container: defi/ain-win-builder:latest
+        - target: x86_64-apple-darwin
+          container: defi/ain-builder:latest
+        - target: aarch64-apple-darwin
+          container: defi/ain-builder:latest
     env:
       TARGET: ${{matrix.target}}
 

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -14,7 +14,6 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    container: defi/ain-builder:latest
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -19,16 +19,9 @@ jobs:
       matrix:
         target: [x86_64-pc-linux-gnu, aarch64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin, aarch64-apple-darwin]
         include:
-        - target: x86_64-pc-linux-gnu
-          container: defi/ain-builder:latest
-        - target: aarch64-linux-gnu
-          container: defi/ain-builder:latest
+        - container: defi/ain-builder:latest
         - target: x86_64-w64-mingw32
           container: defi/ain-win-builder:latest
-        - target: x86_64-apple-darwin
-          container: defi/ain-builder:latest
-        - target: aarch64-apple-darwin
-          container: defi/ain-builder:latest
     container:
       image: ${{ matrix.container }}
     env:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -29,6 +29,8 @@ jobs:
           container: defi/ain-builder:latest
         - target: aarch64-apple-darwin
           container: defi/ain-builder:latest
+    container:
+      image: ${{ matrix.container }}
     env:
       TARGET: ${{matrix.target}}
 

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -17,16 +17,9 @@ jobs:
       matrix:
         target: [x86_64-pc-linux-gnu, aarch64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin, aarch64-apple-darwin]
         include:
-        - target: x86_64-pc-linux-gnu
-          container: defi/ain-builder:latest
-        - target: aarch64-linux-gnu
-          container: defi/ain-builder:latest
+        - container: defi/ain-builder:latest
         - target: x86_64-w64-mingw32
           container: defi/ain-win-builder:latest
-        - target: x86_64-apple-darwin
-          container: defi/ain-builder:latest
-        - target: aarch64-apple-darwin
-          container: defi/ain-builder:latest
     container:
       image: ${{ matrix.container }}
     env:

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -13,10 +13,20 @@ jobs:
   # these don't create end artifacts to use
   stage-release:
     runs-on: ubuntu-latest
-    container: defi/ain-builder:latest
     strategy:
       matrix:
         target: [x86_64-pc-linux-gnu, aarch64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+        - target: x86_64-pc-linux-gnu
+          container: defi/ain-builder:latest
+        - target: aarch64-linux-gnu
+          container: defi/ain-builder:latest
+        - target: x86_64-w64-mingw32
+          container: defi/ain-win-builder:latest
+        - target: x86_64-apple-darwin
+          container: defi/ain-builder:latest
+        - target: aarch64-apple-darwin
+          container: defi/ain-builder:latest
     env:
       TARGET: ${{matrix.target}}
 

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -27,6 +27,8 @@ jobs:
           container: defi/ain-builder:latest
         - target: aarch64-apple-darwin
           container: defi/ain-builder:latest
+    container:
+      image: ${{ matrix.container }}
     env:
       TARGET: ${{matrix.target}}
 


### PR DESCRIPTION
## Summary

- The PR includes fixes to fix the broken win-x64 binaries built on the multi-arch build CI workflows on build dev, staging and release.
- The issue is resolved when cross compilation build is on ubuntu 22.04.
- Temporary workaround to include a new ain-builder specific for windows version while maintaining compatibility for the other target architectures, specifically linux builds due to glibc which is tied to the distro the target binary is being built on.
- To ensure that releases support Ubuntu versions 20.04 onwards (glibc versions >=2.29 onwards), thus the need to separate the pre-warmed containers.
- The new ain-win-builder will run on Ubuntu 22.04, while the ain-builder used in all other workflows will maintain compatibility at 20.04.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
