### PR TITLE
Allow Governance and Foundation to update loan tokens after the fork

### DIFF
--- a/src/dfi/consensus/tokens.cpp
+++ b/src/dfi/consensus/tokens.cpp
@@ -203,7 +203,7 @@ Res CTokensConsensus::operator()(const CUpdateTokenMessage &obj) const {
             if (auto res = authCheck.HasGovOrFoundationAuth(); !res) {
                 return Res::Err("Authentication failed for token owner");
             }
-            
+
             // If it's loan token, that's owned by gov, so we don't need to disallow.
             // Limit update token for governance and foundation for non-loan tokens
             if (!mnview.GetLoanTokenByID(tokenID)) {
@@ -217,7 +217,7 @@ Res CTokensConsensus::operator()(const CUpdateTokenMessage &obj) const {
                     toggledFlags != static_cast<uint8_t>(CToken::TokenFlags::Deprecated);
 
                 const auto disallowedChanges = hasDisallowedFlagToggle || updatedToken.symbol != token.symbol ||
-                                                updatedToken.name != token.name || obj.newCollateralAddress;
+                                               updatedToken.name != token.name || obj.newCollateralAddress;
 
                 if (disallowedChanges) {
                     return Res::Err("Only token deprecation toggle is allowed by governance");

--- a/src/dfi/consensus/tokens.cpp
+++ b/src/dfi/consensus/tokens.cpp
@@ -201,20 +201,23 @@ Res CTokensConsensus::operator()(const CUpdateTokenMessage &obj) const {
         if (!ownerAuth) {
             // Governance or foundation can still mark/unmark token deprecation
             if (auto res = authCheck.HasGovOrFoundationAuth(); res) {
-                // Allow only deprecation. We disallow changes like name or symbol
-                // as a token holder shouldn't be misrepresented by governance.
-                // Governance can choose completely discard it by deprecating it
-                // or keep it in the form as intended by the owner.
+                // Limit update token for governance and foundation for non-loan tokens
+                if (!mnview.GetLoanTokenByID(tokenID)) {
+                    // Allow only deprecation. We disallow changes like name or symbol
+                    // as a token holder shouldn't be misrepresented by governance.
+                    // Governance can choose completely discard it by deprecating it
+                    // or keep it in the form as intended by the owner.
 
-                const auto toggledFlags = static_cast<uint8_t>(updatedToken.flags ^ token.flags);
-                const auto hasDisallowedFlagToggle =
-                    toggledFlags != static_cast<uint8_t>(CToken::TokenFlags::Deprecated);
+                    const auto toggledFlags = static_cast<uint8_t>(updatedToken.flags ^ token.flags);
+                    const auto hasDisallowedFlagToggle =
+                        toggledFlags != static_cast<uint8_t>(CToken::TokenFlags::Deprecated);
 
-                const auto disallowedChanges = hasDisallowedFlagToggle || updatedToken.symbol != token.symbol ||
-                                               updatedToken.name != token.name || obj.newCollateralAddress;
+                    const auto disallowedChanges = hasDisallowedFlagToggle || updatedToken.symbol != token.symbol ||
+                                                   updatedToken.name != token.name || obj.newCollateralAddress;
 
-                if (disallowedChanges) {
-                    return Res::Err("Only token deprecation toggle is allowed by governance");
+                    if (disallowedChanges) {
+                        return Res::Err("Only token deprecation toggle is allowed by governance");
+                    }
                 }
             } else {
                 return Res::Err("Authentication failed for token owner");

--- a/src/dfi/rpc_tokens.cpp
+++ b/src/dfi/rpc_tokens.cpp
@@ -267,8 +267,8 @@ UniValue updatetoken(const JSONRPCRequest &request) {
 
     auto [view, accountView, vaultView] = GetSnapshots();
     auto targetHeight = view->GetLastHeight() + 1;
+    DCT_ID id{};
     {
-        DCT_ID id;
         auto token = view->GetTokenGuessId(tokenStr, id);
         if (!token) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Token %s does not exist!", tokenStr));
@@ -350,6 +350,8 @@ UniValue updatetoken(const JSONRPCRequest &request) {
         const auto members = GetFoundationMembers(*view);
         isFoundersToken =
             !members.empty() ? members.count(owner) : Params().GetConsensus().foundationMembers.count(owner);
+    } else if (view->GetLoanTokenByID(id)) {
+        isFoundersToken = true;
     }
 
     if (isFoundersToken) {  // need any founder's auth


### PR DESCRIPTION
## Summary

- Post fork only token owners can update tokens. However split loan tokens no longer have an owner as there is no collateral for a split token. Loan tokens should still be updatable by Governance and Foundation after the fork, this PR enables that behaviour.

## Implications

- Storage
  - [x] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [ ] None

- Consensus
  - [x] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [ ] None
