### PR TITLE
Toggle block time change via attributes

### DIFF
--- a/src/dfi/govvariables/attributes.cpp
+++ b/src/dfi/govvariables/attributes.cpp
@@ -283,6 +283,7 @@ const std::map<uint8_t, std::map<std::string, uint8_t>> &ATTRIBUTES::allowedKeys
              {"transferdomain", DFIPKeys::TransferDomain},
              {"liquidity_calc_sampling_period", DFIPKeys::LiquidityCalcSamplingPeriod},
              {"average_liquidity_percentage", DFIPKeys::AverageLiquidityPercentage},
+             {"ascending_block_time", DFIPKeys::AscendingBlockTime},
          }},
         {AttributeTypes::EVMType,
          {
@@ -388,6 +389,7 @@ const std::map<uint8_t, std::map<uint8_t, std::string>> &ATTRIBUTES::displayKeys
              {DFIPKeys::TransferDomain, "transferdomain"},
              {DFIPKeys::LiquidityCalcSamplingPeriod, "liquidity_calc_sampling_period"},
              {DFIPKeys::AverageLiquidityPercentage, "average_liquidity_percentage"},
+             {DFIPKeys::AscendingBlockTime, "ascending_block_time"},
          }},
         {AttributeTypes::EVMType,
          {
@@ -817,6 +819,7 @@ const std::map<uint8_t, std::map<uint8_t, std::function<ResVal<CAttributeValue>(
                  {DFIPKeys::TransferDomain, VerifyBool},
                  {DFIPKeys::LiquidityCalcSamplingPeriod, VerifyMoreThenZeroInt64},
                  {DFIPKeys::AverageLiquidityPercentage, VerifyPctInt64},
+                 {DFIPKeys::AscendingBlockTime, VerifyBool},
              }},
             {AttributeTypes::Locks,
              {
@@ -987,7 +990,7 @@ static Res CheckValidAttrV0Key(const uint8_t type, const uint32_t typeId, const 
                 typeKey != DFIPKeys::MNSetOwnerAddress && typeKey != DFIPKeys::GovernanceEnabled &&
                 typeKey != DFIPKeys::CFPPayout && typeKey != DFIPKeys::EmissionUnusedFund &&
                 typeKey != DFIPKeys::MintTokens && typeKey != DFIPKeys::EVMEnabled && typeKey != DFIPKeys::ICXEnabled &&
-                typeKey != DFIPKeys::TransferDomain) {
+                typeKey != DFIPKeys::TransferDomain && typeKey != DFIPKeys::AscendingBlockTime) {
                 return DeFiErrors::GovVarVariableUnsupportedFeatureType(typeKey);
             }
         } else if (typeId == ParamIDs::Foundation) {
@@ -2048,6 +2051,10 @@ Res ATTRIBUTES::Validate(const CCustomCSView &view) const {
                     } else if (attrV0->key == DFIPKeys::EVMEnabled || attrV0->key == DFIPKeys::TransferDomain) {
                         if (view.GetLastHeight() < Params().GetConsensus().DF22MetachainHeight) {
                             return Res::Err("Cannot be set before MetachainHeight");
+                        }
+                    } else if (attrV0->key == DFIPKeys::AscendingBlockTime) {
+                        if (view.GetLastHeight() < Params().GetConsensus().DF24Height) {
+                            return Res::Err("Cannot be set before DF24Height");
                         }
                     }
                 } else if (attrV0->typeId == ParamIDs::Foundation) {

--- a/src/dfi/govvariables/attributes.h
+++ b/src/dfi/govvariables/attributes.h
@@ -124,6 +124,7 @@ enum DFIPKeys : uint8_t {
     TransferDomain = 'w',
     LiquidityCalcSamplingPeriod = 'x',
     AverageLiquidityPercentage = 'y',
+    AscendingBlockTime = 'A',
 };
 
 enum GovernanceKeys : uint8_t {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5070,8 +5070,11 @@ static bool ContextualCheckBlockHeader(const CBlockHeader &block,
                              "bad-fork-prior-to-checkpoint");
     }
 
+    const auto attributes = pcustomcsview->GetAttributes();
+    CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AscendingBlockTime};
+
     // Check timestamp against prev
-    if (nHeight >= consensusParams.DF24Height) {
+    if (attributes->GetValue(enabledKey, false)) {
         if (block.GetBlockTime() <= pindexPrev->GetBlockTime()) {
             return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER,
                                  false,


### PR DESCRIPTION
## Summary

- Adds the ability to toggle the ascending block time change via attributes. Allows us to revert to prior behaviour if there are unexpected outcomes.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
