### PR TITLE
RPC: Fix eth_feeHistory pipeline

### DIFF
--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -247,11 +247,11 @@ impl BlockService {
         }
 
         let mut blocks = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
-        let mut block_num = highest_block
-            .checked_add(U256::one())
-            .ok_or(format_err!("Block number overflow"))?
-            .checked_sub(block_count)
-            .unwrap_or_default();
+        let mut block_num = if let Some(block_num) = highest_block.checked_sub(block_count) {
+            block_num.checked_add(U256::one()).ok_or(format_err!("Block number overflow"))?
+        } else {
+            U256::zero()
+        };
 
         while block_num <= highest_block {
             let block = self

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -281,7 +281,8 @@ impl BlockService {
 
             let mut block_tx_rewards = Vec::new();
             for tx in block.transactions {
-                let tx_rewards = SignedTx::try_from(tx)?.effective_gas_price(base_fee)?;
+                let tx_rewards =
+                    SignedTx::try_from(tx)?.effective_priority_fee_per_gas(base_fee)?;
                 block_tx_rewards.push(u64::try_from(tx_rewards)? as f64);
             }
 

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -13,6 +13,7 @@ use statrs::statistics::{Data, OrderStatistics};
 
 use crate::{
     storage::{traits::BlockStorage, Storage},
+    transaction::SignedTx,
     EVMError, Result,
 };
 
@@ -21,6 +22,7 @@ pub struct BlockService {
     starting_block_number: U256,
 }
 
+#[derive(Default)]
 pub struct FeeHistoryData {
     pub oldest_block: U256,
     pub base_fee_per_gas: Vec<U256>,
@@ -30,6 +32,10 @@ pub struct FeeHistoryData {
 
 pub const INITIAL_BASE_FEE: U256 = U256([10_000_000_000, 0, 0, 0]); // wei
 const MAX_BASE_FEE: U256 = crate::weiamount::MAX_MONEY_SATS;
+
+pub const MIN_BLOCK_COUNT_RANGE: U256 = 1;
+pub const MAX_BLOCK_COUNT_RANGE: U256 = 1024;
+pub const MAX_REWARD_PERCENTILE_VEC_SIZE: usize = 100;
 
 /// Handles getting block data, and contains internal functions for block creation and fees.
 impl BlockService {
@@ -72,13 +78,15 @@ impl BlockService {
         Ok(state_root)
     }
 
-    /// Add new block to storage. This block must have passed validation before being added to storage. Once it is added to storage it becomes the latest confirmed block.
+    /// Add new block to storage. This block must have passed validation before being added to storage.
+    /// Once it is added to storage it becomes the latest confirmed block.
     pub fn connect_block(&self, block: &BlockAny) -> Result<()> {
         self.storage.put_latest_block(Some(block))?;
         self.storage.put_block(block)
     }
 
-    /// Finds base fee for block based on parent gas usage. Can be used to find base fee for next block if latest block data is passed.
+    /// Finds base fee for block based on parent gas usage. Can be used to find base fee for next block
+    /// if latest block data is passed.
     pub fn get_base_fee(
         &self,
         parent_gas_used: u64,
@@ -145,7 +153,8 @@ impl BlockService {
     ///
     /// # Arguments
     /// * `parent_hash` - Parent block hash
-    /// * `block_gas_target_factor` - Determines the gas target for the previous block using the formula `gas target = gas limit / target factor`
+    /// * `block_gas_target_factor` - Determines the gas target for the previous block using the formula:
+    ///   `gas target = gas limit / target factor`
     pub fn calculate_base_fee(
         &self,
         parent_hash: H256,
@@ -159,8 +168,8 @@ impl BlockService {
             return Ok(INITIAL_BASE_FEE);
         }
 
-        // get parent gas usage,
-        // https://eips.ethereum.org/EIPS/eip-1559#:~:text=fee%20is%20correct-,if%20INITIAL_FORK_BLOCK_NUMBER%20%3D%3D%20block.number%3A,-expected_base_fee_per_gas%20%3D%20INITIAL_BASE_FEE
+        // get parent gas usage.
+        // Ref: https://eips.ethereum.org/EIPS/eip-1559#:~:text=fee%20is%20correct-,if%20INITIAL_FORK_BLOCK_NUMBER%20%3D%3D%20block.number%3A,-expected_base_fee_per_gas%20%3D%20INITIAL_BASE_FEE
         let parent_block = self
             .storage
             .get_block_by_hash(&parent_hash)?
@@ -182,137 +191,130 @@ impl BlockService {
     /// Gets base fee, gas usage ratio and priority fees for a range of blocks. Used in `eth_feeHistory`.
     ///
     /// # Arguments
-    /// * `block_count` - Number of blocks' data to return.
-    /// * `first_block` - Block number of first block.
-    /// * `priority_fee_percentile` - Vector of percentiles. This will return percentile priority fee for all blocks. e.g. [20, 50, 70] will return 20th, 50th and 70th percentile priority fee for every block.
+    /// * `block_count` - Number of blocks' data to return. Between 1 and 1024 blocks can be requested in a single query.
+    /// * `highest_block` - Block number of highest block.
+    /// * `priority_fee_percentile` - Vector of percentiles. This will return percentile priority fee for all blocks.
     /// * `block_gas_target_factor` - Determines gas target. Used when latest `block_count` blocks are queried.
     pub fn fee_history(
         &self,
-        block_count: usize,
-        first_block: U256,
-        priority_fee_percentile: Vec<usize>,
+        block_count: U256,
+        highest_block: U256,
+        priority_fee_percentile: Option<Vec<usize>>,
         block_gas_target_factor: u64,
     ) -> Result<FeeHistoryData> {
-        let mut blocks = Vec::with_capacity(block_count);
-        let mut block_number = first_block;
+        // Validate block_count input
+        if block_count < MIN_BLOCK_COUNT_RANGE {
+            return Err(format_err!(
+                "Block count requested smaller than minimum allowed range of {}",
+                MIN_BLOCK_COUNT_RANGE,
+            ));
+        }
+        if block_count > MAX_BLOCK_COUNT_RANGE {
+            return Err(format_err!(
+                "Block count requested larger than maximum allowed range of {}",
+                MAX_BLOCK_COUNT_RANGE,
+            ));
+        }
+        // Validate priority_fee_percentile input
+        if let Some(priority_fee_percentile) = &priority_fee_percentile {
+            if priority_fee_percentile.len() > MAX_REWARD_PERCENTILE_VEC_SIZE {
+                return Err(format_err!(
+                    "List of percentile value exceeds maximum allowed size {}",
+                    MAX_REWARD_PERCENTILE_VEC_SIZE,
+                ));
+            }
 
-        for _ in 1..=block_count {
-            let block = match self.storage.get_block_by_number(&block_number)? {
-                None => Err(format_err!("Block {} out of range", block_number)),
-                Some(block) => Ok(block),
-            }?;
-
-            blocks.push(block);
-
-            block_number = block_number
-                .checked_sub(U256::one())
-                .ok_or_else(|| format_err!("block_number underflow"))?;
+            let mut prev_percentile = 0;
+            for percentile in priority_fee_percentile {
+                if prev_percentile > percentile {
+                    return Err(format_err!("List of percentile value is not monotonically increasing"));
+                }
+                prev_percentile = percentile;
+            }
         }
 
-        let oldest_block = blocks.last().unwrap().header.number;
+        let mut blocks = Vec::with_capacity(block_count);
+        let mut block_num = highest_block.checked_sub(block_count).unwrap_or_default();
+        while block_num <= highest_block {
+            let block = self
+                .storage
+                .get_block_by_number(&block_number)?
+                .ok_or(|| format_err!("Block {} out of range", block_number))?;
+            blocks.push(block);
 
-        let (mut base_fee_per_gas, mut gas_used_ratio) = blocks.iter().try_fold(
-            (Vec::new(), Vec::new()),
-            |(mut base_fee_per_gas, mut gas_used_ratio), block| {
-                trace!("[fee_history] Processing block {}", block.header.number);
-                let base_fee = block.header.base_fee;
-
-                let gas_ratio = if block.header.gas_limit == U256::zero() {
-                    f64::default() // empty block
-                } else {
-                    u64::try_from(block.header.gas_used)? as f64
-                        / u64::try_from(block.header.gas_limit)? as f64 // safe due to check
-                };
-
-                base_fee_per_gas.push(base_fee);
-                gas_used_ratio.push(gas_ratio);
-
-                Ok::<_, EVMError>((base_fee_per_gas, gas_used_ratio))
-            },
-        )?;
-
-        let reward = if priority_fee_percentile.is_empty() {
-            None
-        } else {
-            let mut eip_transactions = Vec::new();
-
-            for block in blocks {
-                let mut block_eip_transaction = Vec::new();
-                for tx in block.transactions {
-                    match tx {
-                        TransactionAny::Legacy(_) | TransactionAny::EIP2930(_) => {
-                            continue;
-                        }
-                        TransactionAny::EIP1559(t) => {
-                            block_eip_transaction.push(t);
-                        }
-                    }
-                }
-                block_eip_transaction
-                    .sort_by(|a, b| a.max_priority_fee_per_gas.cmp(&b.max_priority_fee_per_gas));
-                eip_transactions.push(block_eip_transaction);
-            }
-
-            /*
-                TODO: assumption here is that max priority fee = priority fee paid, however
-                priority fee can be lower if gas costs hit max_fee_per_gas.
-                we will need to check the base fee paid to get the actual priority fee paid
-            */
-
-            let mut reward = Vec::new();
-
-            for block_eip_tx in eip_transactions {
-                if block_eip_tx.is_empty() {
-                    reward.push(vec![U256::zero()]);
-                    continue;
-                }
-
-                let mut block_rewards = Vec::new();
-                let priority_fees = block_eip_tx
-                    .iter()
-                    .map(|tx| Ok(u64::try_from(tx.max_priority_fee_per_gas)? as f64))
-                    .collect::<Result<Vec<f64>>>()?;
-                let mut data = Data::new(priority_fees);
-
-                for pct in &priority_fee_percentile {
-                    block_rewards.push(U256::from(data.percentile(*pct).floor() as u64));
-                }
-
-                reward.push(block_rewards);
-            }
-
-            reward.reverse();
-            Some(reward)
-        };
-
-        // add another entry for baseFeePerGas
-        let next_block_base_fee = match self.storage.get_block_by_number(
-            &(first_block
+            block_num = block_num
                 .checked_add(U256::one())
-                .ok_or_else(|| format_err!("Block number overflow"))?),
-        )? {
-            None => {
-                // get one block earlier (this should exist)
-                let block = self
-                    .storage
-                    .get_block_by_number(&first_block)?
-                    .ok_or_else(|| format_err!("Block {} out of range", first_block))?;
-                self.calculate_base_fee(block.header.hash(), block_gas_target_factor)?
+                .ok_or(|| format_err!("block_number overflow"))?;
+        }
+
+        let mut result = FeeHistoryData::default();
+
+        // Set oldest block number
+        result.oldest_block = blocks
+            .first()
+            .ok_or(|| format_err!("Unable to fetch oldest block"))?
+            .header
+            .number;
+
+        if priority_fee_percentile.is_some() {
+            result.reward = Some(Vec::new());
+        }
+
+        for block in blocks {
+            trace!("[fee_history] Processing block {}", block.header.number);
+            let base_fee = block.header.base_fee;
+            let gas_ratio = if block.header.gas_limit == U256::zero() {
+                f64::default() // empty block
+            } else {
+                u64::try_from(block.header.gas_used)? as f64
+                    / u64::try_from(block.header.gas_limit)? as f64 // safe due to check
+            };
+            result.base_fee_per_gas.push(base_fee);
+            result.gas_used_ratio.push(gas_ratio);
+
+            let block_tx_rewards = Vec::new();
+            for tx in block.transactions {
+                let tx_rewards = SignedTx::try_from(tx)?.effective_gas_price(base_fee)?;
+                block_tx_rewards.push(tx_rewards);
             }
-            Some(block) => self.calculate_base_fee(block.header.hash(), block_gas_target_factor)?,
+            block_tx_rewards.sort_by(|a, b| a.cmp(&b));
+
+            if let Some(rewards) = priority_fee_percentile.as_ref().map(|percentile| {
+                if block_tx_rewards.is_empty() {
+                    vec![U256::zero(); percentile.len()]
+                } else {
+                    let mut reward = Vec::with_capacity(percentile.len());
+                    let mut data = Data::new(block_tx_rewards);
+                    for percent in percentile {
+                        reward.push(U256::from(data.percentile(*percent).floor() as u64));
+                    }
+                    reward
+                }
+            }) {
+                if let Some(mut result_reward) = &result.reward {
+                    result_reward.push(rewards);
+                }
+            }
+        }
+
+        // Add next block entry
+        let attrs = ain_cpp_imports::get_attribute_values(None);
+
+        let next_block = highest_block
+            .checked_add(U256::one())
+            .ok_or_else(|| format_err!("Next block number overflow"))?;
+
+        let next_block_base_fee = match self.storage.get_block_by_number(&next_block)? {
+            Some(block) => block.header.base_fee,
+            None => {
+                let highest_block_info = blocks
+                    .last()
+                    .ok_or(|| format_err!("Unable to fetch highest block"))?;
+                self.calculate_base_fee(highest_block_info.header.hash(), attrs.block_gas_target_factor)?
+            }
         };
-
-        base_fee_per_gas.reverse();
-        base_fee_per_gas.push(next_block_base_fee);
-
-        gas_used_ratio.reverse();
-
-        Ok(FeeHistoryData {
-            oldest_block,
-            base_fee_per_gas,
-            gas_used_ratio,
-            reward,
-        })
+        result.base_fee_per_gas.push(next_block_base_fee);
+        Ok(result)
     }
 
     /// Returns the 60th percentile priority fee for the last 20 blocks. [Reference](https://github.com/ethereum/go-ethereum/blob/c57b3436f4b8aae352cd69c3821879a11b5ee0fb/eth/ethconfig/config.go#L41)

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -259,12 +259,12 @@ impl BlockService {
             let block = self
                 .storage
                 .get_block_by_number(&block_num)?
-                .ok_or(format_err!("Block {} out of range", block_num))?;
+                .ok_or(format_err!("Block {:#?} out of range", block_num))?;
             blocks.push(block);
 
             block_num = block_num
                 .checked_add(U256::one())
-                .ok_or(format_err!("block_number overflow"))?;
+                .ok_or(format_err!("Next block number overflow"))?;
         }
 
         // Set oldest block number

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -248,7 +248,9 @@ impl BlockService {
 
         let mut blocks = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
         let mut block_num = if let Some(block_num) = highest_block.checked_sub(block_count) {
-            block_num.checked_add(U256::one()).ok_or(format_err!("Block number overflow"))?
+            block_num
+                .checked_add(U256::one())
+                .ok_or(format_err!("Block number overflow"))?
         } else {
             U256::zero()
         };

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -226,14 +226,14 @@ impl BlockService {
         }
 
         let mut prev_percentile = 0;
-        for percentile in priority_fee_percentile {
-            if prev_percentile > percentile {
+        for percentile in &priority_fee_percentile {
+            if prev_percentile > *percentile {
                 return Err(format_err!(
                     "List of percentile value is not monotonically increasing"
                 )
                 .into());
             }
-            prev_percentile = percentile;
+            prev_percentile = *percentile;
         }
 
         let mut blocks = Vec::new();
@@ -289,8 +289,8 @@ impl BlockService {
             } else {
                 let mut r = Vec::with_capacity(priority_fee_percentile.len());
                 let mut data = Data::new(block_tx_rewards);
-                for percent in priority_fee_percentile {
-                    r.push(U256::from(data.percentile(percent).floor() as u64));
+                for percent in &priority_fee_percentile {
+                    r.push(U256::from(data.percentile(*percent).floor() as u64));
                 }
                 r
             };

--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -246,7 +246,7 @@ impl BlockService {
             prev_percentile = *percentile;
         }
 
-        let mut blocks = Vec::new();
+        let mut blocks = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
         let mut block_num = highest_block
             .checked_add(U256::one())
             .ok_or(format_err!("Block number overflow"))?
@@ -272,9 +272,9 @@ impl BlockService {
             .header
             .number;
 
-        let mut base_fee_per_gas = Vec::new();
-        let mut gas_used_ratio = Vec::new();
-        let mut rewards = Vec::new();
+        let mut base_fee_per_gas = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
+        let mut gas_used_ratio = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
+        let mut rewards = Vec::with_capacity(MAX_BLOCK_COUNT_RANGE.as_usize());
         for block in blocks.clone() {
             trace!("[fee_history] Processing block {}", block.header.number);
             let base_fee = block.header.base_fee;
@@ -287,7 +287,7 @@ impl BlockService {
             base_fee_per_gas.push(base_fee);
             gas_used_ratio.push(gas_ratio);
 
-            let mut block_tx_rewards = Vec::new();
+            let mut block_tx_rewards = Vec::with_capacity(block.transactions.len());
             for tx in block.transactions {
                 let tx_rewards =
                     SignedTx::try_from(tx)?.effective_priority_fee_per_gas(base_fee)?;

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -761,13 +761,15 @@ impl EVMCoreService {
                     .trie_store
                     .trie_db
                     .trie_restore(address.as_bytes(), None, account.storage_root.into())
-                    .unwrap();
+                    .map_err(|e| BackendError::TrieRestoreFailed(e.to_string()).into());
 
                 let tmp: &mut [u8; 32] = &mut [0; 32];
                 position.to_big_endian(tmp);
-                storage_trie
-                    .get(tmp.as_slice())
-                    .map_err(|e| BackendError::TrieError(e.to_string()).into())
+                storage_trie.and_then(|storage| {
+                    storage
+                        .get(tmp.as_slice())
+                        .map_err(|e| BackendError::TrieError(e.to_string()).into())
+                })
             })
     }
 

--- a/lib/ain-evm/src/transaction/mod.rs
+++ b/lib/ain-evm/src/transaction/mod.rs
@@ -273,6 +273,19 @@ impl SignedTx {
         }
     }
 
+    pub fn effective_priority_fee_per_gas(&self, base_fee: U256) -> Result<U256, EVMError> {
+        match &self.transaction {
+            TransactionV2::Legacy(tx) => Ok(tx.gas_price.checked_sub(base_fee).unwrap_or_default()),
+            TransactionV2::EIP2930(tx) => {
+                Ok(tx.gas_price.checked_sub(base_fee).unwrap_or_default())
+            }
+            TransactionV2::EIP1559(tx) => {
+                let max_priority_fee = tx.max_fee_per_gas.checked_sub(base_fee).unwrap_or_default();
+                Ok(min(tx.max_priority_fee_per_gas, max_priority_fee))
+            }
+        }
+    }
+
     pub fn data(&self) -> &[u8] {
         match &self.transaction {
             TransactionV2::Legacy(tx) => tx.input.as_ref(),

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -228,7 +228,7 @@ pub trait MetachainRPC {
         &self,
         block_count: U256,
         newest_block: BlockNumber,
-        priority_fee_percentile: Vec<usize>,
+        reward_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory>;
 
     #[method(name = "maxPriorityFeePerGas")]
@@ -931,7 +931,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         &self,
         block_count: U256,
         newest_block: BlockNumber,
-        priority_fee_percentile: Vec<usize>,
+        reward_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory> {
         let highest_block_number = self.get_block(Some(newest_block))?.header.number;
         let attrs = ain_cpp_imports::get_attribute_values(None);
@@ -942,7 +942,7 @@ impl MetachainRPCServer for MetachainRPCModule {
             .fee_history(
                 block_count,
                 highest_block_number,
-                priority_fee_percentile,
+                reward_percentile,
                 attrs.block_gas_target_factor,
             )
             .map_err(RPCError::EvmError)?;

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -228,7 +228,7 @@ pub trait MetachainRPC {
         &self,
         block_count: U256,
         newest_block: BlockNumber,
-        priority_fee_percentile: Option<Vec<usize>>,
+        priority_fee_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory>;
 
     #[method(name = "maxPriorityFeePerGas")]
@@ -931,7 +931,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         &self,
         block_count: U256,
         newest_block: BlockNumber,
-        priority_fee_percentile: Option<Vec<usize>>,
+        priority_fee_percentile: Vec<usize>,
     ) -> RpcResult<RpcFeeHistory> {
         let highest_block_number = self.get_block(Some(newest_block))?.header.number;
         let attrs = ain_cpp_imports::get_attribute_values(None);

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -934,6 +934,7 @@ impl MetachainRPCServer for MetachainRPCModule {
         priority_fee_percentile: Option<Vec<usize>>,
     ) -> RpcResult<RpcFeeHistory> {
         let highest_block_number = self.get_block(Some(newest_block))?.header.number;
+        let attrs = ain_cpp_imports::get_attribute_values(None);
 
         let fee_history = self
             .handler
@@ -942,6 +943,7 @@ impl MetachainRPCServer for MetachainRPCModule {
                 block_count,
                 highest_block_number,
                 priority_fee_percentile,
+                attrs.block_gas_target_factor,
             )
             .map_err(RPCError::EvmError)?;
 

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -227,8 +227,8 @@ pub trait MetachainRPC {
     fn fee_history(
         &self,
         block_count: U256,
-        first_block: BlockNumber,
-        priority_fee_percentile: Vec<usize>,
+        newest_block: BlockNumber,
+        priority_fee_percentile: Option<Vec<usize>>,
     ) -> RpcResult<RpcFeeHistory>;
 
     #[method(name = "maxPriorityFeePerGas")]
@@ -930,21 +930,18 @@ impl MetachainRPCServer for MetachainRPCModule {
     fn fee_history(
         &self,
         block_count: U256,
-        first_block: BlockNumber,
-        priority_fee_percentile: Vec<usize>,
+        newest_block: BlockNumber,
+        priority_fee_percentile: Option<Vec<usize>>,
     ) -> RpcResult<RpcFeeHistory> {
-        let first_block_number = self.get_block(Some(first_block))?.header.number;
-        let attrs = ain_cpp_imports::get_attribute_values(None);
+        let highest_block_number = self.get_block(Some(newest_block))?.header.number;
 
-        let block_count = block_count.try_into().map_err(to_custom_err)?;
         let fee_history = self
             .handler
             .block
             .fee_history(
                 block_count,
-                first_block_number,
+                highest_block_number,
                 priority_fee_percentile,
-                attrs.block_gas_target_factor,
             )
             .map_err(RPCError::EvmError)?;
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -391,6 +391,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "eth_estimateGas", 1, "tag"},
     { "eth_createAccessList", 0, "tx"},
     { "eth_createAccessList", 1, "tag"},
+    { "eth_feeHistory", 1, "tag"},
+    { "eth_feeHistory", 2, "rewardPercentile"},
 
     { "eth_newFilter", 0, "filter"},
     { "eth_uninstallFilter", 0, "filterId"},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -431,6 +431,7 @@ static const CRPCAlternateStringValParam vRPCAlternateStringValParams[] =
     { "eth_call", 1, {"earliest", "latest", "pending"}},
     { "eth_estimateGas", 1, {"earliest", "latest", "pending"}},
     { "eth_createAccessList", 1, {"earliest", "latest", "pending"}},
+    { "eth_feeHistory", 1, {"earliest", "latest", "pending"}},
 
     { "eth_getBalance", 1, {"earliest", "latest", "pending"}},
     { "eth_getStorageAt", 2, {"earliest", "latest", "pending"}},

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -163,7 +163,6 @@ class EVMTest(DefiTestFramework):
             assert_equal(Decimal(str(gasUsedRatio)), Decimal("0.033868333333333334"))
 
         assert_equal(len(history["reward"]), numBlocks)
-        assert_equal(history["reward"], False)
         for reward in history["reward"]:
             assert_equal(len(reward), len(rewardPercentiles))
             assert_equal(reward, ["0x2", "0x3", "0x5", "0x7", "0x9", "0xa"])

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -161,6 +161,7 @@ class EVMTest(DefiTestFramework):
         for gasUsedRatio in history["gasUsedRatio"]:
             assert_equal(Decimal(str(gasUsedRatio)), Decimal("0.033868333333333334"))
 
+        assert_equal(len(history["reward"]), numBlocks)
         for reward in history["reward"]:
             assert_equal(len(reward), len(rewardPercentiles))
             assert_equal(reward, ["0x2", "0x3", "0x5", "0x7", "0x9", "0xa"])
@@ -182,6 +183,7 @@ class EVMTest(DefiTestFramework):
         assert_equal(
             Decimal(str(history["gasUsedRatio"][0])), Decimal("0.033868333333333334")
         )
+        assert_equal(len(history["reward"]), 1)
         assert_equal(history["reward"][0], ["0x2", "0x3", "0x5", "0x7", "0x9", "0xa"])
 
     def test_fee_history_empty_percentile(self):
@@ -208,6 +210,7 @@ class EVMTest(DefiTestFramework):
         for gasUsedRatio in history["gasUsedRatio"]:
             assert_equal(Decimal(str(gasUsedRatio)), Decimal("0.033868333333333334"))
 
+        assert_equal(len(history["reward"]), numBlocks)
         for reward in history["reward"]:
             assert_equal(len(reward), len(rewardPercentiles))
             assert_equal(reward, [])

--- a/test/functional/feature_evm_rpc_fee_history.py
+++ b/test/functional/feature_evm_rpc_fee_history.py
@@ -146,7 +146,9 @@ class EVMTest(DefiTestFramework):
         current = self.nodes[0].eth_blockNumber()
         rewardPercentiles = [20, 30, 50, 70, 85, 100]
 
-        history = self.nodes[0].eth_feeHistory(hex(numBlocks), "latest", rewardPercentiles)        
+        history = self.nodes[0].eth_feeHistory(
+            hex(numBlocks), "latest", rewardPercentiles
+        )
         assert_equal(history["oldestBlock"], hex(int(current, 16) - numBlocks + 1))
         # Include next block base fee
         assert_equal(len(history["baseFeePerGas"]), numBlocks + 1)
@@ -170,14 +172,16 @@ class EVMTest(DefiTestFramework):
         current = self.nodes[0].eth_blockNumber()
         rewardPercentiles = [20, 30, 50, 70, 85, 100]
 
-        history = self.nodes[0].eth_feeHistory(hex(1), "latest", rewardPercentiles)        
+        history = self.nodes[0].eth_feeHistory(hex(1), "latest", rewardPercentiles)
         assert_equal(history["oldestBlock"], hex(int(current, 16)))
         # Include next block base fee
         assert_equal(len(history["baseFeePerGas"]), 2)
 
         block = self.nodes[0].eth_getBlockByNumber("latest")
         assert_equal(block["baseFeePerGas"], history["baseFeePerGas"][0])
-        assert_equal(Decimal(str(history["gasUsedRatio"][0])), Decimal("0.033868333333333334"))
+        assert_equal(
+            Decimal(str(history["gasUsedRatio"][0])), Decimal("0.033868333333333334")
+        )
         assert_equal(history["reward"][0], ["0x2", "0x3", "0x5", "0x7", "0x9", "0xa"])
 
     def run_test(self):


### PR DESCRIPTION
## Summary

- PR contains the fixes to correct the erroneous fee_history pipeline.
- Check block range argument limits passed in the RPC.
- Check priority fee percentile vector to be monotonically increasing and not exceed max vec size limit.
- Proper priority fee calculation from the block transactions, taking to account the block base fee and the maxFeePerGas limit set for EIP1559 transactions.
- Proper priority fee calculation for non-EIP1559 transactions (gasPrice - block base fee).
- Clean up and add more test coverage to feature_evm_rpc_fee_history functional test.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
