### PR TITLE
Return crossboundary error message debug info

### DIFF
--- a/lib/ain-macros/src/lib.rs
+++ b/lib/ain-macros/src/lib.rs
@@ -45,8 +45,15 @@ pub fn ffi_fallible(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     cross_boundary_success_return(result, success_value)
                 }
                 Err(err_msg) => {
-                    cross_boundary_error_return(result, err_msg.to_string())
-                }
+                        #[cfg(debug_assertions)]
+                        {
+                            cross_boundary_error_return(result, format!("{err_msg:?}"))
+                        }
+                        #[cfg(not(debug_assertions))]
+                        {
+                            cross_boundary_error_return(result, err_msg.to_string())
+                        }
+                    }
             }
         }
     };


### PR DESCRIPTION
## Summary

- When in debug mode, return the full error as debug
- Will return the backtrace when using transparent anyhow error and running with `RUST_BACKTRACE=1`
