### PR TITLE
Use wrapper functions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2410,7 +2410,7 @@ bool AppInitMain(InitInterfaces& interfaces)
 
         // Create masternode
         CMasternode node;
-        node.creationHeight = chain_active_height - Params().GetConsensus().mn.newActivationDelay;
+        node.creationHeight = chain_active_height - GetMnActivationDelay(chain_active_height);
         node.ownerType = WitV0KeyHashType;
         node.ownerAuthAddress = keyID;
         node.operatorType = WitV0KeyHashType;


### PR DESCRIPTION
## Summary

- Do not use newResignDelay or newActivationDelay directly, use GetMnResignDelay or GetMnActivationDelay respectively. Otherwise future changes to resign or activation delays will not be replicated in areas that use the variables directly.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
