### PR TITLE
Ocean: fix get apr default if any zero

### DIFF
--- a/lib/ain-ocean/src/api/pool_pair/service.rs
+++ b/lib/ain-ocean/src/api/pool_pair/service.rs
@@ -461,6 +461,10 @@ pub async fn get_apr(
     let loan_usd = get_yearly_reward_loan_usd(ctx, id).await?;
     let total_liquidity_usd = get_total_liquidity_usd(ctx, p).await?;
 
+    if custom_usd.is_zero() || pct_usd.is_zero() || loan_usd.is_zero() || total_liquidity_usd.is_zero() {
+        return Ok(PoolPairAprResponse::default());
+    }
+
     let yearly_usd = custom_usd
         .checked_add(pct_usd)
         .context(ArithmeticOverflowSnafu)?


### PR DESCRIPTION
<!-- 
Thanks for sending a pull request!

- Check out our contributing guidelines, https://github.com/DeFiCh/ain/blob/master/CONTRIBUTING.md
- Even small changes will need to have multiple eyes and require substantial time effort to review.
- Please use bullet points to summarize as well as provide detailed info as much as possible.
- Short bullet points are easier to read and process.
- If you'd like to add detailed notes, split the summary with a "Details" section.
- Delete sections that are empty except for implications. 
-->

## Summary

- add missing guard - if any of {field} zero return default
https://github.com/BirthdayResearch/jellyfishsdk/blob/cb1c46722c9495dcfffd1e9f8c6d9a684d4dc7c9/apps/whale-api/src/module.api/poolpair.service.ts#L463-L465
