### PR TITLE
Miner: Check loan tokens are not locked before adding dToken restart

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -185,6 +185,100 @@ static void AddSplitEVMTxs(BlockContext &blockCtx, const SplitMap &splitMap) {
     }
 }
 
+static void AddTokenRestartTxs(BlockContext &blockCtx,
+                               const int height,
+                               const int txVersion,
+                               CBlock &pblock,
+                               CBlockTemplate &pblocktemplate) {
+    auto &mnview = blockCtx.GetView();
+    const auto attributes = mnview.GetAttributes();
+
+    CDataStructureV0 lockKey{AttributeTypes::Param, ParamIDs::dTokenRestart, static_cast<uint32_t>(height)};
+    CDataStructureV0 lockedTokenKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::LockedTokens};
+    const auto lockRatio = attributes->GetValue(lockKey, CAmount{});
+    const auto lockedTokens = attributes->GetValue(lockedTokenKey, CBalances{});
+
+    if (!lockRatio || !lockedTokens.balances.empty()) {
+        return;
+    }
+
+    // Check all collaterals are currently valid
+    auto tokenPricesValid{true};
+
+    auto checkLivePrice = [&](const CTokenCurrencyPair &currencyPair) {
+        if (auto fixedIntervalPrice = mnview.GetFixedIntervalPrice(currencyPair)) {
+            if (!fixedIntervalPrice.val->isLive(mnview.GetPriceDeviation())) {
+                tokenPricesValid = false;
+                return false;
+            }
+        }
+        return true;
+    };
+
+    std::set<uint32_t> loanTokenIds;
+
+    attributes->ForEach(
+        [&](const CDataStructureV0 &attr, const CAttributeValue &) {
+            if (attr.type != AttributeTypes::Token) {
+                return false;
+            }
+            if (attr.key == TokenKeys::LoanCollateralEnabled) {
+                if (auto collateralToken = mnview.GetCollateralTokenFromAttributes({attr.typeId})) {
+                    return checkLivePrice(collateralToken->fixedIntervalPriceId);
+                }
+            } else if (attr.key == TokenKeys::LoanMintingEnabled) {
+                if (auto loanToken = mnview.GetLoanTokenFromAttributes({attr.typeId})) {
+                    loanTokenIds.insert(attr.typeId);
+                    return checkLivePrice(loanToken->fixedIntervalPriceId);
+                }
+            }
+            return true;
+        },
+        CDataStructureV0{AttributeTypes::Token});
+
+    const auto tokensLocked = mnview.AreTokensLocked(loanTokenIds);
+
+    if (!tokenPricesValid || tokensLocked) {
+        return;
+    }
+
+    SplitMap lockSplitMapEVM;
+    auto createTokenLockSplitTx = [&](const uint32_t id, const bool isToken) {
+        CDataStream metadata(DfTokenSplitMarker, SER_NETWORK, PROTOCOL_VERSION);
+        int64_t multiplier = COIN;
+        metadata << (isToken ? 0 : 1) << id << multiplier;
+
+        CMutableTransaction mTx(txVersion);
+        mTx.vin.resize(1);
+        mTx.vin[0].prevout.SetNull();
+        mTx.vin[0].scriptSig = CScript() << height << OP_0;
+        mTx.vout.resize(1);
+        mTx.vout[0].scriptPubKey = CScript() << OP_RETURN << ToByteVector(metadata);
+        mTx.vout[0].nValue = 0;
+        auto tx = MakeTransactionRef(std::move(mTx));
+        if (isToken) {
+            lockSplitMapEVM[id] = std::make_pair(multiplier, tx->GetHash());
+        }
+        pblock.vtx.push_back(tx);
+        pblocktemplate.vTxFees.push_back(0);
+        pblocktemplate.vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock.vtx.back()));
+        LogPrintf("Add creation TX ID: %d isToken: %d Hash: %s\n", id, isToken, tx->GetHash().GetHex());
+    };
+
+    ForEachLockTokenAndPool(
+        [&](const DCT_ID &id, const CLoanSetLoanTokenImplementation &token) {
+            createTokenLockSplitTx(id.v, true);
+            return true;
+        },
+        [&](const DCT_ID &id, const CPoolPair &token) {
+            createTokenLockSplitTx(id.v, false);
+            return true;
+        },
+        mnview);
+
+    AddSplitEVMTxs(blockCtx, lockSplitMapEVM);
+}
+
 template <typename T>
 static void AddSplitDVMTxs(CCustomCSView &mnview,
                            CBlock *pblock,
@@ -427,80 +521,7 @@ ResVal<std::unique_ptr<CBlockTemplate>> BlockAssembler::CreateNewBlock(const CSc
 
     if (nHeight >= chainparams.GetConsensus().DF24Height) {
         // Add token lock creations TXs: duplicate code from AddSplitDVMTxs.
-        // TODO: refactor
-
-        CDataStructureV0 lockedTokenKey{AttributeTypes::Live, ParamIDs::Economy, EconomyKeys::LockedTokens};
-        CDataStructureV0 lockKey{AttributeTypes::Param, ParamIDs::dTokenRestart, static_cast<uint32_t>(nHeight)};
-        const auto lockedTokens = attributes->GetValue(lockedTokenKey, CBalances{});
-        const auto lockRatio = attributes->GetValue(lockKey, CAmount{});
-
-        // Check all collaterals are currently valid
-        auto tokenPricesValid{true};
-
-        auto checkLivePrice = [&](const CTokenCurrencyPair &currencyPair) {
-            if (auto fixedIntervalPrice = mnview.GetFixedIntervalPrice(currencyPair)) {
-                if (!fixedIntervalPrice.val->isLive(mnview.GetPriceDeviation())) {
-                    tokenPricesValid = false;
-                    return false;
-                }
-            }
-            return true;
-        };
-
-        attributes->ForEach(
-            [&](const CDataStructureV0 &attr, const CAttributeValue &) {
-                if (attr.type != AttributeTypes::Token) {
-                    return false;
-                }
-                if (attr.key == TokenKeys::LoanCollateralEnabled) {
-                    if (auto collateralToken = mnview.GetCollateralTokenFromAttributes({attr.typeId})) {
-                        return checkLivePrice(collateralToken->fixedIntervalPriceId);
-                    }
-                } else if (attr.key == TokenKeys::LoanMintingEnabled) {
-                    if (auto loanToken = mnview.GetLoanTokenFromAttributes({attr.typeId})) {
-                        return checkLivePrice(loanToken->fixedIntervalPriceId);
-                    }
-                }
-                return true;
-            },
-            CDataStructureV0{AttributeTypes::Token});
-
-        if (lockedTokens.balances.empty() && lockRatio && tokenPricesValid) {
-            SplitMap lockSplitMapEVM;
-            auto createTokenLockSplitTx = [&](const uint32_t id, const bool isToken) {
-                CDataStream metadata(DfTokenSplitMarker, SER_NETWORK, PROTOCOL_VERSION);
-                int64_t multiplier = COIN;
-                metadata << (isToken ? 0 : 1) << id << multiplier;
-
-                CMutableTransaction mTx(txVersion);
-                mTx.vin.resize(1);
-                mTx.vin[0].prevout.SetNull();
-                mTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
-                mTx.vout.resize(1);
-                mTx.vout[0].scriptPubKey = CScript() << OP_RETURN << ToByteVector(metadata);
-                mTx.vout[0].nValue = 0;
-                auto tx = MakeTransactionRef(std::move(mTx));
-                if (isToken) {
-                    lockSplitMapEVM[id] = std::make_pair(multiplier, tx->GetHash());
-                }
-                pblock->vtx.push_back(tx);
-                pblocktemplate->vTxFees.push_back(0);
-                pblocktemplate->vTxSigOpsCost.push_back(WITNESS_SCALE_FACTOR *
-                                                        GetLegacySigOpCount(*pblock->vtx.back()));
-                LogPrintf("Add creation TX ID: %d isToken: %d Hash: %s\n", id, isToken, tx->GetHash().GetHex());
-            };
-            ForEachLockTokenAndPool(
-                [&](const DCT_ID &id, const CLoanSetLoanTokenImplementation &token) {
-                    createTokenLockSplitTx(id.v, true);
-                    return true;
-                },
-                [&](const DCT_ID &id, const CPoolPair &token) {
-                    createTokenLockSplitTx(id.v, false);
-                    return true;
-                },
-                mnview);
-            AddSplitEVMTxs(blockCtx, lockSplitMapEVM);
-        }
+        AddTokenRestartTxs(blockCtx, nHeight, txVersion, *pblock, *pblocktemplate);
     }
 
     XVM xvm{};


### PR DESCRIPTION
## Summary

- dToken restart will fail if any loan tokens are locked, this will result in a block hash mismatch as the miner will have added the expected token creation TXs and EVM TXs for the restart. This PR adds code to the miner to skip adding these TXs if there are locked loan tokens avoiding creating invalid blocks.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
