### PR TITLE
Set Docker to use 24.04

### DIFF
--- a/contrib/dockerfiles/defi.dockerfile
+++ b/contrib/dockerfiles/defi.dockerfile
@@ -1,6 +1,6 @@
 ARG TARGET=x86_64-pc-linux-gnu
 
-FROM --platform=linux/amd64 ubuntu:latest as defi
+FROM --platform=linux/amd64 ubuntu:24.04 as defi
 ARG TARGET
 ARG BINARY_DIR
 ENV PATH=/app/bin:$PATH


### PR DESCRIPTION
## Summary

- Set Docker to use 24.04

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
