### PR TITLE
Tone down rust logs

### DIFF
--- a/lib/ain-evm/src/block.rs
+++ b/lib/ain-evm/src/block.rs
@@ -8,7 +8,7 @@ use anyhow::format_err;
 use ethereum::BlockAny;
 use ethereum_types::U256;
 use keccak_hash::H256;
-use log::{debug, trace};
+use log::trace;
 use parking_lot::Mutex;
 
 use crate::{
@@ -62,7 +62,6 @@ impl BlockService {
             .unwrap_or_default();
 
         block_handler.starting_block_number = block_number;
-        debug!("Current block number is {:x?}", block_number);
 
         Ok(block_handler)
     }

--- a/lib/ain-evm/src/eventlistener.rs
+++ b/lib/ain-evm/src/eventlistener.rs
@@ -7,7 +7,7 @@ use evm_runtime::{
     tracing::{Event as RuntimeEvent, EventListener as RuntimeEventListener},
     Opcode,
 };
-use log::debug;
+use log::{debug, trace};
 
 #[derive(Clone, Debug)]
 pub struct ExecutionStep {
@@ -70,22 +70,22 @@ impl RuntimeEventListener for ExecListener {
                 result,
                 return_value,
             } => {
-                debug!("result : {:#?}", result);
-                debug!("return_value : {:#?}", return_value);
+                trace!("result : {:#?}", result);
+                trace!("return_value : {:#?}", return_value);
             }
             RuntimeEvent::SLoad {
                 address,
                 index,
                 value,
             } => {
-                debug!("SLOAD, address: {address:#?}, index: {index:#?}, value: {value:#?}")
+                trace!("SLOAD, address: {address:#?}, index: {index:#?}, value: {value:#?}")
             }
             RuntimeEvent::SStore {
                 address,
                 index,
                 value,
             } => {
-                debug!("SSTORE, address: {address:#?}, index: {index:#?}, value: {value:#?}")
+                trace!("SSTORE, address: {address:#?}, index: {index:#?}, value: {value:#?}")
             }
         }
     }

--- a/lib/ain-evm/src/evm.rs
+++ b/lib/ain-evm/src/evm.rs
@@ -9,7 +9,7 @@ use ain_cpp_imports::{get_df23_height, Attributes};
 use anyhow::format_err;
 use ethereum::{Block, PartialHeader};
 use ethereum_types::{Bloom, H160, H256, H64, U256};
-use log::{debug, trace};
+use log::{info, trace};
 
 use crate::{
     backend::{EVMBackend, Vicinity},
@@ -161,7 +161,7 @@ impl EVMServices {
         let mut receipts_v3: Vec<ReceiptAndOptionalContractAddress> = Vec::with_capacity(txs_len);
         let mut total_gas_fees = U256::zero();
 
-        debug!("[construct_block] vicinity: {:?}", template.vicinity);
+        trace!("[construct_block] vicinity: {:?}", template.vicinity);
 
         let mut executor = AinExecutor::new(&mut template.backend);
         for template_tx in template.transactions.clone() {
@@ -179,11 +179,11 @@ impl EVMServices {
         let total_priority_fees = total_gas_fees
             .checked_sub(total_burnt_fees)
             .ok_or_else(|| format_err!("total_priority_fees underflow"))?;
-        debug!(
+        trace!(
             "[construct_block] Total burnt fees : {:#?}",
             total_burnt_fees
         );
-        debug!(
+        trace!(
             "[construct_block] Total priority fees : {:#?}",
             total_priority_fees
         );
@@ -248,7 +248,7 @@ impl EVMServices {
             return Err(format_err!("no constructed EVM block exist in template id").into());
         };
 
-        debug!(
+        info!(
             "[finalize_block] Finalizing block number {:#x}, state_root {:#x}",
             block.header.number, block.header.state_root
         );
@@ -311,7 +311,7 @@ impl EVMServices {
 
         let mut executor = AinExecutor::new(&mut template.backend);
         let base_fee = template.vicinity.block_base_fee_per_gas;
-        debug!(
+        trace!(
             "[update_state_in_block_template] Block base fee: {}",
             base_fee
         );

--- a/lib/ain-evm/src/executor.rs
+++ b/lib/ain-evm/src/executor.rs
@@ -9,7 +9,7 @@ use evm::{
     Config, CreateScheme, ExitReason,
 };
 use evm_runtime::tracing::using as runtime_using;
-use log::{debug, trace};
+use log::trace;
 
 use crate::{
     backend::EVMBackend,
@@ -431,7 +431,7 @@ impl<'backend> AinExecutor<'backend> {
                 let (tx_response, receipt) =
                     self.exec(&signed_tx, signed_tx.gas_limit(), base_fee, false, ctx)?;
 
-                debug!(
+                trace!(
                     "[execute_tx] receipt : {:?}, exit_reason {:#?} for signed_tx : {:#x}",
                     receipt,
                     tx_response.exit_reason,
@@ -468,7 +468,7 @@ impl<'backend> AinExecutor<'backend> {
                 let input = signed_tx.data();
                 let amount = U256::from_big_endian(&input[68..100]);
 
-                debug!(
+                trace!(
                     "[execute_tx] Transfer domain: {} from address {:x?}, nonce {:x?}, to address {:x?}, amount: {}",
                     direction, signed_tx.sender, signed_tx.nonce(), to, amount,
                 );
@@ -483,7 +483,7 @@ impl<'backend> AinExecutor<'backend> {
                     Some(account) => account.code_hash != contract.codehash,
                 };
                 if mismatch {
-                    debug!(
+                    trace!(
                         "[execute_tx] {} failed with as transferdomain account codehash mismatch",
                         direction
                     );
@@ -510,7 +510,7 @@ impl<'backend> AinExecutor<'backend> {
                     .into());
                 }
 
-                debug!(
+                trace!(
                     "[execute_tx] receipt : {:?}, exit_reason {:#?} for signed_tx : {:#x}, logs: {:x?}",
                     receipt,
                     tx_response.exit_reason,
@@ -551,7 +551,7 @@ impl<'backend> AinExecutor<'backend> {
                 let input = signed_tx.data();
                 let amount = U256::from_big_endian(&input[100..132]);
 
-                debug!(
+                trace!(
                     "[execute_tx] DST20Bridge from {}, contract_address {}, amount {}, direction {}",
                     signed_tx.sender, contract_address, amount, direction
                 );
@@ -568,11 +568,6 @@ impl<'backend> AinExecutor<'backend> {
                 let (tx_response, receipt) =
                     self.exec(&signed_tx, U256::MAX, U256::zero(), true, ctx)?;
                 if !tx_response.exit_reason.is_succeed() {
-                    debug!(
-                        "[execute_tx] DST20 bridge failed VM execution {:?}, data {}",
-                        tx_response.exit_reason,
-                        hex::encode(&tx_response.data)
-                    );
                     return Err(format_err!(
                         "[execute_tx] DST20 bridge failed VM execution {:?}, data {:?}",
                         tx_response.exit_reason,
@@ -581,7 +576,7 @@ impl<'backend> AinExecutor<'backend> {
                     .into());
                 }
 
-                debug!(
+                trace!(
                     "[execute_tx] receipt : {:?}, exit_reason {:#?} for signed_tx : {:#x}, logs: {:x?}",
                     receipt,
                     tx_response.exit_reason,
@@ -609,9 +604,11 @@ impl<'backend> AinExecutor<'backend> {
                 address,
                 token_id,
             })) => {
-                debug!(
+                trace!(
                     "[execute_tx] DeployContract for address {:x?}, name {}, symbol {}",
-                    address, name, symbol
+                    address,
+                    name,
+                    symbol
                 );
 
                 let DeployContractInfo {
@@ -637,9 +634,11 @@ impl<'backend> AinExecutor<'backend> {
                 address,
                 token_id,
             })) => {
-                debug!(
+                trace!(
                     "[execute_tx] Rename contract for address {:x?}, name {}, symbol {}",
-                    address, name, symbol
+                    address,
+                    name,
+                    symbol
                 );
 
                 let storage = dst20_name_info(ctx.dvm_block, &name, &symbol);

--- a/lib/ain-evm/src/precompiles/token_split.rs
+++ b/lib/ain-evm/src/precompiles/token_split.rs
@@ -9,7 +9,7 @@ use evm::{
     executor::stack::{PrecompileFailure, PrecompileHandle, PrecompileOutput},
     ExitError, ExitSucceed,
 };
-use log::debug;
+use log::trace;
 
 use super::DVMStatePrecompile;
 use crate::{
@@ -27,7 +27,6 @@ impl TokenSplit {
 
 impl DVMStatePrecompile for TokenSplit {
     fn execute(handle: &mut impl PrecompileHandle, mnview_ptr: usize) -> PrecompileResult {
-        debug!("[TokenSplit]");
         handle.record_cost(TokenSplit::GAS_COST)?;
 
         let input = handle.input();
@@ -41,7 +40,7 @@ impl DVMStatePrecompile for TokenSplit {
             exit_status: ExitError::Other(e.to_string().into()),
         })?;
 
-        debug!("[TokenSplit] sender {sender:x}, original_contract {original_contract:x}, input_amount : {input_amount:x}");
+        trace!("[TokenSplit] sender {sender:x}, original_contract {original_contract:x}, input_amount : {input_amount:x}");
 
         let Ok(amount) = WeiAmount(input_amount).to_satoshi() else {
             return Err(PrecompileFailure::Error {
@@ -64,7 +63,6 @@ impl DVMStatePrecompile for TokenSplit {
             id: old_token_id,
             amount: amount.low_u64(),
         };
-        debug!("[TokenSplit] old_amount : {:?}", old_amount);
 
         let mut new_amount = TokenAmount { id: 0, amount: 0 };
         let res = split_tokens_from_evm(mnview_ptr, old_amount, &mut new_amount);

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -3,7 +3,7 @@ use ain_db::{Column, ColumnName, DBError, LedgerColumn, Rocks, TypedColumn};
 use anyhow::format_err;
 use ethereum::{BlockAny, TransactionV2};
 use ethereum_types::{H160, H256, U256};
-use log::debug;
+use log::{debug, info};
 use std::{
     collections::HashMap, fmt::Write, fs, marker::PhantomData, path::Path, str::FromStr, sync::Arc,
     time::Instant,
@@ -86,10 +86,10 @@ impl DBVersionControl for BlockStore {
 
         for migration in migrations {
             if version < migration.version() {
-                debug!("Migrating to version {}...", migration.version());
+                info!("Migrating to version {}...", migration.version());
                 let start = Instant::now();
                 migration.migrate(self)?;
-                debug!(
+                info!(
                     "Migration to version {} took {:?}",
                     migration.version(),
                     start.elapsed()

--- a/lib/ain-evm/src/transaction/cache.rs
+++ b/lib/ain-evm/src/transaction/cache.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 
 use ethereum::{EnvelopedEncodable, TransactionV2};
 use ethereum_types::U256;
-use log::debug;
+use log::trace;
 use lru::LruCache;
 
 use crate::{transaction::SignedTx, Result};
@@ -26,9 +26,9 @@ impl TransactionCache {
 impl TransactionCache {
     pub fn try_get_or_create(&self, key: &str) -> Result<SignedTx> {
         let mut guard = self.signed_tx_cache.inner.lock();
-        debug!("[signed-tx-cache]::get: {}", key);
+        trace!("[signed-tx-cache]::get: {}", key);
         let res = guard.try_get_or_insert(key.to_string(), || {
-            debug!("[signed-tx-cache]::create {}", key);
+            trace!("[signed-tx-cache]::create {}", key);
             SignedTx::try_from(key)
         })?;
         Ok(res.clone())
@@ -36,9 +36,9 @@ impl TransactionCache {
 
     pub fn pre_populate(&self, key: &str, signed_tx: SignedTx) -> Result<()> {
         let mut guard = self.signed_tx_cache.inner.lock();
-        debug!("[signed-tx-cache]::pre_populate: {}", key);
+        trace!("[signed-tx-cache]::pre_populate: {}", key);
         let _ = guard.get_or_insert(key.to_string(), move || {
-            debug!("[signed-tx-cache]::pre_populate:: create {}", key);
+            trace!("[signed-tx-cache]::pre_populate:: create {}", key);
             signed_tx
         });
 
@@ -49,9 +49,9 @@ impl TransactionCache {
         let data = EnvelopedEncodable::encode(tx);
         let key = hex::encode(&data);
         let mut guard = self.signed_tx_cache.inner.lock();
-        debug!("[signed-tx-cache]::get from tx: {}", &key);
+        trace!("[signed-tx-cache]::get from tx: {}", &key);
         let res = guard.try_get_or_insert(key.clone(), || {
-            debug!("[signed-tx-cache]::create from tx {}", &key);
+            trace!("[signed-tx-cache]::create from tx {}", &key);
             SignedTx::try_from(key.as_str())
         })?;
         Ok(res.clone())

--- a/lib/ain-evm/src/trie.rs
+++ b/lib/ain-evm/src/trie.rs
@@ -34,7 +34,6 @@ impl Default for TrieDBStore {
 
 impl TrieDBStore {
     pub fn new() -> Self {
-        debug!("Creating new trie store");
         let trie_store = MptStore::new();
         let mut trie = trie_store
             .trie_create(&[0], None, false)

--- a/lib/ain-grpc/src/subscription/eth.rs
+++ b/lib/ain-grpc/src/subscription/eth.rs
@@ -7,7 +7,7 @@ use ain_evm::{
 use anyhow::format_err;
 use ethereum_types::U256;
 use jsonrpsee::{proc_macros::rpc, types::SubscriptionEmptyError, SubscriptionSink};
-use log::debug;
+use log::{debug, trace};
 use tokio::runtime::Handle as AsyncHandle;
 
 use crate::subscription::{
@@ -49,8 +49,8 @@ impl MetachainPubSubServer for MetachainPubSubModule {
         params: Option<SubscriptionParams>,
     ) -> Result<(), SubscriptionEmptyError> {
         sink.accept()?;
-        debug!(target: "pubsub", "subscribing to {:#?}", subscription);
-        debug!(target: "pubsub", "params {:?}", params);
+        trace!(target: "pubsub", "subscribing to {:#?}", subscription);
+        trace!(target: "pubsub", "params {:?}", params);
 
         let mut rx = self.handler.subscriptions.tx.subscribe();
         let handler = self.handler.clone();

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -25,7 +25,7 @@ use ain_macros::ffi_fallible;
 use anyhow::format_err;
 use ethereum::{EnvelopedEncodable, TransactionAction, TransactionSignature, TransactionV2};
 use ethereum_types::{H160, H256, U256};
-use log::debug;
+use log::trace;
 use transaction::{LegacyUnsignedTransaction, LOWER_H256};
 
 use crate::{
@@ -347,7 +347,7 @@ fn evm_try_unsafe_validate_raw_tx_in_template(
     template: &BlockTemplateWrapper,
     raw_tx: &str,
 ) -> Result<()> {
-    debug!("[unsafe_validate_raw_tx_in_template]");
+    trace!("[unsafe_validate_raw_tx_in_template]");
     unsafe {
         let _ = SERVICES
             .evm
@@ -385,7 +385,7 @@ fn evm_try_unsafe_validate_transferdomain_tx_in_template(
     raw_tx: &str,
     context: ffi::TransferDomainInfo,
 ) -> Result<()> {
-    debug!("[unsafe_validate_transferdomain_tx_in_template]");
+    trace!("[unsafe_validate_transferdomain_tx_in_template]");
     unsafe {
         let _ = SERVICES.evm.core.validate_raw_transferdomain_tx(
             raw_tx,
@@ -728,7 +728,7 @@ fn evm_try_unsafe_create_dst20(
     token: ffi::DST20TokenInfo,
 ) -> Result<()> {
     let address = ain_contracts::dst20_address_from_token_id(token.id)?;
-    debug!("Deploying to address {:#?}", address);
+    trace!("Deploying to address {:#?}", address);
 
     let system_tx = ExecuteTx::SystemTx(SystemTx::DeployContract(DeployContractData {
         name: token.name,
@@ -868,7 +868,7 @@ fn evm_try_unsafe_rename_dst20(
     token: ffi::DST20TokenInfo,
 ) -> Result<()> {
     let address = ain_contracts::dst20_address_from_token_id(token.id)?;
-    debug!("Renaming token on address {:#?}", address);
+    trace!("Renaming token on address {:#?}", address);
 
     let system_tx = ExecuteTx::SystemTx(SystemTx::UpdateContractName(UpdateContractNameData {
         name: token.name,


### PR DESCRIPTION
## Summary

- Long overdue toning done of Rust logs.
- Switch most of debug logs as trace to reduce verbosity
