### PR TITLE
setloantoken set dust output for collateral

### DIFF
--- a/src/dfi/rpc_loan.cpp
+++ b/src/dfi/rpc_loan.cpp
@@ -3,6 +3,7 @@
 #include <dfi/govvariables/attributes.h>
 #include <dfi/mn_rpc.h>
 #include <dfi/threadpool.h>
+#include <policy/settings.h>
 
 extern UniValue tokenToJSON(CCustomCSView &view, DCT_ID const &id, const CTokenImplementation &token, bool verbose);
 extern std::pair<int, int> GetFixedIntervalPriceBlocks(int currentHeight, const CCustomCSView &mnview);
@@ -419,6 +420,9 @@ UniValue setloantoken(const JSONRPCRequest &request) {
         GetAuthInputsSmart(pwallet, rawTx.nVersion, auths, true, optAuthTx, txInputs, request.metadata.coinSelectOpts);
 
     rawTx.vout.push_back(CTxOut(0, scriptMeta));
+    CTxOut collateralOutput(1, *auths.cbegin());
+    collateralOutput.nValue = GetDustThreshold(collateralOutput, rawTx.nVersion, ::dustRelayFee);
+    rawTx.vout.push_back(collateralOutput);
 
     CCoinControl coinControl;
 

--- a/test/functional/feature_loan_basics.py
+++ b/test/functional/feature_loan_basics.py
@@ -27,6 +27,7 @@ class LoanTakeLoanTest(DefiTestFramework):
                 "-bayfrontgardensheight=1",
                 "-fortcanningheight=50",
                 "-eunosheight=50",
+                "-eunospayaheight=50",
                 "-fortcanninghillheight=220",
             ],
             [
@@ -36,6 +37,7 @@ class LoanTakeLoanTest(DefiTestFramework):
                 "-bayfrontgardensheight=1",
                 "-fortcanningheight=50",
                 "-eunosheight=50",
+                "-eunospayaheight=50",
             ],
         ]
 
@@ -114,6 +116,8 @@ class LoanTakeLoanTest(DefiTestFramework):
         self.nodes[0].generate(1)
         self.sync_blocks()
 
+        utxos_before = self.nodes[0].listunspent()
+
         setLoanTokenTSLA = self.nodes[0].setloantoken(
             {
                 "symbol": symbolTSLA,
@@ -146,6 +150,9 @@ class LoanTakeLoanTest(DefiTestFramework):
 
         self.nodes[0].generate(1)
         self.sync_blocks()
+
+        # Make sure UTXO count is same before and after
+        assert_equal(len(utxos_before), len(self.nodes[0].listunspent()))
 
         self.nodes[0].createloanscheme(150, 5, "LOAN150")
 


### PR DESCRIPTION
## Summary

- When a token is created via `createtoken` the first output is the collateral, the wallet identifies token collateral by first seeing of the `TXID` finds a token under the `CreationTx` and if the output is the second one, first one being OP_RETURN. When `setloantoken` is used a token is created storing the `TXID` as the token `CreationTx`, whatever output one is will become the collateral output and will be unspendable.
- This PR sets the second output to the lowest possible amount, this will then be used as collateral and will allow change to be returned to the wallet.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
