### PR TITLE
Ocean list pool swap verbose api

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 [[package]]
 name = "bitcoin"
 version = "0.31.0"
-source = "git+https://github.com/defich/rust-bitcoin.git#af64fe422669e2d4fc24fca93561566e22cce1df"
+source = "git+https://github.com/defich/rust-bitcoin.git?branch=canonbrother/defichain-network#93c63338d55de3d26e9fd79a60ca88256f60d988"
 dependencies = [
  "bech32",
  "bitcoin-internals",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-io"
 version = "0.1.0"
-source = "git+https://github.com/defich/rust-bitcoin.git#af64fe422669e2d4fc24fca93561566e22cce1df"
+source = "git+https://github.com/defich/rust-bitcoin.git?branch=canonbrother/defichain-network#93c63338d55de3d26e9fd79a60ca88256f60d988"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc"
 version = "0.18.0"
-source = "git+https://github.com/defich/rust-defichain-rpc.git#2e948d7d7ebb9df548c5773903acb0e46c67ab1b"
+source = "git+https://github.com/defich/rust-defichain-rpc.git#c2329bcf26c497cdf4f1c22ef1198819542cf70d"
 dependencies = [
  "async-trait",
  "defichain-rpc-json",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "defichain-rpc-json"
 version = "0.18.0"
-source = "git+https://github.com/defich/rust-defichain-rpc.git#2e948d7d7ebb9df548c5773903acb0e46c67ab1b"
+source = "git+https://github.com/defich/rust-defichain-rpc.git#c2329bcf26c497cdf4f1c22ef1198819542cf70d"
 dependencies = [
  "bitcoin",
  "serde",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 [[package]]
 name = "bitcoin"
 version = "0.31.0"
-source = "git+https://github.com/defich/rust-bitcoin.git?branch=canonbrother/defichain-network#93c63338d55de3d26e9fd79a60ca88256f60d988"
+source = "git+https://github.com/defich/rust-bitcoin.git#c68ce40fd7f618105ab7d6e8be49ce083f97d4e8"
 dependencies = [
  "bech32",
  "bitcoin-internals",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-io"
 version = "0.1.0"
-source = "git+https://github.com/defich/rust-bitcoin.git?branch=canonbrother/defichain-network#93c63338d55de3d26e9fd79a60ca88256f60d988"
+source = "git+https://github.com/defich/rust-bitcoin.git#c68ce40fd7f618105ab7d6e8be49ce083f97d4e8"
 
 [[package]]
 name = "bitcoin_hashes"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,8 +20,8 @@ vsdbsled = { git = "https://github.com/defich/vsdbsled.git" }
 ethereum = { git = "https://github.com/defich/ethereum.git" }
 evm = { git = "https://github.com/defich/evm.git" }
 evm-runtime = { git = "https://github.com/defich/evm.git" }
-bitcoin = { git = "https://github.com/defich/rust-bitcoin.git", branch = "canonbrother/defichain-network" }
-bitcoin-io = { git = "https://github.com/defich/rust-bitcoin.git", branch = "canonbrother/defichain-network" }
+bitcoin = { git = "https://github.com/defich/rust-bitcoin.git" }
+bitcoin-io = { git = "https://github.com/defich/rust-bitcoin.git" }
 
 [workspace.dependencies]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,8 +20,8 @@ vsdbsled = { git = "https://github.com/defich/vsdbsled.git" }
 ethereum = { git = "https://github.com/defich/ethereum.git" }
 evm = { git = "https://github.com/defich/evm.git" }
 evm-runtime = { git = "https://github.com/defich/evm.git" }
-bitcoin = { git = "https://github.com/defich/rust-bitcoin.git" }
-bitcoin-io = { git = "https://github.com/defich/rust-bitcoin.git" }
+bitcoin = { git = "https://github.com/defich/rust-bitcoin.git", branch = "canonbrother/defichain-network" }
+bitcoin-io = { git = "https://github.com/defich/rust-bitcoin.git", branch = "canonbrother/defichain-network" }
 
 [workspace.dependencies]
 

--- a/lib/ain-ocean/src/api/mod.rs
+++ b/lib/ain-ocean/src/api/mod.rs
@@ -80,8 +80,6 @@ pub async fn ocean_router(
             .nest("/masternodes", masternode::router(Arc::clone(&context)))
             .nest("/oracles", oracle::router(Arc::clone(&context)))
             .nest("/poolpairs", pool_pair::router(Arc::clone(&context)))
-            // .nest("/prices", prices::router(Arc::clone(&context)))
-            // .nest("/poolpairs", poolpairs::router(Arc::clone(&context)))
             .nest("/prices", prices::router(Arc::clone(&context)))
             // .nest("/rawtx", rawtx::router(Arc::clone(&context)))
             .nest("/stats", stats::router(Arc::clone(&context)))

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -441,7 +441,7 @@ async fn list_pool_swaps_verbose(
         .transpose()?
         .unwrap_or(PoolSwapRepository::initial_key(id));
 
-    let size = if query.size > 200 { 200 } else { query.size };
+    let size = if query.size > 20 { 20 } else { query.size };
 
     let fut = ctx
         .services

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -1,13 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    str::FromStr,
 };
 
 use ain_macros::ocean_endpoint;
 use anyhow::format_err;
 use axum::{routing::get, Extension, Router};
-use bitcoin::Txid;
 use defichain_rpc::{
     json::{
         poolpair::{PoolPairInfo, PoolPairsResult},
@@ -26,7 +24,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with::skip_serializing_none;
 use service::{
-    check_swap_type, find_swap_from_to, get_aggregated_in_usd, get_apr, get_total_liquidity_usd, get_usd_volume, PoolPairVolumeResponse, PoolSwapFromTo, PoolSwapFromToData, SwapType
+    check_swap_type, find_swap_from_to, get_aggregated_in_usd, get_apr, get_total_liquidity_usd,
+    get_usd_volume, PoolPairVolumeResponse, PoolSwapFromTo, PoolSwapFromToData, SwapType,
 };
 
 use super::{
@@ -455,12 +454,9 @@ async fn list_pool_swaps_verbose(
         })
         .map(|item| async {
             let (_, swap) = item?;
-            let from_to = find_swap_from_to(
-                &ctx,
-                swap.block.height,
-                swap.txid,
-                swap.txno.try_into()?
-            ).await?;
+            let from_to =
+                find_swap_from_to(&ctx, swap.block.height, swap.txid, swap.txno.try_into()?)
+                    .await?;
 
             let swap_type = check_swap_type(&ctx, swap.clone()).await?;
 

--- a/lib/ain-ocean/src/api/pool_pair/mod.rs
+++ b/lib/ain-ocean/src/api/pool_pair/mod.rs
@@ -122,7 +122,7 @@ impl From<PoolSwap> for PoolSwapResponse {
             txid: v.txid.to_string(),
             txno: v.txno,
             pool_pair_id: v.pool_id.to_string(),
-            from_amount: v.from_amount.to_string(),
+            from_amount: Decimal::new(v.from_amount, 8).to_string(),
             from_token_id: v.from_token_id,
             block: v.block,
         }

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::format_err;
-use log;
 use defichain_rpc::json::poolpair::PoolPairInfo;
+use log::debug;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 use rust_decimal_macros::dec;
 use serde::Serialize;
@@ -20,7 +20,7 @@ use crate::{
 
 enum TokenDirection {
     In,
-    Out
+    Out,
 }
 
 #[derive(Debug, Serialize)]
@@ -324,7 +324,7 @@ fn get_dex_fees_pct(
         ab: match token_b_direction {
             TokenDirection::In => format!("{:.8}", dex_fee_in_pct_token_b.unwrap_or_default()),
             TokenDirection::Out => format!("{:.8}", dex_fee_out_pct_token_b.unwrap_or_default()),
-        }
+        },
     })
 }
 

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::format_err;
+use log;
 use defichain_rpc::json::poolpair::PoolPairInfo;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 use rust_decimal_macros::dec;
@@ -518,7 +519,7 @@ pub async fn sync_token_graph(ctx: &Arc<AppContext>) -> Result<()> {
             if !graph.lock().contains_edge(id_token_a, id_token_b) {
                 graph.lock().add_edge(id_token_a, id_token_b, k);
             }
-            log::debug!("sync_token_graph edges: {:?}", graph.lock().edge_count());
+            debug!("sync_token_graph edges: {:?}", graph.lock().edge_count());
         }
 
         // wait 120s

--- a/lib/ain-ocean/src/api/pool_pair/path.rs
+++ b/lib/ain-ocean/src/api/pool_pair/path.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::format_err;
 use defichain_rpc::json::poolpair::PoolPairInfo;
-use log::debug;
 use rust_decimal::{prelude::FromPrimitive, Decimal};
 use rust_decimal_macros::dec;
 use serde::Serialize;
@@ -519,7 +518,6 @@ pub async fn sync_token_graph(ctx: &Arc<AppContext>) -> Result<()> {
             if !graph.lock().contains_edge(id_token_a, id_token_b) {
                 graph.lock().add_edge(id_token_a, id_token_b, k);
             }
-            debug!("sync_token_graph edges: {:?}", graph.lock().edge_count());
         }
 
         // wait 120s

--- a/lib/ain-ocean/src/error.rs
+++ b/lib/ain-ocean/src/error.rs
@@ -61,6 +61,10 @@ pub enum Error {
     SecondaryIndex,
     #[error("Token {0:?} is invalid as it is not tradeable")]
     UntradeableTokenError(String),
+    #[error("Ocean: BitcoinAddressError: {0:?}")]
+    BitcoinAddressError(#[from] bitcoin::address::Error),
+    #[error("Ocean: TryFromIntError: {0:?}")]
+    TryFromIntError(#[from] std::num::TryFromIntError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -166,7 +166,7 @@ pub fn index_block(
                         DfTx::SetOracleData(data) => data.index(services, &ctx)?,
                         DfTx::PoolSwap(data) => data.index(services, &ctx)?,
                         DfTx::SetLoanToken(data) => data.index(services, &ctx)?,
-                        // DfTx::CompositeSwap(data) => data.index(services, &ctx)?,
+                        DfTx::CompositeSwap(data) => data.index(services, &ctx)?,
                         // DfTx::PlaceAuctionBid(data) => data.index(services, &ctx)?,
                         _ => (),
                     }

--- a/lib/ain-ocean/src/model/poolswap.rs
+++ b/lib/ain-ocean/src/model/poolswap.rs
@@ -5,7 +5,7 @@ use super::BlockContext;
 
 pub type PoolSwapKey = (u32, u32, usize);
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolSwap {
     pub id: String,

--- a/lib/ain-ocean/src/network.rs
+++ b/lib/ain-ocean/src/network.rs
@@ -22,6 +22,30 @@ impl Network {
     }
 }
 
+// impl From<bitcoin::Network> for Network {
+//     fn from(network: bitcoin::Network) -> Self {
+//         match network {
+//             bitcoin::Network::Mainnet => Network::Mainnet,
+//             bitcoin::Network::Testnet => Network::Testnet,
+//             bitcoin::Network::Devnet => Network::Devnet,
+//             _ => Network::Regtest,
+//         }
+//     }
+// }
+
+impl Into<bitcoin::Network> for Network {
+    fn into(self) -> bitcoin::Network {
+        match self {
+            Network::Mainnet => bitcoin::Network::Mainnet,
+            Network::Testnet => bitcoin::Network::Testnet,
+            Network::Devnet => bitcoin::Network::Devnet,
+            Network::Regtest => bitcoin::Network::Regtest,
+            _ => bitcoin::Network::Regtest,
+        }
+
+    }
+}
+
 impl std::str::FromStr for Network {
     type Err = &'static str;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/lib/ain-ocean/src/network.rs
+++ b/lib/ain-ocean/src/network.rs
@@ -22,17 +22,7 @@ impl Network {
     }
 }
 
-// impl From<bitcoin::Network> for Network {
-//     fn from(network: bitcoin::Network) -> Self {
-//         match network {
-//             bitcoin::Network::Mainnet => Network::Mainnet,
-//             bitcoin::Network::Testnet => Network::Testnet,
-//             bitcoin::Network::Devnet => Network::Devnet,
-//             _ => Network::Regtest,
-//         }
-//     }
-// }
-
+#[allow(clippy::from_over_into)]
 impl Into<bitcoin::Network> for Network {
     fn into(self) -> bitcoin::Network {
         match self {
@@ -42,7 +32,6 @@ impl Into<bitcoin::Network> for Network {
             Network::Regtest => bitcoin::Network::Regtest,
             _ => bitcoin::Network::Regtest,
         }
-
     }
 }
 

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -1155,7 +1155,8 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView &view,
     result = swapAmountResult.nValue;
 
     // Send final swap amount Rust side for indexer
-    if (txInfo) {
+    bool isOceanEnabled = gArgs.GetBoolArg("-oceanarchive", false);
+    if (txInfo && isOceanEnabled) {
         const auto &[txType, txHash] = *txInfo;
         CrossBoundaryResult ffiResult;
         ocean_try_set_tx_result(ffiResult,


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- check swap type
- enable composite swap indexer
- fix list_pool_swap response convert from_amount base unit to logical unit (8 decimal)

🚫 ~blocked by https://github.com/DeFiCh/rust-bitcoin/pull/6~

## Test coverage

```
/poolpair.swap.controller.defid.ts
/poolpair.swap.verbose.controller.defid.ts
poolswap buy-sell indicator
    ✓ should get pool swap details (50892 ms)
    ✓ should get composite pool swap for 2 jumps (50138 ms)
    ✓ should get composite pool swap for 2 jumps scenario 2 (50080 ms)
    ✓ should get composite pool swap for 3 jumps (49514 ms)
    ✕ should get direct pool swap for composite swap (49471 ms) // <-- require manually get the poolId
```
Regarding `should get direct pool swap for composite swap`..
manually calculate the direct pool id is required
https://github.com/BirthdayResearch/jellyfishsdk/blob/cb1c46722c9495dcfffd1e9f8c6d9a684d4dc7c9/apps/whale-api/src/module.indexer/model/dftx/composite.swap.ts#L25

no json rpc client inject in indexer.. thinking to reuse `graph`.. fix it at another pr
https://github.com/BirthdayResearch/jellyfishsdk/blob/cb1c46722c9495dcfffd1e9f8c6d9a684d4dc7c9/apps/whale-api/src/module.indexer/model/dftx/pool.pair.path.mapping.ts#L29