### PR TITLE
Automatic Setting of Negative Interest

### DIFF
--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -61,33 +61,35 @@ const std::map<uint8_t, std::string> &ATTRIBUTES::displayVersions() {
 
 const std::map<std::string, uint8_t> &ATTRIBUTES::allowedTypes() {
     static const std::map<std::string, uint8_t> types{
-        {"locks",          AttributeTypes::Locks     },
-        {"oracles",        AttributeTypes::Oracles   },
-        {"params",         AttributeTypes::Param     },
-        {"poolpairs",      AttributeTypes::Poolpairs },
-        {"token",          AttributeTypes::Token     },
-        {"gov",            AttributeTypes::Governance},
-        {"transferdomain", AttributeTypes::Transfer  },
-        {"evm",            AttributeTypes::EVMType   },
-        {"vaults",         AttributeTypes::Vaults    },
-        {"rules",          AttributeTypes::Rules     },
+        {"locks",             AttributeTypes::Locks           },
+        {"oracles",           AttributeTypes::Oracles         },
+        {"params",            AttributeTypes::Param           },
+        {"poolpairs",         AttributeTypes::Poolpairs       },
+        {"token",             AttributeTypes::Token           },
+        {"gov",               AttributeTypes::Governance      },
+        {"transferdomain",    AttributeTypes::Transfer        },
+        {"evm",               AttributeTypes::EVMType         },
+        {"vaults",            AttributeTypes::Vaults          },
+        {"rules",             AttributeTypes::Rules           },
+        {"negative_interest", AttributeTypes::NegativeInterst },
     };
     return types;
 }
 
 const std::map<uint8_t, std::string> &ATTRIBUTES::displayTypes() {
     static const std::map<uint8_t, std::string> types{
-        {AttributeTypes::Live,       "live"          },
-        {AttributeTypes::Locks,      "locks"         },
-        {AttributeTypes::Oracles,    "oracles"       },
-        {AttributeTypes::Param,      "params"        },
-        {AttributeTypes::Poolpairs,  "poolpairs"     },
-        {AttributeTypes::Token,      "token"         },
-        {AttributeTypes::Governance, "gov"           },
-        {AttributeTypes::Transfer,   "transferdomain"},
-        {AttributeTypes::EVMType,    "evm"           },
-        {AttributeTypes::Vaults,     "vaults"        },
-        {AttributeTypes::Rules,      "rules"         },
+        {AttributeTypes::Live,            "live"              },
+        {AttributeTypes::Locks,           "locks"             },
+        {AttributeTypes::Oracles,         "oracles"           },
+        {AttributeTypes::Param,           "params"            },
+        {AttributeTypes::Poolpairs,       "poolpairs"         },
+        {AttributeTypes::Token,           "token"             },
+        {AttributeTypes::Governance,      "gov"               },
+        {AttributeTypes::Transfer,        "transferdomain"    },
+        {AttributeTypes::EVMType,         "evm"               },
+        {AttributeTypes::Vaults,          "vaults"            },
+        {AttributeTypes::Rules,           "rules"             },
+        {AttributeTypes::NegativeInterst, "negative_interest" },
     };
     return types;
 }
@@ -226,6 +228,20 @@ const std::map<uint8_t, std::string> &ATTRIBUTES::displayRulesIDs() {
     return params;
 }
 
+const std::map<std::string, uint8_t> &ATTRIBUTES::allowedNegativeInterestIDs() {
+    static const std::map<std::string, uint8_t> params{
+        {"automatic", NegativeInterestIDs::Automatic},
+    };
+    return params;
+}
+
+const std::map<uint8_t, std::string> &ATTRIBUTES::displayNegativeInterestIDs() {
+    static const std::map<uint8_t, std::string> params{
+        {NegativeInterestIDs::Automatic, "automatic"},
+    };
+    return params;
+}
+
 const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys() {
     static const std::map<uint8_t, std::map<std::string, uint8_t>> keys{
         {AttributeTypes::Token,
@@ -274,6 +290,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys
              {"emission-unused-fund", DFIPKeys::EmissionUnusedFund},
              {"mint-tokens-to-address", DFIPKeys::MintTokens},
              {"transferdomain", DFIPKeys::TransferDomain},
+             {"auto-negative-interest", DFIPKeys::AutoNegativeInterest},
          }},
         {AttributeTypes::EVMType,
          {
@@ -316,6 +333,11 @@ const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys
              {"core_op_return_max_size_bytes", RulesKeys::CoreOPReturn},
              {"dvm_op_return_max_size_bytes", RulesKeys::DVMOPReturn},
              {"evm_op_return_max_size_bytes", RulesKeys::EVMOPReturn},
+         }},
+         {AttributeTypes::NegativeInterst,
+         {
+             {"block_period", NegativeInterestKeys::BlockInterval},
+             {"burn_time_period", NegativeInterestKeys::BurnTimePeriod},
          }},
     };
     return keys;
@@ -372,6 +394,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys
              {DFIPKeys::EmissionUnusedFund, "emission-unused-fund"},
              {DFIPKeys::MintTokens, "mint-tokens-to-address"},
              {DFIPKeys::TransferDomain, "transferdomain"},
+             {DFIPKeys::AutoNegativeInterest, "auto-negative-interest"},
          }},
         {AttributeTypes::EVMType,
          {
@@ -433,6 +456,11 @@ const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys
              {RulesKeys::CoreOPReturn, "core_op_return_max_size_bytes"},
              {RulesKeys::DVMOPReturn, "dvm_op_return_max_size_bytes"},
              {RulesKeys::EVMOPReturn, "evm_op_return_max_size_bytes"},
+         }},
+         {AttributeTypes::NegativeInterst,
+         {
+             {NegativeInterestKeys::BlockInterval, "block_period"},
+             {NegativeInterestKeys::BurnTimePeriod, "burn_time_period"},
          }},
     };
     return keys;
@@ -750,6 +778,7 @@ const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(
                  {DFIPKeys::EmissionUnusedFund, VerifyBool},
                  {DFIPKeys::MintTokens, VerifyBool},
                  {DFIPKeys::TransferDomain, VerifyBool},
+                 {DFIPKeys::AutoNegativeInterest, VerifyBool},
              }},
             {AttributeTypes::Locks,
              {
@@ -796,6 +825,11 @@ const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(
                  {RulesKeys::CoreOPReturn, VerifyUInt64},
                  {RulesKeys::DVMOPReturn, VerifyUInt64},
                  {RulesKeys::EVMOPReturn, VerifyUInt64},
+             }},
+             {AttributeTypes::NegativeInterst,
+             {
+                 {NegativeInterestKeys::BlockInterval, VerifyUInt64},
+                 {NegativeInterestKeys::BurnTimePeriod, VerifyUInt64},
              }},
     };
     return parsers;
@@ -914,7 +948,7 @@ static Res CheckValidAttrV0Key(const uint8_t type, const uint32_t typeId, const 
                 typeKey != DFIPKeys::MNSetOwnerAddress && typeKey != DFIPKeys::GovernanceEnabled &&
                 typeKey != DFIPKeys::CFPPayout && typeKey != DFIPKeys::EmissionUnusedFund &&
                 typeKey != DFIPKeys::MintTokens && typeKey != DFIPKeys::EVMEnabled && typeKey != DFIPKeys::ICXEnabled &&
-                typeKey != DFIPKeys::TransferDomain) {
+                typeKey != DFIPKeys::TransferDomain && typeKey != DFIPKeys::AutoNegativeInterest) {
                 return DeFiErrors::GovVarVariableUnsupportedFeatureType(typeKey);
             }
         } else if (typeId == ParamIDs::Foundation) {
@@ -975,6 +1009,14 @@ static Res CheckValidAttrV0Key(const uint8_t type, const uint32_t typeId, const 
         if (typeId == RulesIDs::TXRules) {
             if (typeKey != RulesKeys::CoreOPReturn && typeKey != RulesKeys::DVMOPReturn &&
                 typeKey != RulesKeys::EVMOPReturn) {
+                return DeFiErrors::GovVarVariableUnsupportedRulesType(typeKey);
+            }
+        } else {
+            return DeFiErrors::GovVarVariableUnsupportedGovType();
+        }
+    } else if (type == AttributeTypes::NegativeInterst) {
+        if (typeId == NegativeInterestIDs::Automatic) {
+            if (typeKey != NegativeInterestKeys::BlockInterval && typeKey != NegativeInterestKeys::BurnTimePeriod) {
                 return DeFiErrors::GovVarVariableUnsupportedRulesType(typeKey);
             }
         } else {
@@ -1065,6 +1107,12 @@ Res ATTRIBUTES::ProcessVariable(const std::string &key,
         auto id = allowedRulesIDs().find(keys[2]);
         if (id == allowedRulesIDs().end()) {
             return DeFiErrors::GovVarVariableInvalidKey("rules", allowedRulesIDs());
+        }
+        typeId = id->second;
+    } else if (type == AttributeTypes::NegativeInterst) {
+        auto id = allowedNegativeInterestIDs().find(keys[2]);
+        if (id == allowedNegativeInterestIDs().end()) {
+            return DeFiErrors::GovVarVariableInvalidKey("negative_interest", allowedNegativeInterestIDs());
         }
         typeId = id->second;
     } else {
@@ -1472,6 +1520,10 @@ Res ATTRIBUTES::CheckKeys() const {
             if (!displayRulesIDs().count(attrV0->typeId)) {
                 return DeFiErrors::GovVarVariableInvalidKey("rules", displayRulesIDs());
             }
+        } else if (attrV0->type == AttributeTypes::NegativeInterst) {
+            if (!displayNegativeInterestIDs().count(attrV0->typeId)) {
+                return DeFiErrors::GovVarVariableInvalidKey("negative_interest", displayNegativeInterestIDs());
+            }
         }
 
         // Check key - Locks and Oracles have height int keys so skip.
@@ -1518,6 +1570,8 @@ UniValue ATTRIBUTES::ExportFiltered(GovVarsFilter filter, const std::string &pre
                 id = displayVaultIDs().at(attrV0->typeId);
             } else if (attrV0->type == AttributeTypes::Rules) {
                 id = displayRulesIDs().at(attrV0->typeId);
+            } else if (attrV0->type == AttributeTypes::NegativeInterst) {
+                id = displayNegativeInterestIDs().at(attrV0->typeId);
             } else {
                 id = KeyBuilder(attrV0->typeId);
             }
@@ -1893,6 +1947,10 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                         if (view.GetLastHeight() < Params().GetConsensus().DF22MetachainHeight) {
                             return Res::Err("Cannot be set before MetachainHeight");
                         }
+                    } else if (attrV0->key == DFIPKeys::AutoNegativeInterest) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF23Height) {
+                            return Res::Err("Cannot be set before DF23Height");
+                        }
                     }
                 } else if (attrV0->typeId == ParamIDs::Foundation) {
                     if (view.GetLastHeight() < Params().GetConsensus().DF20GrandCentralHeight) {
@@ -1971,6 +2029,12 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
             case AttributeTypes::Rules:
                 if (view.GetLastHeight() < Params().GetConsensus().DF22MetachainHeight) {
                     return Res::Err("Cannot be set before Metachain");
+                }
+                break;
+
+            case AttributeTypes::NegativeInterst:
+                if (view.GetLastHeight() < Params().GetConsensus().DF23Height) {
+                    return Res::Err("Cannot be set before DF23Height");
                 }
                 break;
 

--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -61,35 +61,35 @@ const std::map<uint8_t, std::string> &ATTRIBUTES::displayVersions() {
 
 const std::map<std::string, uint8_t> &ATTRIBUTES::allowedTypes() {
     static const std::map<std::string, uint8_t> types{
-        {"locks",             AttributeTypes::Locks           },
-        {"oracles",           AttributeTypes::Oracles         },
-        {"params",            AttributeTypes::Param           },
-        {"poolpairs",         AttributeTypes::Poolpairs       },
-        {"token",             AttributeTypes::Token           },
-        {"gov",               AttributeTypes::Governance      },
-        {"transferdomain",    AttributeTypes::Transfer        },
-        {"evm",               AttributeTypes::EVMType         },
-        {"vaults",            AttributeTypes::Vaults          },
-        {"rules",             AttributeTypes::Rules           },
-        {"negative_interest", AttributeTypes::NegativeInterst },
+        {"locks",             AttributeTypes::Locks          },
+        {"oracles",           AttributeTypes::Oracles        },
+        {"params",            AttributeTypes::Param          },
+        {"poolpairs",         AttributeTypes::Poolpairs      },
+        {"token",             AttributeTypes::Token          },
+        {"gov",               AttributeTypes::Governance     },
+        {"transferdomain",    AttributeTypes::Transfer       },
+        {"evm",               AttributeTypes::EVMType        },
+        {"vaults",            AttributeTypes::Vaults         },
+        {"rules",             AttributeTypes::Rules          },
+        {"negative_interest", AttributeTypes::NegativeInterst},
     };
     return types;
 }
 
 const std::map<uint8_t, std::string> &ATTRIBUTES::displayTypes() {
     static const std::map<uint8_t, std::string> types{
-        {AttributeTypes::Live,            "live"              },
-        {AttributeTypes::Locks,           "locks"             },
-        {AttributeTypes::Oracles,         "oracles"           },
-        {AttributeTypes::Param,           "params"            },
-        {AttributeTypes::Poolpairs,       "poolpairs"         },
-        {AttributeTypes::Token,           "token"             },
-        {AttributeTypes::Governance,      "gov"               },
-        {AttributeTypes::Transfer,        "transferdomain"    },
-        {AttributeTypes::EVMType,         "evm"               },
-        {AttributeTypes::Vaults,          "vaults"            },
-        {AttributeTypes::Rules,           "rules"             },
-        {AttributeTypes::NegativeInterst, "negative_interest" },
+        {AttributeTypes::Live,            "live"             },
+        {AttributeTypes::Locks,           "locks"            },
+        {AttributeTypes::Oracles,         "oracles"          },
+        {AttributeTypes::Param,           "params"           },
+        {AttributeTypes::Poolpairs,       "poolpairs"        },
+        {AttributeTypes::Token,           "token"            },
+        {AttributeTypes::Governance,      "gov"              },
+        {AttributeTypes::Transfer,        "transferdomain"   },
+        {AttributeTypes::EVMType,         "evm"              },
+        {AttributeTypes::Vaults,          "vaults"           },
+        {AttributeTypes::Rules,           "rules"            },
+        {AttributeTypes::NegativeInterst, "negative_interest"},
     };
     return types;
 }
@@ -334,7 +334,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys
              {"dvm_op_return_max_size_bytes", RulesKeys::DVMOPReturn},
              {"evm_op_return_max_size_bytes", RulesKeys::EVMOPReturn},
          }},
-         {AttributeTypes::NegativeInterst,
+        {AttributeTypes::NegativeInterst,
          {
              {"block_period", NegativeInterestKeys::BlockInterval},
              {"burn_time_period", NegativeInterestKeys::BurnTimePeriod},
@@ -457,7 +457,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys
              {RulesKeys::DVMOPReturn, "dvm_op_return_max_size_bytes"},
              {RulesKeys::EVMOPReturn, "evm_op_return_max_size_bytes"},
          }},
-         {AttributeTypes::NegativeInterst,
+        {AttributeTypes::NegativeInterst,
          {
              {NegativeInterestKeys::BlockInterval, "block_period"},
              {NegativeInterestKeys::BurnTimePeriod, "burn_time_period"},
@@ -826,7 +826,7 @@ const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(
                  {RulesKeys::DVMOPReturn, VerifyUInt64},
                  {RulesKeys::EVMOPReturn, VerifyUInt64},
              }},
-             {AttributeTypes::NegativeInterst,
+            {AttributeTypes::NegativeInterst,
              {
                  {NegativeInterestKeys::BlockInterval, VerifyUInt64},
                  {NegativeInterestKeys::BurnTimePeriod, VerifyUInt64},

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -31,6 +31,7 @@ enum AttributeTypes : uint8_t {
     EVMType = 'e',
     Vaults = 'v',
     Rules = 'r',
+    NegativeInterst = 'n',
 };
 
 enum ParamIDs : uint8_t {
@@ -78,6 +79,10 @@ enum RulesIDs : uint8_t {
     TXRules = 'a',
 };
 
+enum NegativeInterestIDs : uint8_t {
+    Automatic = 'a',
+};
+
 enum EconomyKeys : uint8_t {
     PaybackDFITokens = 'a',
     PaybackTokens = 'b',
@@ -120,6 +125,7 @@ enum DFIPKeys : uint8_t {
     EVMEnabled = 'u',
     ICXEnabled = 'v',
     TransferDomain = 'w',
+    AutoNegativeInterest = 'x',
 };
 
 enum GovernanceKeys : uint8_t {
@@ -181,6 +187,11 @@ enum RulesKeys : uint8_t {
     CoreOPReturn = 'a',
     DVMOPReturn = 'b',
     EVMOPReturn = 'c',
+};
+
+enum NegativeInterestKeys : uint8_t {
+    BlockInterval = 'a',
+    BurnTimePeriod = 'b',
 };
 
 struct CDataStructureV0 {
@@ -504,6 +515,7 @@ public:
     static const std::map<uint8_t, std::string> &displayEVMIDs();
     static const std::map<uint8_t, std::string> &displayVaultIDs();
     static const std::map<uint8_t, std::string> &displayRulesIDs();
+    static const std::map<uint8_t, std::string> &displayNegativeInterestIDs();
     static const std::map<uint8_t, std::map<uint8_t, std::string>> &displayKeys();
 
     Res RefundFuturesContracts(CCustomCSView &mnview,
@@ -530,6 +542,7 @@ private:
     static const std::map<std::string, uint8_t> &allowedEVMIDs();
     static const std::map<std::string, uint8_t> &allowedVaultIDs();
     static const std::map<std::string, uint8_t> &allowedRulesIDs();
+    static const std::map<std::string, uint8_t> &allowedNegativeInterestIDs();
     static const std::map<uint8_t, std::map<std::string, uint8_t>> &allowedKeys();
     static const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(const std::string &)>>>
         &parseValue();

--- a/src/dfi/rpc_vault.cpp
+++ b/src/dfi/rpc_vault.cpp
@@ -2,8 +2,8 @@
 #include <dfi/auctionhistory.h>
 #include <dfi/govvariables/attributes.h>
 #include <dfi/mn_rpc.h>
-#include <dfi/vaulthistory.h>
 #include <dfi/validation.h>
+#include <dfi/vaulthistory.h>
 
 extern UniValue AmountsToJSON(const TAmounts &diffs, AmountFormat format = AmountFormat::Symbol);
 extern std::string tokenAmountString(const CTokenAmount &amount, AmountFormat format = AmountFormat::Symbol);
@@ -2199,7 +2199,6 @@ UniValue getloantokens(const JSONRPCRequest &request) {
     return GetRPCResultCache().Set(request, ret);
 }
 
-
 UniValue estimatenegativeinterest(const JSONRPCRequest &request) {
     RPCHelpMan{
         "estimatenegativeinterest",
@@ -2207,11 +2206,8 @@ UniValue estimatenegativeinterest(const JSONRPCRequest &request) {
         {
 
         },
-        RPCResult{
-            "n    (numeric) The calculated negative interest rate\n"
-        },
-        RPCExamples{HelpExampleCli("estimatenegativeinterest", "")
-        + HelpExampleRpc("estimatenegativeinterest", "")},
+        RPCResult{"n    (numeric) The calculated negative interest rate\n"},
+        RPCExamples{HelpExampleCli("estimatenegativeinterest", "") + HelpExampleRpc("estimatenegativeinterest", "")},
     }
         .Check(request);
 
@@ -2223,7 +2219,8 @@ UniValue estimatenegativeinterest(const JSONRPCRequest &request) {
 
     auto attributes = pcustomcsview->GetAttributes();
 
-    const CDataStructureV0 burnTimeSampleKey{AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BurnTimePeriod};
+    const CDataStructureV0 burnTimeSampleKey{
+        AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BurnTimePeriod};
     const auto burnTimeSample = attributes->GetValue(burnTimeSampleKey, NEGATIVE_INT_BURN_TIME_SAMPLE);
 
     const auto dusdBurned = GetDexBurnedDUSD(*pcustomcsview, *pburnHistoryDB, burnTimeSample);
@@ -2250,7 +2247,6 @@ UniValue estimatenegativeinterest(const JSONRPCRequest &request) {
 
     return GetRPCResultCache().Set(request, res);
 }
-
 
 static const CRPCCommand commands[] = {
   //  category        name                         actor (function)        params

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2638,8 +2638,8 @@ static Res ValidateCoinbaseXVMOutput(const XVM &xvm, const FinalizeBlockCompleti
 }
 
 static void ProcessAutoNegativeInterest(const CBlockIndex *pindex,
-                                      CCustomCSView &cache,
-                                      const CChainParams &chainparams) {
+                                        CCustomCSView &cache,
+                                        const CChainParams &chainparams) {
     if (pindex->nHeight < chainparams.GetConsensus().DF23Height) {
         return;
     }
@@ -2661,13 +2661,15 @@ static void ProcessAutoNegativeInterest(const CBlockIndex *pindex,
         return;
     }
 
-    const CDataStructureV0 blockPeriodKey{AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BlockInterval};
+    const CDataStructureV0 blockPeriodKey{
+        AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BlockInterval};
     const auto blockPeriod = attributes->GetValue(blockPeriodKey, NEGATIVE_INT_BLOCK_PREIOD);
     if (pindex->nHeight % blockPeriod != 0) {
         return;
     }
 
-    const CDataStructureV0 burnTimeSampleKey{AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BurnTimePeriod};
+    const CDataStructureV0 burnTimeSampleKey{
+        AttributeTypes::NegativeInterst, NegativeInterestIDs::Automatic, NegativeInterestKeys::BurnTimePeriod};
     const auto burnTimeSample = attributes->GetValue(burnTimeSampleKey, NEGATIVE_INT_BURN_TIME_SAMPLE);
 
     const auto dusdBurned = GetDexBurnedDUSD(cache, *burnView, burnTimeSample);
@@ -2837,7 +2839,8 @@ CAmount GetDexBurnedDUSD(const CCustomCSView &view, CBurnHistoryStorage &burnVie
     const auto earliestTime = blockIndex->GetBlockTime() - burnTimeSample;
 
     uint64_t initialHeight{};
-    for (; blockIndex && blockIndex->pprev && blockIndex->GetBlockTime() > earliestTime; blockIndex = blockIndex->pprev) {
+    for (; blockIndex && blockIndex->pprev && blockIndex->GetBlockTime() > earliestTime;
+         blockIndex = blockIndex->pprev) {
         initialHeight = blockIndex->nHeight;
     }
 
@@ -2866,7 +2869,8 @@ CAmount GetDexBurnedDUSD(const CCustomCSView &view, CBurnHistoryStorage &burnVie
         g.AddTask();
         boost::asio::post(pool, [startHeight, stopHeight, dusdID, &burnView, &g, &dusdBurnTotal = dusdBurnTotal] {
             burnView.ForEachAccountHistory(
-                [&dusdBurnTotal = dusdBurnTotal, stopHeight, dusdID](const AccountHistoryKey &key, const AccountHistoryValue &value) {
+                [&dusdBurnTotal = dusdBurnTotal, stopHeight, dusdID](const AccountHistoryKey &key,
+                                                                     const AccountHistoryValue &value) {
                     if (key.blockHeight <= stopHeight) {
                         return false;
                     }

--- a/src/dfi/validation.h
+++ b/src/dfi/validation.h
@@ -7,6 +7,9 @@
 
 #include <amount.h>
 
+const uint64_t NEGATIVE_INT_BURN_TIME_SAMPLE = 30 * 24 * 60 * 60;
+const uint64_t NEGATIVE_INT_BLOCK_PREIOD = 2880;
+
 struct CAuctionBatch;
 class CBlock;
 class CBlockIndex;
@@ -35,5 +38,8 @@ Res ProcessDeFiEventFallible(const CBlock &block,
 std::vector<CAuctionBatch> CollectAuctionBatches(const CVaultAssets &vaultAssets,
                                                  const TAmounts &collBalances,
                                                  const TAmounts &loanBalances);
+
+CAmount GetDexBurnedDUSD(const CCustomCSView &view, CBurnHistoryStorage &burnView, const uint64_t burnTimeSample);
+CAmount GetVaultLoanDUSD(CCustomCSView &view);
 
 #endif  // DEFI_DFI_VALIDATION_H

--- a/test/functional/feature_auto_negative_interest.py
+++ b/test/functional/feature_auto_negative_interest.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test automatic negative interest"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+import time
+from decimal import Decimal
+
+
+class AutoNegativeInterestTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            [
+                "-txnotokens=0",
+                "-amkheight=1",
+                "-bayfrontheight=1",
+                "-eunosheight=1",
+                "-fortcanningheight=1",
+                "-fortcanningmuseumheight=1",
+                "-fortcanningspringheight=1",
+                "-fortcanninghillheight=1",
+                "-fortcanningcrunchheight=1",
+                "-fortcanninggreatworldheight=1",
+                "-fortcanningepilogueheight=1",
+                "-grandcentralheight=1",
+                "-df23height=150",
+                "-jellyfish_regtest=1",
+            ]
+        ]
+
+    def run_test(self):
+        self.setup()
+        self.auto_negative_interest()
+
+    def setup(self):
+        # Generate chain
+        self.nodes[0].generate(101)
+
+        # Store variables
+        self.symbolDFI = "DFI"
+        self.symbolDUSD = "DUSD"
+        self.idDFI = list(self.nodes[0].gettoken(self.symbolDFI).keys())[0]
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+
+        # Set up environment
+        self.create_oracles()
+        self.create_tokens()
+        self.create_pool_pairs()
+        self.setup_negative_interest_env()
+
+    def create_tokens(self):
+        # Create loan scheme
+        self.nodes[0].createloanscheme(150, 1, "LOAN1")
+        self.nodes[0].generate(1)
+
+        # Create collateral token
+        self.nodes[0].setcollateraltoken(
+            {
+                "token": self.idDFI,
+                "factor": 1,
+                "fixedIntervalPriceId": f"{self.symbolDFI}/USD",
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Create loan token
+        self.nodes[0].setloantoken(
+            {
+                "symbol": self.symbolDUSD,
+                "name": self.symbolDUSD,
+                "fixedIntervalPriceId": f"{self.symbolDUSD}/USD",
+                "mintable": True,
+                "interest": -1,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Store DUSD symbol
+        self.idDUSD = list(self.nodes[0].gettoken(self.symbolDUSD).keys())[0]
+
+        # Mint tokens
+        self.nodes[0].minttokens(f"10000@{self.symbolDUSD}")
+        self.nodes[0].generate(1)
+
+        # Fund address
+        self.nodes[0].utxostoaccount({self.address: f"10000@{self.symbolDFI}"})
+        self.nodes[0].generate(1)
+
+    def create_oracles(self):
+        # Appoint oracles
+        oracle_address = self.nodes[0].getnewaddress("", "legacy")
+        price_feeds = [
+            {"currency": "USD", "token": self.symbolDFI},
+            {"currency": "USD", "token": self.symbolDUSD},
+        ]
+        oracle_id = self.nodes[0].appointoracle(oracle_address, price_feeds, 10)
+        self.nodes[0].generate(1)
+
+        # Set Oracle data
+        oracle_prices = [
+            {"currency": "USD", "tokenAmount": f"1@{self.symbolDFI}"},
+            {"currency": "USD", "tokenAmount": f"1@{self.symbolDUSD}"},
+        ]
+        self.nodes[0].setoracledata(oracle_id, int(time.time()), oracle_prices)
+        self.nodes[0].generate(11)
+
+    def create_pool_pairs(self):
+        # Create pool pair
+        self.nodes[0].createpoolpair(
+            {
+                "tokenA": self.symbolDFI,
+                "tokenB": self.symbolDUSD,
+                "commission": 0,
+                "status": True,
+                "ownerAddress": self.address,
+                "pairSymbol": f"{self.symbolDFI}-{self.symbolDUSD}",
+            },
+            [],
+        )
+        self.nodes[0].generate(1)
+
+        # Store pool ID
+        self.idDD = list(
+            self.nodes[0].gettoken(f"{self.symbolDFI}-{self.symbolDUSD}").keys()
+        )[0]
+
+        # Add liquidity
+        self.nodes[0].addpoolliquidity(
+            {self.address: [f"100@{self.symbolDFI}", f"100@{self.symbolDUSD}"]},
+            self.address,
+        )
+        self.nodes[0].generate(1)
+
+    def setup_negative_interest_env(self):
+        # Set 100% DUSD fee on in only
+        self.nodes[0].setgov(
+            {
+                "ATTRIBUTES": {
+                    f"v0/poolpairs/{self.idDD}/token_b_fee_pct": "1",
+                    f"v0/poolpairs/{self.idDD}/token_b_fee_direction": "in",
+                }
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Swap DUSD to DFI, will burn all DUSD.
+        self.nodes[0].poolswap(
+            {
+                "from": self.address,
+                "tokenFrom": self.idDUSD,
+                "amountFrom": 10,
+                "to": self.address,
+                "tokenTo": self.idDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Create vault
+        vault = self.nodes[0].createvault(self.address, "LOAN1")
+        self.nodes[0].generate(1)
+
+        # Deposit to vault
+        self.nodes[0].deposittovault(vault, self.address, f"450@{self.symbolDFI}")
+        self.nodes[0].generate(1)
+
+        # Take DUSD loan
+        self.nodes[0].takeloan({"vaultId": vault, "amounts": f"300@{self.symbolDUSD}"})
+        self.nodes[0].generate(1)
+
+    def auto_negative_interest(self):
+        # Check estimated negative interest
+        result = self.nodes[0].estimatenegativeinterest()
+        assert_equal(result["dusdBurned"], Decimal("10.00000000"))
+        assert_equal(result["dusdLoaned"], Decimal("300.00000000"))
+        assert_equal(result["negativeInterest"], Decimal("-20.26666600"))
+
+        # Check auto negative interest cannot be set before fork
+        assert_raises_rpc_error(
+            -32600,
+            "Cannot be set before DF23Height",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/params/feature/auto-negative-interest": "true"}},
+        )
+        assert_raises_rpc_error(
+            -32600,
+            "Cannot be set before DF23Height",
+            self.nodes[0].setgov,
+            {"ATTRIBUTES": {"v0/negative_interest/automatic/block_period": "10"}},
+        )
+        assert_raises_rpc_error(
+            -32600,
+            "Cannot be set before DF23Height",
+            self.nodes[0].setgov,
+            {
+                "ATTRIBUTES": {
+                    "v0/negative_interest/automatic/burn_time_period": "86400"
+                }
+            },
+        )
+
+        # Move to fork height
+        self.nodes[0].generate(150 - self.nodes[0].getblockcount())
+
+        # Set auto negative interest
+        self.nodes[0].setgov(
+            {
+                "ATTRIBUTES": {
+                    "v0/params/feature/auto-negative-interest": "true",
+                    "v0/negative_interest/automatic/block_period": "10",
+                    "v0/negative_interest/automatic/burn_time_period": "86400",
+                }
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Check auto negative interest is set
+        attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
+        assert_equal(attributes["v0/params/feature/auto-negative-interest"], "true")
+        assert_equal(attributes["v0/negative_interest/automatic/block_period"], "10")
+        assert_equal(
+            attributes["v0/negative_interest/automatic/burn_time_period"], "86400"
+        )
+
+        # Check negative interest has not been calculated yet
+        assert_equal(attributes[f"v0/token/{self.idDUSD}/loan_minting_interest"], "-1")
+
+        # Move to automatic setting of negative interest
+        self.nodes[0].generate(10)
+
+        # Check negative interest has been calculated
+        attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
+        assert_equal(
+            attributes[f"v0/token/{self.idDUSD}/loan_minting_interest"], "-20.266666"
+        )
+
+
+if __name__ == "__main__":
+    AutoNegativeInterestTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -347,6 +347,7 @@ BASE_SCRIPTS = [
     "feature_update_mn.py",
     "feature_block_reward.py",
     "feature_negative_interest.py",
+    "feature_auto_negative_interest.py",
     "rpc_getstoredinterest.py",
     "feature_dusd_loans.py",
     # Don't append tests at the end to avoid merge conflicts


### PR DESCRIPTION
## Summary

- Set the negative interest rate automatically.
- Introduces a new RPC call to estimate the negative interest rate.

## RPCs

- New estimatenegativeinterest RPC call
```
defi-cli estimatenegativeinterest
{
  "dusdBurned": 2463205.39186885,
  "dusdLoaned": 94262062.35901081,
  "negativeInterest": -15.88792800
}
```
## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
