### PR TITLE
Update account history for static rewards. Fix off by one bug.

### DIFF
--- a/src/dfi/masternodes.cpp
+++ b/src/dfi/masternodes.cpp
@@ -981,16 +981,15 @@ bool CCustomCSView::CalculateOwnerRewards(const CScript &owner, uint32_t targetH
 
         if (beginHeight < Params().GetConsensus().DF24Height) {
             // Calculate just up to the fork height
-            const auto targetNewHeight = targetHeight >= Params().GetConsensus().DF24Height
-                                             ? Params().GetConsensus().DF24Height - 1
-                                             : targetHeight;
+            const auto targetNewHeight =
+                targetHeight >= Params().GetConsensus().DF24Height ? Params().GetConsensus().DF24Height : targetHeight;
             CalculatePoolRewards(poolId, onLiquidity, beginHeight, targetNewHeight, onReward);
         }
 
         if (targetHeight >= Params().GetConsensus().DF24Height) {
             // Calculate from the fork height
             const auto beginNewHeight =
-                beginHeight < Params().GetConsensus().DF24Height ? Params().GetConsensus().DF24Height : beginHeight;
+                beginHeight < Params().GetConsensus().DF24Height ? Params().GetConsensus().DF24Height - 1 : beginHeight;
             CalculateStaticPoolRewards(onLiquidity, onReward, poolId.v, beginNewHeight, targetHeight);
         }
 

--- a/src/dfi/poolpairs.cpp
+++ b/src/dfi/poolpairs.cpp
@@ -271,7 +271,7 @@ void CPoolPairView::CalculateStaticPoolRewards(std::function<CAmount()> onLiquid
             // Calculate reward
             const auto reward = (liquidity * rewardPerShare / HIGH_PRECISION_SCALER).GetLow64();
             // Pay reward to the owner
-            onReward(type, {DCT_ID{id}, static_cast<CAmount>(reward)}, endHeight);
+            onReward(type, {DCT_ID{id}, static_cast<CAmount>(reward)}, key.height);
         }
     };
 


### PR DESCRIPTION
## Summary

- Update listaccounthistory for static rewards
- Fix off by one bug in static rewards
- Set onReward height to key height, only used in account history and then shows the correct height, otherwise also off by one.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
