### PR TITLE
Add -daemonwait defid flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -718,8 +718,10 @@ AC_CHECK_DECLS([getifaddrs, freeifaddrs],,,
 )
 AC_CHECK_DECLS([strnlen])
 
-# Check for daemon(3), unrelated to --with-daemon (although used by it)
-AC_CHECK_DECLS([daemon])
+
+dnl These are used for daemonization in bitcoind
+AC_CHECK_DECLS([fork])
+AC_CHECK_DECLS([setsid])
 
 AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
 		[#if HAVE_ENDIAN_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -279,6 +279,7 @@ DEFI_CORE_H = \
   util/bytevectorhash.h \
   util/error.h \
   util/fees.h \
+  util/tokenpipe.h \
   util/system.h \
   util/moneystr.h \
   util/rbf.h \
@@ -701,6 +702,7 @@ libdefi_util_a_SOURCES = \
   util/bytevectorhash.cpp \
   util/error.cpp \
   util/fees.cpp \
+  util/tokenpipe.cpp \
   util/system.cpp \
   util/moneystr.cpp \
   util/rbf.cpp \

--- a/src/defid.cpp
+++ b/src/defid.cpp
@@ -19,12 +19,86 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/threadnames.h>
+#include <util/tokenpipe.h>
 #include <util/translation.h>
 #include <ain_rs_exports.h>
 #include <ffi/ffihelpers.h>
 #include <functional>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
+#if HAVE_DECL_FORK
+
+/** Custom implementation of daemon(). This implements the same order of operations as glibc.
+ * Opens a pipe to the child process to be able to wait for an event to occur.
+ *
+ * @returns 0 if successful, and in child process.
+ *          >0 if successful, and in parent process.
+ *          -1 in case of error (in parent process).
+ *
+ *          In case of success, endpoint will be one end of a pipe from the child to parent process,
+ *          which can be used with TokenWrite (in the child) or TokenRead (in the parent).
+ */
+int fork_daemon(bool nochdir, bool noclose, TokenPipeEnd& endpoint)
+{
+    // communication pipe with child process
+    std::optional<TokenPipe> umbilical = TokenPipe::Make();
+    if (!umbilical) {
+        return -1; // pipe or pipe2 failed.
+    }
+
+    int pid = fork();
+    if (pid < 0) {
+        return -1; // fork failed.
+    }
+    if (pid != 0) {
+        // Parent process gets read end, closes write end.
+        endpoint = umbilical->TakeReadEnd();
+        umbilical->TakeWriteEnd().Close();
+
+        int status = endpoint.TokenRead();
+        if (status != 0) { // Something went wrong while setting up child process.
+            endpoint.Close();
+            return -1;
+        }
+
+        return pid;
+    }
+    // Child process gets write end, closes read end.
+    endpoint = umbilical->TakeWriteEnd();
+    umbilical->TakeReadEnd().Close();
+
+#if HAVE_DECL_SETSID
+    if (setsid() < 0) {
+        exit(1); // setsid failed.
+    }
+#endif
+
+    if (!nochdir) {
+        if (chdir("/") != 0) {
+            exit(1); // chdir failed.
+        }
+    }
+    if (!noclose) {
+        // Open /dev/null, and clone it into STDIN, STDOUT and STDERR to detach
+        // from terminal.
+        int fd = open("/dev/null", O_RDWR);
+        if (fd >= 0) {
+            bool err = dup2(fd, STDIN_FILENO) < 0 || dup2(fd, STDOUT_FILENO) < 0 || dup2(fd, STDERR_FILENO) < 0;
+            // Don't close if fd<=2 to try to handle the case where the program was invoked without any file descriptors open.
+            if (fd > 2) close(fd);
+            if (err) {
+                exit(1); // dup2 failed.
+            }
+        } else {
+            exit(1); // open /dev/null failed.
+        }
+    }
+    endpoint.TokenWrite(0); // Success
+    return 0;
+}
+
+#endif
 
 /* Introduction text for doxygen: */
 
@@ -96,6 +170,14 @@ static bool AppInit(int argc, char* argv[])
         return true;
     }
 
+    #if HAVE_DECL_FORK
+        // Communication with parent after daemonizing. This is used for signalling in the following ways:
+        // - a boolean token is sent when the initialization process (all the Init* functions) have finished to indicate
+        // that the parent process can quit, and whether it was successful/unsuccessful.
+        // - an unexpected shutdown of the child process creates an unexpected end of stream at the parent
+        // end, which is interpreted as failure to start.
+        TokenPipeEnd daemon_ep;
+    #endif
     try
     {
         if (!CheckDataDirOption()) {
@@ -122,7 +204,7 @@ static bool AppInit(int argc, char* argv[])
         gArgs.SoftSetBoolArg("-server", true);
         // Set this early so that parameter interactions go to console
         InitLogging();
-        
+
         auto res = XResultStatusLogged(ain_rs_init_logging(result));
         if (!res) return false;
 
@@ -142,25 +224,35 @@ static bool AppInit(int argc, char* argv[])
             // InitError will have been called with detailed error, which ends up on console
             return false;
         }
-        if (gArgs.GetBoolArg("-daemon", false))
+        if (gArgs.GetBoolArg("-daemon", false) || gArgs.GetBoolArg("-daemonwait", DEFAULT_DAEMONWAIT))
         {
-#if HAVE_DECL_DAEMON
-#if defined(MAC_OSX)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-            tfm::format(std::cout, PACKAGE_NAME " daemon starting\n");
+#if HAVE_DECL_FORK
+            tfm::format(std::cout, PACKAGE_NAME " starting\n");
 
             // Daemonize
-            if (daemon(1, 0)) { // don't chdir (1), do close FDs (0)
-                return InitError(strprintf("daemon() failed: %s\n", strerror(errno)));
+            switch (fork_daemon(1, 0, daemon_ep)) { // don't chdir (1), do close FDs (0)
+            case 0: // Child: continue.
+                // If -daemonwait is not enabled, immediately send a success token the parent.
+                if (!gArgs.GetBoolArg("-daemonwait", DEFAULT_DAEMONWAIT)) {
+                    daemon_ep.TokenWrite(1);
+                    daemon_ep.Close();
+                }
+                break;
+            case -1: // Error happened.
+                return InitError(strprintf("fork_daemon() failed: %s\n", strerror(errno)));
+            default: { // Parent: wait and exit.
+                int token = daemon_ep.TokenRead();
+                if (token) { // Success
+                    exit(EXIT_SUCCESS);
+                } else { // fRet = false or token read error (premature exit).
+                    tfm::format(std::cerr, "Error during initializaton - check debug.log for details\n");
+                    exit(EXIT_FAILURE);
+                }
             }
-#if defined(MAC_OSX)
-#pragma GCC diagnostic pop
-#endif
+            }
 #else
             return InitError("-daemon is not supported on this operating system\n");
-#endif // HAVE_DECL_DAEMON
+#endif // HAVE_DECL_FORK
         }
         // Lock data directory after daemonization
         if (!AppInitLockDataDirectory())
@@ -176,6 +268,13 @@ static bool AppInit(int argc, char* argv[])
         PrintExceptionContinue(nullptr, "AppInit()");
     }
 
+#if HAVE_DECL_FORK
+    if (daemon_ep.IsOpen()) {
+        // Signal initialization status to parent, then close pipe.
+        daemon_ep.TokenWrite(fRet);
+        daemon_ep.Close();
+    }
+#endif
     if (!fRet)
     {
         Interrupt();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -680,10 +680,13 @@ void SetupServerArgs()
     gArgs.AddArg("-ethsubscription", strprintf("Enable subscription notifications ETH RPCs (default: %b)", DEFAULT_ETH_SUBSCRIPTION_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-minerstrategy", "Staking optimisation. Options are none, numeric value indicating the number of subnodes to stake (default: none)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
-#if HAVE_DECL_DAEMON
-    gArgs.AddArg("-daemon", "Run in the background as a daemon and accept commands", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+
+#if HAVE_DECL_FORK
+    gArgs.AddArg("-daemon", strprintf("Run in the background as a daemon and accept commands (default: %d)", DEFAULT_DAEMON), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-daemonwait", strprintf("Wait for initialization to be finished before exiting. This implies -daemon (default: %d)", DEFAULT_DAEMONWAIT), ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
 #else
     hidden_args.emplace_back("-daemon");
+    hidden_args.emplace_back("-daemonwait");
 #endif
 
     RPCMetadata::SetupArgs(gArgs);
@@ -1611,7 +1614,7 @@ static void SetupRPCPorts(std::vector<std::string>& ethEndpoints, std::vector<st
     if (const auto autoPort = gArgs.GetArg("-ports", ""); autoPort == "auto") {
         setAutoPort = true;
     }
-    
+
     // Determine which addresses to bind to ETH RPC server
     int eth_rpc_port = gArgs.GetArg("-ethrpcport", BaseParams().ETHRPCPort());
     if (eth_rpc_port == -1) {

--- a/src/init.h
+++ b/src/init.h
@@ -10,6 +10,11 @@
 #include <string>
 #include <util/system.h>
 
+//! Default value for -daemon option
+static constexpr bool DEFAULT_DAEMON = false;
+//! Default value for -daemonwait option
+static constexpr bool DEFAULT_DAEMONWAIT = false;
+
 namespace interfaces {
 class Chain;
 class ChainClient;

--- a/src/util/tokenpipe.cpp
+++ b/src/util/tokenpipe.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <util/tokenpipe.h>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/defi-config.h>
+#endif
+
+#ifndef WIN32
+
+#include <errno.h>
+#include <fcntl.h>
+#include <optional>
+#include <unistd.h>
+
+TokenPipeEnd TokenPipe::TakeReadEnd()
+{
+    TokenPipeEnd res(m_fds[0]);
+    m_fds[0] = -1;
+    return res;
+}
+
+TokenPipeEnd TokenPipe::TakeWriteEnd()
+{
+    TokenPipeEnd res(m_fds[1]);
+    m_fds[1] = -1;
+    return res;
+}
+
+TokenPipeEnd::TokenPipeEnd(int fd) : m_fd(fd)
+{
+}
+
+TokenPipeEnd::~TokenPipeEnd()
+{
+    Close();
+}
+
+int TokenPipeEnd::TokenWrite(uint8_t token)
+{
+    while (true) {
+        ssize_t result = write(m_fd, &token, 1);
+        if (result < 0) {
+            // Failure. It's possible that the write was interrupted by a signal,
+            // in that case retry.
+            if (errno != EINTR) {
+                return TS_ERR;
+            }
+        } else if (result == 0) {
+            return TS_EOS;
+        } else { // ==1
+            return 0;
+        }
+    }
+}
+
+int TokenPipeEnd::TokenRead()
+{
+    uint8_t token;
+    while (true) {
+        ssize_t result = read(m_fd, &token, 1);
+        if (result < 0) {
+            // Failure. Check if the read was interrupted by a signal,
+            // in that case retry.
+            if (errno != EINTR) {
+                return TS_ERR;
+            }
+        } else if (result == 0) {
+            return TS_EOS;
+        } else { // ==1
+            return token;
+        }
+    }
+    return token;
+}
+
+void TokenPipeEnd::Close()
+{
+    if (m_fd != -1) close(m_fd);
+    m_fd = -1;
+}
+
+std::optional<TokenPipe> TokenPipe::Make()
+{
+    int fds[2] = {-1, -1};
+#if HAVE_O_CLOEXEC && HAVE_DECL_PIPE2
+    if (pipe2(fds, O_CLOEXEC) != 0) {
+        return std::nullopt;
+    }
+#else
+    if (pipe(fds) != 0) {
+        return std::nullopt;
+    }
+#endif
+    return TokenPipe(fds);
+}
+
+TokenPipe::~TokenPipe()
+{
+    Close();
+}
+
+void TokenPipe::Close()
+{
+    if (m_fds[0] != -1) close(m_fds[0]);
+    if (m_fds[1] != -1) close(m_fds[1]);
+    m_fds[0] = m_fds[1] = -1;
+}
+
+#endif // WIN32

--- a/src/util/tokenpipe.h
+++ b/src/util/tokenpipe.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFI_UTIL_TOKENPIPE_H
+#define DEFI_UTIL_TOKENPIPE_H
+
+#ifndef WIN32
+
+#include <cstdint>
+#include <optional>
+
+/** One end of a token pipe. */
+class TokenPipeEnd
+{
+private:
+    int m_fd = -1;
+
+public:
+    TokenPipeEnd(int fd = -1);
+    ~TokenPipeEnd();
+
+    /** Return value constants for TokenWrite and TokenRead. */
+    enum Status {
+        TS_ERR = -1, //!< I/O error
+        TS_EOS = -2, //!< Unexpected end of stream
+    };
+
+    /** Write token to endpoint.
+     *
+     * @returns 0       If successful.
+     *          <0 if error:
+     *            TS_ERR  If an error happened.
+     *            TS_EOS  If end of stream happened.
+     */
+    int TokenWrite(uint8_t token);
+
+    /** Read token from endpoint.
+     *
+     * @returns >=0     Token value, if successful.
+     *          <0 if error:
+     *            TS_ERR  If an error happened.
+     *            TS_EOS  If end of stream happened.
+     */
+    int TokenRead();
+
+    /** Explicit close function.
+     */
+    void Close();
+
+    /** Return whether endpoint is open.
+     */
+    bool IsOpen() { return m_fd != -1; }
+
+    // Move-only class.
+    TokenPipeEnd(TokenPipeEnd&& other)
+    {
+        m_fd = other.m_fd;
+        other.m_fd = -1;
+    }
+    TokenPipeEnd& operator=(TokenPipeEnd&& other)
+    {
+        Close();
+        m_fd = other.m_fd;
+        other.m_fd = -1;
+        return *this;
+    }
+    TokenPipeEnd(const TokenPipeEnd&) = delete;
+    TokenPipeEnd& operator=(const TokenPipeEnd&) = delete;
+};
+
+/** An interprocess or interthread pipe for sending tokens (one-byte values)
+ * over.
+ */
+class TokenPipe
+{
+private:
+    int m_fds[2] = {-1, -1};
+
+    TokenPipe(int fds[2]) : m_fds{fds[0], fds[1]} {}
+
+public:
+    ~TokenPipe();
+
+    /** Create a new pipe.
+     * @returns The created TokenPipe, or an empty std::nullopt in case of error.
+     */
+    static std::optional<TokenPipe> Make();
+
+    /** Take the read end of this pipe. This can only be called once,
+     * as the object will be moved out.
+     */
+    TokenPipeEnd TakeReadEnd();
+
+    /** Take the write end of this pipe. This should only be called once,
+     * as the object will be moved out.
+     */
+    TokenPipeEnd TakeWriteEnd();
+
+    /** Close and end of the pipe that hasn't been moved out.
+     */
+    void Close();
+
+    // Move-only class.
+    TokenPipe(TokenPipe&& other)
+    {
+        for (int i = 0; i < 2; ++i) {
+            m_fds[i] = other.m_fds[i];
+            other.m_fds[i] = -1;
+        }
+    }
+    TokenPipe& operator=(TokenPipe&& other)
+    {
+        Close();
+        for (int i = 0; i < 2; ++i) {
+            m_fds[i] = other.m_fds[i];
+            other.m_fds[i] = -1;
+        }
+        return *this;
+    }
+    TokenPipe(const TokenPipe&) = delete;
+    TokenPipe& operator=(const TokenPipe&) = delete;
+};
+
+#endif // WIN32
+
+#endif // DEFI_UTIL_TOKENPIPE_H


### PR DESCRIPTION
## Summary

- Cherry-picked and adapted from https://github.com/bitcoin/bitcoin/pull/21007

> This adds a -daemonwait flag that does the same as -daemon except that it, from a user perspective, backgrounds the process only after initialization is complete. This is similar to the behaviour of some other software such as c-lightning.