### PR TITLE
Add interruptblock RPC

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -414,6 +414,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "eth_getTransactionByBlockNumberAndIndex", 0, "tag"},
     { "eth_getTransactionByBlockNumberAndIndex", 1, "txIndex"},
     { "debug_feeEstimate", 0, "tx"},
+
+    { "interruptblock", 0, "height" },
 };
 
 /**

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -415,7 +415,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "eth_getTransactionByBlockNumberAndIndex", 1, "txIndex"},
     { "debug_feeEstimate", 0, "tx"},
 
-    { "interruptblock", 0, "height" },
+    { "setinterruptblock", 0, "height" },
 };
 
 /**

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -608,10 +608,10 @@ static UniValue setinterruptblock(const JSONRPCRequest& request)
     {
         LOCK(cs_main);
         currentHeight = ::ChainActive().Height();
+        fInterruptBlockHeight = height;
+        fInterrupt = true;
     }
 
-    fInterruptBlockHeight = height;
-    fInterrupt = true;
 
     // Checks if node has already hit the previous interrupt height.
     // If true, resets the invalid blocks to prevent node from being stuck as

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -15,6 +15,9 @@
 #include <util/strencodings.h>
 #include <util/validation.h>
 
+#include <consensus/validation.h>
+#include <validation.h>
+
 #include <stdint.h>
 #include <tuple>
 #ifdef HAVE_MALLOC_INFO
@@ -580,6 +583,58 @@ static UniValue echo(const JSONRPCRequest& request)
     return request.params;
 }
 
+static UniValue interruptblock(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"interruptblock",
+        "\nSet or update interrupt-block value\n",
+        {
+            {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "block height"},
+        },
+        RPCResults{},
+        RPCExamples{""},
+    }.Check(request);
+
+    RPCTypeCheck(request.params, {UniValue::VNUM});
+
+    int height = request.params[0].get_int();
+    auto previousInterruptHeight = fInterruptBlockHeight;
+
+    uint64_t currentHeight;
+    {
+        LOCK(cs_main);
+        currentHeight = ::ChainActive().Height();
+    }
+
+    fInterruptBlockHeight = height;
+    fInterrupt = true;
+
+    // Checks if node has already hit the previous interrupt height.
+    // If true, resets the invalid blocks to prevent node from being stuck as
+    // the blocks above would be considered invalid by the previous interrupt height
+    if (currentHeight + 1 == previousInterruptHeight) {
+        {
+            LOCK(cs_main);
+
+            const auto hash = ::ChainActive().Tip()->GetBlockHash();
+            CBlockIndex* pblockindex = LookupBlockIndex(hash);
+            if (!pblockindex) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            }
+
+            ResetBlockFailureFlags(pblockindex);
+        }
+
+        CValidationState state;
+        ActivateBestChain(state, Params());
+
+        if (!state.IsValid()) {
+            throw JSONRPCError(RPC_DATABASE_ERROR, FormatStateMessage(state));
+        }
+    }
+
+    return NullUniValue;;
+}
+
 // clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
@@ -598,6 +653,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "setmockcheckpoint",      &setmockcheckpoint,      {"height","blockhash"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
+    { "hidden",             "interruptblock",         &interruptblock,         {"height"}}
 };
 // clang-format on
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -583,15 +583,20 @@ static UniValue echo(const JSONRPCRequest& request)
     return request.params;
 }
 
-static UniValue interruptblock(const JSONRPCRequest& request)
+static UniValue setinterruptblock(const JSONRPCRequest& request)
 {
-    RPCHelpMan{"interruptblock",
+    RPCHelpMan{"setinterruptblock",
         "\nSet or update interrupt-block value\n",
         {
             {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "block height"},
         },
         RPCResults{},
-        RPCExamples{""},
+        RPCExamples{
+            HelpExampleCli("setinterruptblock", "5000")
+            + HelpExampleCli("setinterruptblock", "-1")
+            + HelpExampleRpc("setinterruptblock", "5000")
+            + HelpExampleRpc("setinterruptblock", "-1")
+        },
     }.Check(request);
 
     RPCTypeCheck(request.params, {UniValue::VNUM});
@@ -653,7 +658,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "setmockcheckpoint",      &setmockcheckpoint,      {"height","blockhash"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
-    { "hidden",             "interruptblock",         &interruptblock,         {"height"}}
+    { "hidden",             "setinterruptblock",      &setinterruptblock,      {"height"}}
 };
 // clang-format on
 


### PR DESCRIPTION
## Summary

- Introduces `interruptblock` RPC, which takes a block height as only param.
- If a node is running without `-interrupt-block` startup flag, sets `fInterrupt` and `fInterruptBlockHeight`.
- Can be run multiple times in a row and will update `fInterruptBlockHeight` to the latest height passed to `interruptblock` RPC.

This let's a user easily run a command against a target block height.
Example usage :

```
for height in `5000 10000 15000`
   defi-cli interruptblock height
   wait_for_block height
   ... Run any command at  required height.
```

Idea behind it is to ease diff log generation for full sync CI or Ocean A/B testing.
Current node behaviour requires multiple restart (as interrupt-block height can only be set via startup flag).
This also lets one interrupt an already running node. 



