### PR TITLE
Ocean: fix flooding upstream err

### DIFF
--- a/lib/ain-ocean/src/error.rs
+++ b/lib/ain-ocean/src/error.rs
@@ -306,10 +306,6 @@ impl Error {
     #[must_use]
     pub fn into_code_and_message(self) -> (StatusCode, String) {
         let (code, reason) = match &self {
-            Self::RpcError {
-                error: defichain_rpc::Error::JsonRpc(jsonrpc_async::error::Error::Rpc(e)),
-                ..
-            } => (StatusCode::NOT_FOUND, e.message.to_string()),
             Self::NotFound { kind: _ } => (StatusCode::NOT_FOUND, format!("{self}")),
             Self::NotFoundMessage { msg } => (StatusCode::NOT_FOUND, msg.clone()),
             Self::BadRequest { msg } => (StatusCode::BAD_REQUEST, msg.clone()),


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary
rm upstream err as ocean snafu will do
```
2024-09-27T06:03:12Z [defichain_rpc::client] JSON-RPC request: getpoolpair ["DFI-DUSD",true]
2024-09-27T06:03:12Z [defichain_rpc::client] JSON-RPC error for getpoolpair: RpcError { code: -5, message: "Pool not found", data: None } <-- flooding
2024-09-27T06:03:12Z [ain_ocean::api::cache] get_pool_pair_cached, id: "DFI-DUSD", is_err: false
```
![image](https://github.com/user-attachments/assets/135fa109-d2e7-476a-8987-64d03d7d14b3)
