### PR TITLE
RPC: add missing entry in conversiontable

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -320,6 +320,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listburnhistory", 0, "options" },
     { "accounthistorycount", 1, "options" },
 
+    { "releaselockedtokens", 0, "releasePart" },
+
     { "setgov", 0, "variables" },
     { "setgov", 1, "inputs" },
 


### PR DESCRIPTION
## Summary

`releaselockedtokens` rpc was missing the conversion for the number parameter. This PR fixes this


## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [X] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [X] None
