### PR TITLE
Add ICX Taker Fee logging

### DIFF
--- a/src/dfi/consensus/icxorders.cpp
+++ b/src/dfi/consensus/icxorders.cpp
@@ -585,10 +585,10 @@ Res CICXOrdersConsensus::operator()(const CICXClaimDFCHTLCMessage &obj) const {
                     result.pushKV("dfchtlc_tx", dfchtlc->creationTx.ToString());
                     if (exthtlc) {
                         if (auto extTx = mnview.GetICXSubmitEXTHTLCTXID(dfchtlc->offerTx)) {
-                            result.pushKV("ext_htlc_address", extTx->ToString());
+                            result.pushKV("ext_htlc_tx", extTx->ToString());
                         }
                         result.pushKV("ext_htlc_address", exthtlc->htlcscriptAddress);
-                        result.pushKV("ext_htlc_tx", HexStr(exthtlc->ownerPubkey));
+                        result.pushKV("ext_htlc_pubkey", HexStr(exthtlc->ownerPubkey));
                     }
                     result.pushKV("claim_tx", tx.GetHash().ToString());
                     result.pushKV("address", EncodeDestination(dest));

--- a/src/dfi/consensus/icxorders.h
+++ b/src/dfi/consensus/icxorders.h
@@ -16,7 +16,9 @@ struct CICXCloseOrderMessage;
 struct CICXCloseOfferMessage;
 
 class CICXOrdersConsensus : public CCustomTxVisitor {
-    [[nodiscard]] CAmount CalculateTakerFee(CAmount amount) const;
+    [[nodiscard]] CAmount CalculateTakerFee(const CAmount amount,
+                                            const std::string &txType,
+                                            const std::string &txid) const;
     [[nodiscard]] DCT_ID FindTokenByPartialSymbolName(const std::string &symbol) const;
 
 public:

--- a/src/dfi/icxorder.cpp
+++ b/src/dfi/icxorder.cpp
@@ -373,10 +373,17 @@ void CICXOrderView::ForEachICXSubmitEXTHTLCExpire(std::function<bool(const Statu
     ForEach<ICXSubmitEXTHTLCStatus, StatusKey, uint8_t>(callback, StatusKey{height, {}});
 }
 
-std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmitEXTHTLCOpen(const uint256 &offertxid) {
+std::optional<uint256> CICXOrderView::GetICXSubmitEXTHTLCTXID(const uint256 &offertxid) {
     auto it = LowerBound<ICXSubmitEXTHTLCOpenKey>(TxidPairKey{offertxid, {}});
     if (it.Valid() && it.Key().first == offertxid) {
-        return GetICXSubmitEXTHTLCByCreationTx(it.Key().second);
+        return it.Key().second;
+    }
+    return {};
+}
+
+std::unique_ptr<CICXOrderView::CICXSubmitEXTHTLCImpl> CICXOrderView::HasICXSubmitEXTHTLCOpen(const uint256 &offertxid) {
+    if (const auto extTx = GetICXSubmitEXTHTLCTXID(offertxid)) {
+        return GetICXSubmitEXTHTLCByCreationTx(*extTx);
     }
     return {};
 }

--- a/src/dfi/icxorder.h
+++ b/src/dfi/icxorder.h
@@ -404,6 +404,7 @@ public:
     void ForEachICXMakeOfferExpire(std::function<bool(const StatusKey &, uint8_t)> callback,
                                    const uint32_t &height = 0);
     std::unique_ptr<CICXMakeOfferImpl> HasICXMakeOfferOpen(const uint256 &ordertxid, const uint256 &offertxid);
+    std::optional<uint256> GetICXSubmitEXTHTLCTXID(const uint256 &offertxid);
 
     // SubmitDFCHTLC
     std::unique_ptr<CICXSubmitDFCHTLCImpl> GetICXSubmitDFCHTLCByCreationTx(const uint256 &txid) const;


### PR DESCRIPTION
## Summary

- Add logging for the ICX taker fee calculation.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
