### PR TITLE
Ocean: list dex prices api

### DIFF
--- a/lib/ain-ocean/src/api/cache.rs
+++ b/lib/ain-ocean/src/api/cache.rs
@@ -49,19 +49,18 @@ pub async fn get_token_cached(
     Ok(token)
 }
 
-pub async fn list_token_cached(
-    ctx: &Arc<AppContext>,
-) -> Result<TokenResult> {
+pub async fn list_token_cached(ctx: &Arc<AppContext>) -> Result<TokenResult> {
     let tokens = ctx
         .client
         .list_tokens(
-            Some(TokenPagination{
+            Some(TokenPagination {
                 start: 0,
                 including_start: true,
                 limit: 1000,
-                }),
-            Some(true))
-            .await?;
+            }),
+            Some(true),
+        )
+        .await?;
 
     Ok(tokens)
 }

--- a/lib/ain-ocean/src/api/cache.rs
+++ b/lib/ain-ocean/src/api/cache.rs
@@ -4,7 +4,7 @@ use cached::proc_macro::cached;
 use defichain_rpc::{
     json::{
         poolpair::{PoolPairInfo, PoolPairPagination, PoolPairsResult},
-        token::TokenInfo,
+        token::{TokenInfo, TokenPagination, TokenResult},
     },
     jsonrpc_async::error::{Error as JsonRpcError, RpcError},
     Error, MasternodeRPC, PoolPairRPC, TokenRPC,
@@ -47,6 +47,23 @@ pub async fn get_token_cached(
     };
 
     Ok(token)
+}
+
+pub async fn list_token_cached(
+    ctx: &Arc<AppContext>,
+) -> Result<TokenResult> {
+    let tokens = ctx
+        .client
+        .list_tokens(
+            Some(TokenPagination{
+                start: 0,
+                including_start: true,
+                limit: 1000,
+                }),
+            Some(true))
+            .await?;
+
+    Ok(tokens)
 }
 
 #[cached(

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -61,9 +61,9 @@ struct SwapAggregate {
     interval: u32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct DexPrices {
-    denomination_symbol: String,
+    denomination: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -665,10 +665,10 @@ async fn get_best_path(
 
 #[ocean_endpoint]
 async fn list_dex_prices(
-    Query(DexPrices { denomination_symbol }): Query<DexPrices>,
+    Query(DexPrices { denomination }): Query<DexPrices>,
     Extension(ctx): Extension<Arc<AppContext>>,
 ) -> Result<Response<DexPriceResponse>> {
-    let prices = price::list_dex_prices(&ctx, denomination_symbol).await?;
+    let prices = price::list_dex_prices(&ctx, denomination).await?;
 
     Ok(Response::new(prices))
 }

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -44,8 +44,10 @@ use path::{
 };
 
 use service::{get_aggregated_in_usd, get_apr, get_total_liquidity_usd};
+use price::DexPriceResponse;
 
 pub mod path;
+pub mod price;
 pub mod service;
 
 // #[derive(Deserialize)]
@@ -59,10 +61,10 @@ struct SwapAggregate {
     interval: u32,
 }
 
-// #[derive(Debug, Deserialize)]
-// struct DexPrices {
-//     denomination: Option<String>,
-// }
+#[derive(Debug, Deserialize)]
+struct DexPrices {
+    denomination_symbol: String,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -661,10 +663,15 @@ async fn get_best_path(
     }))
 }
 
-// #[ocean_endpoint]
-// async fn list_dex_prices(Query(DexPrices { denomination }): Query<DexPrices>) -> String {
-//     format!("List of DEX prices with denomination {:?}", denomination)
-// }
+#[ocean_endpoint]
+async fn list_dex_prices(
+    Query(DexPrices { denomination_symbol }): Query<DexPrices>,
+    Extension(ctx): Extension<Arc<AppContext>>,
+) -> Result<Response<DexPriceResponse>> {
+    let prices = price::list_dex_prices(&ctx, denomination_symbol).await?;
+
+    Ok(Response::new(prices))
+}
 
 pub fn router(ctx: Arc<AppContext>) -> Router {
     Router::new()
@@ -682,6 +689,6 @@ pub fn router(ctx: Arc<AppContext>) -> Router {
             get(list_pool_swap_aggregates),
         )
         .route("/paths/swappable/:tokenId", get(get_swappable_tokens))
-        // .route("/dexprices", get(list_dex_prices))
+        .route("/dexprices", get(list_dex_prices))
         .layer(Extension(ctx))
 }

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -43,8 +43,8 @@ use path::{
     SwapPathsResponse,
 };
 
-use service::{get_aggregated_in_usd, get_apr, get_total_liquidity_usd};
 use price::DexPriceResponse;
+use service::{get_aggregated_in_usd, get_apr, get_total_liquidity_usd};
 
 pub mod path;
 pub mod price;

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -13,8 +13,9 @@ use crate::{
         cache::{get_pool_pair_cached, get_token_cached, list_pool_pairs_cached},
         common::{format_number, parse_dat_symbol},
     },
+    error::NotFoundKind,
     network::Network,
-    Result, TokenIdentifier,
+    Error, Result, TokenIdentifier,
 };
 
 #[derive(Debug, Serialize)]
@@ -101,7 +102,7 @@ impl StackSet {
 }
 
 pub async fn get_token_identifier(ctx: &Arc<AppContext>, id: &str) -> Result<TokenIdentifier> {
-    let (id, token) = get_token_cached(ctx, id).await?.unwrap();
+    let (id, token) = get_token_cached(ctx, id).await?.ok_or(Error::NotFound(NotFoundKind::Token))?;
     Ok(TokenIdentifier {
         id,
         display_symbol: parse_dat_symbol(&token.symbol),

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -102,7 +102,9 @@ impl StackSet {
 }
 
 pub async fn get_token_identifier(ctx: &Arc<AppContext>, id: &str) -> Result<TokenIdentifier> {
-    let (id, token) = get_token_cached(ctx, id).await?.ok_or(Error::NotFound(NotFoundKind::Token))?;
+    let (id, token) = get_token_cached(ctx, id)
+        .await?
+        .ok_or(Error::NotFound(NotFoundKind::Token))?;
     Ok(TokenIdentifier {
         id,
         display_symbol: parse_dat_symbol(&token.symbol),

--- a/lib/ain-ocean/src/api/pool_pair/price.rs
+++ b/lib/ain-ocean/src/api/pool_pair/price.rs
@@ -1,0 +1,74 @@
+use std::{collections::HashMap, sync::Arc};
+use serde::Serialize;
+
+use defichain_rpc::json::token::TokenInfo;
+
+use super::{path::get_best_path, AppContext};
+
+use crate::{
+  api::{cache::{get_token_cached, list_token_cached}, common::parse_display_symbol},
+  error::{Error, NotFoundKind},
+  Result, TokenIdentifier,
+};
+
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DexPrice {
+  pub token: TokenIdentifier,
+  pub denomination_price: String,
+}
+
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DexPriceResponse {
+  pub denomination: TokenIdentifier,
+  pub dex_prices: HashMap<String, DexPrice>,
+}
+
+fn is_untradable_token(token: &TokenInfo) -> bool {
+  token.is_lps || !token.is_dat || token.symbol == "BURN".to_string() || !token.tradeable
+}
+
+pub async fn list_dex_prices(ctx: &Arc<AppContext>, symbol: String) -> Result<DexPriceResponse> {
+  let (denomination_token_id, denomination_token_info) = get_token_cached(ctx, &symbol).await?.ok_or(Error::NotFound(NotFoundKind::Token))?;
+
+  if is_untradable_token(&denomination_token_info) {
+    return Err(Error::UntradeableTokenError(denomination_token_info.symbol))
+  };
+
+  let tokens = list_token_cached(ctx)
+    .await?
+    .0
+    .into_iter()
+    .collect::<Vec<_>>();
+
+  let mut dex_prices = HashMap::<String, DexPrice>::new();
+
+  // For every token available, compute estimated return in denomination token
+  for (id, info) in tokens {
+    if id == denomination_token_id {
+      continue;
+    }
+    let best_path = get_best_path(ctx, &id, &denomination_token_id).await?;
+
+    dex_prices.insert(info.clone().symbol, DexPrice {
+      token: TokenIdentifier {
+        id,
+        display_symbol: parse_display_symbol(&info),
+        name: info.name,
+        symbol: info.symbol,
+      },
+      denomination_price: best_path.estimated_return,
+    });
+  }
+
+  Ok(DexPriceResponse {
+    denomination: TokenIdentifier {
+        id: denomination_token_id,
+        display_symbol: parse_display_symbol(&denomination_token_info),
+        name: denomination_token_info.name,
+        symbol: denomination_token_info.symbol,
+    },
+    dex_prices,
+  })
+}

--- a/lib/ain-ocean/src/api/pool_pair/price.rs
+++ b/lib/ain-ocean/src/api/pool_pair/price.rs
@@ -26,7 +26,7 @@ pub struct DexPriceResponse {
 }
 
 fn is_untradable_token(token: &TokenInfo) -> bool {
-  token.is_lps || !token.is_dat || token.symbol == "BURN".to_string() || !token.tradeable
+  token.is_lps || !token.is_dat || token.symbol == *"BURN" || !token.tradeable
 }
 
 pub async fn list_dex_prices(ctx: &Arc<AppContext>, symbol: String) -> Result<DexPriceResponse> {
@@ -40,6 +40,7 @@ pub async fn list_dex_prices(ctx: &Arc<AppContext>, symbol: String) -> Result<De
     .await?
     .0
     .into_iter()
+    .filter(|(_, info)| !is_untradable_token(info))
     .collect::<Vec<_>>();
 
   let mut dex_prices = HashMap::<String, DexPrice>::new();

--- a/lib/ain-ocean/src/api/pool_pair/price.rs
+++ b/lib/ain-ocean/src/api/pool_pair/price.rs
@@ -1,75 +1,83 @@
-use std::{collections::HashMap, sync::Arc};
 use serde::Serialize;
+use std::{collections::HashMap, sync::Arc};
 
 use defichain_rpc::json::token::TokenInfo;
 
 use super::{path::get_best_path, AppContext};
 
 use crate::{
-  api::{cache::{get_token_cached, list_token_cached}, common::parse_display_symbol},
-  error::{Error, NotFoundKind},
-  Result, TokenIdentifier,
+    api::{
+        cache::{get_token_cached, list_token_cached},
+        common::parse_display_symbol,
+    },
+    error::{Error, NotFoundKind},
+    Result, TokenIdentifier,
 };
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DexPrice {
-  pub token: TokenIdentifier,
-  pub denomination_price: String,
+    pub token: TokenIdentifier,
+    pub denomination_price: String,
 }
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DexPriceResponse {
-  pub denomination: TokenIdentifier,
-  pub dex_prices: HashMap<String, DexPrice>,
+    pub denomination: TokenIdentifier,
+    pub dex_prices: HashMap<String, DexPrice>,
 }
 
 fn is_untradable_token(token: &TokenInfo) -> bool {
-  token.is_lps || !token.is_dat || token.symbol == *"BURN" || !token.tradeable
+    token.is_lps || !token.is_dat || token.symbol == *"BURN" || !token.tradeable
 }
 
 pub async fn list_dex_prices(ctx: &Arc<AppContext>, symbol: String) -> Result<DexPriceResponse> {
-  let (denomination_token_id, denomination_token_info) = get_token_cached(ctx, &symbol).await?.ok_or(Error::NotFound(NotFoundKind::Token))?;
+    let (denomination_token_id, denomination_token_info) = get_token_cached(ctx, &symbol)
+        .await?
+        .ok_or(Error::NotFound(NotFoundKind::Token))?;
 
-  if is_untradable_token(&denomination_token_info) {
-    return Err(Error::UntradeableTokenError(denomination_token_info.symbol))
-  };
+    if is_untradable_token(&denomination_token_info) {
+        return Err(Error::UntradeableTokenError(denomination_token_info.symbol));
+    };
 
-  let tokens = list_token_cached(ctx)
-    .await?
-    .0
-    .into_iter()
-    .filter(|(_, info)| !is_untradable_token(info))
-    .collect::<Vec<_>>();
+    let tokens = list_token_cached(ctx)
+        .await?
+        .0
+        .into_iter()
+        .filter(|(_, info)| !is_untradable_token(info))
+        .collect::<Vec<_>>();
 
-  let mut dex_prices = HashMap::<String, DexPrice>::new();
+    let mut dex_prices = HashMap::<String, DexPrice>::new();
 
-  // For every token available, compute estimated return in denomination token
-  for (id, info) in tokens {
-    if id == denomination_token_id {
-      continue;
+    // For every token available, compute estimated return in denomination token
+    for (id, info) in tokens {
+        if id == denomination_token_id {
+            continue;
+        }
+        let best_path = get_best_path(ctx, &id, &denomination_token_id).await?;
+
+        dex_prices.insert(
+            info.clone().symbol,
+            DexPrice {
+                token: TokenIdentifier {
+                    id,
+                    display_symbol: parse_display_symbol(&info),
+                    name: info.name,
+                    symbol: info.symbol,
+                },
+                denomination_price: best_path.estimated_return,
+            },
+        );
     }
-    let best_path = get_best_path(ctx, &id, &denomination_token_id).await?;
 
-    dex_prices.insert(info.clone().symbol, DexPrice {
-      token: TokenIdentifier {
-        id,
-        display_symbol: parse_display_symbol(&info),
-        name: info.name,
-        symbol: info.symbol,
-      },
-      denomination_price: best_path.estimated_return,
-    });
-  }
-
-  Ok(DexPriceResponse {
-    denomination: TokenIdentifier {
-        id: denomination_token_id,
-        display_symbol: parse_display_symbol(&denomination_token_info),
-        name: denomination_token_info.name,
-        symbol: denomination_token_info.symbol,
-    },
-    dex_prices,
-  })
+    Ok(DexPriceResponse {
+        denomination: TokenIdentifier {
+            id: denomination_token_id,
+            display_symbol: parse_display_symbol(&denomination_token_info),
+            name: denomination_token_info.name,
+            symbol: denomination_token_info.symbol,
+        },
+        dex_prices,
+    })
 }

--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -69,7 +69,12 @@ async fn get_total_liquidity_usd_by_best_path(
     ctx: &Arc<AppContext>,
     p: &PoolPairInfo,
 ) -> Result<Decimal> {
-    let (usdt_id, _) = get_token_cached(ctx, "USDT").await?.unwrap();
+    let usdt = get_token_cached(ctx, "USDT").await?;
+    if usdt.is_none() {
+        return Ok(dec!(0))
+    };
+
+    let (usdt_id, _) = usdt.unwrap();
 
     let mut a_token_rate = dec!(1);
     let mut b_token_rate = dec!(1);

--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -71,7 +71,7 @@ async fn get_total_liquidity_usd_by_best_path(
 ) -> Result<Decimal> {
     let usdt = get_token_cached(ctx, "USDT").await?;
     if usdt.is_none() {
-        return Ok(dec!(0))
+        return Ok(dec!(0));
     };
 
     let (usdt_id, _) = usdt.unwrap();

--- a/lib/ain-ocean/src/error.rs
+++ b/lib/ain-ocean/src/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     UnderflowError,
     #[error("Error fetching primary value")]
     SecondaryIndex,
+    #[error("Token {0:?} is invalid as it is not tradeable")]
+    UntradeableTokenError(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Ocean: list dex prices api

> Ignore the failed which is error handling stuff <-- todo!()
```
latest dex prices
    ✓ should get latest dex prices - denomination: DFI (5 ms)
    ✓ should get latest dex prices - denomination: USDT (4 ms)
    ✓ should get consistent, mathematically sound dex prices - USDT and DFI (5 ms)
    ✓ should get consistent, mathematically sound dex prices - A and B (10 ms)
    ✕ should list DAT tokens only - O (non-DAT token) is not included in result (4 ms)
    ✕ should list DAT tokens only - status:false tokens are excluded (4 ms)
    param validation - denomination
      ✕ should throw error for invalid denomination (1 ms)
```

