### PR TITLE
Add check for unspported db version

### DIFF
--- a/lib/ain-db/src/lib.rs
+++ b/lib/ain-db/src/lib.rs
@@ -221,6 +221,7 @@ pub enum DBError {
     ParseKey,
     WrongKeyLength,
     Custom(anyhow::Error),
+    UnsupportedVersion,
 }
 
 impl fmt::Display for DBError {
@@ -231,6 +232,7 @@ impl fmt::Display for DBError {
             DBError::ParseKey => write!(f, "Error parsing key"),
             DBError::WrongKeyLength => write!(f, "Wrong key length"),
             DBError::Custom(e) => write!(f, "Custom Error: {e}"),
+            DBError::UnsupportedVersion => write!(f, "DB version higher than expected. Node should be updated to support new DB version."),
         }
     }
 }

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -1,5 +1,5 @@
 use ain_db::version::{DBVersionControl, Migration};
-use ain_db::{Column, ColumnName, LedgerColumn, Rocks, TypedColumn};
+use ain_db::{Column, ColumnName, DBError, LedgerColumn, Rocks, TypedColumn};
 use anyhow::format_err;
 use ethereum::{BlockAny, TransactionV2};
 use ethereum_types::{H160, H256, U256};
@@ -75,13 +75,17 @@ impl DBVersionControl for BlockStore {
     }
 
     fn migrate(&self) -> DBResult<()> {
-        let current_version = self.get_version().unwrap_or(0);
+        let version = self.get_version().unwrap_or(0);
+        if version > Self::CURRENT_VERSION {
+            return Err(DBError::UnsupportedVersion);
+        }
+
         let mut migrations: [Box<dyn Migration<Self>>; Self::CURRENT_VERSION as usize] =
             [Box::new(MigrationV1)];
         migrations.sort_by_key(|a| a.version());
 
         for migration in migrations {
-            if current_version < migration.version() {
+            if version < migration.version() {
                 debug!("Migrating to version {}...", migration.version());
                 let start = Instant::now();
                 migration.migrate(self)?;


### PR DESCRIPTION
## Summary

- Future proof migrations by checking that the current datadir DB version is not higher than the node DB version.
