### PR TITLE
EVM: Refactor trace tx pipeline into executor

### DIFF
--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -788,7 +788,7 @@ impl EVMCoreService {
         }))
     }
 
-    pub fn trace_transaction(
+    pub fn call_with_tracer(
         &self,
         tx: &SignedTx,
         block_number: U256,

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -186,7 +186,6 @@ impl EVMCoreService {
         }))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn trace_transaction(
         &self,
         tx: &SignedTx,

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -813,6 +813,6 @@ impl EVMCoreService {
             None,
         )
         .map_err(|e| format_err!("Could not restore backend {}", e))?;
-        AinExecutor::new(&mut backend).exec_trace_tx(tx)
+        AinExecutor::new(&mut backend).exec_with_tracer(tx)
     }
 }

--- a/lib/ain-evm/src/core.rs
+++ b/lib/ain-evm/src/core.rs
@@ -813,6 +813,7 @@ impl EVMCoreService {
             None,
         )
         .map_err(|e| format_err!("Could not restore backend {}", e))?;
+        backend.update_vicinity_from_tx(tx)?;
         AinExecutor::new(&mut backend).exec_with_tracer(tx)
     }
 }

--- a/lib/ain-evm/src/eventlistener.rs
+++ b/lib/ain-evm/src/eventlistener.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 
+use crate::opcode;
+use ethereum_types::H256;
 use evm::gasometer::tracing::{Event as GasEvent, EventListener as GasEventListener};
 use evm_runtime::{
     tracing::{Event as RuntimeEvent, EventListener as RuntimeEventListener},
@@ -7,7 +9,15 @@ use evm_runtime::{
 };
 use log::debug;
 
-use crate::{core::ExecutionStep, opcode};
+#[derive(Clone, Debug)]
+pub struct ExecutionStep {
+    pub pc: usize,
+    pub op: String,
+    pub gas: u64,
+    pub gas_cost: u64,
+    pub stack: Vec<H256>,
+    pub memory: Vec<u8>,
+}
 
 pub struct Listener {
     pub trace: Vec<ExecutionStep>,
@@ -38,6 +48,12 @@ impl GasListener {
             gas_cost: VecDeque::new(),
             first_cost: true,
         }
+    }
+}
+
+impl Default for GasListener {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -249,7 +249,7 @@ impl<'backend> AinExecutor<'backend> {
         ))
     }
 
-    pub fn exec_trace_tx(
+    pub fn exec_with_tracer(
         &mut self,
         signed_tx: &SignedTx,
     ) -> Result<(Vec<ExecutionStep>, bool, Vec<u8>, u64)> {

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -20,7 +20,7 @@ use crate::{
         dst20_deploy_info, DST20BridgeInfo, DeployContractInfo,
     },
     core::EVMCoreService,
-    eventlistener::{ExecutionStep, ExecListener, GasListener},
+    eventlistener::{ExecListener, ExecutionStep, GasListener},
     fee::{calculate_current_prepay_gas_fee, calculate_gas_fee},
     precompiles::MetachainPrecompiles,
     transaction::{

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -20,7 +20,7 @@ use crate::{
         dst20_deploy_info, DST20BridgeInfo, DeployContractInfo,
     },
     core::EVMCoreService,
-    eventlistener::{ExecutionStep, GasListener, Listener},
+    eventlistener::{ExecutionStep, ExecListener, GasListener},
     fee::{calculate_current_prepay_gas_fee, calculate_gas_fee},
     precompiles::MetachainPrecompiles,
     transaction::{
@@ -295,7 +295,7 @@ impl<'backend> AinExecutor<'backend> {
 
         let state = MemoryStackState::new(metadata, self.backend);
         let mut executor = StackExecutor::new_with_precompiles(state, &Self::CONFIG, &precompiles);
-        let mut listener = Listener::new(gas_listener.gas, gas_listener.gas_cost);
+        let mut listener = ExecListener::new(gas_listener.gas, gas_listener.gas_cost);
         let (exec_flag, data, used_gas) = runtime_using(&mut listener, move || {
             let (exit_reason, data) = executor.transact_call(
                 ctx.caller,

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -250,23 +250,22 @@ impl<'backend> AinExecutor<'backend> {
     }
 
     pub fn exec_with_tracer(
-        &mut self,
+        &self,
         signed_tx: &SignedTx,
     ) -> Result<(Vec<ExecutionStep>, bool, Vec<u8>, u64)> {
-        let to = signed_tx.to().ok_or(format_err!(
-            "debug_traceTransaction does not support contract creation transactions",
-        ))?;
-        self.backend.update_vicinity_from_tx(signed_tx)?;
         trace!(
             "[Executor] Executing trace EVM TX with vicinity : {:?}",
             self.backend.vicinity
         );
+        let to = signed_tx.to().ok_or(format_err!(
+            "debug_traceTransaction does not support contract creation transactions",
+        ))?;
         let ctx = ExecutorContext {
             caller: signed_tx.sender,
             to: Some(to),
             value: signed_tx.value(),
             data: signed_tx.data(),
-            gas_limit: u64::try_from(signed_tx.gas_limit())?, // Sets to u64 if overflows
+            gas_limit: u64::try_from(signed_tx.gas_limit())?,
             access_list: signed_tx.access_list(),
         };
         let access_list = ctx

--- a/lib/ain-evm/src/lib.rs
+++ b/lib/ain-evm/src/lib.rs
@@ -7,7 +7,7 @@ pub mod bytes;
 mod contract;
 pub mod core;
 mod ecrecover;
-mod eventlistener;
+pub mod eventlistener;
 pub mod evm;
 pub mod executor;
 pub mod fee;

--- a/lib/ain-grpc/src/rpc/debug.rs
+++ b/lib/ain-grpc/src/rpc/debug.rs
@@ -84,7 +84,7 @@ impl MetachainDebugRPCServer for MetachainDebugRPCModule {
         let (logs, succeeded, return_data, gas_used) = self
             .handler
             .core
-            .trace_transaction(&signed_tx, receipt.block_number)
+            .call_with_tracer(&signed_tx, receipt.block_number)
             .map_err(RPCError::EvmError)?;
         let trace_logs = logs.iter().map(|x| TraceLogs::from(x.clone())).collect();
 

--- a/lib/ain-grpc/src/transaction.rs
+++ b/lib/ain-grpc/src/transaction.rs
@@ -1,5 +1,5 @@
 use ain_evm::{
-    core::ExecutionStep,
+    eventlistener::ExecutionStep,
     transaction::{SignedTx, TransactionError},
 };
 use ethereum::{AccessListItem, BlockAny, EnvelopedEncodable, TransactionV2};


### PR DESCRIPTION
## Summary

- Resolves issue raised in https://github.com/DeFiCh/ain/pull/2770#discussion_r1449950193
- Shifts execution tx with trace into ain executor. EVM executor instance should be abstracted from caller and inside ain executor with this PR refactor

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
