### PR TITLE
tests: better resilience for concurrent node starts

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -79,7 +79,7 @@ class TestNode:
         extra_args=None,
         use_cli=False,
         start_perf=False,
-        use_valgrind=False
+        use_valgrind=False,
     ):
         """
         Kwargs:
@@ -389,7 +389,7 @@ class TestNode:
             stdout=stdout,
             stderr=stderr,
             cwd=cwd,
-            **kwargs
+            **kwargs,
         )
 
         self.running = True
@@ -444,7 +444,12 @@ class TestNode:
                 self.w3 = Web3(Web3.HTTPProvider(evm_rpc.url))
                 return
             except IOError as e:
-                if e.errno != errno.ECONNREFUSED:  # Port not yet open?
+                if e.errno not in [
+                    None,
+                    0,
+                    errno.ECONNREFUSED,
+                    errno.ECONNRESET,
+                ]:  # Port not yet open?
                     raise  # unknown IO error
             except JSONRPCException as e:  # Initialization phase
                 # -28 RPC in warmup
@@ -653,7 +658,7 @@ class TestNode:
         expected_msg=None,
         match=ErrorMatch.FULL_TEXT,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """Attempt to start the node and expect it to raise an error.
 


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- Fixes most node start failures due to high concurrency during normal operation. 
- Rationale: When concurrency levels are high, nodes end up failing to start due to the strict flaky way of checking of RPC start. While this is still not bulletproof, and if system is out of resources, there can still be other failures, however this adds significant resiliency for on-start check.
  - For most normal operation (eg: `MAKE_JOBS=<no-of-logical-CPUs>`), this provides a good default and avoids most false failures due to slightly delayed node starts. 

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
