### PR TITLE
RPC: avoid looping over same height in account history

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -201,7 +201,7 @@ static void onPoolRewards(CCustomCSView &view,
             auto beginNewHeight = beginHeight < Params().GetConsensus().DF24Height
                                       ? Params().GetConsensus().DF24Height - 1
                                       : beginHeight - 1;
-            // End must be above start
+            // End must be above start and then one more beyond the range.
             auto newEndHeight = beginNewHeight + 2;
             // Loop over one block a time to build account history with correct height records
             for (; newEndHeight <= end; ++beginNewHeight, ++newEndHeight) {

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -198,12 +198,13 @@ static void onPoolRewards(CCustomCSView &view,
 
         if (end >= Params().GetConsensus().DF24Height) {
             // Calculate from the fork height
-            auto beginNewHeight =
-                beginHeight < Params().GetConsensus().DF24Height ? Params().GetConsensus().DF24Height - 1 : beginHeight;
-            // End must be above start and then one more beyond the range.
+            auto beginNewHeight = beginHeight < Params().GetConsensus().DF24Height
+                                      ? Params().GetConsensus().DF24Height - 1
+                                      : beginHeight - 1;
+            // End must be above start
             auto newEndHeight = beginNewHeight + 2;
             // Loop over one block a time to build account history with correct height records
-            for (; beginNewHeight < end; ++beginNewHeight, ++newEndHeight) {
+            for (; newEndHeight <= end; ++beginNewHeight, ++newEndHeight) {
                 view.CalculateStaticPoolRewards(onLiquidity, onReward, poolId.v, beginNewHeight, newEndHeight);
             }
         }

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -55,6 +55,9 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Setup test
         self.setup_tests()
 
+        # Check commission at the same time as a liquidity change
+        self.change_liquidiity_and_check_commission()
+
         # Test account update on same block as poolswap
         self.static_update_same_block()
 
@@ -327,7 +330,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
         )
 
         # Get current height
-        height = self.nodes[0].getblockcount()
+        height = self.nodes[0].getblockcount() - 1
 
         # Loop over and check account history entries
         for result in self.nodes[0].listaccounthistory(
@@ -474,6 +477,41 @@ class TokenFractionalSplitTest(DefiTestFramework):
         ltc_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
 
         return dfi_balance, ltc_balance
+    
+    def change_liquidiity_and_check_commission(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Fund pool
+        self.nodes[0].addpoolliquidity(
+            {self.owner_address: [f"1000@{self.symbolLTC}", f"1000@{self.symbolDFI}"]},
+            self.address,
+        )
+
+        # Move to fork height
+        self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
+
+
+        self.nodes[0].accounttoaccount(self.address, {self.nodes[0].getnewaddress("", "legacy"): '499.99999000@LTC-DFI'})
+        self.nodes[0].poolswap(
+            {
+                "from": self.owner_address,
+                "tokenFrom": self.symbolLTC,
+                "amountFrom": 0.1,
+                "to": self.owner_address,
+                "tokenTo": self.symbolDFI,
+            }
+        )
+        self.nodes[0].generate(10)
+
+        # Check entry shows correct commission
+        for entry in self.nodes[0].listaccounthistory(self.address, {"depth": 10}):
+            if entry["type"] == "Commission":
+                assert_equal(entry["amounts"], ["0.00050000@LTC"])
+
+        # Check commission in account
+        assert_equal(self.nodes[0].getaccount(self.address)[0], "0.00050000@LTC")
 
     def static_update_same_block(self):
 
@@ -530,7 +568,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
                 "tokenTo": self.symbolLTC,
             }
         )
-        self.nodes[0].generate(1)
+        self.nodes[0].generate(2)
 
         # Check balance
         assert_equal(
@@ -607,6 +645,9 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Check commission is the same pre and post fork
         assert_equal(pre_dfi_balance, post_dfi_balance)
         assert_equal(pre_ltc_balance, post_ltc_balance)
+
+        # Mint another block to populate history
+        self.nodes[0].generate(1)
 
         # Get post fork history
         post_fork_history = self.nodes[0].listaccounthistory(self.address)

--- a/test/functional/feature_static_pool_rewards.py
+++ b/test/functional/feature_static_pool_rewards.py
@@ -477,7 +477,7 @@ class TokenFractionalSplitTest(DefiTestFramework):
         ltc_balance = Decimal(self.nodes[0].getaccount(self.address)[1].split("@")[0])
 
         return dfi_balance, ltc_balance
-    
+
     def change_liquidiity_and_check_commission(self):
 
         # Rollback block
@@ -492,8 +492,10 @@ class TokenFractionalSplitTest(DefiTestFramework):
         # Move to fork height
         self.nodes[0].generate(self.df24height - self.nodes[0].getblockcount())
 
-
-        self.nodes[0].accounttoaccount(self.address, {self.nodes[0].getnewaddress("", "legacy"): '499.99999000@LTC-DFI'})
+        self.nodes[0].accounttoaccount(
+            self.address,
+            {self.nodes[0].getnewaddress("", "legacy"): "499.99999000@LTC-DFI"},
+        )
         self.nodes[0].poolswap(
             {
                 "from": self.owner_address,


### PR DESCRIPTION
## Summary

 - Account history was looping over the same block heights after the DF24 fork. This issue would show up if the owner liquidity changes as then we have additional commission entries with different amounts at the same height.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
