### PR TITLE
Mining: Toggle ascending via Gov var

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1224,7 +1224,7 @@ namespace pos {
                 pcustomcsview->GetBlockTimes(operatorId, blockHeight, creationHeight, *timeLock)[subNode];
             const auto attributes = pcustomcsview->GetAttributes();
             CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AscendingBlockTime};
-            ascendingEnabled = attributes->GetValue(enabledKey, false);
+            ascendingEnabled = attributes->GetValue(enabledKey, false) || gArgs.GetBoolArg("-ascendingstaketime", false);
         }
 
         auto nBits = pos::GetNextWorkRequired(tip, blockTime, chainparams.GetConsensus());
@@ -1239,7 +1239,7 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                if (gArgs.GetBoolArg("-ascendingstaketime", false) || ascendingEnabled) {
+                if (ascendingEnabled) {
                     // Set time to last block time. New blocks must be after the last block.
                     nLastCoinStakeSearchTime = tip->GetBlockTime();
                 } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1204,6 +1204,7 @@ namespace pos {
         uint32_t mintedBlocks{};
         int64_t blockTime{};
         int64_t subNodeBlockTime{};
+        bool ascendingEnabled{};
 
         {
             LOCK(cs_main);
@@ -1221,6 +1222,9 @@ namespace pos {
             }
             subNodeBlockTime =
                 pcustomcsview->GetBlockTimes(operatorId, blockHeight, creationHeight, *timeLock)[subNode];
+            const auto attributes = pcustomcsview->GetAttributes();
+            CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AscendingBlockTime};
+            ascendingEnabled = attributes->GetValue(enabledKey, false);
         }
 
         auto nBits = pos::GetNextWorkRequired(tip, blockTime, chainparams.GetConsensus());
@@ -1235,8 +1239,7 @@ namespace pos {
                     nLastCoinStakeSearchTime = tip->GetMedianTimePast() + 1;
                 }
             } else {
-                if (gArgs.GetBoolArg("-ascendingstaketime", false) ||
-                    blockHeight >= static_cast<int64_t>(Params().GetConsensus().DF24Height)) {
+                if (gArgs.GetBoolArg("-ascendingstaketime", false) || ascendingEnabled) {
                     // Set time to last block time. New blocks must be after the last block.
                     nLastCoinStakeSearchTime = tip->GetBlockTime();
                 } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1224,7 +1224,8 @@ namespace pos {
                 pcustomcsview->GetBlockTimes(operatorId, blockHeight, creationHeight, *timeLock)[subNode];
             const auto attributes = pcustomcsview->GetAttributes();
             CDataStructureV0 enabledKey{AttributeTypes::Param, ParamIDs::Feature, DFIPKeys::AscendingBlockTime};
-            ascendingEnabled = attributes->GetValue(enabledKey, false) || gArgs.GetBoolArg("-ascendingstaketime", false);
+            ascendingEnabled =
+                attributes->GetValue(enabledKey, false) || gArgs.GetBoolArg("-ascendingstaketime", false);
         }
 
         auto nBits = pos::GetNextWorkRequired(tip, blockTime, chainparams.GetConsensus());


### PR DESCRIPTION
## Summary

- Miner should mint blocks in ascending order based on Governance vars, not fork height. Reesolves https://github.com/DeFiCh/ain/issues/3040.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
