### PR TITLE
Restart: Restore loan and collateral from auctions to vaults

### DIFF
--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -3232,9 +3232,9 @@ static Res ForceCloseAllAuctions(const CBlockIndex *pindex, CCustomCSView &cache
     CAccountsHistoryWriter view(cache, pindex->nHeight, ~0u, pindex->GetBlockHash(), uint8_t(CustomTxType::AuctionBid));
 
     auto res = Res::Ok();
-    cache.ForEachVaultAuction(
+    view.ForEachVaultAuction(
         [&](const auto &vaultId, const auto &auctionData) {
-            auto vault = cache.GetVault(vaultId);
+            auto vault = view.GetVault(vaultId);
             if (!vault) {
                 res = Res::Err("Vault not found");
                 return false;

--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -361,21 +361,27 @@ class RestartInterestTest(DefiTestFramework):
         )
         self.nodes[0].generate(1)
 
-        print("Before vault", self.nodes[0].getvault(vault_id))
+        # check balance before
+        assert_equal(
+            self.nodes[0].getaccount(self.address)[1],
+            f"89890.00000000@{self.symbolDUSD}",
+        )
+        assert_equal(
+            self.nodes[0].getaccount(vault_address),
+            [f"100.00000000@{self.symbolDUSD}"],
+        )
 
         # Execute dtoken restart
         self.execute_restart()
 
-        # Verify that auction bid has been refunded
+        # Verify that auction bid has been refunded and DUSD locked afterwards
         assert_equal(
             self.nodes[0].getaccount(self.address)[1],
             f"9000.00000000@{self.symbolDUSD}",
         )
 
-        # Verify 100DUSD loan now 10% of that amount
-        assert_equal(
-            self.nodes[0].getaccount(vault_address)[0], f"10.00000000@{self.symbolDUSD}"
-        )
+        # DUSD is used to pay back loan
+        assert_equal(self.nodes[0].getaccount(vault_address), [])
 
         # Check auctions are not cleared
         assert_equal(self.nodes[0].listauctions(), [])
@@ -385,8 +391,8 @@ class RestartInterestTest(DefiTestFramework):
         print("After vault", result)
         assert_equal(result["loanAmounts"], [])
         assert_equal(
-            result["collateralAmounts"], [f"38.88888888@{self.symbolDFI}"]
-        )  # Adjust for fee payback
+            result["collateralAmounts"], [f"149.99933408@{self.symbolDFI}"]
+        )  # after paying back with account, interest remains which is paid back with collateral
         assert_equal(result["interestAmounts"], [])
 
     def interest_paid_by_balance(self):

--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -35,8 +35,11 @@ class RestartInterestTest(DefiTestFramework):
         # Set up
         self.setup()
 
+        # Check restart on liquidated vault
+        self.vault_liquidation()
+
         # Check restart skips on locked token
-        # self.skip_restart_on_lock()
+        self.skip_restart_on_lock()
 
         # Check restart skips on pool disabled
         self.skip_restart_on_pool_disabled()
@@ -117,14 +120,14 @@ class RestartInterestTest(DefiTestFramework):
         ]
 
         # Appoint Oracle
-        oracle = self.nodes[0].appointoracle(oracle_address, price_feed, 10)
+        self.oracle = self.nodes[0].appointoracle(oracle_address, price_feed, 10)
         self.nodes[0].generate(1)
 
         # Set Oracle prices
         oracle_prices = [
             {"currency": "USD", "tokenAmount": f"1@{self.symbolDFI}"},
         ]
-        self.nodes[0].setoracledata(oracle, int(time.time()), oracle_prices)
+        self.nodes[0].setoracledata(self.oracle, int(time.time()), oracle_prices)
         self.nodes[0].generate(10)
 
         # Create loan scheme
@@ -320,6 +323,71 @@ class RestartInterestTest(DefiTestFramework):
         # Check restart not executed
         attributes = self.nodes[0].getgov("ATTRIBUTES")["ATTRIBUTES"]
         assert "v0/live/economy/token_lock_ratio" not in attributes
+
+    def vault_liquidation(self):
+
+        # Rollback block
+        self.rollback_to(self.start_block)
+
+        # Create vault
+        vault_address = self.nodes[0].getnewaddress("", "legacy")
+        vault_id = self.nodes[0].createvault(vault_address, "LOAN001")
+        self.nodes[0].generate(1)
+
+        # Deposit DFI to vault
+        self.nodes[0].deposittovault(vault_id, self.address, f"150@{self.symbolDFI}")
+        self.nodes[0].generate(1)
+
+        # Take DUSD loan
+        self.nodes[0].takeloan(
+            {"vaultId": vault_id, "amounts": f"100@{self.symbolDUSD}"}
+        )
+        self.nodes[0].generate(1)
+
+        # Set Oracle prices to trigger liquidation
+        oracle_prices = [
+            {"currency": "USD", "tokenAmount": f"0.9@{self.symbolDFI}"},
+        ]
+        self.nodes[0].setoracledata(self.oracle, int(time.time()), oracle_prices)
+        self.nodes[0].generate(7)
+
+        # Check vault in liquidation
+        result = self.nodes[0].getvault(vault_id)
+        assert_equal(result["state"], "inLiquidation")
+
+        # Place bid on auction
+        self.nodes[0].placeauctionbid(
+            vault_id, 0, self.address, f"110@{self.symbolDUSD}"
+        )
+        self.nodes[0].generate(1)
+
+        print("Before vault", self.nodes[0].getvault(vault_id))
+
+        # Execute dtoken restart
+        self.execute_restart()
+
+        # Verify that auction bid has been refunded
+        assert_equal(
+            self.nodes[0].getaccount(self.address)[1],
+            f"9000.00000000@{self.symbolDUSD}",
+        )
+
+        # Verify 100DUSD loan now 10% of that amount
+        assert_equal(
+            self.nodes[0].getaccount(vault_address)[0], f"10.00000000@{self.symbolDUSD}"
+        )
+
+        # Check auctions are not cleared
+        assert_equal(self.nodes[0].listauctions(), [])
+
+        # Check vault
+        result = self.nodes[0].getvault(vault_id)
+        print("After vault", result)
+        assert_equal(result["loanAmounts"], [])
+        assert_equal(
+            result["collateralAmounts"], [f"38.88888888@{self.symbolDFI}"]
+        )  # Adjust for fee payback
+        assert_equal(result["interestAmounts"], [])
 
     def interest_paid_by_balance(self):
 


### PR DESCRIPTION
## Summary

- On restart for vaults in liquidation restore loans and collateral amounts from auctions to vaults.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
