### PR TITLE
EVM: DST20 v2 burn of sent amount

### DIFF
--- a/lib/ain-contracts/dst20_v2/DST20V2.sol
+++ b/lib/ain-contracts/dst20_v2/DST20V2.sol
@@ -588,6 +588,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata, IDST20Upgradeable {
 
         // Upgrade available
         if (newAmount != amount) {
+            _burn(msg.sender, amount);
             IERC20(newTokenContractAddress).transfer(msg.sender, newAmount);
         }
 

--- a/test/functional/feature_evm_token_split.py
+++ b/test/functional/feature_evm_token_split.py
@@ -142,6 +142,10 @@ class EVMTokenSplitTest(DefiTestFramework):
         self.evm_address = self.nodes[0].getnewaddress("", "erc55")
         self.evm_privkey = self.nodes[0].dumpprivkey(self.evm_address)
 
+        self.burn_address = self.nodes[0].w3.to_checksum_address(
+            "0x0000000000000000000000000000000000000000"
+        )
+
         self.contract_address_metav1 = self.nodes[0].w3.to_checksum_address(
             "0xff00000000000000000000000000000000000001"
         )
@@ -769,9 +773,18 @@ class EVMTokenSplitTest(DefiTestFramework):
             address=destination_contract, abi=self.dst20_v2_abi
         )
 
-        # Check transfer token logs on new contract
+        # Check transfer from sender to burn address
         events = meta_contract_new.events.Transfer().process_log(
             list(tx_receipt["logs"])[1]
+        )
+
+        assert_equal(events["event"], "Transfer")
+        assert_equal(events["args"]["to"], self.burn_address)
+        assert_equal(events["args"]["value"], amount_to_send)
+
+        # Check transfer token logs on new contract
+        events = meta_contract_new.events.Transfer().process_log(
+            list(tx_receipt["logs"])[2]
         )
         assert_equal(events["event"], "Transfer")
         assert_equal(events["args"]["to"], self.evm_address)


### PR DESCRIPTION

## Summary

- Remove original contract storage update  from precompile
- Use internal DST20 _burn method instead
- Fix total supplies issues
- Add tests for burn event
- Fixes https://github.com/DeFiCh/ain/issues/2909

<img width="1299" alt="Screenshot 2024-05-06 at 11 30 03" src="https://github.com/DeFiCh/ain/assets/15011228/37a98457-5727-40a0-9d30-877993458613">
<img width="1284" alt="Screenshot 2024-05-06 at 11 30 13" src="https://github.com/DeFiCh/ain/assets/15011228/834b12a6-6506-4053-aeef-018c90f4968d">



## Implications

- Consensus
  - [x] changi rollback
  
