### PR TITLE
Add logs for future swap limit calculation

### DIFF
--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1095,10 +1095,11 @@ static void LiquidityForFuturesLimit(const CBlockIndex *pindex,
         }
 
         const auto tokenAverage = tokenTotal / expectedEntries;
-        LogPrint(BCLog::FUTURESWAP, "Liquidity for future swap limit: token src id: %i, token dest id: %i, new average liquidity: %i\n",
-                  key.sourceID,
-                  key.destID,
-                  tokenAverage.GetLow64());
+        LogPrint(BCLog::FUTURESWAP,
+                 "Liquidity for future swap limit: token src id: %i, token dest id: %i, new average liquidity: %i\n",
+                 key.sourceID,
+                 key.destID,
+                 tokenAverage.GetLow64());
         cache.SetLoanTokenAverageLiquidity(key, tokenAverage.GetLow64());
     }
 }

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1095,7 +1095,7 @@ static void LiquidityForFuturesLimit(const CBlockIndex *pindex,
         }
 
         const auto tokenAverage = tokenTotal / expectedEntries;
-        LogPrintf("Liquidity for future swap limit: token src id: %i, token dest id: %i, new average liquidity: %i\n",
+        LogPrint(BCLog::FUTURESWAP, "Liquidity for future swap limit: token src id: %i, token dest id: %i, new average liquidity: %i\n",
                   key.sourceID,
                   key.destID,
                   tokenAverage.GetLow64());

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1095,6 +1095,10 @@ static void LiquidityForFuturesLimit(const CBlockIndex *pindex,
         }
 
         const auto tokenAverage = tokenTotal / expectedEntries;
+        LogPrintf("Liquidity for future swap limit: token src id: %i, token dest id: %i, new average liquidity: %i\n",
+                  key.sourceID,
+                  key.destID,
+                  tokenAverage.GetLow64());
         cache.SetLoanTokenAverageLiquidity(key, tokenAverage.GetLow64());
     }
 }

--- a/test/functional/feature_future_swap_limitation.py
+++ b/test/functional/feature_future_swap_limitation.py
@@ -46,6 +46,8 @@ class FutureSwapLimitationTest(DefiTestFramework):
         # Test wiping of data on disable
         self.test_wiping_data()
 
+        assert_equal(True, False)
+
     def setup(self):
         # Define address
         self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress

--- a/test/functional/feature_future_swap_limitation.py
+++ b/test/functional/feature_future_swap_limitation.py
@@ -46,8 +46,6 @@ class FutureSwapLimitationTest(DefiTestFramework):
         # Test wiping of data on disable
         self.test_wiping_data()
 
-        assert_equal(True, False)
-
     def setup(self):
         # Define address
         self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress


### PR DESCRIPTION
## Summary

- Add logs for future swap limit calculation


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
