### PR TITLE
getaccount accept valid scriptPubKey

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -461,14 +461,14 @@ UniValue getaccount(const JSONRPCRequest &request) {
 
     // decode owner
     CScript reqOwner;
-    if (IsHex(userAddress)) { // ScriptPubKey
+    if (IsHex(userAddress)) {  // ScriptPubKey
         const auto hexVec = ParseHex(userAddress);
         reqOwner = CScript(hexVec.begin(), hexVec.end());
         CTxDestination owner;
         if (!ExtractDestination(reqOwner, owner) || !IsValidDestination(owner)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner address");
         }
-    } else { // Address
+    } else {  // Address
         const auto owner = DecodeDestination(userAddress);
         if (!IsValidDestination(owner)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner address");

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -457,10 +457,19 @@ UniValue getaccount(const JSONRPCRequest &request) {
         return *res;
     }
 
+    const auto userAddress = request.params[0].get_str();
+
     // decode owner
-    const auto owner = DecodeDestination(request.params[0].get_str());
+    auto owner = DecodeDestination(userAddress);
     if (!IsValidDestination(owner)) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner address");
+        if (IsHex(userAddress)) {
+            const auto hexVec = ParseHex(userAddress);
+            if (!ExtractDestination({hexVec.begin(), hexVec.end()}, owner) || !IsValidDestination(owner)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner address");
+            }
+        } else {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid owner address");
+        }
     }
     const auto reqOwner = GetScriptForDestination(owner);
 

--- a/test/functional/feature_accounts_validation.py
+++ b/test/functional/feature_accounts_validation.py
@@ -53,7 +53,7 @@ class AccountsValidatingTest(DefiTestFramework):
         assert_equal(node1.getaccount(account)[0], "10.00000000@DFI")
 
         # Check we can get the account from the scriptPubKey
-        script_pubkey = self.nodes[0].getaddressinfo(account)['scriptPubKey']
+        script_pubkey = self.nodes[0].getaddressinfo(account)["scriptPubKey"]
         assert_equal(node1.getaccount(script_pubkey)[0], "10.00000000@DFI")
 
         node.accounttoaccount(account, {destination: "1@DFI"})

--- a/test/functional/feature_accounts_validation.py
+++ b/test/functional/feature_accounts_validation.py
@@ -33,14 +33,28 @@ class AccountsValidatingTest(DefiTestFramework):
         node.generate(1)
         self.sync_blocks()
 
+        # Check empty account generates error
         assert_raises_rpc_error(
             -5,
             "Invalid owner address",
             self.nodes[0].getaccount,
             "",
         )
+
+        # Check nonsense account generates error
+        assert_raises_rpc_error(
+            -5,
+            "Invalid owner address",
+            self.nodes[0].getaccount,
+            "AAAAAAAAAA",
+        )
+
         # Check we have expected balance
         assert_equal(node1.getaccount(account)[0], "10.00000000@DFI")
+
+        # Check we can get the account from the scriptPubKey
+        script_pubkey = self.nodes[0].getaddressinfo(account)['scriptPubKey']
+        assert_equal(node1.getaccount(script_pubkey)[0], "10.00000000@DFI")
 
         node.accounttoaccount(account, {destination: "1@DFI"})
         node.accounttoutxos(account, {destination: "1@DFI"})


### PR DESCRIPTION
## Summary

- Fixes https://github.com/DeFiCh/ain/issues/2828
- getaccount accepts valid scriptPubKey as input
- Will still reject nonsense addresses if provided by the user.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
