### PR TITLE
RPC: Enable passing null value in topic list in subscriptions RPC

### DIFF
--- a/lib/ain-grpc/src/subscription/eth.rs
+++ b/lib/ain-grpc/src/subscription/eth.rs
@@ -78,13 +78,25 @@ impl MetachainPubSubServer for MetachainPubSubModule {
                                                     inputs,
                                                 ) => Some(
                                                     inputs
-                                                        .into_iter()
-                                                        .map(|input| vec![input])
+                                                        .iter()
+                                                        .flatten()
+                                                        .map(|input| vec![*input])
                                                         .collect(),
                                                 ),
                                                 LogsSubscriptionParamsTopics::VecOfHashVecs(
                                                     inputs,
-                                                ) => Some(inputs),
+                                                ) => Some(
+                                                    inputs
+                                                        .iter()
+                                                        .map(|hashes| {
+                                                            hashes
+                                                                .iter()
+                                                                .flatten()
+                                                                .copied()
+                                                                .collect()
+                                                        })
+                                                        .collect(),
+                                                ),
                                             }
                                         } else {
                                             None

--- a/lib/ain-grpc/src/subscription/params.rs
+++ b/lib/ain-grpc/src/subscription/params.rs
@@ -31,8 +31,8 @@ pub struct LogsSubscriptionParams {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LogsSubscriptionParamsTopics {
-    VecOfHashes(Vec<H256>),
-    VecOfHashVecs(Vec<Vec<H256>>),
+    VecOfHashes(Vec<Option<H256>>),
+    VecOfHashVecs(Vec<Vec<Option<H256>>>),
 }
 
 /// Subscription kind.


### PR DESCRIPTION
## Summary

- Fix passing null value in topics list in eth_subscribe RPC call, in optional subscription parameters.


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
