### PR TITLE
Add state trie creation to overlay

### DIFF
--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -188,7 +188,6 @@ impl EVMBackend {
 
         if reset_storage || is_empty_account(&account) {
             self.overlay.mark_create(address);
-            account.storage_root = GENESIS_STATE_ROOT;
         }
 
         if let Some(code) = &code {

--- a/lib/ain-evm/src/backend.rs
+++ b/lib/ain-evm/src/backend.rs
@@ -9,7 +9,7 @@ use ethereum::{Account, Header, Log};
 use ethereum_types::{H160, H256, U256};
 use evm::backend::{Apply, ApplyBackend, Backend, Basic};
 use hash_db::Hasher as _;
-use log::{debug, trace};
+use log::trace;
 use rlp::{Decodable, Encodable, Rlp};
 use sp_core::{hexdisplay::AsBytesRef, Blake2Hasher};
 use vsdb_trie_db::{MptOnce, MptRo};
@@ -62,7 +62,6 @@ struct OverlayData {
     account: Account,
     code: Option<Vec<u8>>,
     storage: HashMap<H256, H256>,
-    reset_storage: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -103,7 +102,6 @@ impl Overlay {
             account,
             code: code.or(self.get_code(&address)),
             storage,
-            reset_storage,
         };
         self.state.insert(address, data.clone());
     }
@@ -237,7 +235,6 @@ impl EVMBackend {
                 ref mut account,
                 code,
                 storage,
-                reset_storage,
             },
         ) in self.overlay.state.drain()
         {

--- a/test/functional/feature_evm_rpc_tracer.py
+++ b/test/functional/feature_evm_rpc_tracer.py
@@ -327,17 +327,16 @@ class EvmTracerTest(DefiTestFramework):
 
         self.nodes[0].generate(1)
 
-        # This is failing as of commit ffe007f86826cad654cec8ddfeb6e9436206ed08
-        # Tracing of new contract creation on EVM will overwrite the contract
-        # state trie and lead to an invalid state root
-        # Fixed by adding new contract state trie creation to overlay
+        # These seemingly read-only calls are failing up to commit ffe007f86826cad654cec8ddfeb6e9436206ed08.
+        # Tracing of new contract creation on EVM was overwriting the contract
+        # state trie and corrupted the underlying backend.
+        # Fixed in https://github.com/DeFiCh/ain/pull/2941 by adding new contract state trie creation to overlay.
         self.nodes[0].debug_traceBlockByNumber("latest")
         self.nodes[0].eth_getStorageAt(
             "0xff00000000000000000000000000000000000001", "0x0"
         )
 
         self.nodes[0].minttokens("100@BTC")
-
         self.nodes[0].generate(1)
         self.nodes[0].transferdomain(
             [

--- a/test/functional/feature_evm_rpc_tracer.py
+++ b/test/functional/feature_evm_rpc_tracer.py
@@ -327,7 +327,7 @@ class EvmTracerTest(DefiTestFramework):
 
         self.nodes[0].generate(1)
 
-        # These seemingly read-only calls are failing up to commit ffe007f86826cad654cec8ddfeb6e9436206ed08.
+        # These seemingly benign read-only calls are failing up to commit ffe007f86826cad654cec8ddfeb6e9436206ed08.
         # Tracing of new contract creation on EVM was overwriting the contract
         # state trie and corrupted the underlying backend.
         # Fixed in https://github.com/DeFiCh/ain/pull/2941 by adding new contract state trie creation to overlay.

--- a/test/functional/feature_evm_rpc_tracer.py
+++ b/test/functional/feature_evm_rpc_tracer.py
@@ -324,8 +324,20 @@ class EvmTracerTest(DefiTestFramework):
                 "collateralAddress": self.address,
             }
         )
+
         self.nodes[0].generate(1)
+
+        # This is failing as of commit ffe007f86826cad654cec8ddfeb6e9436206ed08
+        # Tracing of new contract creation on EVM will overwrite the contract
+        # state trie and lead to an invalid state root
+        # Fixed by adding new contract state trie creation to overlay
+        self.nodes[0].debug_traceBlockByNumber("latest")
+        self.nodes[0].eth_getStorageAt(
+            "0xff00000000000000000000000000000000000001", "0x0"
+        )
+
         self.nodes[0].minttokens("100@BTC")
+
         self.nodes[0].generate(1)
         self.nodes[0].transferdomain(
             [


### PR DESCRIPTION
## Summary

- Add state trie creation to overlay
- Prevents trace transaction to re-create a state trie and corrupting the underlying backend
