### PR TITLE
Add Ocean experimental flag alias

### DIFF
--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3740,7 +3740,8 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
         result.pushKV("evmhash", std::string(*evmHashHex));
     }
 
-    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
+    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||
+        gArgs.GetBoolArg("-expr-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
         const auto oceanHashHex = XResultValueLogged(ocean_try_get_hash_db_state(result));
         if (oceanHashHex) {
             result.pushKV("oceanhash", std::string(*oceanHashHex));

--- a/src/dfi/validation.cpp
+++ b/src/dfi/validation.cpp
@@ -4664,7 +4664,8 @@ Res ProcessDeFiEventFallible(const CBlock &block,
     FlushCacheCreateUndo(pindex, mnview, cache, uint256S(std::string(64, '1')));
 
     // Ocean archive
-    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
+    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||
+        gArgs.GetBoolArg("-expr-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
         const UniValue b = blockToJSON(cache, block, ::ChainActive().Tip(), pindex, true, 2);
 
         if (CrossBoundaryResult result = OceanIndex(b, static_cast<uint32_t>(pindex->nHeight)); !result.ok) {

--- a/src/ffi/ffiocean.cpp
+++ b/src/ffi/ffiocean.cpp
@@ -4,11 +4,13 @@
 
 #include <ain_rs_exports.h>
 #include <dfi/customtx.h>
+#include <ffi/ffiexports.h>
 #include <uint256.h>
 #include <util/system.h>
 
 Res OceanSetTxResult(const std::optional<std::pair<CustomTxType, uint256>> &txInfo, const std::size_t result_ptr) {
-    bool isOceanEnabled = gArgs.GetBoolArg("-oceanarchive", false);
+    bool isOceanEnabled = gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||
+                          gArgs.GetBoolArg("-expr-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED);
     if (txInfo && isOceanEnabled) {
         const auto &[txType, txHash] = *txInfo;
         CrossBoundaryResult ffiResult;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -679,6 +679,7 @@ void SetupServerArgs()
     gArgs.AddArg("-ethdebugtrace", strprintf("Enable debug_trace* ETH RPCs (default: %b)", DEFAULT_ETH_DEBUG_TRACE_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-ethsubscription", strprintf("Enable subscription notifications ETH RPCs (default: %b)", DEFAULT_ETH_SUBSCRIPTION_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-oceanarchive", strprintf("Enable ocean archive indexer (default: %b)", DEFAULT_OCEAN_INDEXER_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-expr-oceanarchive", strprintf("Enable ocean archive indexer (default: %b)", DEFAULT_OCEAN_INDEXER_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-oceanarchiveserver", strprintf("Enable ocean archive server (default: %b)", DEFAULT_OCEAN_SERVER_ENABLED), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-oceanarchiveport=<port>", strprintf("Listen for ocean archive connections on <port> (default: %u)", DEFAULT_OCEAN_SERVER_PORT), ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-oceanarchivebind=<addr>[:port]", "Bind to given address to listen for Ocean connections. Do not expose the Ocean server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -oceanarchiveport. This option can be specified multiple times (default: 127.0.0.1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
@@ -2534,7 +2535,8 @@ bool AppInitMain(InitInterfaces& interfaces)
 
 
     // ********************************************************* Step 15: start genesis ocean indexing
-    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
+    if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||
+        gArgs.GetBoolArg("-expr-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
         const CBlock &block = chainparams.GenesisBlock();
 
         const CBlockIndex* pblockindex;
@@ -2553,6 +2555,8 @@ bool AppInitMain(InitInterfaces& interfaces)
         if (bool isIndexed = OceanIndex(b); !isIndexed) {
             return false;
         }
+
+        LogPrintf("WARNING: -expr-oceanarchive flag is turned on. This feature is not yet stable. Please do not use in production unless you're aware of the risks\n");
     }
 
     // ********************************************************* Step 16: start minter thread

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -24,6 +24,7 @@
 #include <dfi/threadpool.h>
 #include <dfi/validation.h>
 #include <dfi/vaulthistory.h>
+#include <ffi/ffiexports.h>
 #include <ffi/ffihelpers.h>
 #include <flatfile.h>
 #include <hash.h>
@@ -3772,7 +3773,8 @@ bool CChainState::DisconnectTip(CValidationState &state,
             XResultThrowOnErr(evm_try_disconnect_latest_block(result));
         }
 
-        if (gArgs.GetBoolArg("-oceanarchive", false)) {
+        if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||
+            gArgs.GetBoolArg("-expr-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED)) {
             const UniValue b = blockToJSON(mnview, block, pindexDelete, pindexDelete, true, 2);
             XResultThrowOnErr(ocean_invalidate_block(result, b.write()));
         }


### PR DESCRIPTION
## Summary

- Add alias for Ocean flag, print out warning message in log file when set.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
