### PR TITLE
accounts: improved utxosToAccount

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -783,9 +783,31 @@ UniValue utxostoaccount(const JSONRPCRequest &request) {
         }
     }
 
+    const UniValue &txInputs = request.params[2];
+    bool funded= false;
+    if (msg.to.size() == 1) {
+        CCoinControl coinControl;
+        //try to fill inputs from target address and use it as change
+        const auto &target = msg.to.begin()->first;
+        CTxDestination dest;
+        ExtractDestination(target, dest);
+        if (IsMineCached(*pwallet, target) == ISMINE_SPENDABLE) {
+            if (IsValidDestination(dest)) {
+                coinControl.destChange = dest;
+                coinControl.matchDestination = dest;
+                try {
+                    fund(rawTx, pwallet, {}, &coinControl, request.metadata.coinSelectOpts);
+                    funded= true;
+                } catch(const UniValue &e) {
+                    //likely not enough utxos, silent catch and try again outside
+                }
+            }
+        }
+    }
     // fund
-    fund(rawTx, pwallet, {}, nullptr, request.metadata.coinSelectOpts);
-
+    if(!funded) {
+        fund(rawTx, pwallet, {}, nullptr, request.metadata.coinSelectOpts);
+    }
     // check execution
     execTestTx(CTransaction(rawTx), targetHeight);
 

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -783,7 +783,6 @@ UniValue utxostoaccount(const JSONRPCRequest &request) {
         }
     }
 
-    const UniValue &txInputs = request.params[2];
     bool funded = false;
     if (msg.to.size() == 1) {
         CCoinControl coinControl;

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -784,10 +784,10 @@ UniValue utxostoaccount(const JSONRPCRequest &request) {
     }
 
     const UniValue &txInputs = request.params[2];
-    bool funded= false;
+    bool funded = false;
     if (msg.to.size() == 1) {
         CCoinControl coinControl;
-        //try to fill inputs from target address and use it as change
+        // try to fill inputs from target address and use it as change
         const auto &target = msg.to.begin()->first;
         CTxDestination dest;
         ExtractDestination(target, dest);
@@ -797,15 +797,15 @@ UniValue utxostoaccount(const JSONRPCRequest &request) {
                 coinControl.matchDestination = dest;
                 try {
                     fund(rawTx, pwallet, {}, &coinControl, request.metadata.coinSelectOpts);
-                    funded= true;
-                } catch(const UniValue &e) {
-                    //likely not enough utxos, silent catch and try again outside
+                    funded = true;
+                } catch (const UniValue &e) {
+                    // likely not enough utxos, silent catch and try again outside
                 }
             }
         }
     }
     // fund
-    if(!funded) {
+    if (!funded) {
         fund(rawTx, pwallet, {}, nullptr, request.metadata.coinSelectOpts);
     }
     // check execution


### PR DESCRIPTION
## Summary

when you create a utxostoaccount message, the wallet selects "random" utxos to use. Most of the time such a tx is used to transfer utxos from the address to the token layer of the same address. The random selection therefore just messes with the accounting (pull utxos from other addresses in the wallet).

This PR changes that: if there is only 1 target address, and the target address is owned by the account,  only utxos of that address are used (if enough are available)

## RPCs

changes in input selection of `utxostoaccount`

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [X] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [X] None
