### PR TITLE
Mint META in specific test to avoid index change

### DIFF
--- a/test/functional/feature_restart_interest.py
+++ b/test/functional/feature_restart_interest.py
@@ -117,7 +117,6 @@ class RestartInterestTest(DefiTestFramework):
 
         # Mint DUSD
         self.nodes[0].minttokens(f"100000@{self.symbolDUSD}")
-        self.nodes[0].minttokens(f"100000@{self.symbolMETA}")
         self.nodes[0].generate(1)
 
         # Create DFI tokens
@@ -196,6 +195,9 @@ class RestartInterestTest(DefiTestFramework):
 
         # Rollback block
         self.rollback_to(self.start_block)
+
+        self.nodes[0].minttokens(f"100000@{self.symbolMETA}")
+        self.nodes[0].generate(1)
 
         # Set all futures attributes
         self.nodes[0].setgov(


### PR DESCRIPTION
## Summary

- Isolate balance change to specific test to avoid balance index changes on other tests.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
