### PR TITLE
Run Jellyfish Tests in parallel

### DIFF
--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -43,4 +43,4 @@ jobs:
         run: |
           npm ci
           npm run compile
-          DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=600000
+          DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=1800000

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -11,12 +11,35 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  BUILD_VERSION: latest # Computed
+  DOCKER_HUB_USER: defi
+  DOCKER_IMAGE: defi/defichain:jellyfish-ci-${GITHUB_SHA:0:10}
 
 jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Populate environment
+        run: ./make.sh ci-export-vars
+
+      - name: Build docker image
+        run: docker build -t ${{ env.DOCKER_IMAGE }} -f ./contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Push to Docker Hub
+        run: docker push ${{ env.DOCKER_IMAGE }}
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [docker-build]
     strategy:
       fail-fast: false
       matrix:
@@ -39,17 +62,15 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Populate environment
-        run: cd defichain && GIT_VERSION=1 ./make.sh ci-export-vars
-
-      - name: Build and setup
-        run: "cd defichain && docker build -t test-build-container
-          -f ./contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile ."
+      - name: Docker pull
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE }}
 
       - name: Run tests
         run: |
           npm ci
           npm run compile
-          DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=600000
+          DEFICHAIN_DOCKER_IMAGE=${{ env.DOCKER_IMAGE }} npm run ci:test -- --testTimeout=600000
         env:
           GH_INSTANCE_INDEX: ${{ matrix.instance }}
+

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -17,6 +17,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+
+    env:
+      GH_INSTANCE_TOTAL: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -44,3 +51,5 @@ jobs:
           npm ci
           npm run compile
           DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=1800000
+        env:
+          GH_INSTANCE_INDEX: ${{ matrix.instance }}

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -50,6 +50,6 @@ jobs:
         run: |
           npm ci
           npm run compile
-          DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=1800000
+          DEFICHAIN_DOCKER_IMAGE=test-build-container npm run ci:test -- --testTimeout=600000
         env:
           GH_INSTANCE_INDEX: ${{ matrix.instance }}

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -11,35 +11,63 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  DOCKER_HUB_USER: defi
-  DOCKER_IMAGE: defi/defichain:jellyfish-ci-${GITHUB_SHA:0:10}
+  BUILD_VERSION: latest
+  MAKE_DEBUG: 0
+  GIT_VERSION: 1
 
 jobs:
-  docker-build:
+  build:
     runs-on: ubuntu-latest
-
+    container: defi/ain-builder:latest
+    env:
+      CARGO_INCREMENTAL: 0
+      TARGET: x86_64-pc-linux-gnu
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    - run: git config --global --add safe.directory '*'
 
-      - name: Populate environment
-        run: ./make.sh ci-export-vars
+    - name: Populate environment
+      run: ./make.sh ci-export-vars
 
-      - name: Build docker image
-        run: docker build -t ${{ env.DOCKER_IMAGE }} -f ./contrib/dockerfiles/x86_64-pc-linux-gnu.dockerfile .
+    - name: Setup dependencies
+      run: ./make.sh ci-setup-deps
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+    - name: Setup user dependencies
+      run: ./make.sh ci-setup-user-deps
 
-      - name: Push to Docker Hub
-        run: docker push ${{ env.DOCKER_IMAGE }}
+    - name: Restore cpp build cache
+      id: cpp-cache-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ./build/depends
+          ./build/src
+          ~/.ccache
+        key: cpp-${{ env.TARGET }}-${{ env.BUILD_TYPE }}
+
+    - name: Rust build cache
+      uses: Swatinem/rust-cache@v2
+      id: rust-cache-restore
+      with:
+        workspaces: lib -> ../build/lib/target
+        save-if: ${{ github.ref == 'refs/heads/master' }}
+        shared-key: ${{ env.TARGET }}
+
+    - name: Build binaries
+      run: ./make.sh build
+
+    - name: Upload binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: defi-bins
+        path: |
+          build/src/defid
+          build/src/defi-cli
 
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: [docker-build]
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -50,27 +78,35 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Populate environment
+        run: ./make.sh ci-export-vars
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
         with:
-          repository: JellyfishSDK/jellyfish
-          ref: 'main'
+          name: defi-bins
+
+      - name: Build defi image
+        run: rm .dockerignore && ./make.sh docker-build-from-binaries
 
       - uses: actions/checkout@v4
         with:
-          path: defichain
+          repository: JellyfishSDK/jellyfish
+          ref: 'main'
+          path: jellyfish
 
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
 
-      - name: Docker pull
-        run: |
-          docker pull ${{ env.DOCKER_IMAGE }}
-
       - name: Run tests
         run: |
+          cd jellyfish
           npm ci
           npm run compile
-          DEFICHAIN_DOCKER_IMAGE=${{ env.DOCKER_IMAGE }} npm run ci:test -- --testTimeout=600000
+          set -e; ver=${{ env.BUILD_VERSION }}
+          DEFICHAIN_DOCKER_IMAGE=defichain-${{ env.TARGET }}:${ver} npm run ci:test -- --testTimeout=600000
         env:
           GH_INSTANCE_INDEX: ${{ matrix.instance }}
 

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   BUILD_VERSION: latest
+  TARGET: x86_64-pc-linux-gnu
   MAKE_DEBUG: 0
   GIT_VERSION: 1
 
@@ -21,7 +22,6 @@ jobs:
     container: defi/ain-builder:latest
     env:
       CARGO_INCREMENTAL: 0
-      TARGET: x86_64-pc-linux-gnu
     steps:
     - uses: actions/checkout@v4
     - run: git config --global --add safe.directory '*'

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -56,11 +56,14 @@ jobs:
     - name: Build binaries
       run: ./make.sh build
 
+    - name: Pack binaries
+      run: ./make.sh deploy && ./make.sh package
+
     - name: Upload binaries
       uses: actions/upload-artifact@v3
       with:
         name: defi-bins
-        path: build/src/defid
+        path: ./build/defichain-${{ env.BUILD_VERSION }}-${{ env.TARGET }}.${{ env.PKG_TYPE }}
 
   test:
     name: Test
@@ -85,6 +88,9 @@ jobs:
         with:
           name: defi-bins
           path: ./build/
+
+      - name: Unpack binaries
+        run: tar -xvzf ./build/defichain-${{ env.BUILD_VERSION }}-${{ env.TARGET }}.${{ env.PKG_TYPE }} -C ./build/
 
       - name: Build defi image
         run: rm .dockerignore && ./make.sh docker-build-from-binaries

--- a/.github/workflows/tests-jellyfish.yml
+++ b/.github/workflows/tests-jellyfish.yml
@@ -60,9 +60,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: defi-bins
-        path: |
-          build/src/defid
-          build/src/defi-cli
+        path: build/src/defid
 
   test:
     name: Test
@@ -86,6 +84,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: defi-bins
+          path: ./build/
 
       - name: Build defi image
         run: rm .dockerignore && ./make.sh docker-build-from-binaries


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- speed up jellyfish ci by running with 10 instances, from (approximately) 2 hrs to 40 (30+15) mins
