### PR TITLE
Ocean: fix ocean api tx get

### DIFF
--- a/lib/ain-ocean/src/api/mod.rs
+++ b/lib/ain-ocean/src/api/mod.rs
@@ -14,6 +14,7 @@ mod masternode;
 // mod rawtx;
 mod cache;
 mod common;
+mod path;
 mod query;
 mod response;
 mod stats;

--- a/lib/ain-ocean/src/api/path.rs
+++ b/lib/ain-ocean/src/api/path.rs
@@ -1,0 +1,102 @@
+use axum::{
+  async_trait,
+  extract::{path::ErrorKind, rejection::PathRejection, FromRequestParts},
+  http::{request::Parts, StatusCode},
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::error::ApiError;
+
+// We define our own `Path` extractor that customizes the error from `axum::extract::Path`
+#[derive(Debug)]
+pub struct Path<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for Path<T>
+where
+    // these trait bounds are copied from `impl FromRequest for axum::extract::path::Path`
+    T: DeserializeOwned + Send,
+    S: Send + Sync,
+{
+  type Rejection = ApiError;
+
+  async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+    match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+      Ok(value) => Ok(Self(value.0)),
+      Err(rejection) => {
+        let error = match rejection {
+          PathRejection::FailedToDeserializePathParams(inner) => {
+            let kind = inner.into_kind();
+            let error = match &kind {
+              ErrorKind::WrongNumberOfParameters { .. } => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                kind.to_string(),
+                parts.uri.to_string(),
+              ),
+
+              ErrorKind::ParseErrorAtKey { key, .. } => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!("key: {key}, {kind}"),
+                parts.uri.to_string(),
+              ),
+
+              ErrorKind::ParseErrorAtIndex { index, .. } => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!("index: {index}, {kind}"),
+                parts.uri.to_string(),
+              ),
+
+              ErrorKind::ParseError { .. } => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                kind.to_string(),
+                parts.uri.to_string(),
+              ),
+
+              ErrorKind::InvalidUtf8InPathParam { key } => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!("key: {key}, {kind}"),
+                parts.uri.to_string(),
+              ),
+
+              ErrorKind::UnsupportedType { .. } => {
+                  // this error is caused by the programmer using an unsupported type
+                  // (such as nested maps) so respond with `500` instead
+                  ApiError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    kind.to_string(),
+                    parts.uri.to_string(),
+                  )
+              },
+
+              ErrorKind::Message(msg) => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                msg.clone(),
+                parts.uri.to_string(),
+              ),
+
+              _ => ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!("Unhandled deserialization error: {kind}"),
+                parts.uri.to_string(),
+              ),
+            };
+
+            error
+          },
+          PathRejection::MissingPathParams(error) => ApiError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            error.to_string(),
+            parts.uri.to_string(),
+          ),
+          _ => ApiError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Unhandled path rejection: {rejection}"),
+            parts.uri.to_string(),
+          ),
+        };
+
+        Err(error)
+      }
+    }
+  }
+}

--- a/lib/ain-ocean/src/api/path.rs
+++ b/lib/ain-ocean/src/api/path.rs
@@ -1,7 +1,7 @@
 use axum::{
-  async_trait,
-  extract::{path::ErrorKind, rejection::PathRejection, FromRequestParts},
-  http::{request::Parts, StatusCode},
+    async_trait,
+    extract::{path::ErrorKind, rejection::PathRejection, FromRequestParts},
+    http::{request::Parts, StatusCode},
 };
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -18,85 +18,85 @@ where
     T: DeserializeOwned + Send,
     S: Send + Sync,
 {
-  type Rejection = ApiError;
+    type Rejection = ApiError;
 
-  async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-    match axum::extract::Path::<T>::from_request_parts(parts, state).await {
-      Ok(value) => Ok(Self(value.0)),
-      Err(rejection) => {
-        let error = match rejection {
-          PathRejection::FailedToDeserializePathParams(inner) => {
-            let kind = inner.into_kind();
-            let error = match &kind {
-              ErrorKind::WrongNumberOfParameters { .. } => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                kind.to_string(),
-                parts.uri.to_string(),
-              ),
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+            Ok(value) => Ok(Self(value.0)),
+            Err(rejection) => {
+                let error = match rejection {
+                    PathRejection::FailedToDeserializePathParams(inner) => {
+                        let kind = inner.into_kind();
+                        let error = match &kind {
+                            ErrorKind::WrongNumberOfParameters { .. } => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                kind.to_string(),
+                                parts.uri.to_string(),
+                            ),
 
-              ErrorKind::ParseErrorAtKey { key, .. } => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                format!("key: {key}, {kind}"),
-                parts.uri.to_string(),
-              ),
+                            ErrorKind::ParseErrorAtKey { key, .. } => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                format!("key: {key}, {kind}"),
+                                parts.uri.to_string(),
+                            ),
 
-              ErrorKind::ParseErrorAtIndex { index, .. } => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                format!("index: {index}, {kind}"),
-                parts.uri.to_string(),
-              ),
+                            ErrorKind::ParseErrorAtIndex { index, .. } => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                format!("index: {index}, {kind}"),
+                                parts.uri.to_string(),
+                            ),
 
-              ErrorKind::ParseError { .. } => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                kind.to_string(),
-                parts.uri.to_string(),
-              ),
+                            ErrorKind::ParseError { .. } => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                kind.to_string(),
+                                parts.uri.to_string(),
+                            ),
 
-              ErrorKind::InvalidUtf8InPathParam { key } => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                format!("key: {key}, {kind}"),
-                parts.uri.to_string(),
-              ),
+                            ErrorKind::InvalidUtf8InPathParam { key } => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                format!("key: {key}, {kind}"),
+                                parts.uri.to_string(),
+                            ),
 
-              ErrorKind::UnsupportedType { .. } => {
-                  // this error is caused by the programmer using an unsupported type
-                  // (such as nested maps) so respond with `500` instead
-                  ApiError::new(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    kind.to_string(),
-                    parts.uri.to_string(),
-                  )
-              },
+                            ErrorKind::UnsupportedType { .. } => {
+                                // this error is caused by the programmer using an unsupported type
+                                // (such as nested maps) so respond with `500` instead
+                                ApiError::new(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    kind.to_string(),
+                                    parts.uri.to_string(),
+                                )
+                            }
 
-              ErrorKind::Message(msg) => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                msg.clone(),
-                parts.uri.to_string(),
-              ),
+                            ErrorKind::Message(msg) => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                msg.clone(),
+                                parts.uri.to_string(),
+                            ),
 
-              _ => ApiError::new(
-                StatusCode::BAD_REQUEST,
-                format!("Unhandled deserialization error: {kind}"),
-                parts.uri.to_string(),
-              ),
-            };
+                            _ => ApiError::new(
+                                StatusCode::BAD_REQUEST,
+                                format!("Unhandled deserialization error: {kind}"),
+                                parts.uri.to_string(),
+                            ),
+                        };
 
-            error
-          },
-          PathRejection::MissingPathParams(error) => ApiError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            error.to_string(),
-            parts.uri.to_string(),
-          ),
-          _ => ApiError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unhandled path rejection: {rejection}"),
-            parts.uri.to_string(),
-          ),
-        };
+                        error
+                    }
+                    PathRejection::MissingPathParams(error) => ApiError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        error.to_string(),
+                        parts.uri.to_string(),
+                    ),
+                    _ => ApiError::new(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Unhandled path rejection: {rejection}"),
+                        parts.uri.to_string(),
+                    ),
+                };
 
-        Err(error)
-      }
+                Err(error)
+            }
+        }
     }
-  }
 }

--- a/lib/ain-ocean/src/api/transactions.rs
+++ b/lib/ain-ocean/src/api/transactions.rs
@@ -1,11 +1,7 @@
 use std::sync::Arc;
 
 use ain_macros::ocean_endpoint;
-use axum::{
-    extract::Query,
-    routing::get,
-    Extension, Router,
-};
+use axum::{extract::Query, routing::get, Extension, Router};
 use bitcoin::Txid;
 use serde::Deserialize;
 

--- a/lib/ain-ocean/src/api/transactions.rs
+++ b/lib/ain-ocean/src/api/transactions.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use ain_macros::ocean_endpoint;
 use axum::{
-    extract::{Path, Query},
+    extract::Query,
     routing::get,
-    Extension, Json, Router,
+    Extension, Router,
 };
 use bitcoin::Txid;
 use serde::Deserialize;
 
-use super::{query::PaginationQuery, response::ApiPagedResponse, AppContext};
+use super::{path::Path, query::PaginationQuery, response::ApiPagedResponse, AppContext};
 use crate::{
     api::response::Response,
     error::ApiError,

--- a/lib/ain-ocean/src/indexer/transaction.rs
+++ b/lib/ain-ocean/src/indexer/transaction.rs
@@ -60,6 +60,7 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
 
     let tx = TransactionMapper {
         id: txid,
+        txid,
         order,
         hash: ctx.tx.hash.clone(),
         block: ctx.block.clone(),

--- a/lib/ain-ocean/src/model/transaction.rs
+++ b/lib/ain-ocean/src/model/transaction.rs
@@ -1,21 +1,24 @@
 use bitcoin::{BlockHash, Txid};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 use super::BlockContext;
 
 pub type TransactionByBlockHashKey = (BlockHash, usize);
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
-    pub id: Txid,
-    pub order: usize,
+    pub id: Txid, // unique id of the transaction, same as the txid
+    pub order: usize, // tx order
     pub block: BlockContext,
     pub hash: String,
     pub version: u32,
     pub size: u64,
     pub v_size: u64,
     pub weight: u64,
+    #[serde_as(as = "DisplayFromStr")]
     pub total_vout_value: f64,
     pub lock_time: u64,
     pub vin_count: usize,

--- a/lib/ain-ocean/src/model/transaction.rs
+++ b/lib/ain-ocean/src/model/transaction.rs
@@ -11,6 +11,7 @@ pub type TransactionByBlockHashKey = (BlockHash, usize);
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     pub id: Txid, // unique id of the transaction, same as the txid
+    pub txid: Txid,
     pub order: usize, // tx order
     pub block: BlockContext,
     pub hash: String,


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

as per title 

- [x] float -> string: fixed by serde_with DisplayFromStr
- [x] missing txid on struct Transaction
- [x] customize-path-rejection

```sh
get
    ✓ should get a single transaction (3 ms)
    ✓ should fail due to non-existent transaction (2 ms)
```
