### PR TITLE
Add TXID to swap results

### DIFF
--- a/src/dfi/consensus/icxorders.cpp
+++ b/src/dfi/consensus/icxorders.cpp
@@ -51,7 +51,7 @@ CAmount CICXOrdersConsensus::CalculateTakerFee(const CAmount amount,
         result.pushKV("calc_taker_fee_in_btc",
                       GetDecimalString(((arith_uint256(amount) * mnview.ICXGetTakerFeePerBTC() / COIN).GetLow64())));
         result.pushKV("calc_taker_fee_in_dfi", GetDecimalString(takerFee));
-        LogPrint(BCLog::ICXBUG, "%s\n", result.write(0));
+        LogPrint(BCLog::ICXBUG, "ICXCalc: %s\n", result.write(0));
     }
     return takerFee;
 }
@@ -593,7 +593,7 @@ Res CICXOrdersConsensus::operator()(const CICXClaimDFCHTLCMessage &obj) const {
                     result.pushKV("claim_tx", tx.GetHash().ToString());
                     result.pushKV("address", EncodeDestination(dest));
                     result.pushKV("amount", GetDecimalString(offer->takerFee * 50 / 100));
-                    LogPrint(BCLog::ICXBUG, "%s\n", result.write(0));
+                    LogPrint(BCLog::ICXBUG, "ICX: %s\n", result.write(0));
                 }
             }
         } else {

--- a/src/dfi/mn_checks.cpp
+++ b/src/dfi/mn_checks.cpp
@@ -1110,11 +1110,14 @@ Res CPoolSwap::ExecuteSwap(CCustomCSView &view,
                 }
 
                 if (LogAcceptCategory(BCLog::SWAPRESULT) && lastSwap) {
-                    LogPrint(BCLog::SWAPRESULT,
-                             "SwapResult: height=%d destination=%s result=%s\n",
-                             height,
-                             ScriptToString(obj.to),
-                             swapAmountResult.ToString());
+                    UniValue result(UniValue::VOBJ);
+                    result.pushKV("height", (int64_t)height);
+                    if (txInfo) {
+                        result.pushKV("txid", txInfo->second.ToString());
+                    }
+                    result.pushKV("destination", ScriptToString(obj.to));
+                    result.pushKV("result", swapAmountResult.ToString());
+                    LogPrint(BCLog::SWAPRESULT, "SwapResult: %s\n", result.write(0));
                 }
 
                 intermediateView.Flush();


### PR DESCRIPTION
## Summary

- When logging the swap results include the TXID when present.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
