### PR TITLE
Update build instructions for Windows

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -3,12 +3,12 @@ WINDOWS BUILD NOTES
 
 > NOTE: This section is a work in progress for DeFi Blockchain, and may not be applicable at it's current state.
 
-Below are some notes on how to build Bitcoin Core for Windows.
+Below are some notes on how to build DeFiChain for Windows.
 
-The options known to work for building Bitcoin Core on Windows are:
+The options known to work for building DeFiChain on Windows are:
 
-* On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Bionic 18.04 is required
-and is the platform used to build the Bitcoin Core Windows release binaries.
+* On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Jammy Jellyfish 22.04 is required
+and is the platform used to build the DeFiChain Windows release binaries.
 * On Windows, using [Windows
 Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about) and the Mingw-w64 cross compiler tool chain.
 
@@ -20,108 +20,44 @@ Other options which may work, but which have not been extensively tested are (pl
 Installing Windows Subsystem for Linux
 ---------------------------------------
 
-With Windows 10, Microsoft has released a new feature named the [Windows
-Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about). This
-feature allows you to run a bash shell directly on Windows in an Ubuntu-based
-environment. Within this environment you can cross compile for Windows without
-the need for a separate Linux VM or server. Note that while WSL can be installed with
-other Linux variants, such as OpenSUSE, the following instructions have only been
-tested with Ubuntu.
-
-This feature is not supported in versions of Windows prior to Windows 10 or on
-Windows Server SKUs. In addition, it is available [only for 64-bit versions of
-Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
-
-Full instructions to install WSL are available on the above link.
-To install WSL on Windows 10 with Fall Creators Update installed (version >= 16215.0) do the following:
-
-1. Enable the Windows Subsystem for Linux feature
-  * Open the Windows Features dialog (`OptionalFeatures.exe`)
-  * Enable 'Windows Subsystem for Linux'
-  * Click 'OK' and restart if necessary
-2. Install Ubuntu
-  * Open Microsoft Store and search for "Ubuntu 18.04" or use [this link](https://www.microsoft.com/store/productId/9N9TNGVNDL3Q)
-  * Click Install
-3. Complete Installation
-  * Open a cmd prompt and type "Ubuntu1804"
-  * Create a new UNIX user account (this is a separate account from your Windows account)
-
-After the bash shell is active, you can follow the instructions below, starting
-with the "Cross-compilation" section. Compiling the 64-bit version is
-recommended, but it is possible to compile the 32-bit version.
+Follow the upstream installation instructions, available [here](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 Cross-compilation for Ubuntu and Windows Subsystem for Linux
 ------------------------------------------------------------
 
-The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
-will also work on other Linux distributions, however the commands for
-installing the toolchain will be different.
+Note that for WSL the DeFiChain source path MUST be somewhere in the default mount file system, for
+example /usr/src/ain, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
+This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
 
-First, install the general dependencies:
-
-    sudo apt update
-    sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-A host toolchain (`build-essential`) is necessary because some dependency
-packages (such as `protobuf`) need to build host utilities that are used in the
-build process.
-
-See [dependencies.md](dependencies.md) for a complete overview.
-
-If you want to build the windows installer with `make deploy` you need [NSIS](https://nsis.sourceforge.io/Main_Page):
-
-    sudo apt install nsis
+The steps below can be performed on Ubuntu (including in a VM) or WSL.
 
 Acquire the source in the usual way:
 
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin
+    git clone https://github.com/DeFiCh/ain.git
+    cd ain
 
-## Building for 64-bit Windows
+The first step is to install the system wide dependencies.
 
-The first step is to install the mingw-w64 cross-compilation tool chain:
+    sudo TARGET=x86_64-w64-mingw32 ./make.sh ci-setup-deps
 
-    sudo apt install g++-mingw-w64-x86-64
+Next install the user dependencies.
 
-Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
+    TARGET=x86_64-w64-mingw32 ./make.sh ci-setup-user-deps
 
-    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+At this point you MUST restart the VM or close and reopen WSL.
 
-Once the toolchain is installed the build steps are common:
+Install the Rust toolchain for Windows.
 
-Note that for WSL the Bitcoin Core source path MUST be somewhere in the default mount file system, for
-example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
-This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
+    rustup target add x86_64-pc-windows-gnu
 
 Build using:
 
     PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
-    cd depends
-    make HOST=x86_64-w64-mingw32
-    cd ..
-    ./autogen.sh # not required when building from tarball
-    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
-    make
+    TARGET=x86_64-w64-mingw32 ./make.sh build
 
 ## Depends system
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-
-Installation
--------------
-
-After building using the Windows subsystem it can be useful to copy the compiled
-executables to a directory on the Windows drive in the same directory structure
-as they appear in the release `.zip` archive. This can be done in the following
-way. This will install to `c:\workspace\bitcoin`, for example:
-
-    make install DESTDIR=/mnt/c/workspace/bitcoin
-
-You can also create an installer using:
-
-    make deploy
 
 Footnotes
 ---------
@@ -130,5 +66,5 @@ Footnotes
 compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
 efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
 required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
-It's not possible to build the Bitcoin Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
+It's not possible to build the DeFiChain code using the win32 version of the Mingw-w64 cross compilers (at least not without
 modifying headers in the Bitcoin Core source code).


### PR DESCRIPTION
## Summary

- Update the out-of-date build for Windows to make use of the make.sh script.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
