### PR TITLE
Ocean: poolpair apr & volume

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc"
 version = "0.18.0"
-source = "git+https://github.com/defich/rust-defichain-rpc.git#ef716fe7080188ddfe5674e88a3aaed9e2c0497d"
+source = "git+https://github.com/defich/rust-defichain-rpc.git#2e948d7d7ebb9df548c5773903acb0e46c67ab1b"
 dependencies = [
  "async-trait",
  "defichain-rpc-json",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/defich/rust-defichain-rpc.git#ef716fe7080188ddfe5674e88a3aaed9e2c0497d"
+source = "git+https://github.com/defich/rust-defichain-rpc.git#2e948d7d7ebb9df548c5773903acb0e46c67ab1b"
 dependencies = [
  "bitcoin",
  "serde",

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -24,7 +24,9 @@ use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use service::{get_aggregated_in_usd, get_apr, get_total_liquidity_usd, get_usd_volume, PoolPairVolumeResponse};
+use service::{
+    get_aggregated_in_usd, get_apr, get_total_liquidity_usd, get_usd_volume, PoolPairVolumeResponse,
+};
 
 use super::{
     cache::{get_pool_pair_cached, get_token_cached},

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -244,7 +244,7 @@ impl PoolPairResponse {
                 name: a_token_name,
                 reserve: p.reserve_a.to_string(),
                 block_commission: p.block_commission_a.to_string(),
-                fee: p.dex_fee_in_pct_token_a.map(|_| PoolPairFeeResponse {
+                fee: p.dex_fee_pct_token_a.map(|_| PoolPairFeeResponse {
                     pct: p.dex_fee_pct_token_a.map(|fee| fee.to_string()),
                     in_pct: p.dex_fee_in_pct_token_a.map(|fee| fee.to_string()),
                     out_pct: p.dex_fee_out_pct_token_a.map(|fee| fee.to_string()),
@@ -257,7 +257,7 @@ impl PoolPairResponse {
                 name: b_token_name,
                 reserve: p.reserve_b.to_string(),
                 block_commission: p.block_commission_b.to_string(),
-                fee: p.dex_fee_in_pct_token_b.map(|_| PoolPairFeeResponse {
+                fee: p.dex_fee_pct_token_b.map(|_| PoolPairFeeResponse {
                     pct: p.dex_fee_pct_token_b.map(|fee| fee.to_string()),
                     in_pct: p.dex_fee_in_pct_token_b.map(|fee| fee.to_string()),
                     out_pct: p.dex_fee_out_pct_token_b.map(|fee| fee.to_string()),

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -209,7 +209,7 @@ pub struct PoolPairResponse {
     reward_loan_pct: String,
     custom_rewards: Option<Vec<String>>,
     creation: PoolPairCreationResponse,
-    apr: Option<PoolPairAprResponse>,
+    apr: PoolPairAprResponse,
     volume: PoolPairVolumeResponse,
 }
 
@@ -220,7 +220,7 @@ impl PoolPairResponse {
         a_token_name: String,
         b_token_name: String,
         total_liquidity_usd: Decimal,
-        apr: Option<PoolPairAprResponse>,
+        apr: PoolPairAprResponse,
         volume: PoolPairVolumeResponse,
     ) -> Result<Self> {
         let parts = p.symbol.split('-').collect::<Vec<&str>>();

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -17,6 +17,11 @@ use crate::{
     Error, Result, TokenIdentifier,
 };
 
+enum TokenDirection {
+    In,
+    Out
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PriceRatio {
@@ -291,15 +296,15 @@ fn get_dex_fees_pct(
     } = pool_pair_info;
 
     let token_a_direction = if id_token_a == *from_token_id {
-        "in"
+        TokenDirection::In
     } else {
-        "out"
+        TokenDirection::Out
     };
 
     let token_b_direction = if id_token_b == *to_token_id {
-        "out"
+        TokenDirection::Out
     } else {
-        "in"
+        TokenDirection::In
     };
 
     if dex_fee_in_pct_token_a.is_none()
@@ -311,16 +316,14 @@ fn get_dex_fees_pct(
     }
 
     Some(EstimatedDexFeesInPct {
-        ba: if token_a_direction == "in" {
-            format!("{:.8}", dex_fee_in_pct_token_a.unwrap_or_default())
-        } else {
-            format!("{:.8}", dex_fee_out_pct_token_a.unwrap_or_default())
+        ba: match token_a_direction {
+            TokenDirection::In => format!("{:.8}", dex_fee_in_pct_token_a.unwrap_or_default()),
+            TokenDirection::Out => format!("{:.8}", dex_fee_out_pct_token_a.unwrap_or_default()),
         },
-        ab: if token_b_direction == "in" {
-            format!("{:.8}", dex_fee_in_pct_token_b.unwrap_or_default())
-        } else {
-            format!("{:.8}", dex_fee_out_pct_token_b.unwrap_or_default())
-        },
+        ab: match token_b_direction {
+            TokenDirection::In => format!("{:.8}", dex_fee_in_pct_token_b.unwrap_or_default()),
+            TokenDirection::Out => format!("{:.8}", dex_fee_out_pct_token_b.unwrap_or_default()),
+        }
     })
 }
 

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -275,7 +275,11 @@ fn all_simple_paths(
     Ok(paths)
 }
 
-fn get_dex_fees_pct(pool_pair_info: PoolPairInfo, from_token_id: &String, to_token_id: &String) -> Option<EstimatedDexFeesInPct> {
+fn get_dex_fees_pct(
+    pool_pair_info: PoolPairInfo,
+    from_token_id: &String,
+    to_token_id: &String,
+) -> Option<EstimatedDexFeesInPct> {
     let PoolPairInfo {
         id_token_a,
         id_token_b,
@@ -298,8 +302,12 @@ fn get_dex_fees_pct(pool_pair_info: PoolPairInfo, from_token_id: &String, to_tok
         "in"
     };
 
-    if dex_fee_in_pct_token_a.is_none() && dex_fee_out_pct_token_a.is_none() && dex_fee_in_pct_token_b.is_none() && dex_fee_out_pct_token_b.is_none() {
-        return None
+    if dex_fee_in_pct_token_a.is_none()
+        && dex_fee_out_pct_token_a.is_none()
+        && dex_fee_in_pct_token_b.is_none()
+        && dex_fee_out_pct_token_b.is_none()
+    {
+        return None;
     }
 
     Some(EstimatedDexFeesInPct {
@@ -357,7 +365,8 @@ pub async fn compute_paths_between_tokens(
 
             let (_, pool_pair_info) = pool.unwrap();
 
-            let estimated_dex_fees_in_pct = get_dex_fees_pct(pool_pair_info.clone(), from_token_id, to_token_id);
+            let estimated_dex_fees_in_pct =
+                get_dex_fees_pct(pool_pair_info.clone(), from_token_id, to_token_id);
 
             let PoolPairInfo {
                 symbol,

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -515,6 +515,7 @@ pub async fn sync_token_graph(ctx: &Arc<AppContext>) -> Result<()> {
             if !graph.lock().contains_edge(id_token_a, id_token_b) {
                 graph.lock().add_edge(id_token_a, id_token_b, k);
             }
+            log::debug!("sync_token_graph edges: {:?}", graph.lock().edge_count());
         }
 
         // wait 120s

--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -397,7 +397,7 @@ pub async fn get_apr(
     id: &String,
     p: &PoolPairInfo,
 ) -> Result<PoolPairAprResponse> {
-    let custom_usd = get_yearly_custom_reward_usd(ctx, p).await?; // 0
+    let custom_usd = get_yearly_custom_reward_usd(ctx, p).await?;
     let pct_usd = get_yearly_reward_pct_usd(ctx, p).await?;
     let loan_usd = get_yearly_reward_loan_usd(ctx, id).await?;
     let total_liquidity_usd = get_total_liquidity_usd(ctx, p).await?;

--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -396,7 +396,7 @@ pub async fn get_apr(
     ctx: &Arc<AppContext>,
     id: &String,
     p: &PoolPairInfo,
-) -> Result<Option<PoolPairAprResponse>> {
+) -> Result<PoolPairAprResponse> {
     let custom_usd = get_yearly_custom_reward_usd(ctx, p).await?; // 0
     let pct_usd = get_yearly_reward_pct_usd(ctx, p).await?;
     let loan_usd = get_yearly_reward_loan_usd(ctx, id).await?;
@@ -409,7 +409,7 @@ pub async fn get_apr(
         .ok_or_else(|| Error::OverflowError)?;
 
     if yearly_usd.is_zero() {
-        return Ok(None)
+        return Ok(PoolPairAprResponse::default())
     };
 
     // 1 == 100%, 0.1 = 10%
@@ -426,11 +426,11 @@ pub async fn get_apr(
         .checked_add(commission)
         .ok_or_else(|| Error::OverflowError)?;
 
-    Ok(Some(PoolPairAprResponse {
+    Ok(PoolPairAprResponse {
         reward,
         commission,
         total,
-    }))
+    })
 }
 
 async fn get_pool_pair(ctx: &Arc<AppContext>, a: &str, b: &str) -> Result<Option<PoolPairInfo>> {

--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -397,24 +397,20 @@ pub async fn get_apr(
     id: &String,
     p: &PoolPairInfo,
 ) -> Result<Option<PoolPairAprResponse>> {
-    let custom_usd = get_yearly_custom_reward_usd(ctx, p).await?;
+    let custom_usd = get_yearly_custom_reward_usd(ctx, p).await?; // 0
     let pct_usd = get_yearly_reward_pct_usd(ctx, p).await?;
     let loan_usd = get_yearly_reward_loan_usd(ctx, id).await?;
     let total_liquidity_usd = get_total_liquidity_usd(ctx, p).await?;
-
-    if custom_usd.is_zero()
-        || pct_usd.is_zero()
-        || loan_usd.is_zero()
-        || total_liquidity_usd.is_zero()
-    {
-        return Ok(None);
-    };
 
     let yearly_usd = custom_usd
         .checked_add(pct_usd)
         .ok_or_else(|| Error::OverflowError)?
         .checked_add(loan_usd)
         .ok_or_else(|| Error::OverflowError)?;
+
+    if yearly_usd.is_zero() {
+        return Ok(None)
+    };
 
     // 1 == 100%, 0.1 = 10%
     let reward = yearly_usd

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -3,7 +3,7 @@ pub mod loan_token;
 mod masternode;
 pub mod oracle;
 pub mod oracle_test;
-mod pool;
+pub mod pool;
 pub mod transaction;
 pub mod tx_result;
 
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Instant};
 use ain_dftx::{deserialize, DfTx, Stack};
 use defichain_rpc::json::blockchain::{Block, Transaction};
 use log::debug;
-pub use pool::AGGREGATED_INTERVALS;
+pub use pool::{AGGREGATED_INTERVALS, PoolSwapAggregatedInterval};
 
 use crate::{
     index_transaction,

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Instant};
 use ain_dftx::{deserialize, DfTx, Stack};
 use defichain_rpc::json::blockchain::{Block, Transaction};
 use log::debug;
-pub use pool::{AGGREGATED_INTERVALS, PoolSwapAggregatedInterval};
+pub use pool::{PoolSwapAggregatedInterval, AGGREGATED_INTERVALS};
 
 use crate::{
     index_transaction,


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- poolpair APR and volume
- fix the `EstimatedDexFees` bug in `if let..else` (get_dex_fees_pct)

coverage:
```
 get best path - DEX burn fees
    ✓ should return fees - CAT to DFI - Both token fees direction are in (8 ms)
    ✓ should return fees - DFI to CAT - Both token fees direction are in (1 ms)
    ✓ should return fees - DFI to DOG - Both token fees direction is out (2 ms)
    ✓ should return fees - DOG to DFI - Both token fees direction is out (4 ms)
    ✓ should return fees - KOALA to DFI - TokenA fee direction is in (3 ms)
    ✓ should return fees - DFI to KOALA - TokenA fee direction is in (1 ms)
    ✓ should return fees - FISH to DFI - TokenB fee direction is out (2 ms)
    ✓ should return fees - DFI to FISH - TokenB fee direction is out (2 ms)
    ✓ should return fees (bidirectional) - DFI <-> TURTLE - TokenA fee direction is both (4 ms)
    ✓ should return fees (bidirectional) - DFI <-> PANDA - TokenA fee direction is both (3 ms)
    ✓ should return fees (bidirectional) - DFI <-> RABBIT - Both token fees direction are both (3 ms)
    ✓ should return fees (bidirectional) - DFI <-> FOX - if tokenA fee direction is not set (3 ms)
    ✓ should return fees (bidirectional) - DFI <-> LION - if tokenB fee direction is not set (3 ms)
    ✓ should return fees (bidirectional) - DFI <-> TIGER - if both token fees direction are not set (2 ms)
    ✓ should return [] if dex fees is not set (3 ms)
  get best path - DEX estimated return
    ✕ should less dex fees in estimatedReturnLessDexFees - 1 leg (19 ms)
    Expected: "14.01557143"
    Received: "14.01557142" // rounding??
    ✕ should less dex fees in estimatedReturnLessDexFees - 2 legs (2 ms)
    Expected: "1.39875403"
    Received: "1.39875402"
    ✓ should not less dex fees if dex fees is not set (1 ms)
```