### PR TITLE
Ocean: CLI indexer  

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.12",
@@ -216,7 +216,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "syn 2.0.50",
+ "syn 2.0.52",
  "tokio",
  "tonic",
  "tonic-build",
@@ -230,7 +230,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -247,7 +247,9 @@ dependencies = [
  "bitcoin",
  "cached",
  "chrono",
+ "clap 4.5.1",
  "defichain-rpc",
+ "env_logger",
  "futures",
  "hex",
  "hyper 0.14.28",
@@ -257,6 +259,7 @@ dependencies = [
  "keccak-hash",
  "lazy_static",
  "log",
+ "num_cpus",
  "rocksdb",
  "rust_decimal",
  "rust_decimal_macros",
@@ -340,6 +343,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,7 +462,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -427,13 +478,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -552,7 +603,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -655,7 +706,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -816,7 +867,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "syn_derive",
 ]
 
@@ -861,9 +912,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "serde",
@@ -957,7 +1008,7 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355face540df58778b96814c48abb3c2ed67c4878a8087ab1819c1fedeec505f"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "async-trait",
  "cached_proc_macro",
  "cached_proc_macro_types",
@@ -989,10 +1040,11 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1029,7 +1081,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1069,6 +1121,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,10 +1171,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.11.0"
+name = "colorchoice"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d59688ad0945eaf6b84cb44fedbe93484c81b48970e98f09db8a22832d7961"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "const-hex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd12d49ab0eaf8193ba9175e45f56bbc2e4b27d57b8cfe62aa47942a46b9a9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1262,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15f3b597018782655a05d417f28bac009f6eb60f4b6703eb818998c1aaa16a"
+checksum = "2673ca5ae28334544ec2a6b18ebe666c42a2650abfb48abbd532ed409a44be2b"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1274,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81699747d109bba60bd6f87e7cb24b626824b8427b32f199b95c7faa06ee3dc9"
+checksum = "9df46fe0eb43066a332586114174c449a62c25689f85a08f28fdcc8e12c380b9"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1284,36 +1382,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cxx-gen"
-version = "0.7.117"
+version = "0.7.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b629c0d006c7e44c1444dd17d18a458c9390d32276b758ac7abd21a75c99b0"
+checksum = "a94f02b4e45d7d00ecabff7635833f71c786576067b3d4158c8bef65d0a8e38b"
 dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7eb4c4fd18505f5a935f9c2ee77780350dcdb56da7cd037634e806141c5c43"
+checksum = "886acf875df67811c11cd015506b3392b9e1820b1627af1a6f4e93ccdfc74d11"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d914fcc6452d133236ee067a9538be25ba6a644a450e1a6c617da84bf029854"
+checksum = "1d151cc139c3080e07f448f93a1284577ab2283d2a44acd902c6fba9ec20b6de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1328,12 +1426,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5d17510e4a1a87f323de70b7b1eaac1ee0e37866c6720b2d279452d0edf389"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.7",
- "darling_macro 0.20.7",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -1352,16 +1450,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98eea36a7ff910fa751413d0895551143a8ea41d695d9798ec7d665df7f7f5e"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1377,19 +1475,19 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a366a3f90c5d59a4b91169775f88e52e8f71a0e7804cc98a8db2932cf4ed57"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.7",
+ "darling_core 0.20.8",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "defichain-rpc"
 version = "0.18.0"
-source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#b69ac6600113d7869b1311381237de0b41debddc"
+source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#fab7f5f9d38fe225b072087d621e8f0bf11706de"
 dependencies = [
  "async-trait",
  "defichain-rpc-json",
@@ -1402,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#b69ac6600113d7869b1311381237de0b41debddc"
+source = "git+https://github.com/Jouzo/rust-defichain-rpc.git#fab7f5f9d38fe225b072087d621e8f0bf11706de"
 dependencies = [
  "bitcoin",
  "serde",
@@ -1446,12 +1544,6 @@ name = "deunicode"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1554,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -2048,7 +2140,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2164,7 +2256,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -2191,7 +2283,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2210,7 +2302,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.0.0",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2253,7 +2345,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -2262,7 +2354,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -2292,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2628,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2661,7 +2753,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2688,7 +2780,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2716,6 +2808,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2983,31 +3084,33 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
  "bit-set",
- "diff",
  "ena",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "string_cache",
  "term",
  "tiny-keccak",
  "unicode-xid",
+ "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.6",
+]
 
 [[package]]
 name = "lazy_static"
@@ -3032,12 +3135,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "2caa5afb8bf9f3a2652760ce7d4f62d21c4d5a423e68466fca30df82f2330164"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3164,15 +3267,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -3314,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -3478,7 +3581,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -3500,7 +3603,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3538,9 +3641,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-fastrlp"
@@ -3692,7 +3795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -3725,7 +3828,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3763,7 +3866,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3829,7 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4139,9 +4242,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -4203,7 +4306,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4214,7 +4317,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -4229,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4243,12 +4346,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -4624,7 +4721,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -4801,7 +4898,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4847,7 +4944,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4861,10 +4958,10 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
- "darling 0.20.7",
+ "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4877,7 +4974,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -4913,7 +5010,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -5019,12 +5116,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5125,7 +5222,7 @@ checksum = "f12dae7cf6c1e825d13ffd4ce16bd9309db7c539929d0302b4443ed451a9f4e5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5219,7 +5316,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5283,7 +5380,7 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf63ea90ffb5d61048d8fb2fac669114dac198fc2739e913e615f0fd2c36c3e7"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "hash-db 0.16.0",
  "hashbrown 0.13.2",
  "lazy_static",
@@ -5406,12 +5503,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -5448,7 +5551,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5516,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5534,7 +5637,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5588,9 +5691,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -5644,7 +5747,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5777,7 +5880,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5828,7 +5931,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -5839,7 +5942,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -5967,7 +6070,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6163,6 +6266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6268,9 +6377,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -6318,7 +6427,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -6352,7 +6461,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6580,7 +6689,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6607,7 +6716,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6642,17 +6751,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -6669,9 +6778,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6687,9 +6796,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6705,9 +6814,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6723,9 +6832,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6741,9 +6850,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6759,9 +6868,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6777,9 +6886,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -6832,7 +6941,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6852,7 +6961,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/lib/ain-db/src/lib.rs
+++ b/lib/ain-db/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 pub type Result<T> = result::Result<T, DBError>;
 
-fn get_db_options() -> Options {
+fn get_db_default_options() -> Options {
     let mut options = Options::default();
     options.create_if_missing(true);
     options.create_missing_column_families(true);
@@ -48,12 +48,12 @@ fn get_db_options() -> Options {
 pub struct Rocks(DB);
 
 impl Rocks {
-    pub fn open(path: &PathBuf, cf_names: &[&'static str]) -> Result<Self> {
+    pub fn open(path: &PathBuf, cf_names: &[&'static str], opts: Option<Options>) -> Result<Self> {
         let cf_descriptors = cf_names
             .iter()
             .map(|cf_name| ColumnFamilyDescriptor::new(*cf_name, Options::default()));
 
-        let db_opts = get_db_options();
+        let db_opts = opts.unwrap_or_else(get_db_default_options);
         let db = DB::open_cf_descriptors(&db_opts, path, cf_descriptors)?;
 
         Ok(Self(db))

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -26,7 +26,7 @@ impl BlockStore {
     pub fn new(path: &Path) -> Result<Self> {
         let path = path.join("indexes");
         fs::create_dir_all(&path)?;
-        let backend = Arc::new(Rocks::open(&path, &COLUMN_NAMES)?);
+        let backend = Arc::new(Rocks::open(&path, &COLUMN_NAMES, None)?);
 
         Ok(Self(backend))
     }

--- a/lib/ain-grpc/src/lib.rs
+++ b/lib/ain-grpc/src/lib.rs
@@ -127,8 +127,9 @@ pub async fn init_ocean_server(addr: String) -> Result<()> {
         )
         .await?,
     );
+    let network = ain_cpp_imports::get_network();
 
-    let ocean_router = ain_ocean::ocean_router(&OCEAN_SERVICES, client).await?;
+    let ocean_router = ain_ocean::ocean_router(&*OCEAN_SERVICES, client, network).await?;
 
     let server_handle = runtime.tokio_runtime.spawn(async move {
         if let Err(e) = axum::serve(listener, ocean_router).await {

--- a/lib/ain-ocean/Cargo.toml
+++ b/lib/ain-ocean/Cargo.toml
@@ -35,8 +35,11 @@ bincode.workspace = true
 defichain-rpc.workspace = true
 jsonrpc-async = "2.0.2"
 serde_urlencoded = "0.7"
+env_logger.workspace = true
 rust_decimal = { version = "1.34", features = ["serde", "serde-float", "serde-with-str"] }
 rust_decimal_macros = "1.34"
+clap = { version = "4.5.0", features = ["derive"] }
+num_cpus.workspace = true
 
 [dev-dependencies]
 tempdir.workspace = true

--- a/lib/ain-ocean/src/api/mod.rs
+++ b/lib/ain-ocean/src/api/mod.rs
@@ -52,18 +52,22 @@ async fn not_found(req: Request<axum::body::Body>) -> impl IntoResponse {
 pub struct AppContext {
     services: Arc<Services>,
     client: Arc<Client>,
+    network: String, // TODO Proper handling of network
 }
 
-pub async fn ocean_router(services: &Arc<Services>, client: Arc<Client>) -> Result<Router> {
+pub async fn ocean_router(
+    services: &Arc<Services>,
+    client: Arc<Client>,
+    network: String,
+) -> Result<Router> {
     let context = Arc::new(AppContext {
         client,
         services: services.clone(),
+        network,
     });
 
-    let network = ain_cpp_imports::get_network();
-
     Ok(Router::new().nest(
-        format!("/v0/{network}").as_str(),
+        format!("/v0/{}", context.network).as_str(),
         Router::new()
             // .nest("/address/", address::router(Arc::clone(&context)))
             .nest("/governance", governance::router(Arc::clone(&context)))

--- a/lib/ain-ocean/src/api/stats/cache.rs
+++ b/lib/ain-ocean/src/api/stats/cache.rs
@@ -116,11 +116,13 @@ lazy_static::lazy_static! {
     key = "String",
     convert = r#"{ format!("burned_total") }"#
 )]
-pub async fn get_burned_total(client: &Client) -> Result<Decimal> {
-    let network = ain_cpp_imports::get_network();
-    let burn_address = BURN_ADDRESS.get(network.as_str()).unwrap();
-    let mut tokens = client.get_account(burn_address, None, Some(true)).await?;
-    let burn_info = client.get_burn_info().await?;
+pub async fn get_burned_total(ctx: &AppContext) -> Result<Decimal> {
+    let burn_address = BURN_ADDRESS.get(ctx.network.as_str()).unwrap();
+    let mut tokens = ctx
+        .client
+        .get_account(&burn_address, None, Some(true))
+        .await?;
+    let burn_info = ctx.client.get_burn_info().await?;
 
     let utxo = Decimal::from_f64(burn_info.amount).ok_or(Error::DecimalError)?;
     let emission = Decimal::from_f64(burn_info.emissionburn).ok_or(Error::DecimalError)?;

--- a/lib/ain-ocean/src/api/stats/mod.rs
+++ b/lib/ain-ocean/src/api/stats/mod.rs
@@ -164,7 +164,7 @@ async fn get_supply(Extension(ctx): Extension<Arc<AppContext>>) -> Result<Respon
     let total =
         Decimal::from_u64(BLOCK_SUBSIDY.get_supply(height)).ok_or(Error::DecimalError)? / COIN;
 
-    let burned = get_burned_total(&ctx.client).await?;
+    let burned = get_burned_total(&ctx).await?;
     let circulating = total - burned;
 
     let supply = SupplyData {

--- a/lib/ain-ocean/src/bin/cli.rs
+++ b/lib/ain-ocean/src/bin/cli.rs
@@ -1,0 +1,111 @@
+use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Instant};
+
+use ain_ocean::{index_block, storage::ocean_store::OceanStore, Result, Services};
+use clap::Parser;
+use defichain_rpc::{json::blockchain::*, Auth, BlockchainRPC, Client};
+use env_logger;
+
+#[derive(Parser, Debug)]
+#[command(
+    author = "Defichain Labs <engineering@defichain.com>",
+    version = "0.1",
+    about = "Runs the Ocean Node Service"
+)]
+struct Cli {
+    /// Sets a custom data directory
+    #[arg(long, value_name = "DATADIR")]
+    datadir: PathBuf,
+
+    /// Sets the RPC server address
+    #[arg(long, value_name = "RPCADDRESS")]
+    rpcaddress: String,
+
+    /// Sets the RPC username
+    #[arg(long, value_name = "USERNAME")]
+    user: String,
+
+    /// Sets the RPC password
+    #[arg(long, value_name = "PASSWORD")]
+    pass: String,
+    /// Sets the bind address for the TCP listener
+    #[arg(long, value_name = "BINDADDRESS", default_value = "0.0.0.0:3002")]
+    bind_address: SocketAddr,
+    /// Sets the benchmark frequency
+    #[arg(long, value_name = "BENCHFREQUENCY", default_value = "10000")]
+    bench_frequency: u32,
+
+    /// Sets Ocean network
+    #[arg(long, value_name = "NETWORK", default_value = "mainnet")]
+    network: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    let store = Arc::new(OceanStore::new(&cli.datadir)?);
+
+    let client = Arc::new(Client::new(&cli.rpcaddress, Auth::UserPass(cli.user, cli.pass)).await?);
+
+    let services = Arc::new(Services::new(store));
+
+    let listener = tokio::net::TcpListener::bind(cli.bind_address).await?;
+    let ocean_router = ain_ocean::ocean_router(&services, client.clone(), cli.network).await?;
+    tokio::spawn(async move { axum::serve(listener, ocean_router).await.unwrap() });
+
+    let mut indexed_block = 0;
+    let mut next_block_hash = None;
+    let mut start_time = Instant::now();
+
+    loop {
+        let highest_block = services
+            .block
+            .by_height
+            .get_highest()?
+            .map_or(0, |b| b.height);
+
+        let new_height = highest_block + 1;
+        let hash = if let Some(hash) = next_block_hash {
+            hash
+        } else {
+            match client.get_block_hash(new_height).await {
+                Ok(hash) => hash,
+                Err(e) => {
+                    println!("e : {:?}", e);
+                    // Out of range, sleep for 10s
+                    std::thread::sleep(std::time::Duration::from_millis(10000));
+                    continue;
+                }
+            }
+        };
+
+        let block = match client.get_block(hash, 2).await {
+            Err(e) => {
+                println!("e : {:?}", e);
+                // Error getting block, sleep for 30s
+                std::thread::sleep(std::time::Duration::from_millis(30000));
+                continue;
+            }
+            Ok(GetBlockResult::Full(block)) => block,
+            Ok(_) => return Err("Error deserializing block".into()),
+        };
+
+        next_block_hash = block.nextblockhash;
+        match index_block(&services, block) {
+            Ok(_) => (),
+            Err(e) => {
+                return Err(e);
+            }
+        }
+
+        indexed_block += 1;
+        if indexed_block % cli.bench_frequency == 0 {
+            let elapsed = start_time.elapsed();
+            println!("Processed {} blocks in {:?}", cli.bench_frequency, elapsed);
+            start_time = Instant::now();
+        }
+    }
+
+    Ok(())
+}

--- a/lib/ain-ocean/src/indexer/auction.rs
+++ b/lib/ain-ocean/src/indexer/auction.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 impl Index for PlaceAuctionBid {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[PlaceAuctionBid] Indexing...");
 
         let auction = VaultAuctionBatchHistory {
@@ -21,7 +21,7 @@ impl Index for PlaceAuctionBid {
             sort: format!("{}-{}", ctx.block.height, ctx.tx_idx),
             vault_id: self.vault_id,
             index: ctx.tx_idx,
-            from: self.from.clone(),
+            from: self.from,
             amount: self.token_amount.amount,
             token_id: self.token_amount.token.0,
             block: ctx.block.clone(),

--- a/lib/ain-ocean/src/indexer/masternode.rs
+++ b/lib/ain-ocean/src/indexer/masternode.rs
@@ -25,7 +25,7 @@ fn get_operator_script(hash: &PubkeyHash, r#type: u8) -> Result<ScriptBuf> {
 }
 
 impl Index for CreateMasternode {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[CreateMasternode] Indexing...");
         let txid = ctx.tx.txid;
         let Some(ref addresses) = ctx.tx.vout[1].script_pub_key.addresses else {
@@ -54,7 +54,7 @@ impl Index for CreateMasternode {
             .by_height
             .put(&(ctx.block.height, txid), &0)?;
 
-        index_stats(self, services, ctx, collateral)
+        index_stats(&self, services, ctx, collateral)
     }
 
     fn invalidate(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
@@ -103,7 +103,7 @@ fn index_stats(
 }
 
 impl Index for UpdateMasternode {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[UpdateMasternode] Indexing...");
         if let Some(mut mn) = services.masternode.by_id.get(&self.node_id)? {
             mn.history.push(HistoryItem {
@@ -149,7 +149,7 @@ impl Index for UpdateMasternode {
 }
 
 impl Index for ResignMasternode {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[ResignMasternode] Indexing...");
         if let Some(mn) = services.masternode.by_id.get(&self.node_id)? {
             services.masternode.by_id.put(

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 pub(crate) trait Index {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()>;
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()>;
 
     fn invalidate(&self, services: &Arc<Services>, ctx: &Context) -> Result<()>;
 }
@@ -73,7 +73,7 @@ pub fn index_block(services: &Arc<Services>, block: Block<Transaction>) -> Resul
                 }
                 Err(e) => return Err(e.into()),
                 Ok(Stack { dftx, .. }) => {
-                    match &dftx {
+                    match dftx {
                         DfTx::CreateMasternode(data) => data.index(services, &ctx)?,
                         DfTx::UpdateMasternode(data) => data.index(services, &ctx)?,
                         DfTx::ResignMasternode(data) => data.index(services, &ctx)?,

--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 impl Index for AppointOracle {
-    fn index(&self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
+    fn index(self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
         todo!()
     }
 
@@ -19,7 +19,7 @@ impl Index for AppointOracle {
 }
 
 impl Index for RemoveOracle {
-    fn index(&self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
+    fn index(self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
         todo!()
     }
 
@@ -29,7 +29,7 @@ impl Index for RemoveOracle {
 }
 
 impl Index for UpdateOracle {
-    fn index(&self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
+    fn index(self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
         todo!()
     }
 
@@ -39,7 +39,7 @@ impl Index for UpdateOracle {
 }
 
 impl Index for SetOracleData {
-    fn index(&self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
+    fn index(self, _services: &Arc<Services>, _ctx: &Context) -> Result<()> {
         todo!()
     }
 

--- a/lib/ain-ocean/src/indexer/pool.rs
+++ b/lib/ain-ocean/src/indexer/pool.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use anyhow::format_err;
+use bitcoin::Address;
 use ain_dftx::pool::*;
 use log::debug;
 
@@ -12,16 +14,21 @@ use crate::{
 };
 
 impl Index for PoolSwap {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[Poolswap] Indexing...");
         let txid = ctx.tx.txid;
         let idx = ctx.tx_idx;
         let Some(TxResult::PoolSwap(PoolSwapResult { to_amount, pool_id })) =
             services.result.get(&txid)?
         else {
+            let address = Address::from_script(&self.to_script, bitcoin::Network::Bitcoin)
+                .map_err(|e| format_err!("Error getting address from script: {e}"));
             debug!("Missing swap result for {}", ctx.tx.txid.to_string());
             return Err("Missing swap result".into());
         };
+
+        let from = self.from_script;
+        let to = self.to_script;
 
         let swap = model::PoolSwap {
             id: format!("{}-{}", pool_id, txid),
@@ -33,8 +40,8 @@ impl Index for PoolSwap {
             to_token_id: self.to_token_id.0,
             to_amount,
             pool_id,
-            from: self.from_script.clone(),
-            to: self.to_script.clone(),
+            from,
+            to,
             block: ctx.block.clone(),
         };
         debug!("swap : {:?}", swap);
@@ -62,16 +69,21 @@ impl Index for PoolSwap {
 }
 
 impl Index for CompositeSwap {
-    fn index(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+    fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[CompositeSwap] Indexing...");
         let txid = ctx.tx.txid;
         let Some(TxResult::PoolSwap(PoolSwapResult { to_amount, .. })) =
             services.result.get(&txid)?
         else {
+            let address =
+                Address::from_script(&self.pool_swap.to_script, bitcoin::Network::Bitcoin)
+                    .map_err(|e| format_err!("Error getting address from script: {e}"));
             debug!("Missing swap result for {}", txid.to_string());
             return Err("Missing swap result".into());
         };
 
+        let from = self.pool_swap.from_script;
+        let to = self.pool_swap.to_script;
         for pool in self.pools.as_ref() {
             let pool_id = pool.id.0 as u32;
             let swap = model::PoolSwap {
@@ -84,11 +96,10 @@ impl Index for CompositeSwap {
                 to_token_id: self.pool_swap.to_token_id.0,
                 to_amount,
                 pool_id,
-                from: self.pool_swap.from_script.clone(),
-                to: self.pool_swap.to_script.clone(),
+                from: from.clone(),
+                to: to.clone(),
                 block: ctx.block.clone(),
             };
-            debug!("swap : {:?}", swap);
             services
                 .pool
                 .by_id

--- a/lib/ain-ocean/src/indexer/transaction.rs
+++ b/lib/ain-ocean/src/indexer/transaction.rs
@@ -66,7 +66,7 @@ pub fn index_transaction(services: &Arc<Services>, ctx: Context) -> Result<()> {
     let tx = TransactionMapper {
         id: txid,
         order,
-        hash: ctx.tx.hash.clone(),
+        hash: ctx.tx.hash,
         block: ctx.block.clone(),
         version: ctx.tx.version,
         size: ctx.tx.size,

--- a/lib/ain-ocean/src/storage/ocean_store.rs
+++ b/lib/ain-ocean/src/storage/ocean_store.rs
@@ -12,7 +12,7 @@ impl OceanStore {
     pub fn new(path: &Path) -> Result<Self> {
         let path = path.join("ocean");
         fs::create_dir_all(&path)?;
-        let backend = Arc::new(Rocks::open(&path, &COLUMN_NAMES)?);
+        let backend = Arc::new(Rocks::open(&path, &COLUMN_NAMES, None)?);
 
         Ok(Self(backend))
     }


### PR DESCRIPTION
- Adds standalone CLI to index Ocean against a running defid node at `RPCADDRESS`
- Runs both the indexer and the axum server at `BINDADDRESS`

Not meant as production ready tool but useful for further developement and debugging.

Usage:
```
cargo run
  --datadir <DATADIR>
  --rpcaddress <RPCADDRESS>
  --user <USERNAME>
  --pass <PASSWORD>

Usage: cli --datadir <DATADIR> --rpcaddress <RPCADDRESS> --user <USERNAME> --pass <PASSWORD>

For more information, try '--help'.
```