### PR TITLE
Upgrade DST20 contract to allow 1:1 splits

### DIFF
--- a/lib/ain-contracts/build.rs
+++ b/lib/ain-contracts/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<()> {
         ("dst20", "DST20"),
         ("dst20_v1", "DST20V1"),
         ("dst20_v2", "DST20V2"),
+        ("dst20_v3", "DST20V3"),
     ];
 
     for (sol_project_name, contract_name) in contracts {

--- a/lib/ain-contracts/dst20_v2/DST20V2.sol
+++ b/lib/ain-contracts/dst20_v2/DST20V2.sol
@@ -587,7 +587,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata, IDST20Upgradeable {
         emit UpgradeResult(newTokenContractAddress, newAmount);
 
         // Upgrade available
-        if (newAmount != amount) {
+        if (newTokenContractAddress != address(this)) {
             _burn(msg.sender, amount);
             IERC20(newTokenContractAddress).transfer(msg.sender, newAmount);
         }

--- a/lib/ain-contracts/dst20_v3/DST20V3.sol
+++ b/lib/ain-contracts/dst20_v3/DST20V3.sol
@@ -587,7 +587,7 @@ contract ERC20 is Context, IERC20, IERC20Metadata, IDST20Upgradeable {
         emit UpgradeResult(newTokenContractAddress, newAmount);
 
         // Upgrade available
-        if (newAmount != amount) {
+        if (newTokenContractAddress != address(this)) {
             _burn(msg.sender, amount);
             IERC20(newTokenContractAddress).transfer(msg.sender, newAmount);
         }
@@ -600,6 +600,6 @@ contract ERC20 is Context, IERC20, IERC20Metadata, IDST20Upgradeable {
 
 pragma solidity ^0.8.0;
 
-contract DST20V2 is ERC20 {
+contract DST20V3 is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 }

--- a/lib/ain-contracts/dst20_v3/IDST20Upgradeable.sol
+++ b/lib/ain-contracts/dst20_v3/IDST20Upgradeable.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IDST20Upgradeable {
+    event UpgradeResult(
+        address indexed newTokenContractAddress,
+        uint256 newAmount
+    );
+
+    function upgradeToken(uint256 amount) external returns (address, uint256);
+}

--- a/lib/ain-contracts/src/lib.rs
+++ b/lib/ain-contracts/src/lib.rs
@@ -213,6 +213,24 @@ lazy_static::lazy_static! {
             fixed_address: H160(slice_20b!(INTRINSICS_ADDR_PREFIX_BYTE, 0x5))
         }
     };
+
+    pub static ref DST20_V3_CONTRACT: FixedContract = {
+        let bytecode = solc_artifact_bytecode_str!(
+            "dst20_v3", "deployed_bytecode.json"
+        );
+        let input = solc_artifact_bytecode_str!(
+            "dst20_v3", "bytecode.json"
+        );
+
+        FixedContract {
+            contract: Contract {
+            codehash: Blake2Hasher::hash(&bytecode),
+            runtime_bytecode: bytecode,
+            init_bytecode: input,
+            },
+            fixed_address: H160(slice_20b!(INTRINSICS_ADDR_PREFIX_BYTE, 0x6))
+        }
+    };
 }
 
 pub fn get_split_tokens_function() -> ethabi::Function {
@@ -368,6 +386,10 @@ pub fn get_dst20_v1_contract() -> FixedContract {
 
 pub fn get_dst20_v2_contract() -> FixedContract {
     DST20_V2_CONTRACT.clone()
+}
+
+pub fn get_dst20_v3_contract() -> FixedContract {
+    DST20_V3_CONTRACT.clone()
 }
 
 #[cfg(test)]

--- a/lib/ain-cpp-imports/src/bridge.rs
+++ b/lib/ain-cpp-imports/src/bridge.rs
@@ -90,6 +90,7 @@ pub mod ffi {
         fn isEthDebugTraceRPCEnabled() -> bool;
         fn getEVMSystemTxsFromBlock(block_hash: [u8; 32]) -> Vec<SystemTxData>;
         fn getDF23Height() -> u64;
+        fn getDF24Height() -> u64;
         fn migrateTokensFromEVM(
             mnview_ptr: usize,
             old_amount: TokenAmount,

--- a/lib/ain-cpp-imports/src/lib.rs
+++ b/lib/ain-cpp-imports/src/lib.rs
@@ -156,6 +156,9 @@ mod ffi {
     pub fn getDF23Height() -> u64 {
         unimplemented!("{}", UNIMPL_MSG)
     }
+    pub fn getDF24Height() -> u64 {
+        unimplemented!("{}", UNIMPL_MSG)
+    }
     pub fn migrateTokensFromEVM(
         _mnview_ptr: usize,
         _old_amount: TokenAmount,
@@ -365,6 +368,11 @@ pub fn get_evm_system_txs_from_block(block_hash: [u8; 32]) -> Vec<ffi::SystemTxD
 /// Gets the DF23 height
 pub fn get_df23_height() -> u64 {
     ffi::getDF23Height()
+}
+
+/// Gets the DF23 height
+pub fn get_df24_height() -> u64 {
+    ffi::getDF24Height()
 }
 
 /// Send tokens to DVM to split

--- a/lib/ain-evm/src/contract/dst20.rs
+++ b/lib/ain-evm/src/contract/dst20.rs
@@ -1,6 +1,7 @@
 use ain_contracts::{
     get_dfi_reserved_contract, get_dst20_contract, get_dst20_v1_contract, get_dst20_v2_contract,
-    get_transfer_domain_contract, Contract, FixedContract, IMPLEMENTATION_SLOT,
+    get_dst20_v3_contract, get_transfer_domain_contract, Contract, FixedContract,
+    IMPLEMENTATION_SLOT,
 };
 use anyhow::format_err;
 use ethereum::{
@@ -78,6 +79,19 @@ pub fn dst20_v2_deploy_info() -> DeployContractInfo {
         contract,
         fixed_address,
     } = get_dst20_v2_contract();
+
+    DeployContractInfo {
+        address: fixed_address,
+        bytecode: Bytes::from(contract.runtime_bytecode),
+        storage: Vec::new(),
+    }
+}
+
+pub fn dst20_v3_deploy_info() -> DeployContractInfo {
+    let FixedContract {
+        contract,
+        fixed_address,
+    } = get_dst20_v3_contract();
 
     DeployContractInfo {
         address: fixed_address,
@@ -245,7 +259,9 @@ pub fn get_dst20_migration_txs(mnview_ptr: usize) -> Result<Vec<ExecuteTx>> {
 }
 
 pub fn dst20_name_info(dvm_block: u64, name: &str, symbol: &str) -> Vec<(H256, H256)> {
-    let contract_address = if dvm_block >= ain_cpp_imports::get_df23_height() {
+    let contract_address = if dvm_block >= ain_cpp_imports::get_df24_height() {
+        get_dst20_v3_contract().fixed_address
+    } else if dvm_block >= ain_cpp_imports::get_df23_height() {
         get_dst20_v2_contract().fixed_address
     } else {
         get_dst20_v1_contract().fixed_address

--- a/src/ffi/ffiexports.cpp
+++ b/src/ffi/ffiexports.cpp
@@ -522,6 +522,10 @@ uint64_t getDF23Height() {
     return Params().GetConsensus().DF23Height;
 }
 
+uint64_t getDF24Height() {
+    return Params().GetConsensus().DF24Height;
+}
+
 bool migrateTokensFromEVM(std::size_t mnview_ptr, TokenAmount old_amount, TokenAmount &new_amount) {
     return ExecuteTokenMigrationEVM(mnview_ptr, old_amount, new_amount);
 }

--- a/src/ffi/ffiexports.h
+++ b/src/ffi/ffiexports.h
@@ -127,6 +127,7 @@ bool isEthDebugTraceRPCEnabled();
 // Gets all EVM system txs and their respective types from DVM block.
 rust::vec<SystemTxData> getEVMSystemTxsFromBlock(std::array<uint8_t, 32> evmBlockHash);
 uint64_t getDF23Height();
+uint64_t getDF24Height();
 bool migrateTokensFromEVM(std::size_t mnview_ptr, TokenAmount old_amount, TokenAmount &new_amount);
 
 #endif  // DEFI_FFI_FFIEXPORTS_H

--- a/test/functional/feature_evm_token_split.py
+++ b/test/functional/feature_evm_token_split.py
@@ -36,6 +36,7 @@ class EVMTokenSplitTest(DefiTestFramework):
                 "-grandcentralheight=1",
                 "-metachainheight=105",
                 "-df23height=150",
+                "-df24height=150",
             ],
         ]
 
@@ -53,8 +54,8 @@ class EVMTokenSplitTest(DefiTestFramework):
         # Split token multiple times via transfer domain
         self.transfer_domain_multiple_split()
 
-        # Split tokens 1:1 via intrinsics contract
-        self.intrinsic_token_split(20, 1)
+        # Split tokens 1:1 via v3 intrinsics contract
+        self.intrinsic_token_split(20, 1, True)
 
         # Split tokens via intrinsics contract
         self.intrinsic_token_split(20, 2)
@@ -170,6 +171,12 @@ class EVMTokenSplitTest(DefiTestFramework):
 
         self.dst20_v2_abi = open(
             get_solc_artifact_path("dst20_v2", "abi.json"),
+            "r",
+            encoding="utf8",
+        ).read()
+
+        self.dst20_v3_abi = open(
+            get_solc_artifact_path("dst20_v3", "abi.json"),
             "r",
             encoding="utf8",
         ).read()
@@ -474,7 +481,7 @@ class EVMTokenSplitTest(DefiTestFramework):
             Decimal(4000.00000000),
         )
 
-    def intrinsic_token_split(self, amount, split_multiplier):
+    def intrinsic_token_split(self, amount, split_multiplier, use_v3=False):
 
         # Rollback
         self.rollback_to(self.block_height)
@@ -502,6 +509,7 @@ class EVMTokenSplitTest(DefiTestFramework):
             self.contract_address_metav2,
             amount,
             split_multiplier,
+            use_v3,
         )
 
         # Get values from after transfer out
@@ -540,8 +548,9 @@ class EVMTokenSplitTest(DefiTestFramework):
             + (amount * decimal_multiplier),
         )
 
+        # Check already updated token cannot be updated again
         self.execute_split_transaction_at_highest_level(
-            self.contract_address_metav2, amount
+            self.contract_address_metav2, amount, use_v3
         )
 
     def intrinsic_token_merge(self, amount, split_multiplier):
@@ -706,7 +715,12 @@ class EVMTokenSplitTest(DefiTestFramework):
         )
 
     def execute_split_transaction(
-        self, source_contract, destination_contract, amount=20, split_multiplier=2
+        self,
+        source_contract,
+        destination_contract,
+        amount=20,
+        split_multiplier=2,
+        use_v3=False,
     ):
 
         # Create the amount to approve
@@ -725,9 +739,14 @@ class EVMTokenSplitTest(DefiTestFramework):
             amount_to_receive = 0
 
         # Get old contract
-        meta_contract = self.nodes[0].w3.eth.contract(
-            address=source_contract, abi=self.dst20_v2_abi
-        )
+        if use_v3:
+            meta_contract = self.nodes[0].w3.eth.contract(
+                address=source_contract, abi=self.dst20_v3_abi
+            )
+        else:
+            meta_contract = self.nodes[0].w3.eth.contract(
+                address=source_contract, abi=self.dst20_v2_abi
+            )
 
         totalSupplyBefore = meta_contract.functions.totalSupply().call()
         balance_before = meta_contract.functions.balanceOf(self.evm_address).call()
@@ -772,9 +791,14 @@ class EVMTokenSplitTest(DefiTestFramework):
         assert_equal(totalSupplyAfter, totalSupplyBefore - amount_to_send)
 
         # Get new contract
-        meta_contract_new = self.nodes[0].w3.eth.contract(
-            address=destination_contract, abi=self.dst20_v2_abi
-        )
+        if use_v3:
+            meta_contract_new = self.nodes[0].w3.eth.contract(
+                address=destination_contract, abi=self.dst20_v3_abi
+            )
+        else:
+            meta_contract_new = self.nodes[0].w3.eth.contract(
+                address=destination_contract, abi=self.dst20_v2_abi
+            )
 
         # Check transfer from sender to burn address
         events = meta_contract_new.events.Transfer().process_log(
@@ -801,10 +825,17 @@ class EVMTokenSplitTest(DefiTestFramework):
 
         return amount_to_receive
 
-    def execute_split_transaction_at_highest_level(self, source_contract, amount=20):
-        meta_contract = self.nodes[0].w3.eth.contract(
-            address=source_contract, abi=self.dst20_v2_abi
-        )
+    def execute_split_transaction_at_highest_level(
+        self, source_contract, amount=20, use_v3=False
+    ):
+        if use_v3:
+            meta_contract = self.nodes[0].w3.eth.contract(
+                address=source_contract, abi=self.dst20_v3_abi
+            )
+        else:
+            meta_contract = self.nodes[0].w3.eth.contract(
+                address=source_contract, abi=self.dst20_v2_abi
+            )
 
         amount_to_send = Web3.to_wei(amount, "ether")
 

--- a/test/functional/feature_evm_token_split.py
+++ b/test/functional/feature_evm_token_split.py
@@ -53,6 +53,9 @@ class EVMTokenSplitTest(DefiTestFramework):
         # Split token multiple times via transfer domain
         self.transfer_domain_multiple_split()
 
+        # Split tokens 1:1 via intrinsics contract
+        self.intrinsic_token_split(20, 1)
+
         # Split tokens via intrinsics contract
         self.intrinsic_token_split(20, 2)
 

--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -388,7 +388,6 @@ class RestartInterestTest(DefiTestFramework):
 
         # Check vault
         result = self.nodes[0].getvault(vault_id)
-        print("After vault", result)
         assert_equal(result["loanAmounts"], [])
         assert_equal(
             result["collateralAmounts"], [f"149.99933408@{self.symbolDFI}"]

--- a/test/functional/feature_restartdtokens.py
+++ b/test/functional/feature_restartdtokens.py
@@ -644,7 +644,6 @@ class RestartdTokensTest(DefiTestFramework):
         tx_receipt = self.nodes[0].w3.eth.wait_for_transaction_receipt(signed_txn.hash)
         assert_equal(tx_receipt["status"], 1)
 
-
         assert_equal(
             self.dusd_contract.functions.balanceOf(self.evmaddress).call() / (10**18),
             Decimal(9.99999999),
@@ -1087,7 +1086,7 @@ class RestartdTokensTest(DefiTestFramework):
             address=self.nodes[0].w3.to_checksum_address(
                 f"0xff0000000000000000000000000000000000{self.usddId:0{4}x}"
             ),
-            abi=self.dst20_v2_abi,
+            abi=self.dst20_v3_abi,
         )
         assert_equal(
             [
@@ -2016,22 +2015,22 @@ class RestartdTokensTest(DefiTestFramework):
         )
 
         # DST20 ABI
-        self.dst20_v2_abi = open(
-            get_solc_artifact_path("dst20_v2", "abi.json"),
+        self.dst20_v3_abi = open(
+            get_solc_artifact_path("dst20_v3", "abi.json"),
             "r",
             encoding="utf8",
         ).read()
 
         # Check DUSD variables
         self.dusd_contract = self.nodes[0].w3.eth.contract(
-            address=self.contract_address_dusdv1, abi=self.dst20_v2_abi
+            address=self.contract_address_dusdv1, abi=self.dst20_v3_abi
         )
         assert_equal(self.dusd_contract.functions.symbol().call(), "DUSD")
         assert_equal(self.dusd_contract.functions.name().call(), "dUSD")
 
         # Check SPY variables
         self.spy_contract = self.nodes[0].w3.eth.contract(
-            address=self.contract_address_spyv1, abi=self.dst20_v2_abi
+            address=self.contract_address_spyv1, abi=self.dst20_v3_abi
         )
         assert_equal(self.spy_contract.functions.symbol().call(), "SPY")
         assert_equal(self.spy_contract.functions.name().call(), "SP500")

--- a/test/functional/feature_restartdtokens.py
+++ b/test/functional/feature_restartdtokens.py
@@ -650,7 +650,7 @@ class RestartdTokensTest(DefiTestFramework):
             Decimal(9.99999999),
         )
         assert_equal(
-            self.usdd_contract.functions.balanceOf(self.evmaddress).call(),
+            self.usdd_contract.functions.balanceOf(self.evmaddress).call() / (10**18),
             Decimal(10),
         )
 


### PR DESCRIPTION
## Summary

Resolves the issue where a 1:1 split fails due to the following DST20V2 contract code. 1:1 splits are used in the dToken restart, without this upgrade it is not possible to use the upgradeToken function in the contract once all locked tokens have been released.

```
if (newAmount != amount) {
        _burn(msg.sender, amount);
        IERC20(newTokenContractAddress).transfer(msg.sender, newAmount);
}
```

Adds a DST20V3 contract that checks the contract address rather than the amount.

```
if (newTokenContractAddress != address(this)) {
    _burn(msg.sender, amount);
     IERC20(newTokenContractAddress).transfer(msg.sender, newAmount);
}
  ```

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
