### PR TITLE
TEST: Check for CI failure with std::mutex

### DIFF
--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(lock_free)
     constexpr int num_threads = 10;
 
     auto testFunc = []() {
-        static AtomicMutex m;
+        static std::mutex m;
         static uint64_t context(0);
         static std::atomic_int threads(num_threads);
 


### PR DESCRIPTION
## Summary

- CI fails a unit test. This PR removes AtomicMutex to see if the failure still occurs.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
