### PR TITLE
Enable renaming of tokens on EVM

### DIFF
--- a/lib/ain-evm/src/transaction/system.rs
+++ b/lib/ain-evm/src/transaction/system.rs
@@ -9,6 +9,7 @@ pub struct DeployContractData {
     pub address: H160,
     pub token_id: u64,
 }
+pub type UpdateContractNameData = DeployContractData;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DST20Data {
@@ -28,6 +29,7 @@ pub enum SystemTx {
     DeployContract(DeployContractData),
     DST20Bridge(DST20Data),
     TransferDomain(TransferDomainData),
+    UpdateContractName(UpdateContractNameData),
 }
 
 impl SystemTx {
@@ -36,6 +38,7 @@ impl SystemTx {
             SystemTx::TransferDomain(data) => Some(data.signed_tx.sender),
             SystemTx::DST20Bridge(data) => Some(data.signed_tx.sender),
             SystemTx::DeployContract(_) => None,
+            SystemTx::UpdateContractName(_) => None,
         }
     }
 }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -728,6 +728,7 @@ fn evm_try_unsafe_create_dst20(
     token: ffi::DST20TokenInfo,
 ) -> Result<()> {
     let address = ain_contracts::dst20_address_from_token_id(token.id)?;
+    debug!("Deploying to address {:#?}", address);
 
     let system_tx = ExecuteTx::SystemTx(SystemTx::DeployContract(DeployContractData {
         name: token.name,
@@ -867,7 +868,7 @@ fn evm_try_unsafe_rename_dst20(
     token: ffi::DST20TokenInfo,
 ) -> Result<()> {
     let address = ain_contracts::dst20_address_from_token_id(token.id)?;
-    debug!("Deploying to address {:#?}", address);
+    debug!("Renaming token on address {:#?}", address);
 
     let system_tx = ExecuteTx::SystemTx(SystemTx::UpdateContractName(UpdateContractNameData {
         name: token.name,

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -343,6 +343,13 @@ pub mod ffi {
         );
 
         fn evm_try_flush_db(result: &mut CrossBoundaryResult);
+
+        fn evm_try_unsafe_rename_dst20(
+            result: &mut CrossBoundaryResult,
+            block_template: &mut BlockTemplateWrapper,
+            native_hash: [u8; 32],
+            token: DST20TokenInfo,
+        );
     }
 
     // =========  Debug ==========

--- a/src/dfi/consensus/loans.cpp
+++ b/src/dfi/consensus/loans.cpp
@@ -301,7 +301,7 @@ Res CLoansConsensus::operator()(const CLoanSetLoanTokenMessage &obj) const {
                                : static_cast<uint8_t>(CToken::TokenFlags::Tradeable);
     token.flags |= static_cast<uint8_t>(CToken::TokenFlags::LoanToken) | static_cast<uint8_t>(CToken::TokenFlags::DAT);
 
-    auto tokenId = mnview.CreateToken(token, false, &blockCtx);
+    auto tokenId = mnview.CreateToken(token, blockCtx);
     if (!tokenId) {
         return tokenId;
     }
@@ -385,6 +385,7 @@ Res CLoansConsensus::operator()(const CLoanUpdateLoanTokenMessage &obj) const {
     const auto &consensus = txCtx.GetConsensus();
     const auto height = txCtx.GetHeight();
     const auto time = txCtx.GetTime();
+    const auto hash = txCtx.GetTransaction().GetHash();
     auto &mnview = blockCtx.GetView();
 
     if (height < static_cast<uint32_t>(consensus.DF18FortCanningGreatWorldHeight)) {
@@ -427,7 +428,9 @@ Res CLoansConsensus::operator()(const CLoanUpdateLoanTokenMessage &obj) const {
         pair->second.flags ^= (uint8_t)CToken::TokenFlags::Mintable;
     }
 
-    if (auto res = mnview.UpdateToken(pair->second); !res) {
+    const auto checkSymbol = height >= static_cast<uint32_t>(consensus.DF23Height);
+    UpdateTokenContext ctx{pair->second, blockCtx, true, false, checkSymbol, hash};
+    if (auto res = mnview.UpdateToken(ctx); !res) {
         return res;
     }
 

--- a/src/dfi/consensus/poolpairs.cpp
+++ b/src/dfi/consensus/poolpairs.cpp
@@ -80,7 +80,9 @@ Res CPoolPairsConsensus::operator()(const CCreatePoolPairMessage &obj) const {
     token.creationTx = tx.GetHash();
     token.creationHeight = height;
 
-    auto tokenId = mnview.CreateToken(token, false);
+    // EVM Template will be null so no DST20 will be created
+    BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, consensus};
+    auto tokenId = mnview.CreateToken(token, dummyContext);
     if (!tokenId) {
         return tokenId;
     }

--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -867,7 +867,7 @@ bool IsEVMEnabled(const std::shared_ptr<ATTRIBUTES> attributes) {
     return attributes->GetValue(enabledKey, false);
 }
 
-bool IsEVMEnabled(const CCustomCSView &view, const Consensus::Params &consensus) {
+bool IsEVMEnabled(const CCustomCSView &view) {
     auto attributes = view.GetAttributes();
 
     return IsEVMEnabled(attributes);

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -387,7 +387,7 @@ void TrackDUSDAdd(CCustomCSView &mnview, const CTokenAmount &amount);
 void TrackDUSDSub(CCustomCSView &mnview, const CTokenAmount &amount);
 
 bool IsEVMEnabled(const std::shared_ptr<ATTRIBUTES> attributes);
-bool IsEVMEnabled(const CCustomCSView &view, const Consensus::Params &consensus);
+bool IsEVMEnabled(const CCustomCSView &view);
 Res StoreGovVars(const CGovernanceHeightMessage &obj, CCustomCSView &view);
 
 enum GovVarsFilter {

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -560,8 +560,7 @@ Res ApplyCustomTx(BlockContext &blockCtx, TransactionContext &txCtx) {
         // TX changes are applied on a different view which
         // is then used to create the TX undo based on the
         // difference between the original and the copy.
-        auto blockCtxTxView{blockCtx};
-        blockCtxTxView.SetView(view);
+        BlockContext blockCtxTxView{blockCtx, view};
 
         res = CustomTxVisit(txMessage, blockCtxTxView, txCtx);
 

--- a/src/dfi/mn_checks.h
+++ b/src/dfi/mn_checks.h
@@ -170,16 +170,10 @@ public:
                           const uint64_t time,
                           const Consensus::Params &consensus,
                           CCustomCSView *view = {},
-                          const std::optional<bool> enabled = {},
+                          const std::optional<bool> enabled = std::nullopt,
                           const std::shared_ptr<CScopedTemplate> &evmTemplate = {},
-                          const bool prevalidate = {})
-        : view(view),
-          isEvmEnabledForBlock(enabled),
-          evmTemplate(evmTemplate),
-          evmPreValidate(prevalidate),
-          height(height),
-          time(time),
-          consensus(consensus) {}
+                          const bool prevalidate = {});
+    explicit BlockContext(BlockContext &other, CCustomCSView &otherView);
 
     [[nodiscard]] CCustomCSView &GetView();
     [[nodiscard]] bool GetEVMEnabledForBlock();

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -201,14 +201,14 @@ Res CTokensView::UpdateToken(UpdateTokenContext &ctx) {
         if (evmEnabled && evmTemplate) {
             const auto &hash = ctx.hash;
             CrossBoundaryResult result;
-            if (oldToken.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
+            if (newToken.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
                 return Res::Err("Error creating DST20 token, token name is larger than max bytes\n");
             }
-            const auto token_name = rs_try_from_utf8(result, ffi_from_string_to_slice(oldToken.name));
+            const auto token_name = rs_try_from_utf8(result, ffi_from_string_to_slice(newToken.name));
             if (!result.ok) {
                 return Res::Err("Error creating DST20 token, token name not valid UTF-8\n");
             }
-            const auto token_symbol = rs_try_from_utf8(result, ffi_from_string_to_slice(oldToken.symbol));
+            const auto token_symbol = rs_try_from_utf8(result, ffi_from_string_to_slice(newToken.symbol));
             if (!result.ok) {
                 return Res::Err("Error creating DST20 token, token symbol not valid UTF-8\n");
             }

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -151,7 +151,7 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
 Res CTokensView::UpdateToken(UpdateTokenContext &ctx) {
     const auto checkFinalised = ctx.checkFinalised;
     const auto tokenSplitUpdate = ctx.tokenSplitUpdate;
-    const bool checkSymbol = ctx.checkSymbol;
+    const auto checkSymbol = ctx.checkSymbol;
     auto &blockCtx = ctx.blockCtx;
     const auto &newToken = ctx.newToken;
 

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -149,6 +149,7 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
 }
 
 Res CTokensView::UpdateToken(UpdateTokenContext &ctx) {
+    // checkFinalised is always true before the bayfront fork.
     const auto checkFinalised = ctx.checkFinalised;
     const auto tokenSplitUpdate = ctx.tokenSplitUpdate;
     const auto checkSymbol = ctx.checkSymbol;
@@ -202,15 +203,15 @@ Res CTokensView::UpdateToken(UpdateTokenContext &ctx) {
             const auto &hash = ctx.hash;
             CrossBoundaryResult result;
             if (newToken.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
-                return Res::Err("Error creating DST20 token, token name is larger than max bytes\n");
+                return Res::Err("Error updating DST20 token, token name is larger than max bytes\n");
             }
             const auto token_name = rs_try_from_utf8(result, ffi_from_string_to_slice(newToken.name));
             if (!result.ok) {
-                return Res::Err("Error creating DST20 token, token name not valid UTF-8\n");
+                return Res::Err("Error updating DST20 token, token name not valid UTF-8\n");
             }
             const auto token_symbol = rs_try_from_utf8(result, ffi_from_string_to_slice(newToken.symbol));
             if (!result.ok) {
-                return Res::Err("Error creating DST20 token, token symbol not valid UTF-8\n");
+                return Res::Err("Error updating DST20 token, token symbol not valid UTF-8\n");
             }
             evm_try_unsafe_rename_dst20(result,
                                         evmTemplate->GetTemplate(),

--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -69,8 +69,8 @@ Res CTokensView::CreateDFIToken() {
 }
 
 ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
-                                        bool isPreBayfront,
-                                        BlockContext *blockCtx) {
+                                        BlockContext &blockCtx,
+                                        bool isPreBayfront) {
     if (GetTokenByCreationTx(token.creationTx)) {
         return Res::Err("token with creation tx %s already exists!", token.creationTx.ToString());
     }
@@ -102,41 +102,39 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
                       id.ToString().c_str());
         }
 
-        if (blockCtx) {
-            const auto shouldCreateDst20 = blockCtx->GetEVMEnabledForBlock();
-            const auto &evmTemplate = blockCtx->GetEVMTemplate();
-            const auto &height = blockCtx->GetHeight();
-            if (shouldCreateDst20 && evmTemplate) {
-                CrossBoundaryResult result;
-                rust::string token_name{};
-                rust::string token_symbol{};
-                if (height >= static_cast<uint32_t>(Params().GetConsensus().DF23Height)) {
-                    if (token.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
-                        return Res::Err("Error creating DST20 token, token name is larger than max bytes\n");
-                    }
-                    token_name = rs_try_from_utf8(result, ffi_from_string_to_slice(token.name));
-                    if (!result.ok) {
-                        return Res::Err("Error creating DST20 token, token name not valid UTF-8\n");
-                    }
-                    token_symbol = rs_try_from_utf8(result, ffi_from_string_to_slice(token.symbol));
-                    if (!result.ok) {
-                        return Res::Err("Error creating DST20 token, token symbol not valid UTF-8\n");
-                    }
-                } else {
-                    token_name = rust::string(token.name);
-                    token_symbol = rust::string(token.symbol);
+        const auto evmEnabled = blockCtx.GetEVMEnabledForBlock();
+        const auto &evmTemplate = blockCtx.GetEVMTemplate();
+        const auto &height = blockCtx.GetHeight();
+        if (evmEnabled && evmTemplate) {
+            CrossBoundaryResult result;
+            rust::string token_name{};
+            rust::string token_symbol{};
+            if (height >= static_cast<uint32_t>(Params().GetConsensus().DF23Height)) {
+                if (token.name.size() > CToken::POST_METACHAIN_TOKEN_NAME_BYTE_SIZE) {
+                    return Res::Err("Error creating DST20 token, token name is larger than max bytes\n");
                 }
-                evm_try_unsafe_create_dst20(result,
-                                            evmTemplate->GetTemplate(),
-                                            token.creationTx.GetByteArray(),
-                                            DST20TokenInfo{
-                                                id.v,
-                                                token_name,
-                                                token_symbol,
-                                            });
+                token_name = rs_try_from_utf8(result, ffi_from_string_to_slice(token.name));
                 if (!result.ok) {
-                    return Res::Err("Error creating DST20 token: %s", result.reason);
+                    return Res::Err("Error creating DST20 token, token name not valid UTF-8\n");
                 }
+                token_symbol = rs_try_from_utf8(result, ffi_from_string_to_slice(token.symbol));
+                if (!result.ok) {
+                    return Res::Err("Error creating DST20 token, token symbol not valid UTF-8\n");
+                }
+            } else {
+                token_name = rust::string(token.name);
+                token_symbol = rust::string(token.symbol);
+            }
+            evm_try_unsafe_create_dst20(result,
+                                        evmTemplate->GetTemplate(),
+                                        token.creationTx.GetByteArray(),
+                                        DST20TokenInfo{
+                                            id.v,
+                                            token_name,
+                                            token_symbol,
+                                        });
+            if (!result.ok) {
+                return Res::Err("Error creating DST20 token: %s", result.reason);
             }
         }
     } else {
@@ -150,16 +148,21 @@ ResVal<DCT_ID> CTokensView::CreateToken(const CTokensView::CTokenImpl &token,
     return {id, Res::Ok()};
 }
 
-Res CTokensView::UpdateToken(const CTokenImpl &newToken, bool isPreBayfront, const bool tokenSplitUpdate) {
+Res CTokensView::UpdateToken(UpdateTokenContext &ctx) {
+    const auto checkFinalised = ctx.checkFinalised;
+    const auto tokenSplitUpdate = ctx.tokenSplitUpdate;
+    const bool checkSymbol = ctx.checkSymbol;
+    auto &blockCtx = ctx.blockCtx;
+    const auto &newToken = ctx.newToken;
+
     auto pair = GetTokenByCreationTx(newToken.creationTx);
     if (!pair) {
         return Res::Err("token with creationTx %s does not exist!", newToken.creationTx.ToString());
     }
 
-    DCT_ID id = pair->first;
-    CTokenImpl &oldToken = pair->second;
+    auto &[id, oldToken] = *pair;
 
-    if (!isPreBayfront) {
+    if (checkFinalised) {
         // for compatibility, in potential case when someone cheat and create finalized token with old node (and then
         // alter dat for ex.)
         if (oldToken.IsFinalized()) {
@@ -167,11 +170,8 @@ Res CTokensView::UpdateToken(const CTokenImpl &newToken, bool isPreBayfront, con
         }
     }
 
-    // 'name' and 'symbol' were trimmed in 'Apply'
-    oldToken.name = newToken.name;
-
     // check new symbol correctness
-    if (!tokenSplitUpdate) {
+    if (checkSymbol) {
         if (auto res = newToken.IsValidSymbol(); !res) {
             return res;
         }
@@ -191,8 +191,31 @@ Res CTokensView::UpdateToken(const CTokenImpl &newToken, bool isPreBayfront, con
         WriteBy<Symbol>(newSymbolKey, id);
     }
 
-    // apply DAT flag and symbol only AFTER dealing with symbol indexes:
+    const auto height = blockCtx.GetHeight();
+    const auto &consensus = blockCtx.GetConsensus();
+    if (height >= consensus.DF23Height && oldToken.IsDAT() &&
+        (oldToken.symbol != newToken.symbol || oldToken.name != newToken.name)) {
+        const auto evmEnabled = blockCtx.GetEVMEnabledForBlock();
+        const auto &evmTemplate = blockCtx.GetEVMTemplate();
+
+        if (evmEnabled && evmTemplate) {
+            const auto hash = ctx.hash;
+            CrossBoundaryResult result;
+            evm_try_unsafe_rename_dst20(result,
+                                        evmTemplate->GetTemplate(),
+                                        hash.GetByteArray(),  // Can be either TX or block hash depending on the source
+                                        DST20TokenInfo{
+                                            id.v,
+                                            newToken.name,
+                                            newToken.symbol,
+                                        });
+        }
+    }
+
+    // 'name' and 'symbol' were trimmed in 'Apply'
+    oldToken.name = newToken.name;
     oldToken.symbol = newToken.symbol;
+
     if (oldToken.IsDAT() != newToken.IsDAT()) {
         oldToken.flags ^= (uint8_t)CToken::TokenFlags::DAT;
     }

--- a/src/dfi/tokens.h
+++ b/src/dfi/tokens.h
@@ -181,6 +181,15 @@ public:
     }
 };
 
+struct UpdateTokenContext {
+    const CTokenImplementation &newToken;
+    BlockContext &blockCtx;
+    const bool checkFinalised{};
+    const bool tokenSplitUpdate{};
+    const bool checkSymbol{};
+    const uint256 hash{};
+};
+
 class CTokensView : public virtual CStorageView {
 public:
     static const DCT_ID DCT_ID_START;            // = 128;
@@ -198,8 +207,8 @@ public:
                       DCT_ID const &start = DCT_ID{0});
 
     Res CreateDFIToken();
-    ResVal<DCT_ID> CreateToken(const CTokenImpl &token, bool isPreBayfront = false, BlockContext *blockCtx = nullptr);
-    Res UpdateToken(const CTokenImpl &newToken, bool isPreBayfront = false, const bool tokenSplitUpdate = false);
+    ResVal<DCT_ID> CreateToken(const CTokenImpl &token, BlockContext &blockCtx, bool isPreBayfront = false);
+    Res UpdateToken(UpdateTokenContext &ctx);
 
     Res BayfrontFlagsCleanup();
     Res AddMintedTokens(DCT_ID const &id, const CAmount &amount);

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2013,15 +2013,15 @@ static void ProcessTokenSplits(const CBlock &block,
             continue;
         }
 
-        UpdateTokenContext ctx{*token, blockCtx, true, true, false, pindex->GetBlockHash()};
+        // TODO pass block context on fork to create new EVM token.
+        BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, consensus};
+        UpdateTokenContext ctx{*token, dummyContext, true, true, false, pindex->GetBlockHash()};
         res = view.UpdateToken(ctx);
         if (!res) {
             LogPrintf("Token split failed on UpdateToken %s\n", res.msg);
             continue;
         }
 
-        // TODO pass block context on fork to create new EVM token.
-        BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, consensus};
         auto resVal = view.CreateToken(newToken, dummyContext);
         if (!resVal) {
             LogPrintf("Token split failed on CreateToken %s\n", resVal.msg);

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2013,7 +2013,7 @@ static void ProcessTokenSplits(const CBlock &block,
             continue;
         }
 
-        // TODO pass block context on fork to create new EVM token.
+        // TODO pass block context to update old EVM token.
         BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, consensus};
         UpdateTokenContext ctx{*token, dummyContext, true, true, false, pindex->GetBlockHash()};
         res = view.UpdateToken(ctx);
@@ -2022,6 +2022,7 @@ static void ProcessTokenSplits(const CBlock &block,
             continue;
         }
 
+        // TODO pass block context on fork to create new EVM token.
         auto resVal = view.CreateToken(newToken, dummyContext);
         if (!resVal) {
             LogPrintf("Token split failed on CreateToken %s\n", resVal.msg);

--- a/src/dfi/validation.h
+++ b/src/dfi/validation.h
@@ -15,7 +15,6 @@ class CChainParams;
 class CCoinsViewCache;
 class CCustomCSView;
 class CVaultAssets;
-class CScopedTemplate;
 
 using CreationTxs = std::map<uint32_t, std::pair<uint256, std::vector<std::pair<DCT_ID, uint256>>>>;
 

--- a/src/dfi/validation.h
+++ b/src/dfi/validation.h
@@ -10,20 +10,20 @@
 struct CAuctionBatch;
 class CBlock;
 class CBlockIndex;
+class CBurnHistoryStorage;
 class CChainParams;
 class CCoinsViewCache;
-class CVaultAssets;
 class CCustomCSView;
+class CVaultAssets;
+class CScopedTemplate;
 
 using CreationTxs = std::map<uint32_t, std::pair<uint256, std::vector<std::pair<DCT_ID, uint256>>>>;
 
 void ProcessDeFiEvent(const CBlock &block,
                       const CBlockIndex *pindex,
-                      CCustomCSView &mnview,
                       const CCoinsViewCache &view,
-                      const CChainParams &chainparams,
                       const CreationTxs &creationTxs,
-                      const std::shared_ptr<CScopedTemplate> &evmTemplate);
+                      BlockContext &blockCtx);
 
 Res ProcessDeFiEventFallible(const CBlock &block,
                              const CBlockIndex *pindex,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -879,8 +879,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected,
                 };
 
                 // Copy block context and update to cache view
-                auto blockCtxTxView{blockCtx};
-                blockCtxTxView.SetView(cache);
+                BlockContext blockCtxTxView{blockCtx, cache};
 
                 const auto res = ApplyCustomTx(blockCtxTxView, txCtx);
                 // Not okay invalidate, undo and skip

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -355,7 +355,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     // Serialize passed information without accessing chain state of the active chain!
     AssertLockNotHeld(cs_main); // For performance reasons
     const auto consensus = Params().GetConsensus();
-    const auto isEvmEnabledForBlock = IsEVMEnabled(*pcustomcsview, consensus);
+    const auto isEvmEnabledForBlock = IsEVMEnabled(*pcustomcsview);
 
     auto txsToUniValue = [&isEvmEnabledForBlock](const CBlock& block, bool txDetails, int version) {
         UniValue txs(UniValue::VARR);

--- a/src/test/liquidity_tests.cpp
+++ b/src/test/liquidity_tests.cpp
@@ -1,6 +1,7 @@
 #include <chainparams.h>
 #include <dfi/govvariables/attributes.h>
 #include <dfi/masternodes.h>
+#include <dfi/mn_checks.h>
 #include <dfi/poolpairs.h>
 #include <validation.h>
 
@@ -26,7 +27,8 @@ DCT_ID CreateToken(CCustomCSView &mnview, std::string const & symbol, uint8_t fl
     token.symbol = symbol;
     token.flags = flags;
 
-    auto res = mnview.CreateToken(token, false);
+    BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, Params().GetConsensus()};
+    auto res = mnview.CreateToken(token, dummyContext);
     if (!res.ok) printf("%s\n", res.msg.c_str());
     BOOST_REQUIRE(res.ok);
     return *res.val;

--- a/src/test/loan_tests.cpp
+++ b/src/test/loan_tests.cpp
@@ -1,7 +1,7 @@
 #include <chainparams.h>
 #include <dfi/loan.h>
 #include <dfi/masternodes.h>
-#include <validation.h>
+#include <dfi/mn_checks.h>
 
 #include <test/setup_common.h>
 #include <boost/test/unit_test.hpp>
@@ -26,7 +26,8 @@ DCT_ID CreateToken(CCustomCSView &mnview, const std::string& symbol, const std::
     token.symbol = symbol;
     token.name = name;
 
-    auto res = mnview.CreateToken(token, false);
+    BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, Params().GetConsensus()};
+    auto res = mnview.CreateToken(token, dummyContext);
     BOOST_REQUIRE(res.ok);
     return *res.val;
 }

--- a/src/test/storage_tests.cpp
+++ b/src/test/storage_tests.cpp
@@ -4,6 +4,7 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <dfi/masternodes.h>
+#include <dfi/mn_checks.h>
 #include <rpc/rawtransaction_util.h>
 #include <test/setup_common.h>
 
@@ -180,11 +181,14 @@ BOOST_AUTO_TEST_CASE(tokens)
         BOOST_REQUIRE(pair->second->symbol == "DFI");
     }
 
+
+    BlockContext dummyContext{std::numeric_limits<uint32_t>::max(), {}, Params().GetConsensus()};
+
     // token creation
     CTokenImplementation token1;
     token1.symbol = "DCT1";
     token1.creationTx = uint256S("0x1111");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok);
     BOOST_REQUIRE(GetTokensCount() == 2);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{128});
@@ -206,11 +210,11 @@ BOOST_AUTO_TEST_CASE(tokens)
     }
 
     // another token creation
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate symbol & tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok == false); /// duplicate symbol & tx
     token1.symbol = "DCT2";
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok == false); /// duplicate tx
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok == false); /// duplicate tx
     token1.creationTx = uint256S("0x2222");
-    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, false).ok);
+    BOOST_REQUIRE(pcustomcsview->CreateToken(token1, dummyContext).ok);
     BOOST_REQUIRE(GetTokensCount() == 3);
     {   // search by id
         auto token = pcustomcsview->GetToken(DCT_ID{129});

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1272,8 +1272,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
     setEntries staged;
     std::vector<CTransactionRef> vtx;
 
-    const auto &consensus = Params().GetConsensus();
-    const auto isEvmEnabledForBlock = IsEVMEnabled(viewDuplicate, consensus);
+    const auto isEvmEnabledForBlock = IsEVMEnabled(viewDuplicate);
 
     // Check custom TX consensus types are now not in conflict with account layer
     auto &txsByEntryTime = mapTx.get<entry_time>();
@@ -1296,7 +1295,7 @@ void CTxMemPool::rebuildAccountsView(int height, const CCoinsViewCache &coinsCac
         auto blockCtx = BlockContext{
             static_cast<uint32_t>(height),
             static_cast<uint64_t>(it->GetTime()),
-            consensus,
+            Params().GetConsensus(),
             &viewDuplicate,
             isEvmEnabledForBlock,
             {},

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -721,7 +721,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams &chainparams,
             static_cast<uint64_t>(nAcceptTime),
             consensus,
             &mnview,
-            IsEVMEnabled(mnview, consensus),
+            IsEVMEnabled(mnview),
             {},
             true,
         };
@@ -3377,7 +3377,10 @@ bool CChainState::ConnectBlock(const CBlock &block,
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 
-    ProcessDeFiEvent(block, pindex, mnview, view, chainparams, creationTxs, evmTemplate);
+    // Set to ConnectBlock CCustomCSView
+    blockCtx.SetView(mnview);
+
+    ProcessDeFiEvent(block, pindex, view, creationTxs, blockCtx);
 
     // Write any UTXO burns
     for (const auto &[key, value] : writeBurnEntries) {
@@ -7223,6 +7226,30 @@ public:
 };
 static CMainCleanup instance_of_cmaincleanup;
 
+BlockContext::BlockContext(const uint32_t height,
+                           const uint64_t time,
+                           const Consensus::Params &consensus,
+                           CCustomCSView *view,
+                           const std::optional<bool> enabled,
+                           const std::shared_ptr<CScopedTemplate> &evmTemplate,
+                           const bool prevalidate)
+    : view(view),
+      isEvmEnabledForBlock(enabled),
+      evmTemplate(evmTemplate),
+      evmPreValidate(prevalidate),
+      height(height),
+      time(time),
+      consensus(consensus) {}
+
+BlockContext::BlockContext(BlockContext &other, CCustomCSView &otherView)
+    : view(&otherView),
+      isEvmEnabledForBlock(other.GetEVMEnabledForBlock()),
+      evmTemplate(other.GetEVMTemplate()),
+      evmPreValidate(other.GetEVMPreValidate()),
+      height(other.GetHeight()),
+      time(other.GetTime()),
+      consensus(other.GetConsensus()) {}
+
 CCustomCSView &BlockContext::GetView() {
     if (!view) {
         cache = std::make_shared<CCustomCSView>(*pcustomcsview);
@@ -7233,7 +7260,7 @@ CCustomCSView &BlockContext::GetView() {
 
 bool BlockContext::GetEVMEnabledForBlock() {
     if (!isEvmEnabledForBlock) {
-        isEvmEnabledForBlock = IsEVMEnabled(GetView(), Params().GetConsensus());
+        isEvmEnabledForBlock = IsEVMEnabled(GetView());
     }
     return *isEvmEnabledForBlock;
 }

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -1005,6 +1005,20 @@ class DST20(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
+        # Check that update has associated EVM TX and receipt
+        update_tx = self.nodes[0].eth_getBlockByNumber("latest")["transactions"][0]
+        receipt = self.nodes[0].eth_getTransactionReceipt(update_tx)
+        tx = self.nodes[0].eth_getTransactionByHash(update_tx)
+        assert_equal(
+            self.w0.to_checksum_address(receipt["contractAddress"]),
+            self.contract_address_btc,
+        )
+        assert_equal(receipt["from"], tx["from"])
+        assert_equal(receipt["gasUsed"], "0x0")
+        assert_equal(receipt["logs"], [])
+        assert_equal(receipt["status"], "0x1")
+        assert_equal(receipt["to"], None)
+
         # Check contract variables
         self.btc = self.nodes[0].w3.eth.contract(
             address=self.contract_address_btc, abi=self.abi

--- a/test/functional/feature_evm_dst20.py
+++ b/test/functional/feature_evm_dst20.py
@@ -42,7 +42,7 @@ class DST20(DefiTestFramework):
                 "-fortcanningepilogueheight=96",
                 "-grandcentralheight=101",
                 "-metachainheight=153",
-                "-df23height=153",
+                "-df23height=200",
                 "-subsidytest=1",
             ]
         ]
@@ -988,6 +988,107 @@ class DST20(DefiTestFramework):
             Decimal(0),
         )
 
+    def test_rename_dst20(self):
+        # Reset test
+        self.rollback_to(self.start_height)
+
+        # Move to fork height
+        self.nodes[0].generate(200 - self.nodes[0].getblockcount())
+
+        # Update token name
+        self.nodes[0].updatetoken(
+            "BTC",
+            {
+                "name": "Litecoin",
+                "symbol": "LTC",
+            },
+        )
+        self.nodes[0].generate(1)
+
+        # Check contract variables
+        self.btc = self.nodes[0].w3.eth.contract(
+            address=self.contract_address_btc, abi=self.abi
+        )
+        assert_equal(self.btc.functions.name().call(), "Litecoin")
+        assert_equal(self.btc.functions.symbol().call(), "LTC")
+
+        assert_raises_rpc_error(
+            -32600,
+            "Invalid token symbol",
+            self.nodes[0].updatetoken,
+            "LTC",
+            {"symbol": "LT#C"},
+        )
+
+        # Move back to fork height
+        self.rollback_to(200)
+
+        # Check contract variables
+        self.btc = self.nodes[0].w3.eth.contract(
+            address=self.contract_address_btc, abi=self.abi
+        )
+        assert_equal(self.btc.functions.name().call(), "BTC token")
+        assert_equal(self.btc.functions.symbol().call(), "BTC")
+
+        # Setup oracle
+        address = self.nodes[0].getnewaddress("", "legacy")
+        prices = [
+            {"currency": "USD", "token": "DFI"},
+            {"currency": "USD", "token": "TSLA"},
+        ]
+        self.nodes[0].appointoracle(address, prices, 10)
+        self.nodes[0].generate(1)
+
+        # Create loan token
+        self.nodes[0].setloantoken(
+            {
+                "symbol": "TSLA",
+                "name": "Tesla Token",
+                "fixedIntervalPriceId": "TSLA/USD",
+                "mintable": True,
+                "interest": 0.01,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Check DST token
+        self.tsla = self.nodes[0].w3.eth.contract(
+            address=self.contract_address_tsla, abi=self.abi
+        )
+
+        assert_equal(self.tsla.functions.name().call(), "Tesla Token")
+        assert_equal(self.tsla.functions.symbol().call(), "TSLA")
+
+        # Update via loan token
+        self.nodes[0].updateloantoken(
+            "TSLA",
+            {
+                "symbol": "META",
+                "name": "Meta",
+            },
+        )
+        self.nodes[0].generate(1)
+
+        # Check contract variables
+        self.tsla = self.nodes[0].w3.eth.contract(
+            address=self.contract_address_tsla, abi=self.abi
+        )
+
+        assert_equal(self.tsla.functions.name().call(), "Meta")
+        assert_equal(self.tsla.functions.symbol().call(), "META")
+
+        # Check invalid symbol
+        assert_raises_rpc_error(
+            -32600,
+            "Invalid token symbol",
+            self.nodes[0].updateloantoken,
+            "META",
+            {
+                "symbol": "ME#/TA",
+                "name": "Me#/ta",
+            },
+        )
+
     def run_test(self):
         self.node = self.nodes[0]
         self.w0 = self.node.w3
@@ -1115,6 +1216,8 @@ class DST20(DefiTestFramework):
         self.test_loan_token()
 
         self.test_dst20_back_and_forth()
+
+        self.test_rename_dst20()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Supports renaming of tokens EVM side after a hard fork. This PR also puts in some groundwork to enable stock split on EVM by passing the BlockContext to ProcessDeFiEvents for CreateToken and UpdateToken inside of ProcessTokenSplits. For now a dummy context is passed in, but the BlockContext is available.
- Updates CreateToken and UpdateToken to take a BlockContext reference, CreateToken previously had a BlockContext as a pointer which is less desirable.
- A previous update prevented tokens from being created with invalid characters in their symbol, however this protection was not included in token updates. This PR prevents using invalid chars when updating a token or loan token symbol.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
