### PR TITLE
Skip pre-eunospaya vout check on regtest

### DIFF
--- a/src/dfi/consensus/txvisitor.cpp
+++ b/src/dfi/consensus/txvisitor.cpp
@@ -141,7 +141,7 @@ Res CCustomTxVisitor::CheckCustomTx() const {
     const auto &consensus = txCtx.GetConsensus();
     const auto height = txCtx.GetHeight();
     const auto &tx = txCtx.GetTransaction();
-    if (static_cast<int>(height) < consensus.DF10EunosPayaHeight) {
+    if (!IsRegtestNetwork() && static_cast<int>(height) < consensus.DF10EunosPayaHeight) {
         if (tx.vout.size() != 2) {
             return Res::Err("malformed tx vouts ((wrong number of vouts)");
         }


### PR DESCRIPTION
## Summary

- Before Eunos Paya account layer TXs were required to only have two vouts. The recent workaround to add an additional output to setloantoken breaks early tests. This PR bypasses the vout check for regtest.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
