### PR TITLE
Restart: Check pools valid

### DIFF
--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1626,9 +1626,12 @@ static Res PoolSplits(CCustomCSView &view,
               pindex->nHeight,
               poolCreationTxs.size());
 
+    if (poolCreationTxs.empty()) {
+        return Res::Err("No pool creation transactions found");
+    }
+
     try {
         const std::string oldPoolSuffix = "/v";
-        assert(poolCreationTxs.size());
         for (const auto &[oldPoolId, creationTx] : poolCreationTxs) {
             auto loopTime = GetTimeMillis();
             auto oldPoolToken = view.GetToken(oldPoolId);

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -1628,8 +1628,8 @@ static Res PoolSplits(CCustomCSView &view,
 
     try {
         const std::string oldPoolSuffix = "/v";
+        assert(poolCreationTxs.size());
         for (const auto &[oldPoolId, creationTx] : poolCreationTxs) {
-            assert(poolCreationTxs.size());
             auto loopTime = GetTimeMillis();
             auto oldPoolToken = view.GetToken(oldPoolId);
             if (!oldPoolToken) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -216,6 +216,7 @@ static void AddTokenRestartTxs(BlockContext &blockCtx,
     };
 
     std::set<uint32_t> loanTokenIds;
+    std::set<uint32_t> collateralTokenIds;
 
     attributes->ForEach(
         [&](const CDataStructureV0 &attr, const CAttributeValue &) {
@@ -224,6 +225,7 @@ static void AddTokenRestartTxs(BlockContext &blockCtx,
             }
             if (attr.key == TokenKeys::LoanCollateralEnabled) {
                 if (auto collateralToken = mnview.GetCollateralTokenFromAttributes({attr.typeId})) {
+                    collateralTokenIds.insert(attr.typeId);
                     return checkLivePrice(collateralToken->fixedIntervalPriceId);
                 }
             } else if (attr.key == TokenKeys::LoanMintingEnabled) {
@@ -240,7 +242,8 @@ static void AddTokenRestartTxs(BlockContext &blockCtx,
 
     bool poolDisabled{false};
     mnview.ForEachPoolPair([&](DCT_ID const &poolId, const CPoolPair &pool) {
-        if (loanTokenIds.count(pool.idTokenA.v) || loanTokenIds.count(pool.idTokenB.v)) {
+        if (loanTokenIds.count(pool.idTokenA.v) || loanTokenIds.count(pool.idTokenB.v) ||
+            collateralTokenIds.count(pool.idTokenA.v) || collateralTokenIds.count(pool.idTokenB.v)) {
             if (!pool.status) {
                 poolDisabled = true;
                 return false;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -238,7 +238,18 @@ static void AddTokenRestartTxs(BlockContext &blockCtx,
 
     const auto tokensLocked = mnview.AreTokensLocked(loanTokenIds);
 
-    if (!tokenPricesValid || tokensLocked) {
+    bool poolDisabled{false};
+    mnview.ForEachPoolPair([&](DCT_ID const &poolId, const CPoolPair &pool) {
+        if (loanTokenIds.count(pool.idTokenA.v) || loanTokenIds.count(pool.idTokenB.v)) {
+            if (!pool.status) {
+                poolDisabled = true;
+                return false;
+            }
+        }
+        return true;
+    });
+
+    if (!tokenPricesValid || tokensLocked || poolDisabled) {
         return;
     }
 

--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -321,8 +321,6 @@ class RestartInterestTest(DefiTestFramework):
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert "v0/live/economy/token_lock_ratio" not in attributes
 
-        assert False
-
     def interest_paid_by_balance(self):
 
         # Rollback block

--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -36,7 +36,10 @@ class RestartInterestTest(DefiTestFramework):
         self.setup()
 
         # Check restart skips on locked token
-        self.skip_restart_on_lock()
+        # self.skip_restart_on_lock()
+
+        # Check restart skips on pool disabled
+        self.skip_restart_on_pool_disabled()
 
         # Check minimal balances after restart
         self.minimal_balances_after_restart()
@@ -147,6 +150,7 @@ class RestartInterestTest(DefiTestFramework):
                 "commission": 0,
                 "status": True,
                 "ownerAddress": self.address,
+                "pairSymbol": "DFI-DUSD",
             }
         )
         self.nodes[0].generate(1)
@@ -294,6 +298,30 @@ class RestartInterestTest(DefiTestFramework):
         # Check restart not executed
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert "v0/live/economy/token_lock_ratio" not in attributes
+
+    def skip_restart_on_pool_disabled(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Disable pool
+        self.nodes[0].updatepoolpair({"pool": "DFI-DUSD", "status": False})
+        self.nodes[0].generate(1)
+
+        # Calculate restart height
+        restart_height = self.nodes[0].getblockcount() + 2
+
+        # Execute dtoken restart
+        self.execute_restart()
+
+        # Check we are at restart height
+        assert_equal(self.nodes[0].getblockcount(), restart_height)
+
+        # Check restart not executed
+        attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
+        assert "v0/live/economy/token_lock_ratio" not in attributes
+
+        assert False
 
     def interest_paid_by_balance(self):
 


### PR DESCRIPTION
## Summary

- Before adding EVM and creation TXs miner side for the dToken restart make sure that all loan and collateral token pools are not disabled.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
