### PR TITLE
Make vault fee settable via Gov vars

### DIFF
--- a/src/dfi/consensus/vaults.cpp
+++ b/src/dfi/consensus/vaults.cpp
@@ -48,7 +48,7 @@ Res CVaultsConsensus::operator()(const CVaultMessage &obj) const {
     auto vaultId = tx.GetHash();
 
     if (height >= consensus.DF23Height) {
-        if (!mnview.SetVaultHeightAndFee(vaultId, height, vaultCreationFee)) {
+        if (!mnview.SetVaultCreationFee(vaultId, vaultCreationFee)) {
             return Res::Err("Failed to set vault height and fee");
         }
     }
@@ -121,13 +121,13 @@ Res CVaultsConsensus::operator()(const CCloseVaultMessage &obj) const {
     }
 
     // return half fee, the rest is burned at creation
-    const auto vaultCreationFee = mnview.GetVaultHeightAndFee(obj.vaultId);
-    auto feeBack = vaultCreationFee ? vaultCreationFee->creationFee / 2 : consensus.vaultCreationFee / 2;
+    const auto vaultCreationFee = mnview.GetVaultCreationFee(obj.vaultId);
+    auto feeBack = vaultCreationFee ? *vaultCreationFee / 2 : consensus.vaultCreationFee / 2;
     if (auto res = mnview.AddBalance(obj.to, {DCT_ID{0}, feeBack}); !res) {
         return res;
     }
 
-    if (vaultCreationFee && !mnview.EraseVaultHeightAndFee(obj.vaultId)) {
+    if (vaultCreationFee && !mnview.EraseVaultCreationFee(obj.vaultId)) {
         return Res::Err("Failed to erase vault height and fee");
     }
 

--- a/src/dfi/consensus/vaults.cpp
+++ b/src/dfi/consensus/vaults.cpp
@@ -127,7 +127,7 @@ Res CVaultsConsensus::operator()(const CCloseVaultMessage &obj) const {
         return res;
     }
 
-    if (!mnview.EraseVaultHeightAndFee(obj.vaultId)) {
+    if (vaultCreationFee && !mnview.EraseVaultHeightAndFee(obj.vaultId)) {
         return Res::Err("Failed to erase vault height and fee");
     }
 

--- a/src/dfi/consensus/vaults.cpp
+++ b/src/dfi/consensus/vaults.cpp
@@ -14,8 +14,11 @@ Res CVaultsConsensus::operator()(const CVaultMessage &obj) const {
     const auto &consensus = txCtx.GetConsensus();
     const auto &tx = txCtx.GetTransaction();
     auto &mnview = blockCtx.GetView();
+    auto &height = blockCtx.GetHeight();
+    auto attributes = mnview.GetAttributes();
 
-    auto vaultCreationFee = consensus.vaultCreationFee;
+    const CDataStructureV0 creationFeeKey{AttributeTypes::Vaults, VaultIDs::Parameters, VaultKeys::CreationFee};
+    const auto vaultCreationFee = attributes->GetValue(creationFeeKey, consensus.vaultCreationFee);
     if (tx.vout[0].nValue != vaultCreationFee || tx.vout[0].nTokenId != DCT_ID{0}) {
         return Res::Err("Malformed tx vouts, creation vault fee is %s DFI", GetDecimalString(vaultCreationFee));
     }
@@ -38,12 +41,18 @@ Res CVaultsConsensus::operator()(const CVaultMessage &obj) const {
     }
 
     // check loan scheme is not to be destroyed
-    auto height = mnview.GetDestroyLoanScheme(obj.schemeId);
-    if (height) {
-        return Res::Err("Cannot set %s as loan scheme, set to be destroyed on block %d", obj.schemeId, *height);
+    if (auto schemeHeight = mnview.GetDestroyLoanScheme(obj.schemeId); schemeHeight) {
+        return Res::Err("Cannot set %s as loan scheme, set to be destroyed on block %d", obj.schemeId, *schemeHeight);
     }
 
     auto vaultId = tx.GetHash();
+
+    if (height >= consensus.DF23Height) {
+        if (!mnview.SetVaultHeightAndFee(vaultId, height, vaultCreationFee)) {
+            return Res::Err("Failed to set vault height and fee");
+        }
+    }
+
     return mnview.StoreVault(vaultId, vault);
 }
 
@@ -112,10 +121,16 @@ Res CVaultsConsensus::operator()(const CCloseVaultMessage &obj) const {
     }
 
     // return half fee, the rest is burned at creation
-    auto feeBack = consensus.vaultCreationFee / 2;
+    const auto vaultCreationFee = mnview.GetVaultHeightAndFee(obj.vaultId);
+    auto feeBack = vaultCreationFee ? vaultCreationFee->creationFee / 2 : consensus.vaultCreationFee / 2;
     if (auto res = mnview.AddBalance(obj.to, {DCT_ID{0}, feeBack}); !res) {
         return res;
     }
+
+    if (!mnview.EraseVaultHeightAndFee(obj.vaultId)) {
+        return Res::Err("Failed to erase vault height and fee");
+    }
+
     return mnview.EraseVault(obj.vaultId);
 }
 

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -72,6 +72,7 @@ enum TransferIDs : uint8_t {
 
 enum VaultIDs : uint8_t {
     DUSDVault = 'a',
+    Parameters = 'b',
 };
 
 enum RulesIDs : uint8_t {
@@ -174,6 +175,7 @@ enum TransferKeys : uint8_t {
 };
 
 enum VaultKeys : uint8_t {
+    CreationFee = 'a',
     DUSDVaultEnabled = 'w',
 };
 

--- a/src/dfi/vault.cpp
+++ b/src/dfi/vault.cpp
@@ -21,6 +21,18 @@ Res CVaultView::StoreVault(const CVaultId &vaultId, const CVaultData &vault) {
     return Res::Ok();
 }
 
+bool CVaultView::SetVaultHeightAndFee(const CVaultId &vaultId, const uint32_t height, const CAmount creationFee) {
+    return WriteBy<HeightAndFeeKey>(vaultId, CHeightAndFeeValue{height, creationFee});
+}
+
+std::optional<CHeightAndFeeValue> CVaultView::GetVaultHeightAndFee(const CVaultId &vaultId) {
+    return ReadBy<HeightAndFeeKey, CHeightAndFeeValue>(vaultId);
+}
+
+bool CVaultView::EraseVaultHeightAndFee(const CVaultId &vaultId) {
+    return EraseBy<HeightAndFeeKey>(vaultId);
+}
+
 Res CVaultView::EraseVault(const CVaultId &vaultId) {
     auto vault = GetVault(vaultId);
     if (!vault) {

--- a/src/dfi/vault.cpp
+++ b/src/dfi/vault.cpp
@@ -21,15 +21,15 @@ Res CVaultView::StoreVault(const CVaultId &vaultId, const CVaultData &vault) {
     return Res::Ok();
 }
 
-bool CVaultView::SetVaultHeightAndFee(const CVaultId &vaultId, const uint32_t height, const CAmount creationFee) {
-    return WriteBy<HeightAndFeeKey>(vaultId, CHeightAndFeeValue{height, creationFee});
+bool CVaultView::SetVaultCreationFee(const CVaultId &vaultId, const CAmount creationFee) {
+    return WriteBy<HeightAndFeeKey>(vaultId, creationFee);
 }
 
-std::optional<CHeightAndFeeValue> CVaultView::GetVaultHeightAndFee(const CVaultId &vaultId) {
-    return ReadBy<HeightAndFeeKey, CHeightAndFeeValue>(vaultId);
+std::optional<CAmount> CVaultView::GetVaultCreationFee(const CVaultId &vaultId) {
+    return ReadBy<HeightAndFeeKey, CAmount>(vaultId);
 }
 
-bool CVaultView::EraseVaultHeightAndFee(const CVaultId &vaultId) {
+bool CVaultView::EraseVaultCreationFee(const CVaultId &vaultId) {
     return EraseBy<HeightAndFeeKey>(vaultId);
 }
 

--- a/src/dfi/vault.h
+++ b/src/dfi/vault.h
@@ -141,19 +141,6 @@ struct CAuctionBatch {
     }
 };
 
-struct CHeightAndFeeValue {
-    uint32_t height;
-    CAmount creationFee;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action) {
-        READWRITE(height);
-        READWRITE(creationFee);
-    }
-};
-
 class CVaultView : public virtual CStorageView {
 public:
     using COwnerTokenAmount = std::pair<CScript, CTokenAmount>;
@@ -167,9 +154,9 @@ public:
                       const CVaultId &start = {},
                       const CScript &ownerAddress = {});
 
-    bool SetVaultHeightAndFee(const CVaultId &vaultId, const uint32_t height, const CAmount creationFee);
-    std::optional<CHeightAndFeeValue> GetVaultHeightAndFee(const CVaultId &vaultId);
-    bool EraseVaultHeightAndFee(const CVaultId &vaultId);
+    bool SetVaultCreationFee(const CVaultId &vaultId, const CAmount creationFee);
+    std::optional<CAmount> GetVaultCreationFee(const CVaultId &vaultId);
+    bool EraseVaultCreationFee(const CVaultId &vaultId);
 
     virtual Res AddVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);
     virtual Res SubVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);

--- a/src/dfi/vault.h
+++ b/src/dfi/vault.h
@@ -141,6 +141,19 @@ struct CAuctionBatch {
     }
 };
 
+struct CHeightAndFeeValue {
+    uint32_t height;
+    CAmount creationFee;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(height);
+        READWRITE(creationFee);
+    }
+};
+
 class CVaultView : public virtual CStorageView {
 public:
     using COwnerTokenAmount = std::pair<CScript, CTokenAmount>;
@@ -153,6 +166,10 @@ public:
     void ForEachVault(std::function<bool(const CVaultId &, const CVaultData &)> callback,
                       const CVaultId &start = {},
                       const CScript &ownerAddress = {});
+
+    bool SetVaultHeightAndFee(const CVaultId &vaultId, const uint32_t height, const CAmount creationFee);
+    std::optional<CHeightAndFeeValue> GetVaultHeightAndFee(const CVaultId &vaultId);
+    bool EraseVaultHeightAndFee(const CVaultId &vaultId);
 
     virtual Res AddVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);
     virtual Res SubVaultCollateral(const CVaultId &vaultId, CTokenAmount amount);
@@ -192,6 +209,10 @@ public:
     };
     struct AuctionBidKey {
         static constexpr uint8_t prefix() { return 0x25; }
+    };
+
+    struct HeightAndFeeKey {
+        static constexpr uint8_t prefix() { return 0x26; }
     };
 };
 

--- a/test/functional/feature_vault_creation_fee.py
+++ b/test/functional/feature_vault_creation_fee.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test vault creation fee"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+from decimal import Decimal
+
+
+class VaultCreationFeeTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            [
+                "-txnotokens=0",
+                "-txindex=1",
+                "-subsidytest=1",
+                "-amkheight=1",
+                "-bayfrontheight=1",
+                "-dakotaheight=1",
+                "-eunosheight=1",
+                "-fortcanningheight=1",
+                "-fortcanninghillheight=1",
+                "-fortcanningroadheight=1",
+                "-fortcanningcrunchheight=1",
+                "-fortcanningspringheight=1",
+                "-fortcanninggreatworldheight=1",
+                "-fortcanningepilogueheight=1",
+                "-grandcentralheight=1",
+                "-metachainheight=100",
+                "-df23height=150",
+            ],
+        ]
+
+    def run_test(self):
+        # Run setup
+        self.setup()
+
+        # Test future swap limitation
+        self.test_vault_creation_fee()
+
+    def setup(self):
+        # Define address
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+
+        # Generate chain
+        self.nodes[0].generate(105)
+
+        # Create vault scheme
+        self.nodes[0].createloanscheme(150, 1, "LOAN150")
+        self.nodes[0].generate(1)
+
+    def test_vault_creation_fee(self):
+
+        # Try and set creation fee before fork
+        assert_raises_rpc_error(
+            -32600,
+            "Cannot be set before DF23Height",
+            self.nodes[0].setgov,
+            {
+                "ATTRIBUTES": {
+                    "v0/vaults/params/creation_fee": "100",
+                }
+            },
+        )
+
+        vault1 = self.nodes[0].createvault(self.address)
+        self.nodes[0].generate(1)
+
+        # Move to fork height
+        self.nodes[0].generate(150 - self.nodes[0].getblockcount())
+
+        # Create vault with old fee
+        vault1 = self.nodes[0].createvault(self.address)
+        self.nodes[0].generate(1)
+
+        # Verify vault
+        assert_equal(self.nodes[0].getvault(vault1)["state"], "active")
+
+        # Verify fee
+        assert_equal(
+            self.nodes[0].getrawtransaction(vault1, 1)["vout"][0]["value"],
+            Decimal("1.00000000"),
+        )
+
+        # Set new fee
+        self.nodes[0].setgov({"ATTRIBUTES": {"v0/vaults/params/creation_fee": "100"}})
+        self.nodes[0].generate(1)
+
+        # Verify new fee
+        assert_equal(
+            self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"][
+                "v0/vaults/params/creation_fee"
+            ],
+            "100",
+        )
+
+        # Create vault with new fee
+        vault2 = self.nodes[0].createvault(self.address)
+        self.nodes[0].generate(1)
+
+        # Verify vault
+        assert_equal(self.nodes[0].getvault(vault2)["state"], "active")
+
+        # Verify fee
+        assert_equal(
+            self.nodes[0].getrawtransaction(vault2, 1)["vout"][0]["value"],
+            Decimal("100.00000000"),
+        )
+
+        # Set new fee
+        self.nodes[0].setgov({"ATTRIBUTES": {"v0/vaults/params/creation_fee": "200"}})
+        self.nodes[0].generate(1)
+
+        # Verify new fee
+        assert_equal(
+            self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"][
+                "v0/vaults/params/creation_fee"
+            ],
+            "200",
+        )
+
+        # Create vault with new fee
+        vault3 = self.nodes[0].createvault(self.address)
+        self.nodes[0].generate(1)
+
+        # Verify vault
+        assert_equal(self.nodes[0].getvault(vault3)["state"], "active")
+
+        # Verify fee
+        assert_equal(
+            self.nodes[0].getrawtransaction(vault3, 1)["vout"][0]["value"],
+            Decimal("200.00000000"),
+        )
+
+        # Close old fee vault and check refund
+        self.nodes[0].closevault(vault1, self.address)
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].gettokenbalances(), ["0.50000000@0"])
+
+        # Close first new fee vault and check refund
+        self.nodes[0].closevault(vault2, self.address)
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].gettokenbalances(), ["50.50000000@0"])
+
+        # Close second new fee vault and check refund
+        self.nodes[0].closevault(vault3, self.address)
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].gettokenbalances(), ["150.50000000@0"])
+
+
+if __name__ == "__main__":
+    VaultCreationFeeTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -321,6 +321,7 @@ BASE_SCRIPTS = [
     "feature_evm_vmmap_rpc.py",
     "feature_loan_low_interest.py",
     "feature_loan_estimatecollateral.py",
+    "feature_vault_creation_fee.py",
     "feature_vault_pct_check_factor.py",
     "feature_address_map.py",
     "p2p_node_network_limited.py",


### PR DESCRIPTION
## Summary

- Make it so that the collateral fee for creating a vault can be set via Gov vars. The refund of half the collateral fee will be half of what was set at the time of vault creation.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
