### PR TITLE
EVM fractional split support for 64bit splits

### DIFF
--- a/src/dfi/tokens.cpp
+++ b/src/dfi/tokens.cpp
@@ -363,12 +363,15 @@ inline Res CTokenImplementation::IsValidSymbol() const {
     return Res::Ok();
 }
 
-void CTokensView::SetTokenSplitMultiplier(const uint32_t oldId, const uint32_t newId, const int32_t multiplier) {
+void CTokensView::SetTokenSplitMultiplier(const uint32_t oldId,
+                                          const uint32_t newId,
+                                          const SplitMultiplier multiplier) {
     WriteBy<TokenSplitMultiplier>(oldId, std::make_pair(newId, multiplier));
 }
 
-std::optional<std::pair<uint32_t, int32_t>> CTokensView::GetTokenSplitMultiplier(const uint32_t id) const {
-    std::pair<uint32_t, int32_t> idMultiplierPair;
+std::optional<std::pair<uint32_t, CTokensView::SplitMultiplier>> CTokensView::GetTokenSplitMultiplier(
+    const uint32_t id) const {
+    std::pair<uint32_t, SplitMultiplier> idMultiplierPair;
     if (ReadBy<TokenSplitMultiplier, uint32_t>(id, idMultiplierPair)) {
         return idMultiplierPair;
     }

--- a/src/dfi/tokens.h
+++ b/src/dfi/tokens.h
@@ -195,6 +195,8 @@ public:
     static const DCT_ID DCT_ID_START;            // = 128;
     static const unsigned char DB_TOKEN_LASTID;  // = 'L';
 
+    using SplitMultiplier = std::variant<int32_t, CAmount>;
+
     using CTokenImpl = CTokenImplementation;
     using TokenIDPair = std::pair<DCT_ID, std::optional<CTokenImpl>>;
     std::optional<CTokenImpl> GetToken(DCT_ID id) const;
@@ -202,8 +204,8 @@ public:
     // the only possible type of token (with creationTx) is CTokenImpl
     std::optional<std::pair<DCT_ID, CTokenImpl>> GetTokenByCreationTx(const uint256 &txid) const;
     [[nodiscard]] virtual std::optional<CTokenImpl> GetTokenGuessId(const std::string &str, DCT_ID &id) const = 0;
-    void SetTokenSplitMultiplier(const uint32_t oldId, const uint32_t newId, const int32_t multiplier);
-    [[nodiscard]] std::optional<std::pair<uint32_t, int32_t>> GetTokenSplitMultiplier(const uint32_t id) const;
+    void SetTokenSplitMultiplier(const uint32_t oldId, const uint32_t newId, const SplitMultiplier multiplier);
+    [[nodiscard]] std::optional<std::pair<uint32_t, SplitMultiplier>> GetTokenSplitMultiplier(const uint32_t id) const;
 
     void ForEachToken(std::function<bool(DCT_ID const &, CLazySerialize<CTokenImpl>)> callback,
                       DCT_ID const &start = DCT_ID{0});

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -3214,10 +3214,16 @@ bool ExecuteTokenMigrationEVM(std::size_t mnview_ptr, const TokenAmount oldAmoun
         return false;
     }
 
-    auto &[id, multiplier] = *idMultiplierPair;
+    auto &[id, multiplierVariant] = *idMultiplierPair;
 
     newAmount.id = id;
-    newAmount.amount = CalculateNewAmount(multiplier, oldAmount.amount);
+
+    if (const auto multiplier64 = std::get_if<CAmount>(&multiplierVariant); multiplier64) {
+        newAmount.amount = CalculateNewAmount(*multiplier64, oldAmount.amount);
+    } else {
+        const auto multiplier32 = std::get<int32_t>(multiplierVariant);
+        newAmount.amount = CalculateNewAmount(multiplier32, oldAmount.amount);
+    }
 
     // Only increment minted tokens if there is no additional split on new token.
     if (const auto additionalSplit = cache->GetTokenSplitMultiplier(newAmount.id); !additionalSplit) {
@@ -3268,8 +3274,14 @@ Res ExecuteTokenMigrationTransferDomain(CCustomCSView &view, CTokenAmount &amoun
             return Res::Err("Token not found");
         }
 
-        auto &[id, multiplier] = *idMultiplierPair;
-        amount = {{id}, CalculateNewAmount(multiplier, amount.nValue)};
+        auto &[id, multiplierVariant] = *idMultiplierPair;
+
+        if (const auto multiplier64 = std::get_if<CAmount>(&multiplierVariant); multiplier64) {
+            amount = {{id}, CalculateNewAmount(*multiplier64, amount.nValue)};
+        } else {
+            const auto multiplier32 = std::get<int32_t>(multiplierVariant);
+            amount = {{id}, CalculateNewAmount(multiplier32, amount.nValue)};
+        }
 
         if (const auto res = view.AddMintedTokens(amount.nTokenId, amount.nValue); !res) {
             return res;


### PR DESCRIPTION
## Summary

- Enables support for fractional splits on EVM by using the correct multiplier type when calculating the new amount.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
