### PR TITLE
Remove view snapshot from RPC call

### DIFF
--- a/src/dfi/rpc_poolpair.cpp
+++ b/src/dfi/rpc_poolpair.cpp
@@ -1428,12 +1428,12 @@ UniValue listloantokenliquidity(const JSONRPCRequest &request) {
         return *res;
     }
 
-    auto view = ::GetViewSnapshot();
+    LOCK(cs_main);
 
     UniValue ret(UniValue::VOBJ);
-    view->ForEachTokenAverageLiquidity([&](const LoanTokenAverageLiquidityKey &key, const uint64_t liquidity) {
-        const auto sourceToken = view->GetToken(DCT_ID{key.sourceID});
-        const auto destToken = view->GetToken(DCT_ID{key.destID});
+    pcustomcsview->ForEachTokenAverageLiquidity([&](const LoanTokenAverageLiquidityKey &key, const uint64_t liquidity) {
+        const auto sourceToken = pcustomcsview->GetToken(DCT_ID{key.sourceID});
+        const auto destToken = pcustomcsview->GetToken(DCT_ID{key.destID});
         if (sourceToken && destToken) {
             ret.pushKV(sourceToken->symbol + '-' + destToken->symbol, GetDecimalString(liquidity));
         }


### PR DESCRIPTION
## Summary

- When the PR for future swap limitation was created the RPC call used the view snapshot which has since been removed until a better solution is implemented. This PR removes the usage of the view snapshot from the future swap limitation RPC call.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
