### PR TITLE
Fix deprecation warnings on CI

### DIFF
--- a/test/functional/feature_evm.py
+++ b/test/functional/feature_evm.py
@@ -78,7 +78,7 @@ class EVMTest(DefiTestFramework):
         }
 
         signed_tx = node.w3.eth.account.sign_transaction(tx, evmkeypair.privkey)
-        node.w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        node.w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         node.generate(1)
 
     def erc55_wallet_support(self):
@@ -1454,7 +1454,7 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.nodes[0].generate(1)
 
@@ -1488,7 +1488,7 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         codeAfterSelfDestruct = self.nodes[0].eth_getCode(self.contract_address)

--- a/test/functional/feature_evm_contract_env_vars.py
+++ b/test/functional/feature_evm_contract_env_vars.py
@@ -94,7 +94,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         node.generate(1)
         self.block_info = self.nodes[0].getblock(self.nodes[0].getbestblockhash())

--- a/test/functional/feature_evm_contracts.py
+++ b/test/functional/feature_evm_contracts.py
@@ -132,7 +132,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -158,7 +158,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -186,7 +186,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -212,7 +212,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         self.node.generate(1)
         self.node.w3.eth.wait_for_transaction_receipt(hash)
 
@@ -240,7 +240,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         self.node.generate(1)
         self.node.w3.eth.wait_for_transaction_receipt(hash)
 
@@ -275,7 +275,7 @@ class EVMTest(DefiTestFramework):
             signed = self.node.w3.eth.account.sign_transaction(
                 tx, self.evm_key_pair.privkey
             )
-            hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
             self.node.generate(1)
             receipt = self.node.w3.eth.wait_for_transaction_receipt(hash)
@@ -310,7 +310,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -350,7 +350,7 @@ class EVMTest(DefiTestFramework):
             -32001,
             "reason: tx-size",
             self.node.w3.eth.send_raw_transaction,
-            signed.rawTransaction,
+            signed.raw_transaction,
         )
 
     def non_payable_proxied_contract(self):
@@ -374,7 +374,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -398,7 +398,7 @@ class EVMTest(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 

--- a/test/functional/feature_evm_dfi_intrinsics.py
+++ b/test/functional/feature_evm_dfi_intrinsics.py
@@ -169,7 +169,7 @@ class DFIIntrinsicsTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         contract = node.w3.eth.contract(address=receipt["contractAddress"], abi=abi)

--- a/test/functional/feature_evm_eip1559_fees.py
+++ b/test/functional/feature_evm_eip1559_fees.py
@@ -45,7 +45,7 @@ class EIP1559Fees(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         self.node.generate(1)
         return self.node.w3.eth.wait_for_transaction_receipt(hash)
 
@@ -101,7 +101,7 @@ class EIP1559Fees(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         self.node.generate(1)
 
@@ -291,7 +291,7 @@ class EIP1559Fees(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         assert_equal(len(self.nodes[0].getrawmempool()), 1)
 
         # RBF should happen
@@ -310,7 +310,7 @@ class EIP1559Fees(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         assert_equal(len(self.nodes[0].getrawmempool()), 1)
 
         # send lower priority fee tx, RBF should not happen
@@ -333,7 +333,7 @@ class EIP1559Fees(DefiTestFramework):
             -32001,
             "evm-low-fee",
             self.node.w3.eth.send_raw_transaction,
-            signed.rawTransaction,
+            signed.raw_transaction,
         )
         assert_equal(len(self.nodes[0].getrawmempool()), 1)
 
@@ -357,7 +357,7 @@ class EIP1559Fees(DefiTestFramework):
             -32001,
             "evm-low-fee",
             self.node.w3.eth.send_raw_transaction,
-            signed.rawTransaction,
+            signed.raw_transaction,
         )
 
         # send higher max fee tx but lower priority fee tx, RBF should not happen
@@ -380,7 +380,7 @@ class EIP1559Fees(DefiTestFramework):
             -32001,
             "evm-low-fee",
             self.node.w3.eth.send_raw_transaction,
-            signed.rawTransaction,
+            signed.raw_transaction,
         )
 
         # send less than 10% increase in priority fees, RBF should not happen
@@ -403,7 +403,7 @@ class EIP1559Fees(DefiTestFramework):
             -32001,
             "evm-low-fee",
             self.node.w3.eth.send_raw_transaction,
-            signed.rawTransaction,
+            signed.raw_transaction,
         )
 
         # send exactly 10% increase in priority fees, RBF should happen
@@ -422,7 +422,7 @@ class EIP1559Fees(DefiTestFramework):
         signed = self.node.w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.node.w3.eth.send_raw_transaction(signed.raw_transaction)
         assert_equal(len(self.nodes[0].getrawmempool()), 1)
 
         self.nodes[0].generate(1)

--- a/test/functional/feature_evm_gas.py
+++ b/test/functional/feature_evm_gas.py
@@ -259,7 +259,7 @@ class EVMGasTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -284,7 +284,7 @@ class EVMGasTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append(hash)
         self.nodes[0].generate(1)
 
@@ -312,7 +312,7 @@ class EVMGasTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -330,7 +330,7 @@ class EVMGasTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         tx_receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
@@ -352,7 +352,7 @@ class EVMGasTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -372,7 +372,7 @@ class EVMGasTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         tx_receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(gas, tx_receipt["gasUsed"])

--- a/test/functional/feature_evm_logs.py
+++ b/test/functional/feature_evm_logs.py
@@ -99,7 +99,7 @@ class EVMTestLogs(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         node.generate(1)
 
@@ -120,7 +120,7 @@ class EVMTestLogs(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
 
         node.generate(1)
 

--- a/test/functional/feature_evm_miner.py
+++ b/test/functional/feature_evm_miner.py
@@ -124,7 +124,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -144,7 +144,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append(signed.hash.hex().lower()[2:])
 
         hash = self.nodes[0].eth_sendTransaction(
@@ -251,7 +251,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -271,7 +271,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         nonce = self.nodes[0].w3.eth.get_transaction_count(self.ethAddress)
@@ -490,7 +490,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -510,7 +510,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             evmtx_hashes.append(signed.hash.hex().lower()[2:])
 
         first_block_total_evm_txs = 17
@@ -618,7 +618,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -640,7 +640,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append(signed.hash.hex().lower()[2:])
 
         # Do valid RBF for nonce zero with incrementing fee
@@ -655,7 +655,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes[0] = signed.hash.hex().lower()[2:]
 
         # Accounting
@@ -803,7 +803,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         contract_address = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)[
             "contractAddress"
@@ -825,7 +825,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         tx = contract.functions.loop(9_000).build_transaction(
@@ -837,7 +837,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         gas_used = Decimal(
             self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
@@ -854,7 +854,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         gas_used = Decimal(
             self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
@@ -870,7 +870,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         gas_used = Decimal(
             self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)["gasUsed"]
@@ -887,7 +887,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         hashes = []
@@ -902,7 +902,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append((signed.hash.hex()))
 
         # Send change of state
@@ -915,7 +915,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         hashes.append(signed.hash.hex())
 
         for idx in range(15):
@@ -928,7 +928,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append(signed.hash.hex())
 
         self.nodes[0].generate(1)
@@ -988,7 +988,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         start_nonce = self.nodes[0].w3.eth.get_transaction_count(self.ethAddress)
@@ -1012,7 +1012,7 @@ class EVMTest(DefiTestFramework):
                 }
             )
             signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-            self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
 
         for i in range(6):
             self.nodes[0].transferdomain(

--- a/test/functional/feature_evm_proxy.py
+++ b/test/functional/feature_evm_proxy.py
@@ -93,7 +93,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         implementation_contract = node.w3.eth.contract(
@@ -125,7 +125,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
 
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
@@ -147,7 +147,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 1)
@@ -167,7 +167,7 @@ class EVMTest(DefiTestFramework):
         signed = node.w3.eth.account.sign_transaction(
             transaction, self.evm_key_pair.privkey
         )
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 0)
@@ -189,7 +189,7 @@ class EVMTest(DefiTestFramework):
         signed = node.w3.eth.account.sign_transaction(
             transaction, self.evm_key_pair.privkey
         )
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 0)
@@ -212,7 +212,7 @@ class EVMTest(DefiTestFramework):
         signed = node.w3.eth.account.sign_transaction(
             transaction, self.evm_key_pair.privkey
         )
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 0)
@@ -233,7 +233,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         new_implementation_contract = node.w3.eth.contract(
@@ -260,7 +260,7 @@ class EVMTest(DefiTestFramework):
         signed = node.w3.eth.account.sign_transaction(
             transaction, self.evm_key_pair.privkey
         )
-        node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
 
         assert_equal(
@@ -280,7 +280,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, second_evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 0)
@@ -301,7 +301,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = node.w3.eth.account.sign_transaction(tx, self.evm_key_pair.privkey)
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 1)
@@ -336,7 +336,7 @@ class EVMTest(DefiTestFramework):
             transaction, self.evm_key_pair.privkey
         )
 
-        hash = node.w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = node.w3.eth.send_raw_transaction(signed.raw_transaction)
         node.generate(1)
         receipt = node.w3.eth.wait_for_transaction_receipt(hash)
         assert_equal(receipt["status"], 1)

--- a/test/functional/feature_evm_rpc.py
+++ b/test/functional/feature_evm_rpc.py
@@ -267,7 +267,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(
@@ -306,7 +306,7 @@ class EVMTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         contract = self.nodes[0].w3.eth.contract(

--- a/test/functional/feature_evm_rpc_filters.py
+++ b/test/functional/feature_evm_rpc_filters.py
@@ -129,7 +129,7 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)
         self.contract_address = receipt["contractAddress"]
@@ -151,7 +151,7 @@ class EVMTest(DefiTestFramework):
             signed = self.nodes[0].w3.eth.account.sign_transaction(
                 tx, self.evm_key_pair.privkey
             )
-            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+            hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
             hashes.append(hash)
 
         self.nodes[0].generate(1)

--- a/test/functional/feature_evm_rpc_tracer.py
+++ b/test/functional/feature_evm_rpc_tracer.py
@@ -138,7 +138,7 @@ class EvmTracerTest(DefiTestFramework):
             }
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         contract_address = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)[
@@ -158,7 +158,7 @@ class EvmTracerTest(DefiTestFramework):
         )
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         state_change_tx_hash = self.nodes[0].w3.eth.send_raw_transaction(
-            signed.rawTransaction
+            signed.raw_transaction
         )
 
         # Run loop contract call in the same block
@@ -173,7 +173,7 @@ class EvmTracerTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(tx, self.ethPrivKey)
         # TODO: Disabled for now because state consistency of the debug_traceTransaction is
         # incorrect.
-        # loop_tx_hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        # loop_tx_hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         # Test tracer for contract call txs

--- a/test/functional/feature_evm_token_split.py
+++ b/test/functional/feature_evm_token_split.py
@@ -786,7 +786,7 @@ class EVMTokenSplitTest(DefiTestFramework):
         total_supply_before = meta_contract.functions.totalSupply().call()
 
         # Send the signed transaction
-        self.nodes[0].w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        self.nodes[0].w3.eth.send_raw_transaction(signed_txn.raw_transaction)
         self.nodes[0].generate(1)
 
         # Check source contract balance on sender

--- a/test/functional/feature_evm_transferdomain.py
+++ b/test/functional/feature_evm_transferdomain.py
@@ -1101,7 +1101,7 @@ class EVMTest(DefiTestFramework):
         signed = self.nodes[0].w3.eth.account.sign_transaction(
             tx, self.evm_key_pair.privkey
         )
-        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.rawTransaction)
+        hash = self.nodes[0].w3.eth.send_raw_transaction(signed.raw_transaction)
         self.nodes[0].generate(1)
 
         receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(hash)


### PR DESCRIPTION
## Summary

- Update rawTransaction to raw_transaction to  avoid deprecation warning.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
