### PR TITLE
Update consensus that blocks must be in chronological order

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -536,6 +536,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blocktimeordering", strprintf("(Deprecated) Whether to order transactions by time, otherwise ordered by fee (default: %u)", false), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-txordering", strprintf("Whether to order transactions by entry time, fee or both randomly (0: mixed, 1: fee based, 2: entry time) (default: %u)", DEFAULT_TX_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-ethstartstate", strprintf("Initialise Ethereum state trie using JSON input"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-testfuturestakingonly", strprintf("Test staking forward in time from the current block"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -536,7 +536,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blocktimeordering", strprintf("(Deprecated) Whether to order transactions by time, otherwise ordered by fee (default: %u)", false), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-txordering", strprintf("Whether to order transactions by entry time, fee or both randomly (0: mixed, 1: fee based, 2: entry time) (default: %u)", DEFAULT_TX_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-ethstartstate", strprintf("Initialise Ethereum state trie using JSON input"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-incrementalstaketimeonly", strprintf("Test staking forward in time from the current block"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-ascendingstaketime", strprintf("Test staking forward in time from the current block"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -536,7 +536,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blocktimeordering", strprintf("(Deprecated) Whether to order transactions by time, otherwise ordered by fee (default: %u)", false), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-txordering", strprintf("Whether to order transactions by entry time, fee or both randomly (0: mixed, 1: fee based, 2: entry time) (default: %u)", DEFAULT_TX_ORDERING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-ethstartstate", strprintf("Initialise Ethereum state trie using JSON input"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-testfuturestakingonly", strprintf("Test staking forward in time from the current block"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-incrementalstaketimeonly", strprintf("Test staking forward in time from the current block"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #ifdef USE_UPNP
 #if USE_UPNP
     gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1177,7 +1177,8 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                if (blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
+                if (gArgs.GetBoolArg("-testfuturestakingonly", false) ||
+                    blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
                     // Set time to last block time. New blocks must be after the last block.
                     nLastCoinStakeSearchTime = tip->GetBlockTime();
                 } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1177,7 +1177,7 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                if (gArgs.GetBoolArg("-incrementalstaketimeonly", false) ||
+                if (gArgs.GetBoolArg("-ascendingstaketime", false) ||
                     blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
                     // Set time to last block time. New blocks must be after the last block.
                     nLastCoinStakeSearchTime = tip->GetBlockTime();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1177,7 +1177,7 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                if (gArgs.GetBoolArg("-testfuturestakingonly", false) ||
+                if (gArgs.GetBoolArg("-incrementalstaketimeonly", false) ||
                     blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
                     // Set time to last block time. New blocks must be after the last block.
                     nLastCoinStakeSearchTime = tip->GetBlockTime();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1177,8 +1177,13 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                // Plus one to avoid time-too-old error on exact median time.
-                nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
+                if (blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
+                    // Set time to last block time. New blocks must be after the last block.
+                    nLastCoinStakeSearchTime = tip->GetBlockTime();
+                } else {
+                    // Plus one to avoid time-too-old error on exact median time.
+                    nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
+                }
             }
 
             lastBlockSeen = tip->GetBlockHash();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5051,13 +5051,22 @@ static bool ContextualCheckBlockHeader(const CBlockHeader &block,
     }
 
     // Check timestamp against prev
-    if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast()) {
-        return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER,
-                             false,
-                             "time-too-old",
-                             strprintf("block's timestamp is too early. Block time: %d Min time: %d",
-                                       block.GetBlockTime(),
-                                       pindexPrev->GetMedianTimePast()));
+    if (nHeight >= consensusParams.DF24Height) {
+        if (block.GetBlockTime() <= pindexPrev->GetBlockTime()) {
+            return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER,
+                                 false,
+                                 "time-before-prev",
+                                 "block's timestamp cannot be the same or before previous block's timestamp");
+        }
+    } else {
+        if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast()) {
+            return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER,
+                                 false,
+                                 "time-too-old",
+                                 strprintf("block's timestamp is too early. Block time: %d Min time: %d",
+                                           block.GetBlockTime(),
+                                           pindexPrev->GetMedianTimePast()));
+        }
     }
 
     // Check timestamp


### PR DESCRIPTION
## Summary

- This PR makes it that all blocks must be ahead of the previous block time wise. This is consistent with the behaviour of Ethereum and will solve some issues faced with Smart Contracts that have made this assumption on DeFiChain's EVM.
- Based on previous experience, reducing the seconds available in the staking range range lowers difficulty and reduces the number of empty blocks generated. Each new block opens up the entire range of time from the median of the last few blocks to 30 seconds ahead. To limit to future only blocks would reduce this range to the previous block time to 30 seconds ahead of the current time. For active miners when a new block is minted this would be somewhere between 0 to 30 seconds.
- Fixes https://github.com/DeFiCh/ain/issues/2929

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
