### PR TITLE
Health check API: Add verbose option

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -648,12 +648,14 @@ static bool rest_blockchain_liveness(HTTPRequest* req,
     if (RPCIsInWarmup(&statusmessage)) {
         if (verbose) {
             msg += "startup failed: rpc in warm up\n";
+            msg += "livez check failed\n";
         }
         RESTERR(req, HTTP_SERVICE_UNAVAILABLE, msg);
         return false;
     }
     if (verbose) {
         msg += "startup: ok\n";
+        msg += "livez check passed\n";
     }
     req->WriteHeader("Content-Type", "text/plain");
     req->WriteReply(HTTP_OK, msg);
@@ -674,9 +676,9 @@ struct ReadyzFlags {
     std::string ToLogOutput() const {
         std::string msg{};
         if (inStartup) {
-            msg += "startup: ok\n";
-        } else {
             msg += "startup failed: rpc in warm up\n";
+        } else {
+            msg += "startup: ok\n";
         }
         if (syncToTip) {
             msg += "sync to tip: ok\n";

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -695,7 +695,7 @@ struct ReadinessFlags {
             }
         }
         if (healthz) {
-            msg = "healthz check passed\n";
+            msg += "healthz check passed\n";
         } else {
             msg += "healthz check failed\n";
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -694,7 +694,7 @@ struct ReadinessFlags {
                 msg += "p2p check failed: insufficent active peers\n";
             }
         }
-        if (healthz) {
+        if (GetReadiness()) {
             msg += "healthz check passed\n";
         } else {
             msg += "healthz check failed\n";

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -754,7 +754,7 @@ static const struct {
       {"/rest/mempool/contents", rest_mempool_contents},
       {"/rest/headers/", rest_headers},
       {"/rest/getutxos", rest_getutxos},
-      {"/rest/blockhashbyheight", rest_blockhash_by_height},
+      {"/rest/blockhashbyheight/", rest_blockhash_by_height},
 };
 
 static const struct {


### PR DESCRIPTION
## Summary

- Add verbose flag when passing ?verbose suffix. /readyz?verbose and /livez?verbose returns health check API logs

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
