### PR TITLE
Add mocknet to all networks

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1526,11 +1526,6 @@ namespace pos {
     void stakingManagerThread(std::vector<std::shared_ptr<CWallet>> wallets, const int subnodeCount) {
         auto operators = gArgs.GetArgs("-masternode_operator");
 
-        if (fMockNetwork) {
-            auto mocknet_operator = "df1qu04hcpd3untnm453mlkgc0g9mr9ap39lyx4ajc";
-            operators.push_back(mocknet_operator);
-        }
-
         std::map<CKeyID, CKey> minterKeyMap;
 
         while (!ShutdownRequested()) {


### PR DESCRIPTION
## Summary

- Add `-mocknet` to all networks, not just mainnet.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
