### PR TITLE
Fix skipping of static rewards

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2254,10 +2254,6 @@ bool AppInitMain(InitInterfaces& interfaces)
     }
 
     if (gArgs.IsArgSet("-consolidaterewards")) {
-        // Due to higher precision reward consolidation after the DF24 fork consolidate rewards
-        // cannot be used. The following skipStatic flag is used to skip the static consolidation
-        // and only run the per-block consolidation.
-        const bool skipStatic = ::ChainActive().Height() >= chainparams.GetConsensus().DF24Height;
         const std::vector<std::string> tokenSymbolArgs = gArgs.GetArgs("-consolidaterewards");
         auto fullRewardConsolidation = false;
         for (const auto &tokenSymbolInput : tokenSymbolArgs) {
@@ -2283,7 +2279,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                 }
                 return true;
             });
-            ConsolidateRewards(*pcustomcsview, ::ChainActive().Height(), ownersToConsolidate, true, skipStatic);
+            ConsolidateRewards(*pcustomcsview, ::ChainActive().Height(), ownersToConsolidate, true, true);
         } else {
             //one set for all tokens, ConsolidateRewards runs on the address, so no need to run multiple times for multiple token inputs
             std::unordered_set<CScript, CScriptHasher> ownersToConsolidate;
@@ -2303,9 +2299,10 @@ bool AppInitMain(InitInterfaces& interfaces)
                     return true;
                 });
             }
-            ConsolidateRewards(*pcustomcsview, ::ChainActive().Height(), ownersToConsolidate, true, skipStatic);
+            ConsolidateRewards(*pcustomcsview, ::ChainActive().Height(), ownersToConsolidate, true, true);
         }
         pcustomcsview->Flush();
+        pcustomcsDB->Flush();
 
         {
             auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);

--- a/src/validation.h
+++ b/src/validation.h
@@ -936,7 +936,6 @@ void ConsolidateRewards(CCustomCSView &view,
                         int height,
                         const std::unordered_set<CScript, CScriptHasher> &owners,
                         bool interruptOnShutdown,
-                        int numWorkers = 0,
                         bool skipStatic = false);
 
 extern std::map<CScript, CBalances> mapBurnAmounts;

--- a/test/functional/feature_consolidate_rewards.py
+++ b/test/functional/feature_consolidate_rewards.py
@@ -167,7 +167,7 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.stop_node(1)
 
         # Start node with consolidation
-        self.args.append(f"-consolidaterewards={self.symbolGD}")
+        self.args.append(f"-consolidaterewards={self.symbolGOOGL}")
         self.start_node(1, self.args)
         connect_nodes_bi(self.nodes, 0, 1)
 
@@ -208,7 +208,7 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.stop_node(1)
 
         # Start node with consolidation
-        self.args.append(f"-consolidaterewards={self.symbolGD}")
+        self.args.append(f"-consolidaterewards={self.symbolGOOGL}")
         self.start_node(1, self.args)
         connect_nodes_bi(self.nodes, 0, 1)
 


### PR DESCRIPTION
## Summary

- Fix skipping of static rewards when consolidating rewards.
- Flush DB after consolidating rewards.
- Fix consolidate rewards test.
- Always set skip static when consolidating rewards, we never want them.
- Remove passing of workers as this is always from RewardConsolidationWorkersCount() which is called internally anyway.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
