### PR TITLE
Update createtoken RPC to allow Gov to create DATs

### DIFF
--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -142,14 +142,9 @@ UniValue createtoken(const JSONRPCRequest &request) {
     auto [view, accountView, vaultView] = GetSnapshots();
     CTransactionRef optAuthTx;
     std::set<CScript> auths;
-    rawTx.vin = GetAuthInputsSmart(pwallet,
-                                   rawTx.nVersion,
-                                   auths,
-                                   metaObj["isDAT"].getBool(),
-                                   optAuthTx,
-                                   txInputs,
-                                   *view,
-                                   request.metadata.coinSelectOpts);
+    const auto isDAT = metaObj["isDAT"].getBool();
+    rawTx.vin = GetAuthInputsSmart(
+        pwallet, rawTx.nVersion, auths, isDAT, optAuthTx, txInputs, *view, request.metadata.coinSelectOpts, isDAT);
 
     rawTx.vout.push_back(CTxOut(GetTokenCreationFee(targetHeight), scriptMeta));
     rawTx.vout.push_back(CTxOut(GetTokenCollateralAmount(), GetScriptForDestination(collateralDest)));


### PR DESCRIPTION
## Summary

- In the createtoken RPC call pass true to Gov required bool to allow Gov nodes to create DAT tokens.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
