### PR TITLE
Check future swap limitation block period more than sample period

### DIFF
--- a/src/dfi/errors.h
+++ b/src/dfi/errors.h
@@ -156,6 +156,8 @@ public:
 
     static Res GovVarVerifyPositiveNumber() { return Res::Err("Value must be a positive integer"); }
 
+    static Res GovVarVerifyMoreThanZero() { return Res::Err("Value must more than zero"); }
+
     static Res GovVarInvalidNumber() { return Res::Err("Amount must be a valid number"); }
 
     static Res GovVarVerifySplitValues() { return Res::Err("Two int values expected for split in id/mutliplier"); }
@@ -287,6 +289,8 @@ public:
     }
 
     static Res GovVarUnsupportedValue() { return Res::Err("Unsupported value"); }
+
+    static Res GovVarValidateBlockPeriod() { return Res::Err("Block period must be more than sampling period"); }
 
     static Res GovVarValidateUnsupportedKey() { return Res::Err("Unsupported key"); }
 

--- a/test/functional/feature_future_swap_limitation.py
+++ b/test/functional/feature_future_swap_limitation.py
@@ -221,6 +221,30 @@ class FutureSwapLimitationTest(DefiTestFramework):
         # Move to fork height
         self.nodes[0].generate(150 - self.nodes[0].getblockcount())
 
+        # Try and set block period below default sample size
+        assert_raises_rpc_error(
+            -32600,
+            "Block period must be more than sampling period",
+            self.nodes[0].setgov,
+            {
+                "ATTRIBUTES": {
+                    "v0/params/dfip2211f/block_period": "20",
+                }
+            },
+        )
+
+        # Try and set sample size of zero
+        assert_raises_rpc_error(
+            -5,
+            "Value must more than zero",
+            self.nodes[0].setgov,
+            {
+                "ATTRIBUTES": {
+                    "v0/params/dfip2211f/liquidity_calc_sampling_period": "0",
+                }
+            },
+        )
+
         # Set future swap limitaiton
         self.nodes[0].setgov(
             {
@@ -233,6 +257,18 @@ class FutureSwapLimitationTest(DefiTestFramework):
             }
         )
         self.nodes[0].generate(1)
+
+        # Try and set block period below defined sample size
+        assert_raises_rpc_error(
+            -32600,
+            "Block period must be more than sampling period",
+            self.nodes[0].setgov,
+            {
+                "ATTRIBUTES": {
+                    "v0/params/dfip2211f/block_period": "1",
+                }
+            },
+        )
 
         # Verify Gov vars
         result = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]


### PR DESCRIPTION
## Summary

- If sample period is set to zero or block period is less than the sample period in DFIP2211-F then this will result in a crash. These values would not be used but should be safe guarded against.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
