### PR TITLE
fix: revert wrong refactor of GetLoanTokensForFutures

### DIFF
--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1132,28 +1132,42 @@ static auto GetLoanTokensForFutures(CCustomCSView &cache, ATTRIBUTES attributes)
     LoanTokenCollection loanTokens;
 
     CDataStructureV0 tokenKey{AttributeTypes::Token, 0, TokenKeys::DFIP2203Enabled};
-    attributes.ForEach(
-        [&](const CDataStructureV0 &attr, const CAttributeValue &) {
-            if (attr.type != AttributeTypes::Token) {
-                return false;
-            }
-
-            tokenKey.typeId = attr.typeId;
-            const auto enabled = attributes.GetValue(tokenKey, true);
-            if (!enabled) {
-                return true;
-            }
-
-            if (attr.key == TokenKeys::LoanMintingEnabled) {
-                auto tokenId = DCT_ID{attr.typeId};
-                if (auto loanToken = cache.GetLoanTokenFromAttributes(tokenId)) {
-                    loanTokens.emplace_back(tokenId, *loanToken);
-                }
-            }
-
+    cache.ForEachLoanToken([&](const DCT_ID &id, const CLoanView::CLoanSetLoanTokenImpl &loanToken) {
+        tokenKey.typeId = id.v;
+        const auto enabled = attributes.GetValue(tokenKey, true);
+        if (!enabled) {
             return true;
-        },
-        CDataStructureV0{AttributeTypes::Token});
+        }
+
+        loanTokens.emplace_back(id, loanToken);
+
+        return true;
+    });
+
+    if (loanTokens.empty()) {
+        attributes.ForEach(
+            [&](const CDataStructureV0 &attr, const CAttributeValue &) {
+                if (attr.type != AttributeTypes::Token) {
+                    return false;
+                }
+
+                tokenKey.typeId = attr.typeId;
+                const auto enabled = attributes.GetValue(tokenKey, true);
+                if (!enabled) {
+                    return true;
+                }
+
+                if (attr.key == TokenKeys::LoanMintingEnabled) {
+                    auto tokenId = DCT_ID{attr.typeId};
+                    if (auto loanToken = cache.GetLoanTokenFromAttributes(tokenId)) {
+                        loanTokens.emplace_back(tokenId, *loanToken);
+                    }
+                }
+
+                return true;
+            },
+            CDataStructureV0{AttributeTypes::Token});
+    }
 
     return loanTokens;
 }


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

During the restart PR, the method `GetLoanTokensForFutures` was copied to `GetLoanTokensForLocks`. This method was later simplified cause the "old way" of getting loan tokens is not needed for the restart case. With this refactor, the GetLoanTokensForFutures was simplified the same way which leads to errors in FutureSwaps before the loanTokens moved to attributes.

This PR fixes this by reverting the change in the GetLoanTokensForFutures method.

nodes with existing data on changi should be fine with the fork. I guess this fix is only needed to make the full reindex work again.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [X] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [X] None
