### PR TITLE
Prune undos on startup

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -376,7 +376,9 @@ public:
                 {3600000,uint256S("cd7fb7dd41b2f77a6895133d15b81a4294663963512d756c75e6974e09a1e335")},
                 {3700000,uint256S("e579ea61173bce909b2bf13f2ede98c1025cef51350209953f235209a73bad01")},
                 {3800000,uint256S("8930b8a43a6413dc8739bec47123b0bb556f6ce2dac3583acefa533b966cb719")},
-
+                {3900000,uint256S("1118ddefb8b3c550421ccd71bf13794f0969f2f72f6ab72e0bf411e21a7bce96")},
+                {4000000,uint256S("bc04577f86b72eb5fb4db79fb19a1f019afa6378ce6ef7e6401d3e14f55d6cb4")},
+                {4100000,uint256S("5a173418adc9a1aa5bab4370871b2526771ec81ea445e963971bfafe88cba4b5")},
             }
         };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2048,6 +2048,25 @@ bool AppInitMain(InitInterfaces& interfaces)
                         break;
                     }
                 }
+
+                // Prune based on checkpoints
+                auto &checkpoints = chainparams.Checkpoints().mapCheckpoints;
+                auto it = checkpoints.lower_bound(::ChainActive().Tip()->nHeight);
+                if (it != checkpoints.begin()) {
+                    auto &[height, _] = *(--it);
+                    std::vector<unsigned char> compactBegin;
+                    std::vector<unsigned char> compactEnd;
+                    PruneCheckpoint(*pcustomcsview, height, compactBegin, compactEnd);
+                    if (!compactBegin.empty() && !compactEnd.empty()) {
+                        pcustomcsview->Flush();
+                        pcustomcsDB->Flush();
+                        auto time = GetTimeMillis();
+                        pcustomcsDB->Compact(compactBegin, compactEnd);
+                        compactBegin.clear();
+                        compactEnd.clear();
+                        LogPrint(BCLog::BENCH, "    - DB compacting takes: %dms\n", GetTimeMillis() - time);
+                    }
+                }
             } catch (const std::exception& e) {
                 LogPrintf("%s\n", e.what());
                 strLoadError = _("Error opening block database").translated;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3416,27 +3416,8 @@ bool CChainState::ConnectBlock(const CBlock &block,
     auto &checkpoints = chainparams.Checkpoints().mapCheckpoints;
     auto it = checkpoints.find(pindex->nHeight);
     if (it != checkpoints.end()) {
-        bool pruneStarted = false;
-        auto time = GetTimeMillis();
-        CCustomCSView pruned(mnview);
-        mnview.ForEachUndo([&](const UndoKey &key, CLazySerialize<CUndo>) {
-            if (key.height >= static_cast<uint32_t>(it->first)) {  // don't erase checkpoint height
-                return false;
-            }
-            if (!pruneStarted) {
-                pruneStarted = true;
-                LogPrintf("Pruning undo data prior %d, it can take a while...\n", it->first);
-            }
-            return pruned.DelUndo(key).ok;
-        });
-        if (pruneStarted) {
-            auto &map = pruned.GetStorage().GetRaw();
-            compactBegin = map.begin()->first;
-            compactEnd = map.rbegin()->first;
-            pruned.Flush();
-            LogPrintf("Pruning undo data finished.\n");
-            LogPrint(BCLog::BENCH, "    - Pruning undo data takes: %dms\n", GetTimeMillis() - time);
-        }
+        auto &[height, _] = *it;
+        PruneCheckpoint(mnview, height, compactBegin, compactEnd);
         // we can safety delete old interest keys
         if (it->first > consensus.DF14FortCanningHillHeight) {
             CCustomCSView view(mnview);
@@ -3474,6 +3455,33 @@ bool CChainState::ConnectBlock(const CBlock &block,
              nTimeCallbacks * MILLI / nBlocksTotal);
 
     return true;
+}
+
+void PruneCheckpoint(CCustomCSView &mnview,
+                     const int height,
+                     std::vector<unsigned char> &begin,
+                     std::vector<unsigned char> &end) {
+    bool pruneStarted{};
+    auto time = GetTimeMillis();
+    CCustomCSView pruned(mnview);
+    mnview.ForEachUndo([&](const UndoKey &key, CLazySerialize<CUndo>) {
+        if (key.height >= static_cast<uint32_t>(height)) {  // don't erase checkpoint height
+            return false;
+        }
+        if (!pruneStarted) {
+            pruneStarted = true;
+            LogPrintf("Pruning undo data prior %d, it can take a while...\n", height);
+        }
+        return pruned.DelUndo(key).ok;
+    });
+    if (pruneStarted) {
+        auto &map = pruned.GetStorage().GetRaw();
+        begin = map.begin()->first;
+        end = map.rbegin()->first;
+        pruned.Flush();
+        LogPrintf("Pruning undo data finished.\n");
+        LogPrint(BCLog::BENCH, "    - Pruning undo data takes: %dms\n", GetTimeMillis() - time);
+    }
 }
 
 bool CChainState::FlushStateToDisk(const CChainParams &chainparams,

--- a/src/validation.h
+++ b/src/validation.h
@@ -254,6 +254,12 @@ bool ProcessNewBlock(const CChainParams &chainparams,
                      bool fForceProcessing,
                      bool *fNewBlock) LOCKS_EXCLUDED(cs_main);
 
+// Prunes undos based on checkpoints
+void PruneCheckpoint(CCustomCSView &mnview,
+                     const int height,
+                     std::vector<unsigned char> &begin,
+                     std::vector<unsigned char> &end);
+
 /**
  * Process incoming block headers.
  *


### PR DESCRIPTION
## Summary

- Prune undos based on checkpoints on startup

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
