### PR TITLE
Enable neutral votes in RPC by default

### DIFF
--- a/src/dfi/rpc_proposals.cpp
+++ b/src/dfi/rpc_proposals.cpp
@@ -3,7 +3,7 @@
 
 #include <functional>
 
-const bool DEFAULT_RPC_GOV_NEUTRAL = false;
+const bool DEFAULT_RPC_GOV_NEUTRAL = true;
 const int SLEEP_TIME_MILLIS = 500;
 
 struct VotingInfo {

--- a/test/functional/feature_on_chain_government.py
+++ b/test/functional/feature_on_chain_government.py
@@ -36,6 +36,7 @@ class OnChainGovernanceTest(DefiTestFramework):
                 "-grandcentralheight=101",
                 "-subsidytest=1",
                 "-txindex=1",
+                "-rpc-governance-accept-neutral=0",
             ],
             [
                 "-dummypos=0",
@@ -52,6 +53,7 @@ class OnChainGovernanceTest(DefiTestFramework):
                 "-fortcanningepilogueheight=96",
                 "-grandcentralheight=101",
                 "-subsidytest=1",
+                "-rpc-governance-accept-neutral=0",
             ],
             [
                 "-dummypos=0",
@@ -68,6 +70,7 @@ class OnChainGovernanceTest(DefiTestFramework):
                 "-fortcanningepilogueheight=96",
                 "-grandcentralheight=101",
                 "-subsidytest=1",
+                "-rpc-governance-accept-neutral=0",
             ],
             [
                 "-dummypos=0",
@@ -84,6 +87,7 @@ class OnChainGovernanceTest(DefiTestFramework):
                 "-fortcanningepilogueheight=96",
                 "-grandcentralheight=101",
                 "-subsidytest=1",
+                "-rpc-governance-accept-neutral=0",
             ],
         ]
 


### PR DESCRIPTION
## Summary

- Neutral votes were fixed in the DMC hard fork by https://github.com/DeFiCh/ain/pull/1711. Neutral votes are still disabled by default in RPCs, this PR changes neutral votes to be enabled by default.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
