### PR TITLE
fix: add missing minter info to verbose 3+ outputs

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -405,7 +405,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
 
     if (v3plus) {
-        MinterInfo::From(block, blockindex, *pcustomcsview).ToUniValue();
+        auto minterInfo = MinterInfo::From(block, blockindex, *pcustomcsview);
+        result.pushKV("minter", minterInfo.ToUniValue());
         auto rewardInfo = RewardInfo::TryFrom(block, blockindex, consensus);
         if (rewardInfo) {
             result.pushKV("rewards", rewardInfo->ToUniValue());


### PR DESCRIPTION
- Add missing `minter` info from v3 or v4 getblock outputs.