### PR TITLE
Remove redundant -stop-block

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -404,7 +404,7 @@ void SetupServerArgs()
     // Hidden Options
     std::vector<std::string> hidden_args = {
         "-dbcrashratio", "-forcecompactdb",
-        "-interrupt-block=<hash|height>", "-stop-block=<hash|height>",
+        "-interrupt-block=<hash|height>",
         "-mocknet", "-mocknet-blocktime=<secs>", "-mocknet-key=<pubkey>",
         "-checkpoints-file",
         // GUI args. These will be overwritten by SetupUIArgs for the GUI
@@ -1712,10 +1712,7 @@ bool SetupInterruptArg(const std::string &argName, std::string &hashStore, int &
 }
 
 void SetupInterrupts() {
-    auto isSet = false;
-    isSet = SetupInterruptArg("-interrupt-block", fInterruptBlockHash, fInterruptBlockHeight) || isSet;
-    isSet = SetupInterruptArg("-stop-block", fStopBlockHash, fStopBlockHeight) || isSet;
-    fStopOrInterrupt = isSet;
+    fInterrupt = SetupInterruptArg("-interrupt-block", fInterruptBlockHash, fInterruptBlockHeight);
 }
 
 bool AppInitMain(InitInterfaces& interfaces)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -153,11 +153,9 @@ bool fPruneMode = false;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
 
-bool fStopOrInterrupt = false;
+bool fInterrupt = false;
 std::string fInterruptBlockHash = "";
 int fInterruptBlockHeight = -1;
-std::string fStopBlockHash = "";
-int fStopBlockHeight = -1;
 
 size_t nCoinCacheUsage = 5000 * 300;
 size_t nCustomMemUsage = nDefaultDbCache << 10;
@@ -2583,7 +2581,7 @@ uint32_t GetNextAccPosition() {
 }
 
 bool StopOrInterruptConnect(const CBlockIndex *pIndex, CValidationState &state) {
-    if (!fStopOrInterrupt) {
+    if (!fInterrupt) {
         return false;
     }
 
@@ -2591,13 +2589,7 @@ bool StopOrInterruptConnect(const CBlockIndex *pIndex, CValidationState &state) 
         return height == index->nHeight || (!hash.empty() && hash == index->phashBlock->ToString());
     };
 
-    // Stop is processed first. So, if a block has both stop and interrupt
-    // stop will take priority.
-    if (checkMatch(pIndex, fStopBlockHeight, fStopBlockHash) ||
-        checkMatch(pIndex, fInterruptBlockHeight, fInterruptBlockHash)) {
-        if (pIndex->nHeight == fStopBlockHeight) {
-            StartShutdown();
-        }
+    if (checkMatch(pIndex, fInterruptBlockHeight, fInterruptBlockHash)) {
         state.Invalid(
             ValidationInvalidReason::CONSENSUS, error("%s: user interrupt", __func__), "user-interrupt-request");
         return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -174,11 +174,9 @@ extern std::atomic_bool fReindex;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 
-extern bool fStopOrInterrupt;
+extern bool fInterrupt;
 extern std::string fInterruptBlockHash;
 extern int fInterruptBlockHeight;
-extern std::string fStopBlockHash;
-extern int fStopBlockHeight;
 
 extern size_t nCoinCacheUsage;
 extern size_t nCustomMemUsage;


### PR DESCRIPTION
## Summary

- There is already a -stopatheight start up param that can be used to stop the node at a certain height, our bespoke -stop-block is redundant and can be removed.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
