### PR TITLE
Ocean: fix `PoolCreationHeight` sorting & add `CompositeSwap` Aggregated

### DIFF
--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -48,7 +48,7 @@ fn get_bucket(block: &Block<Transaction>, interval: i64) -> i64 {
 }
 
 fn index_block_start(services: &Arc<Services>, block: &Block<Transaction>) -> Result<()> {
-    let pool_pairs = services
+    let mut pool_pairs = services
         .poolpair
         .by_height
         .list(None, SortOrder::Ascending)?
@@ -62,6 +62,8 @@ fn index_block_start(services: &Arc<Services>, block: &Block<Transaction>) -> Re
             })
         })
         .collect::<Result<Vec<_>>>()?;
+
+    pool_pairs.sort_by(|a, b| b.creation_height.cmp(&a.creation_height));
 
     for interval in AGGREGATED_INTERVALS {
         for pool_pair in &pool_pairs {

--- a/lib/ain-ocean/src/indexer/mod.rs
+++ b/lib/ain-ocean/src/indexer/mod.rs
@@ -48,10 +48,10 @@ fn get_bucket(block: &Block<Transaction>, interval: i64) -> i64 {
 }
 
 fn index_block_start(services: &Arc<Services>, block: &Block<Transaction>) -> Result<()> {
-    let mut pool_pairs = services
+    let pool_pairs = services
         .poolpair
         .by_height
-        .list(None, SortOrder::Ascending)?
+        .list(None, SortOrder::Descending)?
         .map(|el| {
             let ((k, _), (pool_id, id_token_a, id_token_b)) = el?;
             Ok(PoolCreationHeight {
@@ -62,8 +62,6 @@ fn index_block_start(services: &Arc<Services>, block: &Block<Transaction>) -> Re
             })
         })
         .collect::<Result<Vec<_>>>()?;
-
-    pool_pairs.sort_by(|a, b| b.creation_height.cmp(&a.creation_height));
 
     for interval in AGGREGATED_INTERVALS {
         for pool_pair in &pool_pairs {

--- a/lib/ain-ocean/src/indexer/poolswap.rs
+++ b/lib/ain-ocean/src/indexer/poolswap.rs
@@ -2,7 +2,7 @@ use std::{ops::Div, str::FromStr, sync::Arc};
 
 use ain_dftx::pool::*;
 use anyhow::format_err;
-use bitcoin::BlockHash;
+use bitcoin::{BlockHash, Txid};
 // use bitcoin::Address;
 use log::debug;
 use rust_decimal::Decimal;
@@ -34,6 +34,132 @@ pub struct PoolCreationHeight {
     pub id_token_a: u32,
     pub id_token_b: u32,
     pub creation_height: u32,
+}
+
+fn index_swap_aggregated(
+    services: &Arc<Services>,
+    pool_id: u32,
+    from_token_id: u64,
+    from_amount: i64,
+    txid: Txid,
+) -> Result<()> {
+    for interval in AGGREGATED_INTERVALS {
+        let repository = &services.pool_swap_aggregated;
+        let mut prevs = repository
+            .by_key
+            .list(Some((pool_id, interval, i64::MAX)), SortOrder::Descending)?
+            .take(1)
+            .take_while(|item| match item {
+                Ok((k, _)) => k.0 == pool_id && k.1 == interval,
+                _ => true,
+            })
+            .map(|e| repository.by_key.retrieve_primary_value(e))
+            .collect::<Result<Vec<_>>>()?;
+
+        if prevs.is_empty() {
+            log::error!(
+                "index swap {txid}: Unable to find {pool_id}-{interval} for Aggregate Indexing"
+            );
+            continue;
+        }
+
+        let aggregated = prevs.first_mut();
+        if let Some(aggregated) = aggregated {
+            let amount = aggregated
+                .aggregated
+                .amounts
+                .get(&from_token_id.to_string())
+                .map(|amt| Decimal::from_str(amt))
+                .transpose()?
+                .unwrap_or(dec!(0));
+
+            let aggregated_amount = amount
+                .checked_add(Decimal::from(from_amount).div(dec!(100_000_000)))
+                .ok_or(Error::OverflowError)?;
+
+            aggregated.aggregated.amounts.insert(
+                from_token_id.to_string(),
+                format!("{:.8}", aggregated_amount),
+            );
+
+            let parts = aggregated.id.split('-').collect::<Vec<&str>>();
+            if parts.len() != 3 {
+                return Err(format_err!("Invalid poolswap aggregated id format").into());
+            };
+            let pool_id = parts[0].parse::<u32>()?;
+            let interval = parts[1].parse::<u32>()?;
+            let hash = parts[2].parse::<BlockHash>()?;
+
+            repository
+                .by_id
+                .put(&(pool_id, interval, hash), aggregated)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn invalidate_swap_aggregated(
+    services: &Arc<Services>,
+    pool_id: u32,
+    from_token_id: u64,
+    from_amount: i64,
+    txid: Txid,
+) -> Result<()> {
+    for interval in AGGREGATED_INTERVALS {
+        let repository = &services.pool_swap_aggregated;
+        let mut prevs = repository
+            .by_key
+            .list(Some((pool_id, interval, i64::MAX)), SortOrder::Descending)?
+            .take(1)
+            .take_while(|item| match item {
+                Ok((k, _)) => k.0 == pool_id && k.1 == interval,
+                _ => true,
+            })
+            .map(|e| repository.by_key.retrieve_primary_value(e))
+            .collect::<Result<Vec<_>>>()?;
+
+        if prevs.is_empty() {
+            log::error!(
+                "invalidate swap {txid}: Unable to find {pool_id}-{interval} for Aggregate Indexing"
+            );
+            continue;
+        }
+
+        let aggregated = prevs.first_mut();
+        if let Some(aggregated) = aggregated {
+            let amount = aggregated
+                .aggregated
+                .amounts
+                .get(&from_token_id.to_string())
+                .map(|amt| Decimal::from_str(amt))
+                .transpose()?
+                .unwrap_or(dec!(0));
+
+            let aggregated_amount = amount
+                .checked_sub(Decimal::from(from_amount).div(dec!(100_000_000)))
+                .ok_or(Error::UnderflowError)?;
+
+            aggregated.aggregated.amounts.insert(
+                from_token_id.to_string(),
+                format!("{:.8}", aggregated_amount),
+            );
+
+            let parts = aggregated.id.split('-').collect::<Vec<&str>>();
+            if parts.len() != 3 {
+                return Err(format_err!("Invalid poolswap aggregated id format").into());
+            };
+            let pool_id = parts[0].parse::<u32>()?;
+            let interval = parts[1].parse::<u32>()?;
+            let hash = parts[2].parse::<BlockHash>()?;
+
+            repository
+                .by_id
+                .put(&(pool_id, interval, hash), aggregated)?;
+        }
+    }
+
+    Ok(())
 }
 
 impl Index for PoolSwap {
@@ -82,64 +208,16 @@ impl Index for PoolSwap {
             .by_id
             .put(&(pool_id, ctx.block.height, idx), &swap)?;
 
-        for interval in AGGREGATED_INTERVALS {
-            let repository = &services.pool_swap_aggregated;
-            let mut prevs = repository
-                .by_key
-                .list(Some((pool_id, interval, i64::MAX)), SortOrder::Descending)?
-                .take(1)
-                .take_while(|item| match item {
-                    Ok((k, _)) => k.0 == pool_id && k.1 == interval,
-                    _ => true,
-                })
-                .map(|e| repository.by_key.retrieve_primary_value(e))
-                .collect::<Result<Vec<_>>>()?;
-
-            if prevs.is_empty() {
-                log::error!(
-                    "index swap {txid}: Unable to find {pool_id}-{interval} for Aggregate Indexing"
-                );
-                continue;
-            }
-
-            let aggregated = prevs.first_mut();
-            if let Some(aggregated) = aggregated {
-                let amount = aggregated
-                    .aggregated
-                    .amounts
-                    .get(&from_token_id.to_string())
-                    .map(|amt| Decimal::from_str(amt))
-                    .transpose()?
-                    .unwrap_or(dec!(0));
-
-                let aggregated_amount = amount
-                    .checked_add(Decimal::from(from_amount).div(dec!(100_000_000)))
-                    .ok_or(Error::OverflowError)?;
-
-                aggregated.aggregated.amounts.insert(
-                    from_token_id.to_string(),
-                    format!("{:.8}", aggregated_amount),
-                );
-
-                let parts = aggregated.id.split('-').collect::<Vec<&str>>();
-                if parts.len() != 3 {
-                    return Err(format_err!("Invalid poolswap aggregated id format").into());
-                };
-                let pool_id = parts[0].parse::<u32>()?;
-                let interval = parts[1].parse::<u32>()?;
-                let hash = parts[2].parse::<BlockHash>()?;
-
-                repository
-                    .by_id
-                    .put(&(pool_id, interval, hash), aggregated)?;
-            }
-        }
+        index_swap_aggregated(services, pool_id, from_token_id, from_amount, txid)?;
 
         Ok(())
     }
 
     fn invalidate(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         let txid = ctx.tx.txid;
+        let from_token_id = self.from_token_id.0;
+        let from_amount = self.from_amount;
+
         let Some(TxResult::PoolSwap(PoolSwapResult { pool_id, .. })) =
             services.result.get(&txid)?
         else {
@@ -152,61 +230,7 @@ impl Index for PoolSwap {
             .delete(&(pool_id, ctx.block.height, ctx.tx_idx))?;
         tx_result::invalidate(services, &txid)?;
 
-        for interval in AGGREGATED_INTERVALS {
-            let repository = &services.pool_swap_aggregated;
-            let mut prevs = repository
-                .by_key
-                .list(Some((pool_id, interval, i64::MAX)), SortOrder::Descending)?
-                .take(1)
-                .take_while(|item| match item {
-                    Ok((k, _)) => k.0 == pool_id && k.1 == interval,
-                    _ => true,
-                })
-                .map(|e| repository.by_key.retrieve_primary_value(e))
-                .collect::<Result<Vec<_>>>()?;
-
-            if prevs.is_empty() {
-                log::error!(
-                    "invalidate swap {txid}: Unable to find {pool_id}-{interval} for Aggregate Indexing"
-                );
-                continue;
-            }
-
-            let from_token_id = self.from_token_id.0;
-            let from_amount = self.from_amount;
-
-            let aggregated = prevs.first_mut();
-            if let Some(aggregated) = aggregated {
-                let amount = aggregated
-                    .aggregated
-                    .amounts
-                    .get(&from_token_id.to_string())
-                    .map(|amt| Decimal::from_str(amt))
-                    .transpose()?
-                    .unwrap_or(dec!(0));
-
-                let aggregated_amount = amount
-                    .checked_sub(Decimal::from(from_amount).div(dec!(100_000_000)))
-                    .ok_or(Error::UnderflowError)?;
-
-                aggregated.aggregated.amounts.insert(
-                    from_token_id.to_string(),
-                    format!("{:.8}", aggregated_amount),
-                );
-
-                let parts = aggregated.id.split('-').collect::<Vec<&str>>();
-                if parts.len() != 3 {
-                    return Err(format_err!("Invalid poolswap aggregated id format").into());
-                };
-                let pool_id = parts[0].parse::<u32>()?;
-                let interval = parts[1].parse::<u32>()?;
-                let hash = parts[2].parse::<BlockHash>()?;
-
-                repository
-                    .by_id
-                    .put(&(pool_id, interval, hash), aggregated)?;
-            }
-        }
+        invalidate_swap_aggregated(services, pool_id, from_token_id, from_amount, txid)?;
 
         Ok(())
     }
@@ -216,6 +240,9 @@ impl Index for CompositeSwap {
     fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         debug!("[CompositeSwap] Indexing...");
         let txid = ctx.tx.txid;
+        let from_token_id = self.pool_swap.from_token_id.0;
+        let from_amount = self.pool_swap.from_amount;
+        let to_token_id = self.pool_swap.to_token_id.0;
 
         let Some(TxResult::PoolSwap(PoolSwapResult { to_amount, .. })) =
             services.result.get(&txid)?
@@ -229,10 +256,10 @@ impl Index for CompositeSwap {
         let pools = self.pools.as_ref();
 
         let pool_ids = if pools.is_empty() {
-            let Some(pool_id) = services.poolpair.by_id.get(&(
-                self.pool_swap.from_token_id.0 as u32,
-                self.pool_swap.to_token_id.0 as u32,
-            ))?
+            let Some(pool_id) = services
+                .poolpair
+                .by_id
+                .get(&(from_token_id as u32, to_token_id as u32))?
             else {
                 return Err("Missing pool_id".into());
             };
@@ -248,8 +275,8 @@ impl Index for CompositeSwap {
                 txid,
                 txno: ctx.tx_idx,
                 from_amount: self.pool_swap.from_amount,
-                from_token_id: self.pool_swap.from_token_id.0,
-                to_token_id: self.pool_swap.to_token_id.0,
+                from_token_id,
+                to_token_id,
                 to_amount,
                 pool_id,
                 from: from.clone(),
@@ -260,18 +287,25 @@ impl Index for CompositeSwap {
                 .pool
                 .by_id
                 .put(&(pool_id, ctx.block.height, ctx.tx_idx), &swap)?;
+
+            index_swap_aggregated(services, pool_id, from_token_id, from_amount, txid)?;
         }
 
         Ok(())
     }
 
     fn invalidate(&self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
+        let from_token_id = self.pool_swap.from_token_id.0;
+        let from_amount = self.pool_swap.from_amount;
+        let txid = ctx.tx.txid;
         for pool in self.pools.as_ref() {
             let pool_id = pool.id.0 as u32;
             services
                 .pool
                 .by_id
                 .delete(&(pool_id, ctx.block.height, ctx.tx_idx))?;
+
+            invalidate_swap_aggregated(services, pool_id, from_token_id, from_amount, txid)?;
         }
         tx_result::invalidate(services, &ctx.tx.txid)
     }

--- a/lib/ain-ocean/src/repository/poolpair.rs
+++ b/lib/ain-ocean/src/repository/poolpair.rs
@@ -9,7 +9,7 @@ use crate::{
     Result,
 };
 
-type PoolPairByHeightKey = (u32, usize);
+type PoolPairByHeightKey = (u32, usize); // block_height, tx_idx
 type PoolPairValue = (u32, u32, u32); // pool_id, id_token_a, id_token_b
 
 #[derive(Repository)]


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- re-fix `should show aggregated swaps for 24h and 30d` by sorted poolpair creation height
- add missing index composite swap aggregated
