### PR TITLE
Log DVM hash without undos

### DIFF
--- a/src/dfi/masternodes.cpp
+++ b/src/dfi/masternodes.cpp
@@ -1435,3 +1435,51 @@ void CalcMissingRewardTempFix(CCustomCSView &mnview, const uint32_t targetHeight
         }
     }
 }
+
+std::pair<std::string, std::string> GetDVMDBHashes(CCustomCSView &view) {
+    auto db = view.GetStorage().GetStorageLevelDB()->GetDB();
+
+    // Create a CDBIterator
+    auto pcursor = db->NewIterator(leveldb::ReadOptions());
+
+    // Create SHA256 hashers
+    CSHA256 hasher;
+    CSHA256 hasherNoUndo;
+
+    // Seek to the beginning of the database
+    pcursor->SeekToFirst();
+
+    // Iterate over all key-value pairs
+    while (pcursor->Valid()) {
+        // Get the key and value slices
+        auto keySlice = pcursor->GetKey();
+        auto valueSlice = pcursor->GetValue();
+
+        const auto key = std::string(keySlice.data(), keySlice.size());
+        if (!key.empty() && key[0] != 'u') {
+            hasherNoUndo.Write((const unsigned char *)keySlice.data(), keySlice.size());
+            hasherNoUndo.Write((const unsigned char *)valueSlice.data(), valueSlice.size());
+        }
+
+        hasher.Write((const unsigned char *)keySlice.data(), keySlice.size());
+        hasher.Write((const unsigned char *)valueSlice.data(), valueSlice.size());
+
+        // Move to the next key-value pair
+        pcursor->Next();
+    }
+
+    // Delete iterator
+    delete pcursor;
+
+    // Finalize the hashes
+    unsigned char hash[CSHA256::OUTPUT_SIZE];
+    unsigned char hashNoUndo[CSHA256::OUTPUT_SIZE];
+    hasher.Finalize(hash);
+    hasher.Finalize(hashNoUndo);
+
+    // Convert hashes to hex string
+    const auto hashHex = HexStr(hash, hash + CSHA256::OUTPUT_SIZE);
+    const auto hashHexNoUndo = HexStr(hashNoUndo, hashNoUndo + CSHA256::OUTPUT_SIZE);
+
+    return {hashHex, hashHexNoUndo};
+}

--- a/src/dfi/masternodes.h
+++ b/src/dfi/masternodes.h
@@ -51,6 +51,8 @@ CAmount GetProposalCreationFee(int height, const CCustomCSView &view, const CCre
 // Missing call fixed in: https://github.com/DeFiCh/ain/pull/1766
 void CalcMissingRewardTempFix(CCustomCSView &mnview, const uint32_t targetHeight, const CWallet &wallet);
 
+std::pair<std::string, std::string> GetDVMDBHashes(CCustomCSView &view);
+
 enum class UpdateMasternodeType : uint8_t {
     None = 0x00,
     OwnerAddress = 0x01,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2268,6 +2268,11 @@ bool AppInitMain(InitInterfaces& interfaces)
             }
         }
 
+        {
+            auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);
+            LogPrintf("Pre-consolidate rewards for DVM hash: %s hash-no-undo: %s\n", hashHex, hashHexNoUndo);
+        }
+
         if (fullRewardConsolidation) {
             LogPrintf("Consolidate rewards for all addresses..\n");
 
@@ -2301,6 +2306,11 @@ bool AppInitMain(InitInterfaces& interfaces)
             ConsolidateRewards(*pcustomcsview, ::ChainActive().Height(), ownersToConsolidate, true, skipStatic);
         }
         pcustomcsview->Flush();
+
+        {
+            auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);
+            LogPrintf("Post-consolidate rewards for DVM hash: %s hash-no-undo: %s\n", hashHex, hashHexNoUndo);
+        }
     }
 
     // ********************************************************* Step 12: import blocks


### PR DESCRIPTION
## Summary

- Hashes DVM DB without undos which were changed from the 4.1.0 release onwards. This PR then allows us to compare nodes using the hash without undos which should match regardless of whether they were synced with 4.1.0+ or not.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
