### PR TITLE
Ocean: Initial Scan support

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.12",
@@ -205,7 +205,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "syn 2.0.48",
+ "syn 2.0.50",
  "tokio",
  "tonic",
  "tonic-build",
@@ -219,7 +219,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "approx"
@@ -401,7 +401,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -542,7 +542,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -821,7 +821,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "syn_derive",
 ]
 
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
 
 [[package]]
 name = "byte-slice-cast"
@@ -962,7 +962,7 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355face540df58778b96814c48abb3c2ed67c4878a8087ab1819c1fedeec505f"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.9",
  "async-trait",
  "cached_proc_macro",
  "cached_proc_macro_types",
@@ -994,11 +994,10 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -1268,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aff472b83efd22bfc0176aa8ba34617dd5c17364670eb201a5f06d339b8abf7"
+checksum = "0c15f3b597018782655a05d417f28bac009f6eb60f4b6703eb818998c1aaa16a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1280,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf6e7a52c19013a9a0ec421c7d9c2d1125faf333551227e0a017288d71b47c3"
+checksum = "81699747d109bba60bd6f87e7cb24b626824b8427b32f199b95c7faa06ee3dc9"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1290,36 +1289,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "cxx-gen"
-version = "0.7.116"
+version = "0.7.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a39f7064dacffa9bf2d33d8dcc7777b60c789a95e1cd62d5fbeb1161428f2"
+checksum = "54b629c0d006c7e44c1444dd17d18a458c9390d32276b758ac7abd21a75c99b0"
 dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589e83d02fc1d4fb78f5ad56ca08835341e23499d086d2821315869426d618dc"
+checksum = "7a7eb4c4fd18505f5a935f9c2ee77780350dcdb56da7cd037634e806141c5c43"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
+checksum = "5d914fcc6452d133236ee067a9538be25ba6a644a450e1a6c617da84bf029854"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1367,7 +1366,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1389,13 +1388,13 @@ checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
 dependencies = [
  "darling_core 0.20.6",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "defichain-rpc"
 version = "0.18.0"
-source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#324f8cf4bf0973be34ae1bb6da26de21b29f03fd"
+source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#b69ac6600113d7869b1311381237de0b41debddc"
 dependencies = [
  "async-trait",
  "defichain-rpc-json",
@@ -1408,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#324f8cf4bf0973be34ae1bb6da26de21b29f03fd"
+source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#b69ac6600113d7869b1311381237de0b41debddc"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1449,24 +1448,24 @@ dependencies = [
 
 [[package]]
 name = "deunicode"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
+checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
 
 [[package]]
 name = "dftx-macro"
 version = "0.1.0"
-source = "git+https://github.com/Jouzo/dftx-rs.git#c6ff7772f6bfe8a6d0804c40b2f53f3de69e295e"
+source = "git+https://github.com/Jouzo/dftx-rs.git#869a8ceee86c8e98d3a6a3acc7a8abf8fb2f150c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "dftx-rs"
 version = "0.1.0"
-source = "git+https://github.com/Jouzo/dftx-rs.git#c6ff7772f6bfe8a6d0804c40b2f53f3de69e295e"
+source = "git+https://github.com/Jouzo/dftx-rs.git#869a8ceee86c8e98d3a6a3acc7a8abf8fb2f150c"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1835,7 +1834,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver 1.0.21",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "solang-parser",
@@ -2076,7 +2075,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2281,7 +2280,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.9",
 ]
 
 [[package]]
@@ -2290,7 +2289,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.9",
  "allocator-api2",
 ]
 
@@ -2503,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2517,6 +2516,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
 ]
 
@@ -2559,7 +2559,7 @@ dependencies = [
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2743,15 +2743,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -3547,7 +3538,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3772,7 +3763,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3810,7 +3801,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3876,7 +3867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4250,7 +4241,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4374,16 +4365,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4607,9 +4599,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "safe_arch"
@@ -4670,7 +4662,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.9",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -4817,9 +4809,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
 ]
@@ -4832,29 +4824,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -4910,7 +4902,7 @@ dependencies = [
  "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5171,7 +5163,7 @@ checksum = "f12dae7cf6c1e825d13ffd4ce16bd9309db7c539929d0302b4443ed451a9f4e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5265,7 +5257,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5329,7 +5321,7 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf63ea90ffb5d61048d8fb2fac669114dac198fc2739e913e615f0fd2c36c3e7"
 dependencies = [
- "ahash 0.8.8",
+ "ahash 0.8.9",
  "hash-db 0.16.0",
  "hashbrown 0.13.2",
  "lazy_static",
@@ -5494,7 +5486,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5540,7 +5532,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest",
- "semver 1.0.21",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -5562,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5580,7 +5572,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5690,14 +5682,14 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5823,7 +5815,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -6013,7 +6005,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -6166,9 +6158,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -6364,7 +6356,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -6398,7 +6390,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6878,7 +6870,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -6898,7 +6890,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/lib/ain-db/src/lib.rs
+++ b/lib/ain-db/src/lib.rs
@@ -183,7 +183,6 @@ where
         from: Option<C::Index>,
         direction: Direction,
     ) -> Result<impl Iterator<Item = Result<(C::Index, C::Type)>> + '_> {
-        let skip = if from.as_ref().is_some() { 1 } else { 0 };
         let index = from
             .as_ref()
             .map(|i| C::key(i))
@@ -206,8 +205,7 @@ where
                 let value = bincode::deserialize(&value)?;
                 let key = C::get_key(key)?;
                 Ok((key, value))
-            })
-            .skip(skip))
+            }))
     }
 }
 

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -237,7 +237,10 @@ impl Rollback for BlockStore {
             let block_deployed_codes_cf = self.column::<columns::BlockDeployedCodeHashes>();
             let address_codes_cf = self.column::<columns::AddressCodeMap>();
 
-            for item in block_deployed_codes_cf.iter(Some((block.header.number, H160::zero())))? {
+            for item in block_deployed_codes_cf.iter(
+                Some((block.header.number, H160::zero())),
+                rocksdb::Direction::Reverse,
+            )? {
                 let ((block_number, address), hash) = item?;
 
                 if block_number == block.header.number {
@@ -325,7 +328,11 @@ impl BlockStore {
         let response_max_size = usize::try_from(ain_cpp_imports::get_max_response_byte_size())
             .map_err(|_| format_err!("failed to convert response size limit to usize"))?;
 
-        for item in self.column::<C>().iter(from)?.take(limit) {
+        for item in self
+            .column::<C>()
+            .iter(from, rocksdb::Direction::Reverse)?
+            .take(limit)
+        {
             let (k, v) = item?;
 
             if out.len() > response_max_size {

--- a/lib/ain-macros/src/lib.rs
+++ b/lib/ain-macros/src/lib.rs
@@ -113,9 +113,9 @@ pub fn repository_derive(input: TokenStream) -> TokenStream {
                 Ok(self.col.delete(id)?)
             }
 
-            fn list<'a>(&'a self, from: Option<#key_type_ident>) -> Result<Box<dyn Iterator<Item = std::result::Result<(#key_type_ident, #value_type_ident), ain_db::DBError>> + 'a>>
+            fn list<'a>(&'a self, from: Option<#key_type_ident>, dir: crate::storage::SortOrder) -> Result<Box<dyn Iterator<Item = std::result::Result<(#key_type_ident, #value_type_ident), ain_db::DBError>> + 'a>>
             {
-                let it = self.col.iter(from)?;
+                let it = self.col.iter(from, dir.into())?;
                 Ok(Box::new(it))
             }
         }

--- a/lib/ain-ocean/src/api/loan.rs
+++ b/lib/ain-ocean/src/api/loan.rs
@@ -27,6 +27,7 @@ use crate::{
     error::{ApiError, Error, NotFoundKind},
     model::VaultAuctionBatchHistory,
     repository::RepositoryOps,
+    storage::SortOrder,
     Result,
 };
 
@@ -76,7 +77,6 @@ async fn get_scheme(
     Path(scheme_id): Path<String>,
     Extension(ctx): Extension<Arc<AppContext>>,
 ) -> Result<Response<LoanSchemeData>> {
-    println!("[get_scheme]");
     Ok(Response::new(
         ctx.client.get_loan_scheme(scheme_id).await?.into(),
     ))
@@ -259,7 +259,10 @@ async fn list_vault_auction_history(
         .services
         .auction
         .by_height
-        .list(Some((vault_id, batch_index, next.0, next.1)))?
+        .list(
+            Some((vault_id, batch_index, next.0, next.1)),
+            SortOrder::Descending,
+        )?
         .take(size)
         .take_while(|item| match item {
             Ok((k, _)) => k.0 == vault_id && k.1 == batch_index,

--- a/lib/ain-ocean/src/api/loan.rs
+++ b/lib/ain-ocean/src/api/loan.rs
@@ -64,7 +64,7 @@ async fn list_scheme(
         .list_loan_schemes()
         .await?
         .into_iter()
-        .paginate(&query, skip_while)
+        .fake_paginate(&query, skip_while)
         .map(Into::into)
         .collect();
     Ok(ApiPagedResponse::of(res, query.size, |loan_scheme| {
@@ -120,7 +120,7 @@ async fn list_collateral_token(
 
     let fut = tokens
         .into_iter()
-        .paginate(&query, skip_while)
+        .fake_paginate(&query, skip_while)
         .map(|v| async {
             let (id, info) = get_token_cached(&ctx, &v.token_id).await?;
             Ok::<CollateralToken, Error>(CollateralToken::from_with_id(id, v, info))
@@ -187,7 +187,7 @@ async fn list_loan_token(
                     interest: el.interest,
                 })
         })
-        .paginate(&query, |token| match &query.next {
+        .fake_paginate(&query, |token| match &query.next {
             None => false,
             Some(v) => v != &token.id,
         })

--- a/lib/ain-ocean/src/api/masternode.rs
+++ b/lib/ain-ocean/src/api/masternode.rs
@@ -19,6 +19,7 @@ use crate::{
     error::{ApiError, Error, NotFoundKind},
     model::Masternode,
     repository::RepositoryOps,
+    storage::SortOrder,
     Result,
 };
 
@@ -121,7 +122,7 @@ async fn list_masternodes(
         .services
         .masternode
         .by_height
-        .list(next)?
+        .list(next, SortOrder::Descending)?
         .take(query.size)
         .map(|item| {
             let ((_, id), _) = item?;

--- a/lib/ain-ocean/src/api/masternode.rs
+++ b/lib/ain-ocean/src/api/masternode.rs
@@ -16,6 +16,7 @@ use super::{
     AppContext,
 };
 use crate::{
+    api::common::Paginate,
     error::{ApiError, Error, NotFoundKind},
     model::Masternode,
     repository::RepositoryOps,
@@ -106,6 +107,7 @@ async fn list_masternodes(
 ) -> Result<ApiPagedResponse<MasternodeData>> {
     let next = query
         .next
+        .as_ref()
         .map(|q| {
             let height = q[0..8]
                 .parse::<u32>()
@@ -123,7 +125,7 @@ async fn list_masternodes(
         .masternode
         .by_height
         .list(next, SortOrder::Descending)?
-        .take(query.size)
+        .paginate(&query)
         .map(|item| {
             let ((_, id), _) = item?;
             let mn = ctx

--- a/lib/ain-ocean/src/api/mod.rs
+++ b/lib/ain-ocean/src/api/mod.rs
@@ -18,7 +18,7 @@ mod query;
 mod response;
 mod stats;
 mod tokens;
-// mod transactions;
+mod transactions;
 
 use defichain_rpc::Client;
 use serde::{Deserialize, Serialize};
@@ -59,19 +59,22 @@ pub async fn ocean_router(services: &Arc<Services>, client: Arc<Client>) -> Resu
         services: services.clone(),
     });
 
-    Ok(Router::new()
-        // .nest("/address", address::router(Arc::clone(&context)))
-        .nest("/governance", governance::router(Arc::clone(&context)))
-        .nest("/loans", loan::router(Arc::clone(&context)))
-        .nest("/fee", fee::router(Arc::clone(&context)))
-        .nest("/masternodes", masternode::router(Arc::clone(&context)))
-        // .nest("/oracles", oracle::router(Arc::clone(&context)))
-        // .nest("/poolpairs", poolpairs::router(Arc::clone(&context)))
-        // .nest("/prices", prices::router(Arc::clone(&context)))
-        // .nest("/rawtx", rawtx::router(Arc::clone(&context)))
-        .nest("/stats", stats::router(Arc::clone(&context)))
-        .nest("/tokens", tokens::router(Arc::clone(&context)))
-        // .nest("/transactions", transactions::router(Arc::clone(&context)))
-        .nest("/blocks", block::router(Arc::clone(&context)))
-        .fallback(not_found))
+    Ok(Router::new().nest(
+        "/v0/mainnet",
+        Router::new()
+            // .nest("/address/", address::router(Arc::clone(&context)))
+            .nest("/governance", governance::router(Arc::clone(&context)))
+            .nest("/loans", loan::router(Arc::clone(&context)))
+            .nest("/fee", fee::router(Arc::clone(&context)))
+            .nest("/masternodes", masternode::router(Arc::clone(&context)))
+            // .nest("/oracles", oracle::router(Arc::clone(&context)))
+            // .nest("/poolpairs", poolpairs::router(Arc::clone(&context)))
+            // .nest("/prices", prices::router(Arc::clone(&context)))
+            // .nest("/rawtx", rawtx::router(Arc::clone(&context)))
+            .nest("/stats", stats::router(Arc::clone(&context)))
+            .nest("/tokens", tokens::router(Arc::clone(&context)))
+            .nest("/transactions", transactions::router(Arc::clone(&context)))
+            .nest("/blocks", block::router(Arc::clone(&context)))
+            .fallback(not_found),
+    ))
 }

--- a/lib/ain-ocean/src/api/mod.rs
+++ b/lib/ain-ocean/src/api/mod.rs
@@ -59,8 +59,10 @@ pub async fn ocean_router(services: &Arc<Services>, client: Arc<Client>) -> Resu
         services: services.clone(),
     });
 
+    let network = ain_cpp_imports::get_network();
+
     Ok(Router::new().nest(
-        "/v0/mainnet",
+        format!("/v0/{network}").as_str(),
         Router::new()
             // .nest("/address/", address::router(Arc::clone(&context)))
             .nest("/governance", governance::router(Arc::clone(&context)))

--- a/lib/ain-ocean/src/api/query.rs
+++ b/lib/ain-ocean/src/api/query.rs
@@ -23,6 +23,7 @@ pub struct PaginationQuery {
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default = "default_pagination_size")]
     pub size: usize,
+    #[serde(default)]
     #[serde(deserialize_with = "undefined_to_none")]
     pub next: Option<String>,
 }

--- a/lib/ain-ocean/src/api/stats/stats.rs
+++ b/lib/ain-ocean/src/api/stats/stats.rs
@@ -100,7 +100,6 @@ pub async fn get_count(ctx: &Arc<AppContext>) -> Result<Count> {
     })
 }
 
-
 // TODO Shove it into network struct when available
 lazy_static::lazy_static! {
     pub static ref  BURN_ADDRESS: HashMap<&'static str, &'static str> = HashMap::from([
@@ -133,9 +132,6 @@ pub async fn get_burned_total(client: &Client) -> Result<Decimal> {
 
     Ok(utxo + account_balance + emission + fee)
 }
-
-156843117.64243466 + 98783549.83821494 + 382621.96000000 + 62723836.52605750
-
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct Emission {
@@ -311,4 +307,3 @@ pub async fn get_tvl(ctx: &Arc<AppContext>) -> Result<Tvl> {
         ..Default::default()
     })
 }
-

--- a/lib/ain-ocean/src/api/stats/stats.rs
+++ b/lib/ain-ocean/src/api/stats/stats.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use cached::proc_macro::cached;
 use defichain_rpc::{
@@ -100,6 +100,18 @@ pub async fn get_count(ctx: &Arc<AppContext>) -> Result<Count> {
     })
 }
 
+
+// TODO Shove it into network struct when available
+lazy_static::lazy_static! {
+    pub static ref  BURN_ADDRESS: HashMap<&'static str, &'static str> = HashMap::from([
+        ("mainnet", "8defichainBurnAddressXXXXXXXdRQkSm"),
+        ("testnet", "7DefichainBurnAddressXXXXXXXdMUE5n"),
+        ("devnet", "7DefichainBurnAddressXXXXXXXdMUE5n"),
+        ("changi", "7DefichainBurnAddressXXXXXXXdMUE5n"),
+        ("regtest", "mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG"),
+    ]);
+}
+
 #[cached(
     result = true,
     time = 1800,
@@ -107,8 +119,8 @@ pub async fn get_count(ctx: &Arc<AppContext>) -> Result<Count> {
     convert = r#"{ format!("burned_total") }"#
 )]
 pub async fn get_burned_total(client: &Client) -> Result<Decimal> {
-    static ADDRESS: &'static str = "76a914f7874e8821097615ec345f74c7e5bcf61b12e2ee88ac";
-    let mut tokens = client.get_account(ADDRESS, None, Some(true)).await?;
+    let burn_address = BURN_ADDRESS.get("mainnet").unwrap();
+    let mut tokens = client.get_account(&burn_address, None, Some(true)).await?;
     let burn_info = client.get_burn_info().await?;
 
     let utxo = Decimal::from_f64(burn_info.amount).ok_or(Error::DecimalError)?;
@@ -121,6 +133,9 @@ pub async fn get_burned_total(client: &Client) -> Result<Decimal> {
 
     Ok(utxo + account_balance + emission + fee)
 }
+
+156843117.64243466 + 98783549.83821494 + 382621.96000000 + 62723836.52605750
+
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct Emission {
@@ -296,3 +311,4 @@ pub async fn get_tvl(ctx: &Arc<AppContext>) -> Result<Tvl> {
         ..Default::default()
     })
 }
+

--- a/lib/ain-ocean/src/api/stats/stats.rs
+++ b/lib/ain-ocean/src/api/stats/stats.rs
@@ -118,7 +118,8 @@ lazy_static::lazy_static! {
     convert = r#"{ format!("burned_total") }"#
 )]
 pub async fn get_burned_total(client: &Client) -> Result<Decimal> {
-    let burn_address = BURN_ADDRESS.get("mainnet").unwrap();
+    let network = ain_cpp_imports::get_network();
+    let burn_address = BURN_ADDRESS.get(network.as_str()).unwrap();
     let mut tokens = client.get_account(&burn_address, None, Some(true)).await?;
     let burn_info = client.get_burn_info().await?;
 

--- a/lib/ain-ocean/src/api/transactions.rs
+++ b/lib/ain-ocean/src/api/transactions.rs
@@ -15,6 +15,7 @@ use crate::{
     error::ApiError,
     model::{Transaction, TransactionVin, TransactionVout},
     repository::RepositoryOps,
+    storage::SortOrder,
     Result,
 };
 
@@ -42,7 +43,7 @@ async fn get_vins(
         .services
         .transaction
         .vin_by_id
-        .list(None)?
+        .list(None, SortOrder::Descending)?
         .take(query.size)
         .map(|item| {
             let (txid, id) = item?;
@@ -74,7 +75,7 @@ async fn get_vouts(
         .services
         .transaction
         .vout_by_id
-        .list(None)?
+        .list(None, SortOrder::Descending)?
         .take(query.size)
         .map(|item| {
             let (txid, id) = item?;

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -49,6 +49,7 @@ pub fn index_block(services: &Arc<Services>, block: Block<Transaction>) -> Resul
 
     let block_mapper = BlockMapper {
         hash: block_hash,
+        id: block_hash,
         previous_hash: block.previousblockhash,
         height: block.height,
         version: block.version,

--- a/lib/ain-ocean/src/indexer/transaction.rs
+++ b/lib/ain-ocean/src/indexer/transaction.rs
@@ -56,7 +56,7 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
         services.transaction.vin_by_id.put(&vin.id, &vin)?;
     }
 
-    let order = idx + 1;
+    let order = idx;
 
     let tx = TransactionMapper {
         id: txid,

--- a/lib/ain-ocean/src/indexer/transaction.rs
+++ b/lib/ain-ocean/src/indexer/transaction.rs
@@ -56,9 +56,11 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
         services.transaction.vin_by_id.put(&vin.id, &vin)?;
     }
 
+    let order = idx + 1;
+
     let tx = TransactionMapper {
         id: txid,
-        order: idx,
+        order,
         hash: ctx.tx.hash.clone(),
         block: ctx.block.clone(),
         version: ctx.tx.version,
@@ -75,7 +77,8 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
     services
         .transaction
         .by_block_hash
-        .put(&(ctx.block.hash, idx), &txid)?;
+        .put(&(ctx.block.hash, order), &txid)?;
+
     Ok(())
 }
 

--- a/lib/ain-ocean/src/indexer/transaction.rs
+++ b/lib/ain-ocean/src/indexer/transaction.rs
@@ -72,7 +72,10 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
     };
     // Index transaction
     services.transaction.by_id.put(&txid, &tx)?;
-
+    services
+        .transaction
+        .by_block_hash
+        .put(&(ctx.block.hash, idx), &txid)?;
     Ok(())
 }
 

--- a/lib/ain-ocean/src/lib.rs
+++ b/lib/ain-ocean/src/lib.rs
@@ -9,8 +9,8 @@ pub use indexer::{index_block, invalidate_block, transaction::index_transaction,
 use repository::{
     AuctionHistoryByHeightRepository, AuctionHistoryRepository, BlockByHeightRepository,
     BlockRepository, MasternodeByHeightRepository, MasternodeRepository, MasternodeStatsRepository,
-    PoolSwapRepository, RawBlockRepository, TransactionRepository, TransactionVinRepository,
-    TransactionVoutRepository, TxResultRepository,
+    PoolSwapRepository, RawBlockRepository, TransactionByBlockHashRepository,
+    TransactionRepository, TransactionVinRepository, TransactionVoutRepository, TxResultRepository,
 };
 pub mod api;
 mod model;
@@ -54,6 +54,7 @@ pub struct PoolService {
 
 pub struct TransactionService {
     by_id: TransactionRepository,
+    by_block_hash: TransactionByBlockHashRepository,
     vin_by_id: TransactionVinRepository,
     vout_by_id: TransactionVoutRepository,
 }
@@ -90,6 +91,7 @@ impl Services {
             },
             transaction: TransactionService {
                 by_id: TransactionRepository::new(Arc::clone(&store)),
+                by_block_hash: TransactionByBlockHashRepository::new(Arc::clone(&store)),
                 vin_by_id: TransactionVinRepository::new(Arc::clone(&store)),
                 vout_by_id: TransactionVoutRepository::new(Arc::clone(&store)),
             },

--- a/lib/ain-ocean/src/model/block.rs
+++ b/lib/ain-ocean/src/model/block.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct Block {
     pub hash: BlockHash,
+    pub id: BlockHash,
     pub previous_hash: Option<BlockHash>,
     pub height: u32,
     pub version: i32,

--- a/lib/ain-ocean/src/model/transaction.rs
+++ b/lib/ain-ocean/src/model/transaction.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use super::BlockContext;
 
+pub type TransactionByBlockHashKey = (BlockHash, usize);
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {

--- a/lib/ain-ocean/src/repository/block.rs
+++ b/lib/ain-ocean/src/repository/block.rs
@@ -7,7 +7,7 @@ use bitcoin::BlockHash;
 use super::RepositoryOps;
 use crate::{
     model::Block,
-    storage::{columns, ocean_store::OceanStore},
+    storage::{columns, ocean_store::OceanStore, SortOrder},
     Result,
 };
 
@@ -45,7 +45,7 @@ impl BlockByHeightRepository {
 
 impl BlockByHeightRepository {
     pub fn get_highest(&self) -> Result<Option<Block>> {
-        match self.col.iter(None)?.next() {
+        match self.col.iter(None, SortOrder::Descending.into())?.next() {
             None => Ok(None),
             Some(Ok((_, id))) => {
                 let col = self.store.column::<columns::Block>();

--- a/lib/ain-ocean/src/repository/masternode_stats.rs
+++ b/lib/ain-ocean/src/repository/masternode_stats.rs
@@ -6,7 +6,7 @@ use ain_macros::Repository;
 use super::RepositoryOps;
 use crate::{
     model::MasternodeStats,
-    storage::{columns, ocean_store::OceanStore},
+    storage::{columns, ocean_store::OceanStore, SortOrder},
     Result,
 };
 
@@ -28,7 +28,7 @@ impl MasternodeStatsRepository {
 
 impl MasternodeStatsRepository {
     pub fn get_latest(&self) -> Result<Option<MasternodeStats>> {
-        match self.col.iter(None)?.next() {
+        match self.col.iter(None, SortOrder::Descending.into())?.next() {
             None => Ok(None),
             Some(Ok((_, id))) => Ok(Some(id)),
             Some(Err(e)) => Err(e.into()),

--- a/lib/ain-ocean/src/repository/mod.rs
+++ b/lib/ain-ocean/src/repository/mod.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{storage::SortOrder, Result};
 
 mod block;
 mod masternode;
@@ -51,5 +51,6 @@ pub trait RepositoryOps<K, V> {
     fn list<'a>(
         &'a self,
         from: Option<K>,
+        dir: SortOrder,
     ) -> Result<Box<dyn Iterator<Item = std::result::Result<(K, V), ain_db::DBError>> + 'a>>;
 }

--- a/lib/ain-ocean/src/repository/transaction.rs
+++ b/lib/ain-ocean/src/repository/transaction.rs
@@ -6,10 +6,11 @@ use bitcoin::Txid;
 
 use super::RepositoryOps;
 use crate::{
-    model::Transaction,
+    model::{Transaction, TransactionByBlockHashKey},
     storage::{columns, ocean_store::OceanStore},
     Result,
 };
+
 #[derive(Repository)]
 #[repository(K = "Txid", V = "Transaction")]
 pub struct TransactionRepository {
@@ -18,6 +19,22 @@ pub struct TransactionRepository {
 }
 
 impl TransactionRepository {
+    pub fn new(store: Arc<OceanStore>) -> Self {
+        Self {
+            col: store.column(),
+            store,
+        }
+    }
+}
+
+#[derive(Repository)]
+#[repository(K = "TransactionByBlockHashKey", V = "Txid")]
+pub struct TransactionByBlockHashRepository {
+    pub store: Arc<OceanStore>,
+    col: LedgerColumn<columns::TransactionByBlockHash>,
+}
+
+impl TransactionByBlockHashRepository {
     pub fn new(store: Arc<OceanStore>) -> Self {
         Self {
             col: store.column(),

--- a/lib/ain-ocean/src/repository/vault_auction_batch_history.rs
+++ b/lib/ain-ocean/src/repository/vault_auction_batch_history.rs
@@ -6,7 +6,7 @@ use ain_macros::Repository;
 use super::RepositoryOps;
 use crate::{
     model::{AuctionHistoryByHeightKey, AuctionHistoryKey, VaultAuctionBatchHistory},
-    storage::{columns, ocean_store::OceanStore},
+    storage::{columns, ocean_store::OceanStore, SortOrder},
     Result,
 };
 
@@ -44,7 +44,7 @@ impl AuctionHistoryByHeightRepository {
 
 impl AuctionHistoryByHeightRepository {
     pub fn get_latest(&self) -> Result<Option<VaultAuctionBatchHistory>> {
-        match self.list(None)?.next() {
+        match self.list(None, SortOrder::Descending)?.next() {
             None => Ok(None),
             Some(Ok((_, id))) => {
                 let col = self.store.column::<columns::VaultAuctionHistory>();

--- a/lib/ain-ocean/src/storage/columns/mod.rs
+++ b/lib/ain-ocean/src/storage/columns/mod.rs
@@ -43,7 +43,7 @@ pub use transaction_vout::*;
 pub use tx_result::*;
 pub use vault_auction_history::*;
 
-pub const COLUMN_NAMES: [&'static str; 24] = [
+pub const COLUMN_NAMES: [&'static str; 25] = [
     block::Block::NAME,
     block::BlockByHeight::NAME,
     masternode_stats::MasternodeStats::NAME,
@@ -63,6 +63,7 @@ pub const COLUMN_NAMES: [&'static str; 24] = [
     script_aggregation::ScriptAggregation::NAME,
     script_unspent::ScriptUnspent::NAME,
     transaction::Transaction::NAME,
+    transaction::TransactionByBlockHash::NAME,
     transaction_vin::TransactionVin::NAME,
     transaction_vout::TransactionVout::NAME,
     tx_result::TxResult::NAME,

--- a/lib/ain-ocean/src/storage/columns/transaction.rs
+++ b/lib/ain-ocean/src/storage/columns/transaction.rs
@@ -1,5 +1,5 @@
 use ain_db::{Column, ColumnName, TypedColumn};
-use bitcoin::{BlockHash, Txid};
+use bitcoin::Txid;
 
 use crate::model;
 #[derive(Debug)]

--- a/lib/ain-ocean/src/storage/columns/transaction.rs
+++ b/lib/ain-ocean/src/storage/columns/transaction.rs
@@ -1,5 +1,7 @@
-use ain_db::{Column, ColumnName, TypedColumn};
-use bitcoin::Txid;
+use ain_db::{Column, ColumnName, DBError, TypedColumn};
+use anyhow::format_err;
+use bitcoin::{hashes::Hash, BlockHash, Txid};
+use log::debug;
 
 use crate::model;
 #[derive(Debug)]
@@ -25,6 +27,27 @@ impl ColumnName for TransactionByBlockHash {
 
 impl Column for TransactionByBlockHash {
     type Index = model::TransactionByBlockHashKey;
+
+    fn key(index: &Self::Index) -> Result<Vec<u8>, DBError> {
+        let (hash, txno) = index;
+        let mut vec = hash.as_byte_array().to_vec();
+        vec.extend_from_slice(&txno.to_be_bytes());
+        Ok(vec)
+    }
+
+    fn get_key(raw_key: Box<[u8]>) -> Result<Self::Index, DBError> {
+        if raw_key.len() != 40 {
+            return Err(format_err!("Length of the slice is not 40").into());
+        }
+        let mut hash_array = [0u8; 32];
+        hash_array.copy_from_slice(&raw_key[..32]);
+        let mut txno_array = [0u8; 8];
+        txno_array.copy_from_slice(&raw_key[32..]);
+
+        let hash = BlockHash::from_byte_array(hash_array);
+        let txno = usize::from_be_bytes(txno_array);
+        Ok((hash, txno))
+    }
 }
 
 impl TypedColumn for TransactionByBlockHash {

--- a/lib/ain-ocean/src/storage/columns/transaction.rs
+++ b/lib/ain-ocean/src/storage/columns/transaction.rs
@@ -24,9 +24,9 @@ impl ColumnName for TransactionByBlockHash {
 }
 
 impl Column for TransactionByBlockHash {
-    type Index = BlockHash;
+    type Index = model::TransactionByBlockHashKey;
 }
 
 impl TypedColumn for TransactionByBlockHash {
-    type Type = model::Transaction;
+    type Type = Txid;
 }

--- a/lib/ain-ocean/src/storage/mod.rs
+++ b/lib/ain-ocean/src/storage/mod.rs
@@ -1,4 +1,4 @@
-use rocksdb::IteratorMode;
+use rocksdb::Direction;
 
 pub mod columns;
 pub mod ocean_store;
@@ -9,11 +9,11 @@ pub enum SortOrder {
     Descending,
 }
 
-impl<'a> From<SortOrder> for IteratorMode<'a> {
+impl From<SortOrder> for Direction {
     fn from(sort_order: SortOrder) -> Self {
         match sort_order {
-            SortOrder::Ascending => IteratorMode::Start,
-            SortOrder::Descending => IteratorMode::End,
+            SortOrder::Ascending => Direction::Forward,
+            SortOrder::Descending => Direction::Reverse,
         }
     }
 }


### PR DESCRIPTION
- Fix `PaginationQuery`  when next is not set
- List querying takes an extra `SortOrder` parameter to be able to query ASC
- Adds `/blocks/:hash/transactions` endpoint
- Fixes Burn address. Related issue : https://github.com/DeFiCh/ain/issues/2828