### PR TITLE
Fix error in no undo hash

### DIFF
--- a/src/dfi/masternodes.cpp
+++ b/src/dfi/masternodes.cpp
@@ -1475,7 +1475,7 @@ std::pair<std::string, std::string> GetDVMDBHashes(CCustomCSView &view) {
     unsigned char hash[CSHA256::OUTPUT_SIZE];
     unsigned char hashNoUndo[CSHA256::OUTPUT_SIZE];
     hasher.Finalize(hash);
-    hasher.Finalize(hashNoUndo);
+    hasherNoUndo.Finalize(hashNoUndo);
 
     // Convert hashes to hex string
     const auto hashHex = HexStr(hash, hash + CSHA256::OUTPUT_SIZE);

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3668,6 +3668,9 @@ UniValue logdvmstate(const JSONRPCRequest &request) {
         pcursor->Next();
     }
 
+    // Delete iterator
+    delete pcursor;
+
     if (outFile.is_open()) {
         outFile.close();
     }

--- a/test/functional/feature_consolidate_rewards.py
+++ b/test/functional/feature_consolidate_rewards.py
@@ -155,8 +155,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
     def pre_fork24_consolidate(self):
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
         assert_equal(hash_0, hash_1)
 
         # Generate rewards
@@ -167,7 +167,7 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.stop_node(1)
 
         # Start node with consolidation
-        self.args.append(f"-consolidaterewards={self.symbolGOOGL}")
+        self.args.append(f"-consolidaterewards={self.symbolGD}")
         self.start_node(1, self.args)
         connect_nodes_bi(self.nodes, 0, 1)
 
@@ -186,8 +186,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.idGOOGL = list(self.nodes[0].gettoken(self.symbolGOOGL).keys())[0]
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
         assert_equal(hash_0, hash_1)
 
     def post_fork24_consolidate(self):
@@ -200,15 +200,15 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.sync_blocks()
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
         assert_equal(hash_0, hash_1)
 
         # Stop node
         self.stop_node(1)
 
         # Start node with consolidation
-        self.args.append(f"-consolidaterewards={self.symbolGOOGL}")
+        self.args.append(f"-consolidaterewards={self.symbolGD}")
         self.start_node(1, self.args)
         connect_nodes_bi(self.nodes, 0, 1)
 
@@ -224,8 +224,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.sync_blocks()
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
         assert_equal(hash_0, hash_1)
 
 


### PR DESCRIPTION
## Summary

- Use the correct hasher when creating the no-undo hash in logdbhashes.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
