### PR TITLE
Fix lints and compiler warnings

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -311,9 +311,9 @@ if __name__ == "__main__":
     if "netmagic" not in settings:
         settings["netmagic"] = "f9beb4d9"
     if "genesis" not in settings:
-        settings["genesis"] = (
-            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
-        )
+        settings[
+            "genesis"
+        ] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
     if "input" not in settings:
         settings["input"] = "input"
     if "hashlist" not in settings:

--- a/lib/ain-evm/src/precompiles/mod.rs
+++ b/lib/ain-evm/src/precompiles/mod.rs
@@ -12,7 +12,7 @@ use ethereum_types::H160;
 use evm::executor::stack::IsPrecompileResult;
 pub use evm::{
     executor::stack::{PrecompileFailure, PrecompileHandle, PrecompileOutput, PrecompileSet},
-    Context, ExitError, ExitRevert, ExitSucceed, Transfer,
+    ExitError, ExitSucceed,
 };
 use modexp::Modexp;
 use simple::{ECRecover, Identity, Ripemd160, Sha256};

--- a/src/amount.h
+++ b/src/amount.h
@@ -138,7 +138,7 @@ struct CTokenAmount { // simple std::pair is less informative
         // add
         auto sumRes = SafeAdd(nValue, amount);
         if (!sumRes) {
-            return std::move(sumRes);
+            return sumRes;
         }
 
         nValue = *sumRes;

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1297,9 +1297,9 @@ class FullBlockTest(DefiTestFramework):
         b76 = self.next_block(76)
         size = MAX_BLOCK_SIGOPS - 1 + MAX_SCRIPT_ELEMENT_SIZE + 1 + 5
         a = bytearray([OP_CHECKSIG] * size)
-        a[MAX_BLOCK_SIGOPS - 1] = (
-            0x4E  # PUSHDATA4, but leave the following bytes as just checksigs
-        )
+        a[
+            MAX_BLOCK_SIGOPS - 1
+        ] = 0x4E  # PUSHDATA4, but leave the following bytes as just checksigs
         tx = self.create_and_sign_transaction(out[23], 1, CScript(a))
         b76 = self.update_block(76, [tx])
         self.send_blocks([b76], True)

--- a/test/functional/feature_evm_gas.py
+++ b/test/functional/feature_evm_gas.py
@@ -115,9 +115,9 @@ class EVMGasTest(DefiTestFramework):
             "gas": "0x7a120",
             "gasPrice": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["valid_balance_transfer_tx_with_gas"] = (
-            valid_balance_transfer_tx_with_gas
-        )
+        dict_txs[
+            "valid_balance_transfer_tx_with_gas"
+        ] = valid_balance_transfer_tx_with_gas
 
         # Eth call for balance transfer with exact gas specified
         valid_balance_transfer_tx_with_exact_gas = {
@@ -127,9 +127,9 @@ class EVMGasTest(DefiTestFramework):
             "gas": "0x5208",
             "gasPrice": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["valid_balance_transfer_tx_with_exact_gas"] = (
-            valid_balance_transfer_tx_with_exact_gas
-        )
+        dict_txs[
+            "valid_balance_transfer_tx_with_exact_gas"
+        ] = valid_balance_transfer_tx_with_exact_gas
 
         # Valid eth call for balance transfer without gas specified
         valid_balance_transfer_tx_without_gas = {
@@ -138,9 +138,9 @@ class EVMGasTest(DefiTestFramework):
             "value": "0xDE0B6B3A7640000",  # 1 DFI
             "gasPrice": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["valid_balance_transfer_tx_without_gas"] = (
-            valid_balance_transfer_tx_without_gas
-        )
+        dict_txs[
+            "valid_balance_transfer_tx_without_gas"
+        ] = valid_balance_transfer_tx_without_gas
 
         # Invalid eth call for balance transfer with both gasPrice and maxFeePerGas specified
         invalid_balance_transfer_tx_specified_gas_1 = {
@@ -150,9 +150,9 @@ class EVMGasTest(DefiTestFramework):
             "gasPrice": "0x37E11D600",  # 15_000_000_000
             "maxFeePerGas": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["invalid_balance_transfer_tx_specified_gas_1"] = (
-            invalid_balance_transfer_tx_specified_gas_1
-        )
+        dict_txs[
+            "invalid_balance_transfer_tx_specified_gas_1"
+        ] = invalid_balance_transfer_tx_specified_gas_1
 
         # Invalid eth call for balance transfer with both gasPrice and priorityFeePerGas specified
         invalid_balance_transfer_tx_specified_gas_2 = {
@@ -162,9 +162,9 @@ class EVMGasTest(DefiTestFramework):
             "gasPrice": "0x37E11D600",  # 15_000_000_000
             "maxPriorityFeePerGas": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["invalid_balance_transfer_tx_specified_gas_2"] = (
-            invalid_balance_transfer_tx_specified_gas_2
-        )
+        dict_txs[
+            "invalid_balance_transfer_tx_specified_gas_2"
+        ] = invalid_balance_transfer_tx_specified_gas_2
 
         # Invalid eth call for balance transfer with both data and input fields specified
         invalid_balance_transfer_tx_specified_data_and_input = {
@@ -175,9 +175,9 @@ class EVMGasTest(DefiTestFramework):
             "data": "0xffffffffffffffff",
             "input": "0xffffffffffffffff",
         }
-        dict_txs["invalid_balance_transfer_tx_specified_data_and_input"] = (
-            invalid_balance_transfer_tx_specified_data_and_input
-        )
+        dict_txs[
+            "invalid_balance_transfer_tx_specified_data_and_input"
+        ] = invalid_balance_transfer_tx_specified_data_and_input
 
         # Invalid eth call from insufficient balance for balance transfer
         invalid_balance_transfer_tx_insufficient_funds = {
@@ -186,9 +186,9 @@ class EVMGasTest(DefiTestFramework):
             "value": "0x152D02C7E14AF6800000",  # 100_000 DFI
             "gasPrice": "0x37E11D600",  # 15_000_000_000
         }
-        dict_txs["invalid_balance_transfer_tx_insufficient_funds"] = (
-            invalid_balance_transfer_tx_insufficient_funds
-        )
+        dict_txs[
+            "invalid_balance_transfer_tx_insufficient_funds"
+        ] = invalid_balance_transfer_tx_insufficient_funds
         return dict_txs
 
     def test_estimate_gas_balance_transfer(self):

--- a/test/functional/feature_vault_creation_fee.py
+++ b/test/functional/feature_vault_creation_fee.py
@@ -56,7 +56,6 @@ class VaultCreationFeeTest(DefiTestFramework):
         self.nodes[0].generate(1)
 
     def test_vault_creation_fee(self):
-
         # Try and set creation fee before fork
         assert_raises_rpc_error(
             -32600,

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -204,9 +204,9 @@ class MempoolAcceptanceTest(DefiTestFramework):
             "A transaction with missing inputs, that existed once in the past"
         )
         tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_0)))
-        tx.vin[0].prevout.n = (
-            1  # Set vout to 1, to spend the other outpoint (49 coins) of the in-chain-tx we want to double spend
-        )
+        tx.vin[
+            0
+        ].prevout.n = 1  # Set vout to 1, to spend the other outpoint (49 coins) of the in-chain-tx we want to double spend
         raw_tx_1 = node.signrawtransactionwithwallet(tx.serialize().hex())["hex"]
         txid_1 = node.sendrawtransaction(hexstring=raw_tx_1, maxfeerate=0)
         # Now spend both to "clearly hide" the outputs, ie. remove the coins from the utxo set by spending them
@@ -445,9 +445,9 @@ class MempoolAcceptanceTest(DefiTestFramework):
 
         self.log.info("A transaction that is locked by BIP68 sequence logic")
         tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_reference)))
-        tx.vin[0].nSequence = (
-            2  # We could include it in the second block mined from now, but not the very next one
-        )
+        tx.vin[
+            0
+        ].nSequence = 2  # We could include it in the second block mined from now, but not the very next one
         # Can skip re-signing the tx because of early rejection
         self.check_mempool_result(
             result_expected=[

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -707,9 +707,9 @@ class SegWitTest(DefiTestFramework):
         tx.vin = [CTxIn(COutPoint(p2sh_tx.sha256, 0), CScript([witness_program]))]
         tx.vout = [CTxOut(p2sh_tx.vout[0].nValue - 10000, script_pubkey)]
         tx.vout.append(CTxOut(8000, script_pubkey))  # Might burn this later
-        tx.vin[0].nSequence = (
-            BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
-        )
+        tx.vin[
+            0
+        ].nSequence = BIP125_SEQUENCE_NUMBER  # Just to have the option to bump this tx from the mempool
         tx.rehash()
 
         # This is always accepted, since the mempool policy is to consider segwit as always active


### PR DESCRIPTION
- ./make fmt
- Remove redundant std::move
- Remove redundant imports in Rust files