### PR TITLE
Enable snapshots by default

### DIFF
--- a/src/dfi/accountshistory.h
+++ b/src/dfi/accountshistory.h
@@ -78,6 +78,6 @@ extern std::unique_ptr<CAccountHistoryStorage> paccountHistoryDB;
 extern std::unique_ptr<CBurnHistoryStorage> pburnHistoryDB;
 
 static constexpr bool DEFAULT_ACINDEX = true;
-static constexpr bool DEFAULT_SNAPSHOT = false;
+static constexpr bool DEFAULT_SNAPSHOT = true;
 
 #endif  // DEFI_DFI_ACCOUNTSHISTORY_H


### PR DESCRIPTION
## Summary

- Set `-enablesnapshot` to be true by default.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
