### PR TITLE
add history entries for loan payback during dToken restart

### DIFF
--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2790,7 +2790,13 @@ static Res PaybackLoanWithTokenOrDUSDCollateral(
 
             // subtract loan amount first, interest is burning below
             if (!useDUSDCollateral) {
-                res = mnview.SubBalance(owner, CTokenAmount{loanTokenId, subLoan});
+                CAccountsHistoryWriter subView(mnview,
+                                               height,
+                                               GetNextAccPosition(),
+                                               {},  // TODO: use blockHash?
+                                               uint8_t(CustomTxType::PaybackLoan));
+                res = subView.SubBalance(owner, CTokenAmount{loanTokenId, subLoan});
+                subView.Flush();
 
                 VaultHistoryKey subKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), owner};
                 VaultHistoryValue subValue{

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -2059,14 +2059,14 @@ static Res VaultSplits(CCustomCSView &view,
             return res;
         }
 
-        // FIXME: make this clear to be a collateral change
         if (const auto vault = view.GetVault(vaultId)) {
-            VaultHistoryKey subKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), vault->ownerAddress};
+            // no address -> vault collateral
+            VaultHistoryKey subKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), {}};
             VaultHistoryValue subValue{
                 uint256{}, static_cast<uint8_t>(CustomTxType::TokenSplit), {{oldTokenId, -amount}}};
             view.GetHistoryWriters().WriteVaultHistory(subKey, subValue);
 
-            VaultHistoryKey addKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), vault->ownerAddress};
+            VaultHistoryKey addKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), {}};
             VaultHistoryValue addValue{
                 uint256{}, static_cast<uint8_t>(CustomTxType::TokenSplit), {{newTokenId, newAmount}}};
             view.GetHistoryWriters().WriteVaultHistory(addKey, addValue);
@@ -2791,9 +2791,26 @@ static Res PaybackLoanWithTokenOrDUSDCollateral(
             // subtract loan amount first, interest is burning below
             if (!useDUSDCollateral) {
                 res = mnview.SubBalance(owner, CTokenAmount{loanTokenId, subLoan});
+
+                VaultHistoryKey subKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), owner};
+                VaultHistoryValue subValue{
+                    uint256{}, static_cast<uint8_t>(CustomTxType::PaybackLoan), {{loanTokenId, -subLoan}}};
+                mnview.GetHistoryWriters().WriteVaultHistory(subKey, subValue);
             } else {
                 // paying back DUSD loan with DUSD collateral -> no need to multiply
                 res = mnview.SubVaultCollateral(vaultId, CTokenAmount{dusdToken->first, subLoan});
+
+                // remove collateral
+                VaultHistoryKey subCollKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), {}};
+                VaultHistoryValue subCollValue{
+                    uint256{}, static_cast<uint8_t>(CustomTxType::PaybackWithCollateral), {{loanTokenId, -subLoan}}};
+                mnview.GetHistoryWriters().WriteVaultHistory(subCollKey, subCollValue);
+
+                // reduce loan (address = reduced loan?)
+                VaultHistoryKey subLoanKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), owner};
+                VaultHistoryValue subLoanValue{
+                    uint256{}, static_cast<uint8_t>(CustomTxType::PaybackWithCollateral), {{loanTokenId, -subLoan}}};
+                mnview.GetHistoryWriters().WriteVaultHistory(subLoanKey, subLoanValue);
             }
             if (!res) {
                 return res;
@@ -2853,6 +2870,19 @@ static Res PaybackLoanWithTokenOrDUSDCollateral(
         if (!res) {
             return res;
         }
+
+        // history
+        //  remove collateral
+        VaultHistoryKey subCollKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), {}};
+        VaultHistoryValue subCollValue{
+            uint256{}, static_cast<uint8_t>(CustomTxType::PaybackWithCollateral), {{dusdToken->first, -subInDUSD}}};
+        mnview.GetHistoryWriters().WriteVaultHistory(subCollKey, subCollValue);
+
+        // reduce loan (address = reduced loan?)
+        VaultHistoryKey subLoanKey{static_cast<uint32_t>(height), vaultId, GetNextAccPosition(), owner};
+        VaultHistoryValue subLoanValue{
+            uint256{}, static_cast<uint8_t>(CustomTxType::PaybackWithCollateral), {{loanTokenId, -subLoan}}};
+        mnview.GetHistoryWriters().WriteVaultHistory(subLoanKey, subLoanValue);
     }
 
     mnview.Flush();
@@ -3132,6 +3162,17 @@ static Res PaybackWithSwappedCollateral(const DCT_ID &collId,
             dUsdToken.first, MultiplyDivideAmounts(availableDUSD.nValue, data.usedCollateralAmount, totalCollToSwap)};
         cache.AddVaultCollateral(data.vaultId, dusdResult);
         cache.SubBalance(contractAddressValue, dusdResult);
+
+        // history entry
+        VaultHistoryKey subCollKey{blockCtx.GetHeight(), data.vaultId, GetNextAccPosition(), {}};
+        VaultHistoryValue subCollValue{
+            uint256{},
+            static_cast<uint8_t>(CustomTxType::TokenLock),
+            {{collId, -data.usedCollateralAmount}, {dUsdToken.first, dusdResult.nValue}}
+        };
+        cache.GetHistoryWriters().WriteVaultHistory(subCollKey, subCollValue);
+        // ---
+
         if (data.usedCollateralAmount < data.useableCollateralAmount && dusdResult.nValue < data.totalUSDNeeded) {
             LogPrintf(
                 "didn't use full collateral, but did not get all needed USD. usedColl: %s, availableColl: %s, "
@@ -3791,6 +3832,13 @@ static Res LockTokensOfBalancesCollAndPools(const CBlock &block,
                 if (!res) {
                     return false;
                 }
+
+                // history entry
+                VaultHistoryKey subCollKey{static_cast<uint32_t>(pindex->nHeight), vaultId, GetNextAccPosition(), {}};
+                VaultHistoryValue subCollValue{
+                    uint256{}, static_cast<uint8_t>(CustomTxType::TokenLock), {{tokenId, -amountToLock}}};
+                cache.GetHistoryWriters().WriteVaultHistory(subCollKey, subCollValue);
+                // ---
             }
         }
         return true;

--- a/test/functional/feature_restartdtokens.py
+++ b/test/functional/feature_restartdtokens.py
@@ -1538,18 +1538,20 @@ class RestartdTokensTest(DefiTestFramework):
             ],
         )
 
+        # no tokenlock, just payback
         assert_equal(
-            len(
-                self.nodes[0].listaccounthistory(self.address1, {"txtypes": ["P", "?"]})
-            ),
-            0,
+            [
+                {"h": entry["blockHeight"], "t": entry["type"], "a": entry["amounts"]}
+                for entry in self.nodes[0].listaccounthistory(
+                    self.address1, {"depth": 1}
+                )
+            ],
+            [{"h": 1000, "t": "PaybackLoan", "a": ["-0.09999909@SPY/v1"]}],
         )
 
+        # nothing happening on address2 (only in its vault)
         assert_equal(
-            len(
-                self.nodes[0].listaccounthistory(self.address2, {"txtypes": ["P", "?"]})
-            ),
-            0,
+            len(self.nodes[0].listaccounthistory(self.address2, {"depth": 1})), 0
         )
 
         assert_equal(

--- a/test/functional/feature_restartdtokens.py
+++ b/test/functional/feature_restartdtokens.py
@@ -27,6 +27,7 @@ class RestartdTokensTest(DefiTestFramework):
         self.extra_args = [
             DefiTestFramework.fork_params_till(21)
             + [
+                "-vaultindex=1",
                 "-txnotokens=0",
                 "-subsidytest=1",
                 "-metachainheight=105",
@@ -80,8 +81,6 @@ class RestartdTokensTest(DefiTestFramework):
         self.do_and_check_restart()
 
         self.check_token_lock()
-
-        # TODO: check history entries
 
         self.check_upgrade_fail()
 
@@ -1337,6 +1336,154 @@ class RestartdTokensTest(DefiTestFramework):
             ],
         )
 
+        # Check split history
+        # vaults
+        assert_equal(
+            [
+                {
+                    "ad": entry["address"],
+                    "h": entry["blockHeight"],
+                    "t": entry["type"],
+                    "a": entry["amounts"],
+                }
+                for entry in self.nodes[0].listvaulthistory(
+                    self.vault_id2_1,
+                    {"maxBlockHeight": self.nodes[0].getblockcount(), "depth": 1},
+                )
+            ],
+            [
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-9.99825838@DUSD/v1"],
+                },
+                {
+                    "ad": self.address2,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-9.99825838@DUSD/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-10.00000900@DUSD/v1"],
+                },
+                {
+                    "ad": self.address2,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-0.10000000@SPY/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "TokenSplit",
+                    "a": ["-20.00173262@DUSD/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "TokenSplit",
+                    "a": ["20.00173262@DUSD"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "TokenLock",
+                    "a": ["-18.00155936@DUSD"],
+                },
+            ],
+        )
+
+        assert_equal(
+            [
+                {
+                    "ad": entry["address"],
+                    "h": entry["blockHeight"],
+                    "t": entry["type"],
+                    "a": entry["amounts"],
+                }
+                for entry in self.nodes[0].listvaulthistory(
+                    self.vault_id1,
+                    {"maxBlockHeight": self.nodes[0].getblockcount(), "depth": 1},
+                )
+            ],
+            [
+                # payback DUSD loan with DUSD collateral
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-1.00000000@DUSD/v1"],
+                },
+                {
+                    "ad": self.address1,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-1.00000000@DUSD/v1"],
+                },
+                # payback SPY loan with funds from address
+                {
+                    "ad": self.address1,
+                    "h": 1000,
+                    "t": "PaybackLoan",
+                    "a": ["-0.09999909@SPY/v1"],
+                },
+                # swap collateral to DUSD and use to paybackwithCollateral, first DFI coll for SPY and part of DUSD loan
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "TokenLock",
+                    "a": ["-30.00000000@DFI", "147.64445053@DUSD/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-90.00009100@DUSD/v1"],
+                },
+                {
+                    "ad": self.address1,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-0.90000091@SPY/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-57.64435953@DUSD/v1"],
+                },
+                {
+                    "ad": self.address1,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-57.64435953@DUSD/v1"],
+                },
+                # now USDT coll for remaining DUSD loan
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "TokenLock",
+                    "a": ["-38.88589949@USDT", "41.33765630@DUSD/v1"],
+                },
+                {
+                    "ad": "vaultCollateral",
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-41.33765627@DUSD/v1"],
+                },
+                {
+                    "ad": self.address1,
+                    "h": 1000,
+                    "t": "PaybackWithCollateral",
+                    "a": ["-41.33765627@DUSD/v1"],
+                },
+            ],
+        )
+        # addresses
         assert_equal(
             [
                 {"h": entry["blockHeight"], "t": entry["type"], "a": entry["amounts"]}
@@ -2174,7 +2321,6 @@ class RestartdTokensTest(DefiTestFramework):
             }
         )
         self.nodes[0].generate(1)
-
         # address3
 
         self.vault_id3 = self.nodes[0].createvault(self.address3, "")


### PR DESCRIPTION
## Summary

dToken restart is missing the vaulthistory entries.

Please review the resulting entries, I am not sure how vaultHistory should behave. From existing entries I assumed that a vaulthistory entry with the owner address references loan changes and without address (resulting in "vault collateral") references collateral changes.

I marked the payback during the restart as `PaybackLoan` and `PaybackWithCollateral` to have a better understanding of what actually happened. 


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [X] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [X] None
