### PR TITLE
Add evmhash and oceanahsh to logdbhashes

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -111,10 +111,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "hex",
  "log",
  "num_cpus",
  "rocksdb",
  "serde",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/lib/ain-db/Cargo.toml
+++ b/lib/ain-db/Cargo.toml
@@ -12,3 +12,5 @@ rocksdb.workspace = true
 anyhow.workspace = true
 num_cpus.workspace = true
 log.workspace = true
+sha2.workspace = true
+hex.workspace = true

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -54,6 +54,10 @@ impl BlockStore {
             column: PhantomData,
         }
     }
+
+    pub fn hash_db_state(&self) -> Result<String> {
+        Ok(self.0.hash_db_state(&COLUMN_NAMES)?)
+    }
 }
 
 impl DBVersionControl for BlockStore {

--- a/lib/ain-evm/src/storage/mod.rs
+++ b/lib/ain-evm/src/storage/mod.rs
@@ -214,6 +214,10 @@ impl Storage {
     pub fn dump_db(&self, arg: DumpArg, from: Option<&str>, limit: usize) -> Result<String> {
         self.blockstore.dump(&arg, from, limit)
     }
+
+    pub fn hash_db_state(&self) -> Result<String> {
+        self.blockstore.hash_db_state()
+    }
 }
 
 impl Rollback for Storage {

--- a/lib/ain-ocean/src/storage/ocean_store.rs
+++ b/lib/ain-ocean/src/storage/ocean_store.rs
@@ -90,6 +90,10 @@ impl OceanStore {
         Ok(self.0.dump_table_sizes(&COLUMN_NAMES)?)
     }
 
+    pub fn hash_db_state(&self) -> Result<String> {
+        Ok(self.0.hash_db_state(&COLUMN_NAMES)?)
+    }
+
     pub fn compact(&self) {
         self.0.compact();
     }

--- a/lib/ain-rs-exports/src/evm.rs
+++ b/lib/ain-rs-exports/src/evm.rs
@@ -882,3 +882,8 @@ fn evm_try_unsafe_rename_dst20(
             .push_tx_in_block_template(template.get_inner_mut()?, system_tx, native_hash)
     }
 }
+
+#[ffi_fallible]
+fn evm_try_get_hash_db_state() -> Result<String> {
+    SERVICES.evm.storage.hash_db_state()
+}

--- a/lib/ain-rs-exports/src/lib.rs
+++ b/lib/ain-rs-exports/src/lib.rs
@@ -361,6 +361,8 @@ pub mod ffi {
             native_hash: [u8; 32],
             token: DST20TokenInfo,
         );
+        fn evm_try_get_hash_db_state(result: &mut CrossBoundaryResult) -> String;
+        fn ocean_try_get_hash_db_state(result: &mut CrossBoundaryResult) -> String;
     }
 
     // =========  Debug ==========

--- a/lib/ain-rs-exports/src/ocean.rs
+++ b/lib/ain-rs-exports/src/ocean.rs
@@ -23,3 +23,8 @@ pub fn ocean_invalidate_block(block_str: String) -> Result<()> {
 fn ocean_try_set_tx_result(tx_type: u8, tx_hash: [u8; 32], result_ptr: usize) -> Result<()> {
     ain_ocean::tx_result::index(&ain_ocean::SERVICES, tx_type, tx_hash, result_ptr)
 }
+
+#[ffi_fallible]
+fn ocean_try_get_hash_db_state() -> Result<String> {
+    ain_ocean::SERVICES.store.hash_db_state()
+}

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -6,6 +6,7 @@
 #include <dfi/validation.h>
 #include <dfi/vaulthistory.h>
 #include <ffi/ffihelpers.h>
+#include <ffi/ffiexports.h>
 #include <boost/asio.hpp>
 
 #include <fstream>
@@ -3726,6 +3727,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     // Convert hash to hex string
     const auto hashHex = HexStr(hash, hash + CSHA256::OUTPUT_SIZE);
 
+
     // Get the current block height
     const auto height = ::ChainActive().Height();
 
@@ -3733,6 +3735,18 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     UniValue result(UniValue::VOBJ);
     result.pushKV("height", height);
     result.pushKV("dvmhash", hashHex);
+
+    const auto evmHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
+    if (evmHashHex) {
+        result.pushKV("evmhash", std::string(*evmHashHex));
+    }
+
+    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED))  {
+        const auto oceanHashHex = XResultValueLogged(ocean_try_get_hash_db_state(result));
+        if (oceanHashHex) {
+            result.pushKV("oceanhash", std::string(*oceanHashHex));
+        }
+    }
 
     return result;
 }


### PR DESCRIPTION
- outputs :

```
{
  "height": 64,
  "dvmhash": "d609d17a28ad23d8a0e58bac8205b237436afd93f2d56b9d7f6d5955a1a38808",
  "evmhash": "1832b8ead04d0f44f630b8dbd869fd4f87b225a92fc02ca1de0426319f95e78b",
  "oceanhash": "8fd273ee426d05d1cb5d47c0b4673574fc3d34f45deaf7acede409dc0f27f072"
}
```