### PR TITLE
Allow flag to disable wallet ownership checks

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -267,7 +267,9 @@ static UniValue DecodeRecipientsGetRecipients(const UniValue &values) {
     return recipients;
 }
 
-static CAccounts DecodeRecipientsDefaultInternal(CWallet *const pwallet, const UniValue &values, bool checkOwnership = true) {
+static CAccounts DecodeRecipientsDefaultInternal(CWallet *const pwallet,
+                                                 const UniValue &values,
+                                                 bool checkOwnership = true) {
     const auto recipients = DecodeRecipientsGetRecipients(values);
     auto accounts = DecodeRecipients(pwallet->chain(), recipients);
     if (!checkOwnership) {

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -6,7 +6,6 @@
 #include <dfi/validation.h>
 #include <ffi/ffihelpers.h>
 #include <boost/asio.hpp>
-#include "dfi/poolpairs.h"
 
 static bool DEFAULT_DVM_OWNERSHIP_CHECK = true;
 

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -6,6 +6,9 @@
 #include <dfi/validation.h>
 #include <ffi/ffihelpers.h>
 #include <boost/asio.hpp>
+#include "dfi/poolpairs.h"
+
+static bool DEFAULT_DVM_OWNERSHIP_CHECK = true;
 
 std::string tokenAmountString(const CTokenAmount &amount, AmountFormat format = AmountFormat::Symbol) {
     const auto token = pcustomcsview->GetToken(amount.nTokenId);
@@ -265,9 +268,12 @@ static UniValue DecodeRecipientsGetRecipients(const UniValue &values) {
     return recipients;
 }
 
-static CAccounts DecodeRecipientsDefaultInternal(CWallet *const pwallet, const UniValue &values) {
+static CAccounts DecodeRecipientsDefaultInternal(CWallet *const pwallet, const UniValue &values, bool checkOwnership = true) {
     const auto recipients = DecodeRecipientsGetRecipients(values);
     auto accounts = DecodeRecipients(pwallet->chain(), recipients);
+    if (!checkOwnership) {
+        return accounts;
+    }
     for (const auto &account : accounts) {
         if (IsMineCached(*pwallet, account.first) != ISMINE_SPENDABLE &&
             account.second.balances.find(DCT_ID{0}) != account.second.balances.end()) {
@@ -750,7 +756,8 @@ UniValue utxostoaccount(const JSONRPCRequest &request) {
 
     // decode recipients
     CUtxosToAccountMessage msg{};
-    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[0].get_obj());
+    auto ownershipCheck = gArgs.GetBoolArg("-dvmownershipcheck", DEFAULT_DVM_OWNERSHIP_CHECK);
+    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[0].get_obj(), ownershipCheck);
 
     for (const auto &[to, amount] : msg.to) {
         RejectErc55Address(to);
@@ -915,7 +922,8 @@ UniValue accounttoaccount(const JSONRPCRequest &request) {
 
     // decode sender and recipients
     CAccountToAccountMessage msg{};
-    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[1].get_obj());
+    auto ownershipCheck = gArgs.GetBoolArg("-dvmownershipcheck", DEFAULT_DVM_OWNERSHIP_CHECK);
+    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[1].get_obj(), ownershipCheck);
 
     if (SumAllTransfers(msg.to).balances.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "zero amounts");
@@ -2045,7 +2053,8 @@ UniValue sendtokenstoaddress(const JSONRPCRequest &request) {
     RPCTypeCheck(request.params, {UniValue::VOBJ, UniValue::VOBJ, UniValue::VSTR}, false);
 
     CAnyAccountsToAccountsMessage msg;
-    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[1].get_obj());
+    auto ownershipCheck = gArgs.GetBoolArg("-dvmownershipcheck", DEFAULT_DVM_OWNERSHIP_CHECK);
+    msg.to = DecodeRecipientsDefaultInternal(pwallet, request.params[1].get_obj(), ownershipCheck);
 
     const CBalances sumTransfersTo = SumAllTransfers(msg.to);
     if (sumTransfersTo.balances.empty()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -618,6 +618,7 @@ void SetupServerArgs()
     gArgs.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-tdsinglekeycheck", "Set the single key check flag for transferdomain RPC. If enabled, transfers between domain are only allowed if the addresses specified corresponds to the same key (default: true)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-dvmownershipcheck", "If enabled, utxostoaccount, sendtokenstoaddress and accounttoaccount APIs enforce a check to only allow to owned addresses (default: true)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-evmtxpriorityfeepercentile", strprintf("Set the suggested priority fee for EVM transactions (default: %u)", DEFAULT_SUGGESTED_PRIORITY_FEE_PERCENTILE), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-evmestimategaserrorratio", strprintf("Set the gas estimation error ratio for eth_estimateGas RPC (default: %u)", DEFAULT_ESTIMATE_GAS_ERROR_RATIO), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-uacomment=<cmt>", "Append comment to the user agent string", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Adds `-dvmownershipcheck` flag that to control the enforcement of wallet ownership checks on DVM RPCs
- Note that the protocol always allows any address to any address. 
- The RPC restrict this to prevent accidental usages, however currently offers no solution to by-pass this. 
- This allows the flag to opt-in when needed. 
- Default remains the same. 

DVM RPCs: 

- `accounttoaccount`
- `utxostoaccount`
- `sendtokenstoaddress`

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
