### PR TITLE
[breaking] Simplify UpdateTip log entry

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3708,18 +3708,14 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams &chainPar
     auto currentTime = GetSystemTimeInSeconds();
     if (!warningMessages.empty() || !::ChainstateActive().IsInitialBlockDownload() || lastTipTime < currentTime - 20) {
         lastTipTime = currentTime;
-        LogPrintf(
-            "%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)",
-            __func__, /* Continued */
-            pindexNew->GetBlockHash().ToString(),
-            pindexNew->nHeight,
-            pindexNew->nVersion,
-            log(pindexNew->nChainWork.getdouble()) / log(2.0),
-            (unsigned long)pindexNew->nChainTx,
-            FormatISO8601DateTime(pindexNew->GetBlockTime()),
-            GuessVerificationProgress(chainParams.TxData(), pindexNew),
-            ::ChainstateActive().CoinsTip().DynamicMemoryUsage() * (1.0 / (1 << 20)),
-            ::ChainstateActive().CoinsTip().GetCacheSize());
+        LogPrintf("%s: height=%d hash=%s p=%f d=%.8g tx=%lu date='%s'",
+                  __func__, /* Continued */
+                  pindexNew->nHeight,
+                  pindexNew->GetBlockHash().ToString(),
+                  GuessVerificationProgress(chainParams.TxData(), pindexNew),
+                  log(pindexNew->nChainWork.getdouble()) / log(2.0),
+                  (unsigned long)pindexNew->nChainTx,
+                  FormatISO8601DateTime(pindexNew->GetBlockTime()));
         if (!warningMessages.empty()) {
             LogPrintf(" warning='%s'", warningMessages); /* Continued */
         }


### PR DESCRIPTION
## Summary

- Simplify the overly verbose UpdateTip log entry to the following.

```
UpdateTip: height=4062963 hash=ed6ddcc70f13e798afa14a4529162a077bc56c740980f2b1d92cbc71d3bdf792 progress=1.000000 tx=32104696 date='2024-06-12T09:50:51Z'
```

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
