### PR TITLE
Remove ports just before usage. Use network specific folders.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1053,8 +1053,6 @@ void InitLogging()
     version_string += " (release build)";
 #endif
     LogPrintf(PACKAGE_NAME " version %s\n", version_string);
-    // Remove ports.lock on startup in case of an unclean shutdown.
-    RemovePortUsage();
 }
 
 namespace { // Variables internal to initialization process only
@@ -1828,6 +1826,9 @@ bool AppInitMain(InitInterfaces& interfaces)
 #if ENABLE_ZMQ
     RegisterZMQRPCCommands(tableRPC);
 #endif
+
+    // Remove ports.lock on startup in case of an unclean shutdown.
+    RemovePortUsage();
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -348,7 +348,7 @@ static std::string GetAutoPortString(const AutoPort type)
 
 uint16_t GetPortFromLockFile(const AutoPort type)
 {
-    const fs::path lockFilePath = GetDataDir() / "ports.lock";
+    const fs::path lockFilePath = GetDataDir(true) / "ports.lock";
     const std::string portTypeStr = GetAutoPortString(type);
 
     std::ifstream lockFile(lockFilePath);
@@ -376,7 +376,7 @@ void SetPortToLockFile(const AutoPort portType, const uint16_t portNumber)
         return;
     }
 
-    const fs::path lockFilePath = GetDataDir() / "ports.lock";
+    const fs::path lockFilePath = GetDataDir(true) / "ports.lock";
 
     std::ofstream lockFile(lockFilePath, std::ios_base::app);
     if (!lockFile.is_open()) {
@@ -389,7 +389,7 @@ void SetPortToLockFile(const AutoPort portType, const uint16_t portNumber)
 
 void RemovePortUsage()
 {
-    const fs::path lockFilePath = GetDataDir() / "ports.lock";
+    const fs::path lockFilePath = GetDataDir(true) / "ports.lock";
 
     // Remove the file. Ignore errors, file might not be present.
     std::error_code ec;


### PR DESCRIPTION
## Summary

- Move removal of old ports.lock to just before it is created again to avoid removing it for an already running instance.
- Use network specific directories so we can use ports auto for mainnet, testnet, changi and regtest on the same data directory.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
