### PR TITLE
Ocean: fix set oracle mul overflow

### DIFF
--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -471,6 +471,8 @@ impl Index for SetOracleData {
                 }
             }
 
+            // asdf
+
             let amount = total
                 .checked_div(Decimal::from(weightage))
                 .unwrap_or(dec!(1));

--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -460,7 +460,11 @@ impl Index for SetOracleData {
                             if (oracle_price.time - context.block.time as i32) < 3600 {
                                 count += 1;
                                 weightage += oracle.weightage as i32;
-                                log::debug!("SetOracleData weightage: {:?} * oracle_price.amount: {:?}", weightage, oracle_price.amount);
+                                log::debug!(
+                                    "SetOracleData weightage: {:?} * oracle_price.amount: {:?}",
+                                    weightage,
+                                    oracle_price.amount
+                                );
                                 let weighted_amount = Decimal::from(oracle_price.amount)
                                     .checked_mul(Decimal::from(oracle.weightage))
                                     .context("weighted_amount overflow")?;

--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -460,6 +460,7 @@ impl Index for SetOracleData {
                             if (oracle_price.time - context.block.time as i32) < 3600 {
                                 count += 1;
                                 weightage += oracle.weightage as i32;
+                                log::debug!("SetOracleData weightage: {:?} * oracle_price.amount: {:?}", weightage, oracle_price.amount);
                                 let weighted_amount = Decimal::from(oracle_price.amount)
                                     .checked_mul(Decimal::from(oracle.weightage))
                                     .context("weighted_amount overflow")?;

--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -777,8 +777,33 @@ pub fn invalidate_oracle_interval(
                 .by_id
                 .delete(&oracle_price_aggreated[0].id);
         } else {
-            let lastprice = oracle_price_aggreated[0].aggregated.clone();
-            let count = lastprice.count - 1;
+            let last_price = oracle_price_aggreated[0].aggregated.clone();
+            let count = last_price.count - 1;
+
+            let aggregated_amount = backward_aggregate_value(
+                Decimal::from_str(&last_price.amount)?,
+                Decimal::from_str(&aggregated.aggregated.amount)?,
+                Decimal::from(count),
+            )?;
+
+            let aggregated_weightage = backward_aggregate_value(
+                Decimal::from(last_price.weightage),
+                Decimal::from(aggregated.aggregated.weightage),
+                Decimal::from(count),
+            )?;
+
+            let aggregated_active = backward_aggregate_value(
+                Decimal::from(last_price.oracles.active),
+                Decimal::from(aggregated.aggregated.oracles.active),
+                Decimal::from(last_price.count),
+            )?;
+
+            let aggregated_total = backward_aggregate_value(
+                Decimal::from(last_price.oracles.total),
+                Decimal::from(aggregated.aggregated.oracles.total),
+                Decimal::from(last_price.count),
+            )?;
+
             let previous_aggregated_interval = OraclePriceAggregatedInterval {
                 id: oracle_price_aggreated[0].id.clone(),
                 key: oracle_price_aggreated[0].key.clone(),
@@ -786,29 +811,12 @@ pub fn invalidate_oracle_interval(
                 token: oracle_price_aggreated[0].token.clone(),
                 currency: oracle_price_aggreated[0].currency.clone(),
                 aggregated: OraclePriceAggregatedIntervalAggregated {
-                    amount: backward_aggregate_value(
-                        lastprice.amount.as_str(),
-                        &aggregated.aggregated.amount.to_string(),
-                        count as u32,
-                    )?
-                    .to_string(),
-                    weightage: backward_aggregate_number(
-                        lastprice.weightage,
-                        aggregated.aggregated.weightage,
-                        count as u32,
-                    )?,
+                    amount: aggregated_amount.to_string(),
+                    weightage: aggregated_weightage.to_i32().context("Err: Decimal.to_i32()")?,
                     count,
                     oracles: OraclePriceAggregatedIntervalAggregatedOracles {
-                        active: backward_aggregate_number(
-                            lastprice.oracles.active,
-                            aggregated.aggregated.oracles.active,
-                            lastprice.count as u32,
-                        )?,
-                        total: backward_aggregate_number(
-                            lastprice.oracles.total,
-                            aggregated.aggregated.oracles.total,
-                            lastprice.count as u32,
-                        )?,
+                        active: aggregated_active.to_i32().context("Err: Decimal.to_i32()")?,
+                        total: aggregated_total.to_i32().context("Err: Decimal.to_i32()")?,
                     },
                 },
                 block: oracle_price_aggreated[0].block.clone(),
@@ -902,26 +910,10 @@ fn forward_aggregate_value(last_value: Decimal, new_value: Decimal, count: Decim
         .ok_or_else(|| Error::UnderflowError)
 }
 
-fn backward_aggregate_value(last_value: &str, new_value: &str, count: u32) -> Result<Decimal> {
-    let last_value_decimal = Decimal::from_str(last_value)?;
-    let new_value_decimal = Decimal::from_str(new_value)?;
-    let count_decimal = Decimal::from(count);
-
-    (last_value_decimal * count_decimal - new_value_decimal)
-        .checked_div(count_decimal - dec!(1))
+fn backward_aggregate_value(last_value: Decimal, new_value: Decimal, count: Decimal) -> Result<Decimal> {
+    (last_value * count - new_value)
+        .checked_div(count - dec!(1))
         .ok_or_else(|| Error::UnderflowError)
-}
-
-fn backward_aggregate_number(last_value: i32, new_value: i32, count: u32) -> Result<i32> {
-    let last_value_decimal = Decimal::from(last_value);
-    let new_value_decimal = Decimal::from(new_value);
-    let count_decimal = Decimal::from(count);
-
-    let result = (last_value_decimal * count_decimal - new_value_decimal)
-        .checked_div(count_decimal - dec!(1))
-        .ok_or_else(|| Error::UnderflowError)?;
-
-    Ok(result.to_i32().unwrap_or(0))
 }
 
 fn get_previous_oracle_history_list(

--- a/lib/ain-ocean/src/indexer/oracle.rs
+++ b/lib/ain-ocean/src/indexer/oracle.rs
@@ -28,14 +28,14 @@ use crate::{
 impl Index for AppointOracle {
     fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         let oracle_id = ctx.tx.txid;
-        let price_feeds_items: Vec<PriceFeedsItem> = self
+        let price_feeds_items = self
             .price_feeds
             .iter()
             .map(|pair| PriceFeedsItem {
                 token: pair.token.clone(),
                 currency: pair.currency.clone(),
             })
-            .collect();
+            .collect::<Vec<PriceFeedsItem>>();
         let oracle = Oracle {
             id: oracle_id,
             owner_address: self.script.to_hex_string(),
@@ -220,7 +220,7 @@ impl Index for RemoveOracle {
 impl Index for UpdateOracle {
     fn index(self, services: &Arc<Services>, ctx: &Context) -> Result<()> {
         let oracle_id = ctx.tx.txid;
-        let price_feeds_items: Vec<PriceFeedsItem> = self
+        let price_feeds_items = self
             .price_feeds
             .iter()
             .map(|pair| PriceFeedsItem {
@@ -395,7 +395,7 @@ impl Index for SetOracleData {
             services.oracle_price_feed.by_key.put(&feed.key, &feed.id)?;
             services.oracle_price_feed.by_id.put(&feed.id, feed)?;
         }
-        let intervals: Vec<OracleIntervalSeconds> = vec![
+        let intervals = vec![
             OracleIntervalSeconds::FifteenMinutes,
             OracleIntervalSeconds::OneHour,
             OracleIntervalSeconds::OneDay,
@@ -576,7 +576,7 @@ impl Index for SetOracleData {
             timestamp: self.timestamp,
             token_prices: CompactVec::from(Vec::new()),
         };
-        let intervals: Vec<OracleIntervalSeconds> = vec![
+        let intervals = vec![
             OracleIntervalSeconds::FifteenMinutes,
             OracleIntervalSeconds::OneHour,
             OracleIntervalSeconds::OneDay,
@@ -622,7 +622,7 @@ fn map_price_feeds(
     set_oracle_data: &SetOracleData,
     context: &Context,
 ) -> Result<Vec<OraclePriceFeed>> {
-    let mut result: Vec<OraclePriceFeed> = Vec::new();
+    let mut result = Vec::new();
     let token_prices = set_oracle_data.token_prices.as_ref();
     for token_price in token_prices {
         for token_amount in token_price.prices.as_ref() {


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- typing weightage: u8 https://github.com/DeFiCh/ain/blob/9181c3e4b65f9d2f7d0a5b4f159d0270382d7b64/src/dfi/rpc_oracles.cpp#L32

#### Trace

```
attempt to multiply with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_const::panic_const_mul_overflow
             at /rustc/8f9080db423ca0fb6bef0686ce9a93940cdf1f13/library/core/src/panicking.rs:179:21
   3: ain_ocean::indexer::oracle::<impl ain_ocean::indexer::Index for ain_dftx::types::oracles::SetOracleData>::index
             at ./lib/ain-ocean/src/indexer/oracle.rs:463:55
```

