### PR TITLE
RPC: Fix de-serializing null values in topic lists

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -311,9 +311,9 @@ if __name__ == "__main__":
     if "netmagic" not in settings:
         settings["netmagic"] = "f9beb4d9"
     if "genesis" not in settings:
-        settings[
-            "genesis"
-        ] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        settings["genesis"] = (
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        )
     if "input" not in settings:
         settings["input"] = "input"
     if "hashlist" not in settings:

--- a/lib/ain-grpc/src/logs.rs
+++ b/lib/ain-grpc/src/logs.rs
@@ -66,6 +66,6 @@ pub struct GetLogsRequest {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LogRequestTopics {
-    VecOfHashes(Vec<H256>),
-    VecOfHashVecs(Vec<Vec<H256>>),
+    VecOfHashes(Vec<Option<H256>>),
+    VecOfHashVecs(Vec<Vec<Option<H256>>>),
 }

--- a/lib/ain-grpc/src/rpc/eth.rs
+++ b/lib/ain-grpc/src/rpc/eth.rs
@@ -1029,9 +1029,12 @@ impl MetachainRPCServer for MetachainRPCModule {
         };
         let topics = input.topics.map(|topics| match topics {
             LogRequestTopics::VecOfHashes(inputs) => {
-                inputs.into_iter().map(|input| vec![input]).collect()
+                inputs.iter().flatten().map(|input| vec![*input]).collect()
             }
-            LogRequestTopics::VecOfHashVecs(inputs) => inputs,
+            LogRequestTopics::VecOfHashVecs(inputs) => inputs
+                .iter()
+                .map(|hashes| hashes.iter().flatten().copied().collect())
+                .collect(),
         });
         let curr_block = self.get_block(Some(BlockNumber::Latest))?.header.number;
         let mut criteria = FilterCriteria {
@@ -1075,9 +1078,12 @@ impl MetachainRPCServer for MetachainRPCModule {
         };
         let topics = input.topics.map(|topics| match topics {
             LogRequestTopics::VecOfHashes(inputs) => {
-                inputs.into_iter().map(|input| vec![input]).collect()
+                inputs.iter().flatten().map(|input| vec![*input]).collect()
             }
-            LogRequestTopics::VecOfHashVecs(inputs) => inputs,
+            LogRequestTopics::VecOfHashVecs(inputs) => inputs
+                .iter()
+                .map(|hashes| hashes.iter().flatten().copied().collect())
+                .collect(),
         });
         let curr_block = self.get_block(Some(BlockNumber::Latest))?.header.number;
         let mut criteria = FilterCriteria {

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1297,9 +1297,9 @@ class FullBlockTest(DefiTestFramework):
         b76 = self.next_block(76)
         size = MAX_BLOCK_SIGOPS - 1 + MAX_SCRIPT_ELEMENT_SIZE + 1 + 5
         a = bytearray([OP_CHECKSIG] * size)
-        a[
-            MAX_BLOCK_SIGOPS - 1
-        ] = 0x4E  # PUSHDATA4, but leave the following bytes as just checksigs
+        a[MAX_BLOCK_SIGOPS - 1] = (
+            0x4E  # PUSHDATA4, but leave the following bytes as just checksigs
+        )
         tx = self.create_and_sign_transaction(out[23], 1, CScript(a))
         b76 = self.update_block(76, [tx])
         self.send_blocks([b76], True)

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -48,9 +48,11 @@ class NotificationsTest(DefiTestFramework):
         block_count = 10
         blocks = self.nodes[1].generate(
             nblocks=block_count,
-            address=self.nodes[1].getnewaddress()
-            if self.is_wallet_compiled()
-            else ADDRESS_BCRT1_UNSPENDABLE,
+            address=(
+                self.nodes[1].getnewaddress()
+                if self.is_wallet_compiled()
+                else ADDRESS_BCRT1_UNSPENDABLE
+            ),
         )
 
         # wait at most 10 seconds for expected number of files before reading the content

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -204,9 +204,9 @@ class MempoolAcceptanceTest(DefiTestFramework):
             "A transaction with missing inputs, that existed once in the past"
         )
         tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_0)))
-        tx.vin[
-            0
-        ].prevout.n = 1  # Set vout to 1, to spend the other outpoint (49 coins) of the in-chain-tx we want to double spend
+        tx.vin[0].prevout.n = (
+            1  # Set vout to 1, to spend the other outpoint (49 coins) of the in-chain-tx we want to double spend
+        )
         raw_tx_1 = node.signrawtransactionwithwallet(tx.serialize().hex())["hex"]
         txid_1 = node.sendrawtransaction(hexstring=raw_tx_1, maxfeerate=0)
         # Now spend both to "clearly hide" the outputs, ie. remove the coins from the utxo set by spending them
@@ -445,9 +445,9 @@ class MempoolAcceptanceTest(DefiTestFramework):
 
         self.log.info("A transaction that is locked by BIP68 sequence logic")
         tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_reference)))
-        tx.vin[
-            0
-        ].nSequence = 2  # We could include it in the second block mined from now, but not the very next one
+        tx.vin[0].nSequence = (
+            2  # We could include it in the second block mined from now, but not the very next one
+        )
         # Can skip re-signing the tx because of early rejection
         self.check_mempool_result(
             result_expected=[

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -707,9 +707,9 @@ class SegWitTest(DefiTestFramework):
         tx.vin = [CTxIn(COutPoint(p2sh_tx.sha256, 0), CScript([witness_program]))]
         tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
         tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
-        tx.vin[
-            0
-        ].nSequence = BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
+        tx.vin[0].nSequence = (
+            BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
+        )
         tx.rehash()
 
         # This is always accepted, since the mempool policy is to consider segwit as always active

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -71,9 +71,11 @@ class Variant(collections.namedtuple("Variant", "call data address_type rescan p
 
         elif self.call in (Call.multiaddress, Call.multiscript):
             request = {
-                "scriptPubKey": {"address": self.address["address"]}
-                if self.call == Call.multiaddress
-                else self.address["scriptPubKey"],
+                "scriptPubKey": (
+                    {"address": self.address["address"]}
+                    if self.call == Call.multiaddress
+                    else self.address["scriptPubKey"]
+                ),
                 "timestamp": timestamp
                 + TIMESTAMP_WINDOW
                 + (1 if self.rescan == Rescan.late_timestamp else 0),


### PR DESCRIPTION
## Summary

- Fix de-serializing null values in topic lists for all log filters RPCs

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
