### PR TITLE
Set Changi DF24Height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -652,7 +652,7 @@ public:
         consensus.DF21GrandCentralEpilogueHeight = 1438200;
         consensus.DF22MetachainHeight = 1586750;
         consensus.DF23Height = 1985600;
-        consensus.DF24Height = std::numeric_limits<int>::max();
+        consensus.DF24Height = 2241000;
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.pos.nTargetTimespan = 5 * 60; // 5 min == 10 blocks


### PR DESCRIPTION
## Summary

- Sets the Changi fork to Sept 7th 2024 at approx 14:00 UTC.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
