### PR TITLE
Static pool reward

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -79,6 +79,7 @@ static constexpr CAmount COIN = 100000000;
 static constexpr CAmount CENT = 1000000;
 static constexpr int64_t WEI_IN_GWEI    = 1000000000;
 static constexpr int64_t CAMOUNT_TO_GWEI = 10;
+static constexpr CAmount HIGH_PRECISION_SCALER = COIN * COIN;  // 1,0000,0000,0000,0000
 
 //Converts the given value to decimal format string with COIN precision.
 inline std::string GetDecimalString(CAmount nValue)

--- a/src/dfi/loan.h
+++ b/src/dfi/loan.h
@@ -328,8 +328,6 @@ inline auto InterestAddition = [](const CInterestAmount &a, const CInterestAmoun
     return interest;
 };
 
-static const CAmount HIGH_PRECISION_SCALER = COIN * COIN;  // 1,0000,0000,0000,0000
-
 CAmount TotalInterest(const CInterestRateV3 &rate, const uint32_t height);
 CInterestAmount TotalInterestCalculation(const CInterestRateV3 &rate, const uint32_t height);
 CAmount CeilInterest(const base_uint<128> &value, uint32_t height);

--- a/src/dfi/masternodes.cpp
+++ b/src/dfi/masternodes.cpp
@@ -969,17 +969,29 @@ bool CCustomCSView::CalculateOwnerRewards(const CScript &owner, uint32_t targetH
             return true;  // no share or target height is before a pool share' one
         }
         auto onLiquidity = [&]() -> CAmount { return GetBalance(owner, poolId).nValue; };
-        auto beginHeight = std::max(*height, balanceHeight);
-        CalculatePoolRewards(
-            poolId, onLiquidity, beginHeight, targetHeight, [&](RewardType, CTokenAmount amount, uint32_t height) {
-                auto res = AddBalance(owner, amount);
-                if (!res) {
-                    LogPrintf("Pool rewards: can't update balance of %s: %s, height %ld\n",
-                              owner.GetHex(),
-                              res.msg,
-                              targetHeight);
-                }
-            });
+        const auto beginHeight = std::max(*height, balanceHeight);
+        auto onReward = [&](RewardType, const CTokenAmount &amount, const uint32_t height) {
+            if (auto res = AddBalance(owner, amount); !res) {
+                LogPrintf(
+                    "Pool rewards: can't update balance of %s: %s, height %ld\n", owner.GetHex(), res.msg, height);
+            }
+        };
+
+        if (beginHeight < Params().GetConsensus().DF24Height) {
+            // Calculate just up to the fork height
+            const auto targetNewHeight = targetHeight >= Params().GetConsensus().DF24Height
+                                             ? Params().GetConsensus().DF24Height - 1
+                                             : targetHeight;
+            CalculatePoolRewards(poolId, onLiquidity, beginHeight, targetNewHeight, onReward);
+        }
+
+        if (targetHeight >= Params().GetConsensus().DF24Height) {
+            // Calculate from the fork height
+            const auto beginNewHeight =
+                beginHeight < Params().GetConsensus().DF24Height ? Params().GetConsensus().DF24Height : beginHeight;
+            CalculateStaticPoolRewards(onLiquidity, onReward, poolId.v, beginNewHeight, targetHeight);
+        }
+
         return true;
     });
 

--- a/src/dfi/poolpairs.cpp
+++ b/src/dfi/poolpairs.cpp
@@ -275,13 +275,13 @@ void CPoolPairView::CalculateStaticPoolRewards(std::function<CAmount()> onLiquid
         }
     };
 
-    calcReward(RewardType::Coinbase, startCoinbase, endCoinbase, {});
-    calcReward(RewardType::LoanTokenDEXReward, startLoan, endLoan, {});
+    calcReward(RewardType::Coinbase, startCoinbase, endCoinbase, 0);
+    calcReward(RewardType::LoanTokenDEXReward, startLoan, endLoan, 0);
     calcReward(RewardType::Commission, startCommission.commissionA, endCommission.commissionA, endCommission.tokenA);
     calcReward(RewardType::Commission, startCommission.commissionB, endCommission.commissionB, endCommission.tokenB);
 
-    for (const auto &[id, endCustom] : endCustom) {
-        calcReward(RewardType::Pool, startCustom[id], endCustom, id);
+    for (const auto &[id, end] : endCustom) {
+        calcReward(RewardType::Pool, startCustom[id], end, id);
     }
 }
 

--- a/src/dfi/poolpairs.h
+++ b/src/dfi/poolpairs.h
@@ -225,6 +225,19 @@ struct PoolShareKey {
     }
 };
 
+struct TotalRewardPerShareKey {
+    uint32_t height;
+    uint32_t poolID;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(WrapBigEndian(height));
+        READWRITE(WrapBigEndian(poolID));
+    }
+};
+
 struct LoanTokenAverageLiquidityKey {
     uint32_t sourceID;
     uint32_t destID;
@@ -320,6 +333,12 @@ public:
                               uint32_t end,
                               std::function<void(RewardType, CTokenAmount, uint32_t)> onReward);
 
+    void CalculateStaticPoolRewards(std::function<CAmount()> onLiquidity,
+                                    std::function<void(RewardType, CTokenAmount, uint32_t)> onReward,
+                                    const uint32_t poolID,
+                                    const uint32_t beginHeight,
+                                    const uint32_t endHeight);
+
     Res SetLoanDailyReward(const uint32_t height, const CAmount reward);
     Res SetDailyReward(uint32_t height, CAmount reward);
     Res SetRewardPct(DCT_ID const &poolId, uint32_t height, CAmount rewardPct);
@@ -348,6 +367,9 @@ public:
     void ForEachTokenAverageLiquidity(
         std::function<bool(const LoanTokenAverageLiquidityKey &key, const uint64_t liquidity)> callback,
         const LoanTokenAverageLiquidityKey start = LoanTokenAverageLiquidityKey{});
+
+    bool SetTotalRewardPerShare(const TotalRewardPerShareKey &key, const arith_uint256 &totalReward);
+    arith_uint256 GetTotalRewardPerShare(const TotalRewardPerShareKey &totalReward);
 
     // tags
     struct ByID {
@@ -400,6 +422,9 @@ public:
     };
     struct ByLoanTokenLiquidityAverage {
         static constexpr uint8_t prefix() { return '+'; }
+    };
+    struct ByTotalRewardPerShare {
+        static constexpr uint8_t prefix() { return '-'; }
     };
 };
 

--- a/src/dfi/poolpairs.h
+++ b/src/dfi/poolpairs.h
@@ -370,6 +370,8 @@ public:
 
     bool SetTotalRewardPerShare(const TotalRewardPerShareKey &key, const arith_uint256 &totalReward);
     arith_uint256 GetTotalRewardPerShare(const TotalRewardPerShareKey &totalReward);
+    bool SetTotalLoanRewardPerShare(const TotalRewardPerShareKey &key, const arith_uint256 &totalReward);
+    arith_uint256 GetTotalLoanRewardPerShare(const TotalRewardPerShareKey &totalReward);
 
     // tags
     struct ByID {
@@ -425,6 +427,10 @@ public:
     };
     struct ByTotalRewardPerShare {
         static constexpr uint8_t prefix() { return '-'; }
+    };
+
+    struct ByTotalLoanRewardPerShare {
+        static constexpr uint8_t prefix() { return '='; }
     };
 };
 

--- a/src/dfi/poolpairs.h
+++ b/src/dfi/poolpairs.h
@@ -238,6 +238,23 @@ struct TotalRewardPerShareKey {
     }
 };
 
+struct TotalCommissionPerShareValue {
+    uint32_t tokenA;
+    uint32_t tokenB;
+    arith_uint256 commissionA;
+    arith_uint256 commissionB;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action) {
+        READWRITE(tokenA);
+        READWRITE(tokenB);
+        READWRITE(commissionA);
+        READWRITE(commissionB);
+    }
+};
+
 struct LoanTokenAverageLiquidityKey {
     uint32_t sourceID;
     uint32_t destID;
@@ -369,9 +386,15 @@ public:
         const LoanTokenAverageLiquidityKey start = LoanTokenAverageLiquidityKey{});
 
     bool SetTotalRewardPerShare(const TotalRewardPerShareKey &key, const arith_uint256 &totalReward);
-    arith_uint256 GetTotalRewardPerShare(const TotalRewardPerShareKey &totalReward);
+    arith_uint256 GetTotalRewardPerShare(const TotalRewardPerShareKey &totalReward) const;
     bool SetTotalLoanRewardPerShare(const TotalRewardPerShareKey &key, const arith_uint256 &totalReward);
-    arith_uint256 GetTotalLoanRewardPerShare(const TotalRewardPerShareKey &totalReward);
+    arith_uint256 GetTotalLoanRewardPerShare(const TotalRewardPerShareKey &totalReward) const;
+    bool SetTotalCustomRewardPerShare(const TotalRewardPerShareKey &key,
+                                      const std::map<uint32_t, arith_uint256> &customRewards);
+    std::map<uint32_t, arith_uint256> GetTotalCustomRewardPerShare(const TotalRewardPerShareKey &key) const;
+    bool SetTotalCommissionPerShare(const TotalRewardPerShareKey &key,
+                                    const TotalCommissionPerShareValue &totalCommission);
+    TotalCommissionPerShareValue GetTotalCommissionPerShare(const TotalRewardPerShareKey &key) const;
 
     // tags
     struct ByID {
@@ -431,6 +454,14 @@ public:
 
     struct ByTotalLoanRewardPerShare {
         static constexpr uint8_t prefix() { return '='; }
+    };
+
+    struct ByTotalCustomRewardPerShare {
+        static constexpr uint8_t prefix() { return '_'; }
+    };
+
+    struct ByTotalCommissionPerShare {
+        static constexpr uint8_t prefix() { return '/'; }
     };
 };
 

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -9,14 +9,17 @@ from test_framework.test_framework import DefiTestFramework
 from test_framework.util import assert_equal
 
 from decimal import Decimal
+import time
 
 
 class TokenFractionalSplitTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+        self.df24height = 150
         self.extra_args = [
             [
+                "-jellyfish_regtest=1",
                 "-subsidytest=1",
                 "-txnotokens=0",
                 "-amkheight=1",
@@ -34,7 +37,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
                 "-grandcentralepilogueheight=1",
                 "-metachainheight=105",
                 "-df23height=110",
-                "-df24height=120",
+                f"-df24height={self.df24height}",
             ]
         ]
 
@@ -46,6 +49,18 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Test new pool reward
         self.static_reward_calculation()
 
+        # Test reward when LP_SPLITS zeroed
+        self.lp_split_zero_reward()
+
+        # Add liquidity before LP_SPLITS
+        self.liquidity_before_setting_splits()
+
+        # Add liquidity after LP_SPLITS
+        self.liquidity_after_setting_splits()
+
+        # Check loan token reward
+        self.static_loan_reward_calculation()
+
     def setup_tests(self):
 
         # Set up test tokens
@@ -54,36 +69,81 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Set up pool pair
         self.setup_poolpair()
 
+        # Save start block
+        self.start_block = self.nodes[0].getblockcount()
+
     def setup_poolpair(self):
+
+        # Enable mint tokens to address
+        self.nodes[0].setgov(
+            {"ATTRIBUTES": {"v0/params/feature/mint-tokens-to-address": "true"}}
+        )
+        self.nodes[0].generate(1)
 
         # Fund address for pool
         self.nodes[0].utxostoaccount({self.address: f"1000@{self.symbolDFI}"})
+        self.nodes[0].utxostoaccount({self.alt_address: f"1000@{self.symbolDFI}"})
         self.nodes[0].minttokens([f"1000@{self.idBTC}"])
+        self.nodes[0].minttokens([f"1000@{self.idLTC}"])
+        self.nodes[0].minttokens([f"1000@{self.idTSLA}"], [], self.alt_address)
         self.nodes[0].generate(1)
 
         # Create pool symbol
-        pool_symbol = self.symbolBTC + "-" + self.symbolDFI
+        btc_pool_symbol = self.symbolBTC + "-" + self.symbolDFI
+        ltc_pool_symbol = self.symbolLTC + "-" + self.symbolDFI
+        tsla_pool_symbol = self.symbolTSLA + "-" + self.symbolDFI
 
-        # Create pool pair
+        # Create pool pairs
         self.nodes[0].createpoolpair(
             {
                 "tokenA": self.symbolBTC,
                 "tokenB": self.symbolDFI,
                 "status": True,
                 "ownerAddress": self.address,
-                "symbol": pool_symbol,
+                "symbol": btc_pool_symbol,
             }
         )
         self.nodes[0].generate(1)
 
-        # Set pool pair splits
-        pool_id = list(self.nodes[0].getpoolpair(pool_symbol).keys())[0]
-        self.nodes[0].setgov({"LP_SPLITS": {pool_id: 1}})
+        self.nodes[0].createpoolpair(
+            {
+                "tokenA": self.symbolLTC,
+                "tokenB": self.symbolDFI,
+                "status": True,
+                "ownerAddress": self.address,
+                "symbol": ltc_pool_symbol,
+            }
+        )
         self.nodes[0].generate(1)
 
-        # Fund pool
+        self.nodes[0].createpoolpair(
+            {
+                "tokenA": self.symbolTSLA,
+                "tokenB": self.symbolDFI,
+                "status": True,
+                "ownerAddress": self.address,
+                "symbol": self.symbolTSLA + "-" + self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Get pool pair IDs
+        btc_pool_id = list(self.nodes[0].getpoolpair(btc_pool_symbol).keys())[0]
+        self.ltc_pool_id = list(self.nodes[0].getpoolpair(ltc_pool_symbol).keys())[0]
+        tsla_pool_id = list(self.nodes[0].getpoolpair(tsla_pool_symbol).keys())[0]
+
+        # Set pool pair splits
+        self.nodes[0].setgov({"LP_SPLITS": {btc_pool_id: 1}})
+        self.nodes[0].setgov({"LP_LOAN_TOKEN_SPLITS": {tsla_pool_id: 1}})
+        self.nodes[0].generate(1)
+
+        # Fund pools
         self.nodes[0].addpoolliquidity(
             {self.address: [f"1000@{self.symbolBTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+        self.nodes[0].addpoolliquidity(
+            {self.alt_address: [f"1000@{self.symbolTSLA}", f"1000@{self.symbolDFI}"]},
             self.address,
         )
         self.nodes[0].generate(1)
@@ -93,12 +153,15 @@ class TokenFractionalSplitTest(DefiTestFramework):
 
         # Symbols
         self.symbolBTC = "BTC"
+        self.symbolLTC = "LTC"
         self.symbolDFI = "DFI"
+        self.symbolTSLA = "TSLA"
 
-        # Store address
+        # Store addresses
         self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+        self.alt_address = self.nodes[0].getnewaddress("", "legacy")
 
-        # Create token
+        # Create tokens
         self.nodes[0].createtoken(
             {
                 "symbol": self.symbolBTC,
@@ -109,10 +172,56 @@ class TokenFractionalSplitTest(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
+        self.nodes[0].createtoken(
+            {
+                "symbol": self.symbolLTC,
+                "name": self.symbolLTC,
+                "isDAT": True,
+                "collateralAddress": self.address,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Price feeds
+        price_feed = [
+            {"currency": "USD", "token": self.symbolTSLA},
+            {"currency": "USD", "token": self.symbolDFI},
+        ]
+
+        # Appoint oracle
+        oracle_address = self.nodes[0].getnewaddress("", "legacy")
+        oracle = self.nodes[0].appointoracle(oracle_address, price_feed, 10)
+        self.nodes[0].generate(1)
+
+        # Set Oracle prices
+        oracle_prices = [
+            {"currency": "USD", "tokenAmount": f"1@{self.symbolTSLA}"},
+            {"currency": "USD", "tokenAmount": f"1@{self.symbolDFI}"},
+        ]
+        self.nodes[0].setoracledata(oracle, int(time.time()), oracle_prices)
+        self.nodes[0].generate(11)
+
+        # Create loan token
+        self.nodes[0].setloantoken(
+            {
+                "symbol": self.symbolTSLA,
+                "name": self.symbolTSLA,
+                "fixedIntervalPriceId": f"{self.symbolTSLA}/USD",
+                "mintable": True,
+                "interest": 0,
+            }
+        )
+        self.nodes[0].generate(1)
+
         # Store token IDs
         self.idBTC = list(self.nodes[0].gettoken(self.symbolBTC).keys())[0]
+        self.idLTC = list(self.nodes[0].gettoken(self.symbolLTC).keys())[0]
+        self.idTSLA = list(self.nodes[0].gettoken(self.symbolTSLA).keys())[0]
 
     def static_reward_calculation(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
 
         # Get initial balance
         start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
@@ -122,10 +231,10 @@ class TokenFractionalSplitTest(DefiTestFramework):
         end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
 
         # Calculate pre-fork reward
-        pre_fork_reward = end_balance - start_balance
+        self.pre_fork_reward = end_balance - start_balance
 
-        # Move past fork height
-        self.nodes[0].generate(120 - self.nodes[0].getblockcount())
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
 
         # Get initial balance
         start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
@@ -133,6 +242,137 @@ class TokenFractionalSplitTest(DefiTestFramework):
 
         # Get balance after a block
         end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Calculate post-fork reward
+        post_fork_reward = end_balance - start_balance
+
+        # Check rewards are the same
+        assert_equal(self.pre_fork_reward, post_fork_reward)
+
+    def lp_split_zero_reward(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Set pool pair splits to different pool
+        self.nodes[0].setgov({"LP_SPLITS": {self.ltc_pool_id: 1}})
+        self.nodes[0].generate(1)
+
+        # Get initial balance
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Check balances are the same
+        assert_equal(start_balance, end_balance)
+
+    def liquidity_before_setting_splits(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Fund pool
+        self.nodes[0].addpoolliquidity(
+            {self.address: [f"1000@{self.symbolLTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+        self.nodes[0].generate(1)
+
+        # Set pool pair splits to different pool and calculate owner rewards
+        self.nodes[0].setgov({"LP_SPLITS": {self.ltc_pool_id: 1}})
+        self.nodes[0].accounttoaccount(
+            self.address, {self.alt_address: f"1@{self.symbolDFI}"}
+        )
+        self.nodes[0].generate(1)
+
+        # Get initial balance
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Calculate new pool reward
+        new_pool_reward = end_balance - start_balance
+
+        # Check rewards matches previous pre-fork reward. Different pool but same liquidty and reward share
+        assert_equal(self.pre_fork_reward, new_pool_reward)
+
+    def liquidity_after_setting_splits(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Set pool pair splits to different pool
+        self.nodes[0].setgov({"LP_SPLITS": {self.ltc_pool_id: 1}})
+        self.nodes[0].generate(10)
+
+        # Fund pool and calculate owner rewards
+        self.nodes[0].addpoolliquidity(
+            {self.address: [f"1000@{self.symbolLTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+        self.nodes[0].accounttoaccount(
+            self.address, {self.alt_address: f"1@{self.symbolDFI}"}
+        )
+        self.nodes[0].generate(1)
+
+        # Get initial balance
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Calculate new pool reward
+        new_pool_reward = end_balance - start_balance
+
+        # Check rewards matches previous pre-fork reward. Different pool but same liquidty and reward share
+        assert_equal(self.pre_fork_reward, new_pool_reward)
+
+    def static_loan_reward_calculation(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Get initial balance
+        start_balance = Decimal(
+            self.nodes[0].getaccount(self.alt_address)[0].split("@")[0]
+        )
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(
+            self.nodes[0].getaccount(self.alt_address)[0].split("@")[0]
+        )
+
+        # Calculate pre-fork reward
+        pre_fork_reward = end_balance - start_balance
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Get initial balance
+        start_balance = Decimal(
+            self.nodes[0].getaccount(self.alt_address)[0].split("@")[0]
+        )
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(
+            self.nodes[0].getaccount(self.alt_address)[0].split("@")[0]
+        )
 
         # Calculate post-fork reward
         post_fork_reward = end_balance - start_balance

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -16,7 +16,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.df24height = 150
+        self.df24height = 250
         self.extra_args = [
             [
                 "-jellyfish_regtest=1",
@@ -47,8 +47,29 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Setup test
         self.setup_tests()
 
-        # Test new pool reward
-        self.static_reward_calculation()
+        # Test new pool reward with single share
+        self.static_reward_single()
+
+        # Test new pool reward with multiple share
+        self.static_reward_multiple()
+
+        # Test loan token reward
+        self.static_loan_single()
+
+        # Test loan token reward
+        self.static_loan_multiple()
+
+        # Test custom token reward
+        self.static_custom_single()
+
+        # Test custom token reward
+        self.static_custom_multiple()
+
+        # Test commission
+        self.static_commission_single()
+
+        # Test commission
+        self.static_commission_multiple()
 
         # Test reward when LP_SPLITS zeroed
         self.lp_split_zero_reward()
@@ -58,15 +79,6 @@ class TokenFractionalSplitTest(DefiTestFramework):
 
         # Add liquidity after LP_SPLITS
         self.liquidity_after_setting_splits()
-
-        # Test loan token reward
-        self.static_loan_reward()
-
-        # Test custom token reward
-        self.static_custom_reward()
-
-        # Test commission
-        self.static_commission()
 
     def setup_tests(self):
 
@@ -79,20 +91,17 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Save start block
         self.start_block = self.nodes[0].getblockcount()
 
+        # Create variable for pre-fork coinbase reward
+        self.pre_fork_reward = None
+
     def setup_poolpair(self):
 
-        # Enable mint tokens to address
-        self.nodes[0].setgov(
-            {"ATTRIBUTES": {"v0/params/feature/mint-tokens-to-address": "true"}}
-        )
-        self.nodes[0].generate(1)
-
         # Fund address for pool
-        self.nodes[0].utxostoaccount({self.owner_address: f"2000@{self.symbolDFI}"})
-        self.nodes[0].minttokens([f"2000@{self.idBTC}"])
-        self.nodes[0].minttokens([f"2000@{self.idLTC}"])
-        self.nodes[0].minttokens([f"2000@{self.idTSLA}"])
-        self.nodes[0].minttokens([f"2000@{self.idETH}"])
+        self.nodes[0].utxostoaccount({self.owner_address: f"100000@{self.symbolDFI}"})
+        self.nodes[0].minttokens([f"100000@{self.idBTC}"])
+        self.nodes[0].minttokens([f"100000@{self.idLTC}"])
+        self.nodes[0].minttokens([f"100000@{self.idTSLA}"])
+        self.nodes[0].minttokens([f"100000@{self.idETH}"])
         self.nodes[0].generate(1)
 
         # Create pool symbol
@@ -225,7 +234,159 @@ class TokenFractionalSplitTest(DefiTestFramework):
         self.idTSLA = list(self.nodes[0].gettoken(self.symbolTSLA).keys())[0]
         self.idETH = list(self.nodes[0].gettoken(self.symbolETH).keys())[0]
 
-    def static_reward_calculation(self):
+    def fund_pool_multiple(self, token_a, token_b):
+
+        # Fund pool with multiple addresses
+        liquidity_addresses = []
+        for i in range(100):
+            address = self.nodes[0].getnewaddress()
+            amount = 10 + (i * 10)
+            self.nodes[0].addpoolliquidity(
+                {self.owner_address: [f"{amount}@{token_a}", f"{amount}@{token_b}"]},
+                address,
+            )
+            self.nodes[0].generate(1)
+            liquidity_addresses.append(address)
+
+        return liquidity_addresses
+
+    def test_single_liquidity(
+        self, token_a, token_b, balance_index=0, custom_token=None
+    ):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Fund pool
+        self.nodes[0].addpoolliquidity(
+            {self.owner_address: [f"1000@{token_a}", f"1000@{token_b}"]},
+            self.address,
+        )
+        self.nodes[0].generate(1)
+
+        # Add custom reward
+        if custom_token:
+            self.nodes[0].updatepoolpair(
+                {"pool": self.btc_pool_id, "customRewards": [f"1@{custom_token}"]}
+            )
+            self.nodes[0].generate(1)
+
+        # Calculate pre-fork reward
+        pre_fork_reward = Decimal(
+            self.nodes[0].getaccount(self.address)[balance_index].split("@")[0]
+        )
+
+        # Save first pre-fork reward
+        if self.pre_fork_reward is None:
+            self.pre_fork_reward = pre_fork_reward
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Get initial balance
+        start_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[balance_index].split("@")[0]
+        )
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[balance_index].split("@")[0]
+        )
+
+        # Calculate post-fork reward
+        post_fork_reward = end_balance - start_balance
+
+        # Check rewards are the same
+        assert_equal(pre_fork_reward, post_fork_reward)
+
+    def test_multiple_liquidity(
+        self, token_a, token_b, balance_index=0, custom_token=None
+    ):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Fund pool with multiple addresses
+        liquidity_addresses = self.fund_pool_multiple(token_a, token_b)
+
+        # Add custom reward
+        if custom_token:
+            self.nodes[0].updatepoolpair(
+                {"pool": self.btc_pool_id, "customRewards": [f"1@{custom_token}"]}
+            )
+            self.nodes[0].generate(1)
+
+        # Get initial balances
+        intitial_balances = []
+        for address in liquidity_addresses:
+            intitial_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[balance_index].split("@")[0])
+            )
+        self.nodes[0].generate(1)
+
+        # Get balances after a block
+        end_balances = []
+        for address in liquidity_addresses:
+            end_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[balance_index].split("@")[0])
+            )
+
+        # Calculate pre-fork rewards
+        pre_fork_rewards = [
+            end - start for start, end in zip(intitial_balances, end_balances)
+        ]
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Get initial balances
+        intitial_balances = []
+        for address in liquidity_addresses:
+            intitial_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[balance_index].split("@")[0])
+            )
+        self.nodes[0].generate(1)
+
+        # Get balances after a block
+        end_balances = []
+        for address in liquidity_addresses:
+            end_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[balance_index].split("@")[0])
+            )
+
+        # Calculate post-fork reward
+        post_fork_rewards = [
+            end - start for start, end in zip(intitial_balances, end_balances)
+        ]
+
+        # Check rewards are the same
+        assert_equal(pre_fork_rewards, post_fork_rewards)
+
+    def static_reward_single(self):
+
+        # Test single coinbase reward
+        self.test_single_liquidity(self.symbolBTC, self.symbolDFI)
+
+    def static_reward_multiple(self):
+
+        # Test multiple coinbase reward
+        self.test_multiple_liquidity(self.symbolTSLA, self.symbolDFI)
+
+    def static_loan_single(self):
+
+        # Test single loan reward
+        self.test_single_liquidity(self.symbolTSLA, self.symbolDFI)
+
+    def static_loan_multiple(self):
+
+        # Test multiple loan reward
+        self.test_multiple_liquidity(self.symbolBTC, self.symbolDFI)
+
+    def static_custom_single(self):
+
+        # Test single custom reward
+        self.test_single_liquidity(self.symbolBTC, self.symbolDFI, 1, self.symbolETH)
 
         # Rollback block
         self.rollback_to(self.start_block)
@@ -237,31 +398,219 @@ class TokenFractionalSplitTest(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
-        # Get initial balance
-        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        # Add custom reward
+        self.nodes[0].updatepoolpair(
+            {"pool": self.btc_pool_id, "customRewards": [f"1@{self.symbolETH}"]}
+        )
         self.nodes[0].generate(1)
 
-        # Get balance after a block
-        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
-
         # Calculate pre-fork reward
-        self.pre_fork_reward = end_balance - start_balance
+        pre_fork_reward = Decimal(
+            self.nodes[0].getaccount(self.address)[1].split("@")[0]
+        )
 
         # Move to fork height
         self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
 
         # Get initial balance
-        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
         self.nodes[0].generate(1)
 
         # Get balance after a block
-        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
 
         # Calculate post-fork reward
         post_fork_reward = end_balance - start_balance
 
         # Check rewards are the same
-        assert_equal(self.pre_fork_reward, post_fork_reward)
+        assert_equal(pre_fork_reward, post_fork_reward)
+
+    def static_custom_multiple(self):
+
+        # Test multiple custom reward
+        self.test_multiple_liquidity(self.symbolBTC, self.symbolDFI, 1, self.symbolETH)
+
+    def static_commission_single(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Fund pool
+        self.nodes[0].addpoolliquidity(
+            {self.owner_address: [f"1000@{self.symbolLTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+        self.nodes[0].generate(1)
+
+        # Store rollback block
+        rollback_block = self.nodes[0].getblockcount()
+
+        # Swap LTC to DFI
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolLTC,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Swap DFI to LTC
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolDFI,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolLTC,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Get commission balances
+        pre_dfi_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[0].split("@")[0]
+        )
+        pre_ltc_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[1].split("@")[0]
+        )
+
+        # Rollback swaps
+        self.rollback_to(rollback_block)
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Swap LTC to DFI
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolLTC,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Swap DFI to LTC
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolDFI,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolLTC,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Get commission balances
+        post_dfi_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[0].split("@")[0]
+        )
+        post_ltc_balance = Decimal(
+            self.nodes[0].getaccount(self.address)[1].split("@")[0]
+        )
+
+        # Check commission is the same pre and post fork
+        assert_equal(pre_dfi_balance, post_dfi_balance)
+        assert_equal(pre_ltc_balance, post_ltc_balance)
+
+    def static_commission_multiple(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Fund pool with multiple addresses
+        liquidity_addresses = self.fund_pool_multiple(self.symbolLTC, self.symbolDFI)
+
+        # Store rollback block
+        rollback_block = self.nodes[0].getblockcount()
+
+        # Swap LTC to DFI
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolLTC,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Swap DFI to LTC
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolDFI,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolLTC,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Get commission balances
+        pre_dfi_balances = []
+        for address in liquidity_addresses:
+            pre_dfi_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[0].split("@")[0])
+            )
+        pre_ltc_balances = []
+        for address in liquidity_addresses:
+            pre_ltc_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[1].split("@")[0])
+            )
+
+        # Rollback swaps
+        self.rollback_to(rollback_block)
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+        # Swap LTC to DFI
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolLTC,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Swap DFI to LTC
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolDFI,
+                "amountFrom": 1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolLTC,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Get commission balances
+        post_dfi_balances = []
+        for address in liquidity_addresses:
+            post_dfi_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[0].split("@")[0])
+            )
+        post_ltc_balances = []
+        for address in liquidity_addresses:
+            post_ltc_balances.append(
+                Decimal(self.nodes[0].getaccount(address)[1].split("@")[0])
+            )
+
+        # Check commission is the same pre and post fork
+        assert_equal(pre_dfi_balances, post_dfi_balances)
+        assert_equal(pre_ltc_balances, post_ltc_balances)
 
     def lp_split_zero_reward(self):
 
@@ -353,172 +702,6 @@ class TokenFractionalSplitTest(DefiTestFramework):
 
         # Check rewards matches
         assert_equal(self.pre_fork_reward, new_pool_reward)
-
-    def static_loan_reward(self):
-
-        # Rollback block
-        self.rollback_to(self.start_block)
-
-        # Fund pool
-        self.nodes[0].addpoolliquidity(
-            {self.owner_address: [f"1000@{self.symbolTSLA}", f"1000@{self.symbolDFI}"]},
-            self.address,
-        )
-        self.nodes[0].generate(1)
-
-        # Get reward after a block
-        pre_fork_reward = Decimal(
-            self.nodes[0].getaccount(self.address)[0].split("@")[0]
-        )
-
-        # Move to fork height
-        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
-
-        # Get initial balance
-        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
-        self.nodes[0].generate(1)
-
-        # Get balance after a block
-        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
-
-        # Calculate post-fork reward
-        post_fork_reward = end_balance - start_balance
-
-        # Check rewards are the same
-        assert_equal(pre_fork_reward, post_fork_reward)
-
-    def static_custom_reward(self):
-
-        # Rollback block
-        self.rollback_to(self.start_block)
-
-        # Fund pool
-        self.nodes[0].addpoolliquidity(
-            {self.owner_address: [f"1000@{self.symbolBTC}", f"1000@{self.symbolDFI}"]},
-            self.address,
-        )
-        self.nodes[0].generate(1)
-
-        # Add custom reward
-        self.nodes[0].updatepoolpair(
-            {"pool": self.btc_pool_id, "customRewards": [f"1@{self.symbolETH}"]}
-        )
-        self.nodes[0].generate(1)
-
-        # Get initial balance
-        start_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
-        self.nodes[0].generate(1)
-
-        # Get balance after a block
-        end_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
-
-        # Calculate pre-fork reward
-        self.pre_fork_reward = end_balance - start_balance
-
-        # Move to fork height
-        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
-
-        # Get initial balance
-        start_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
-        self.nodes[0].generate(1)
-
-        # Get balance after a block
-        end_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
-
-        # Calculate post-fork reward
-        post_fork_reward = end_balance - start_balance
-
-        # Check rewards are the same
-        assert_equal(self.pre_fork_reward, post_fork_reward)
-
-    def static_commission(self):
-
-        # Rollback block
-        self.rollback_to(self.start_block)
-
-        # Fund pool
-        self.nodes[0].addpoolliquidity(
-            {self.owner_address: [f"1000@{self.symbolLTC}", f"1000@{self.symbolDFI}"]},
-            self.address,
-        )
-        self.nodes[0].generate(1)
-
-        # Store rollback block
-        rollback_block = self.nodes[0].getblockcount()
-
-        # Swap LTC to DFI
-        self.nodes[0].poolswap(
-            {
-                "from": self.owner_address,
-                "tokenFrom": self.symbolLTC,
-                "amountFrom": 1,
-                "to": self.owner_address,
-                "tokenTo": self.symbolDFI,
-            }
-        )
-        self.nodes[0].generate(1)
-
-        # Swap DFI to LTC
-        self.nodes[0].poolswap(
-            {
-                "from": self.owner_address,
-                "tokenFrom": self.symbolDFI,
-                "amountFrom": 1,
-                "to": self.owner_address,
-                "tokenTo": self.symbolLTC,
-            }
-        )
-        self.nodes[0].generate(1)
-
-        # Get commission balances
-        pre_dfi_balance = Decimal(
-            self.nodes[0].getaccount(self.address)[0].split("@")[0]
-        )
-        pre_ltc_balance = Decimal(
-            self.nodes[0].getaccount(self.address)[1].split("@")[0]
-        )
-
-        # Rollback swaps
-        self.rollback_to(rollback_block)
-
-        # Move to fork height
-        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
-
-        # Swap LTC to DFI
-        self.nodes[0].poolswap(
-            {
-                "from": self.owner_address,
-                "tokenFrom": self.symbolLTC,
-                "amountFrom": 1,
-                "to": self.owner_address,
-                "tokenTo": self.symbolDFI,
-            }
-        )
-        self.nodes[0].generate(1)
-
-        # Swap DFI to LTC
-        self.nodes[0].poolswap(
-            {
-                "from": self.owner_address,
-                "tokenFrom": self.symbolDFI,
-                "amountFrom": 1,
-                "to": self.owner_address,
-                "tokenTo": self.symbolLTC,
-            }
-        )
-        self.nodes[0].generate(1)
-
-        # Get commission balances
-        post_dfi_balance = Decimal(
-            self.nodes[0].getaccount(self.address)[0].split("@")[0]
-        )
-        post_ltc_balance = Decimal(
-            self.nodes[0].getaccount(self.address)[1].split("@")[0]
-        )
-
-        # Check commission is the same pre and post fork
-        assert_equal(pre_dfi_balance, post_dfi_balance)
-        assert_equal(pre_ltc_balance, post_ltc_balance)
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) DeFi Blockchain Developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+"""Test static pool rewards"""
+
+from test_framework.test_framework import DefiTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+from decimal import Decimal, ROUND_DOWN
+import time
+
+
+class TokenFractionalSplitTest(DefiTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            [
+                "-subsidytest=1",
+                "-txnotokens=0",
+                "-amkheight=1",
+                "-bayfrontheight=1",
+                "-eunosheight=1",
+                "-fortcanningheight=1",
+                "-fortcanningmuseumheight=1",
+                "-fortcanninghillheight=1",
+                "-fortcanningroadheight=1",
+                "-fortcanningcrunchheight=1",
+                "-fortcanningspringheight=1",
+                "-fortcanninggreatworldheight=1",
+                "-grandcentralheight=1",
+                "-grandcentralepilogueheight=1",
+                "-metachainheight=105",
+                "-df23height=110",
+                "-df24height=120",
+            ]
+        ]
+
+    def run_test(self):
+
+        # Setup test
+        self.setup_tests()
+
+        # Test new pool reward
+        self.static_reward_calculation()
+
+    def setup_tests(self):
+
+        # Set up test tokens
+        self.setup_test_tokens()
+
+        # Set up pool pair
+        self.setup_poolpair()
+
+    def setup_poolpair(self):
+
+        # Fund address for pool
+        self.nodes[0].utxostoaccount({self.address: f"1000@{self.symbolDFI}"})
+        self.nodes[0].minttokens([f"1000@{self.idBTC}"])
+        self.nodes[0].generate(1)
+
+        # Create pool symbol
+        pool_symbol = self.symbolBTC + "-" + self.symbolDFI
+
+        # Create pool pair
+        self.nodes[0].createpoolpair(
+            {
+                "tokenA": self.symbolBTC,
+                "tokenB": self.symbolDFI,
+                "status": True,
+                "ownerAddress": self.address,
+                "symbol": pool_symbol,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Set pool pair splits
+        pool_id = list(self.nodes[0].getpoolpair(pool_symbol).keys())[0]
+        self.nodes[0].setgov({"LP_SPLITS": {pool_id: 1}})
+        self.nodes[0].generate(1)
+
+        # Fund pool
+        self.nodes[0].addpoolliquidity(
+            {self.address: [f"1000@{self.symbolBTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+        self.nodes[0].generate(1)
+
+    def setup_test_tokens(self):
+        self.nodes[0].generate(110)
+
+        # Symbols
+        self.symbolBTC = "BTC"
+        self.symbolDFI = "DFI"
+
+        # Store address
+        self.address = self.nodes[0].get_genesis_keys().ownerAuthAddress
+
+        # Create token
+        self.nodes[0].createtoken(
+            {
+                "symbol": self.symbolBTC,
+                "name": self.symbolBTC,
+                "isDAT": True,
+                "collateralAddress": self.address,
+            }
+        )
+        self.nodes[0].generate(1)
+
+        # Store token IDs
+        self.idBTC = list(self.nodes[0].gettoken(self.symbolBTC).keys())[0]
+
+    def static_reward_calculation(self):
+
+        # Get initial balance
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Calculate pre-fork reward
+        pre_fork_reward = end_balance - start_balance
+
+        # Move past fork height
+        self.nodes[0].generate(120 - self.nodes[0].getblockcount())
+
+        # Get initial balance
+        start_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+        self.nodes[0].generate(1)
+
+        # Get balance after a block
+        end_balance = Decimal(self.nodes[0].getaccount(self.address)[0].split("@")[0])
+
+        # Calculate post-fork reward
+        post_fork_reward = end_balance - start_balance
+
+        # Check rewards are the same
+        assert_equal(pre_fork_reward, post_fork_reward)
+
+
+if __name__ == "__main__":
+    TokenFractionalSplitTest().main()

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -6,13 +6,9 @@
 """Test static pool rewards"""
 
 from test_framework.test_framework import DefiTestFramework
-from test_framework.util import (
-    assert_equal,
-    assert_raises_rpc_error,
-)
+from test_framework.util import assert_equal
 
-from decimal import Decimal, ROUND_DOWN
-import time
+from decimal import Decimal
 
 
 class TokenFractionalSplitTest(DefiTestFramework):
@@ -25,6 +21,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
                 "-txnotokens=0",
                 "-amkheight=1",
                 "-bayfrontheight=1",
+                "-bayfrontgardensheight=1",
                 "-eunosheight=1",
                 "-fortcanningheight=1",
                 "-fortcanningmuseumheight=1",

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -298,6 +298,7 @@ BASE_SCRIPTS = [
     "feature_loan_estimateloan.py",
     "feature_loan_priceupdate.py",
     "feature_loan_vaultstate.py",
+    "feature_static_pool_rewards.py",
     "feature_loan.py",
     "feature_evm_miner.py",
     "feature_evm.py",


### PR DESCRIPTION
## Summary

The CalculateOwnerRewards function is currently the most performance intensive part of DeFiChain, this function calculates the coinbase, loan, commission and custom pool rewards for a liquidity owner from when their address was last used to the current usage which triggers this call. When calculating rewards, every single block since between the last usage and now is checked with the coinbase, loan, commission and custom pool rewards calculated for the address' liquidity against the total liquidity. This is heavy, especially if the address has not been used for a long time and has liquidity in multiple pools.

This PR greatly simplifies this process by avoiding working through each block a time. On each block we workout the coinbase, loan, commission and custom pool reward for each liquidity share in the pool and save this against a running total stored with the current height. When an address is used we get this total from the last time the address was used and the current total, deducting the last usage total from the current we can see the reward per liquidity share for this period and use that to reward the address for however many liquidity shares it has.

Rather than work through each block and run calculations for each reward type, we get the two totals from the last usage block to the current block for each reward type and calculate the rewards. There is additional work storing these totals on each block, but this can be considered negligible and a reasonable trade off.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
