### PR TITLE
Future Swap avoid division by zero

### DIFF
--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -797,7 +797,7 @@ const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(
                  {DFIPKeys::Premium, VerifyPctInt64},
                  {DFIPKeys::MinSwap, VerifyPositiveFloat},
                  {DFIPKeys::RewardPct, VerifyPctInt64},
-                 {DFIPKeys::BlockPeriod, VerifyInt64},
+                 {DFIPKeys::BlockPeriod, VerifyMoreThenZeroInt64},
                  {DFIPKeys::DUSDInterestBurn, VerifyBool},
                  {DFIPKeys::DUSDLoanBurn, VerifyBool},
                  {DFIPKeys::StartBlock, VerifyInt64},


### PR DESCRIPTION
## Summary

- Avoids a potential crash by making sure that block period is always set to be more than zero.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
