### PR TITLE
CI: Enable frontier test trigger on push to master

### DIFF
--- a/.github/workflows/tests-frontier.yml
+++ b/.github/workflows/tests-frontier.yml
@@ -2,6 +2,9 @@ name: Tests - DeFiCh/metachain-ts-suite
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary

- Enable CI frontier test trigger on push to master

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
