### PR TITLE
Allow updating of DAT tokens

### DIFF
--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -270,10 +270,6 @@ UniValue updatetoken(const JSONRPCRequest &request) {
         if (id == DCT_ID{0}) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Can't alter DFI token!"));
         }
-        // Note: This is expected to be removed after DF23
-        if (Params().NetworkIDString() != CBaseChainParams::REGTEST && token->IsDAT()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot update DAT token");
-        }
         tokenImpl = static_cast<const CTokenImplementation &>(*token);
         if (tokenImpl.IsPoolShare()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,


### PR DESCRIPTION
## Summary

- In preparation for the hard fork remove the block on updating DAT tokens.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
