### PR TITLE
Allow minting of loan tokens on mocknet

### DIFF
--- a/src/dfi/consensus/tokens.cpp
+++ b/src/dfi/consensus/tokens.cpp
@@ -60,7 +60,7 @@ ResVal<CScript> CTokensConsensus::MintableToken(DCT_ID id,
     static const auto isMainNet = Params().NetworkIDString() == CBaseChainParams::MAIN;
     // may be different logic with LPS, so, dedicated check:
     auto &mnview = blockCtx.GetView();
-    if (!token.IsMintable() || (isMainNet && mnview.GetLoanTokenByID(id))) {
+    if (!token.IsMintable() || (isMainNet && !fMockNetwork && mnview.GetLoanTokenByID(id))) {
         return Res::Err("token %s is not mintable!", id.ToString());
     }
 


### PR DESCRIPTION
## Summary

- For ease of testing allow minting of loan tokens on mocknet

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
