### PR TITLE
Add block hash to logdbhashes

### DIFF
--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -56,7 +56,7 @@ impl BlockStore {
     }
 
     pub fn hash_db_state(&self) -> Result<String> {
-        Ok(self.0.hash_db_state(&[columns::Blocks::NAME])?)
+        Ok(self.0.hash_db_state(&COLUMN_NAMES)?)
     }
 }
 

--- a/lib/ain-evm/src/storage/block_store.rs
+++ b/lib/ain-evm/src/storage/block_store.rs
@@ -56,7 +56,7 @@ impl BlockStore {
     }
 
     pub fn hash_db_state(&self) -> Result<String> {
-        Ok(self.0.hash_db_state(&COLUMN_NAMES)?)
+        Ok(self.0.hash_db_state(&[columns::Blocks::NAME])?)
     }
 }
 

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3713,7 +3713,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     // Other known instance that can cause this to differ:
     // - consolidaterewards at different points if pre-static addresses are involved.
     result.pushKV("dvmhash", hashHex);
-    result.pushKV("dvmhash_no_undo", hashHexNoUndo);
+    result.pushKV("dvmwithoutundohash", hashHexNoUndo);
 
     auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
     if (res) {
@@ -3727,7 +3727,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     const auto evmDbNodeHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
     if (evmDbNodeHashHex) {
         // Note: This can vary from node to node unlike the rest. 
-        result.pushKV("evm_db_node_hash", std::string(*evmDbNodeHashHex));
+        result.pushKV("varhash_evmalldb", std::string(*evmDbNodeHashHex));
     }
 
     if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3710,15 +3710,15 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     result.pushKV("blockhash", blockHash);
     // Note that this only guaranteed to be equal with other nodes
     // if they didn't hit undo changes at different points. 
-    // Other instances that can cause this to differ are:
-    // consolidaterewards at different points, etc  
+    // Other known instance that can cause this to differ:
+    // - consolidaterewards at different points if pre-static addresses are involved.
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmhash_no_undo", hashHexNoUndo);
 
     auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
     if (res) {
         // Only available after EVM activation
-        // EVM block hash already is inclusive of it's all it's 
+        // EVM block hash already is inclusive of all it's 
         // state, so we don't need to do the DVM shenangins.
         auto evmBlockHash = uint256::FromByteArray(*res).GetHex();
         result.pushKV("evmhash", evmBlockHash);

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3701,10 +3701,12 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
 
     // Get the current block height
     const auto height = ::ChainActive().Height();
+    const auto blockHash = ::ChainActive().Tip()->GetBlockHash().ToString();
 
     // Prepare result
     UniValue result(UniValue::VOBJ);
     result.pushKV("height", height);
+    result.pushKV("blockhash", blockHash);
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmhash_no_undo", hashHexNoUndo);
 

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3703,6 +3703,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     const auto height = ::ChainActive().Height();
     const auto blockHash = ::ChainActive().Tip()->GetBlockHash().ToString();
 
+
     // Prepare result
     UniValue result(UniValue::VOBJ);
     result.pushKV("height", height);
@@ -3710,9 +3711,16 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmhash_no_undo", hashHexNoUndo);
 
-    const auto evmHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
-    if (evmHashHex) {
-        result.pushKV("evm_db_node_hash", std::string(*evmHashHex));
+    auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
+    if (res) {
+        // Only available after EVM activation
+        auto evmBlockHash = uint256::FromByteArray(*res).GetHex();
+        result.pushKV("evmhash", evmBlockHash);
+    }
+
+    const auto evmDbNodeHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
+    if (evmDbNodeHashHex) {
+        result.pushKV("evm_db_node_hash", std::string(*evmDbNodeHashHex));
     }
 
     if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3710,8 +3710,8 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     result.pushKV("blockhash", blockHash);
     // Note that this only guaranteed to be equal with other nodes
     // if they didn't hit undo changes at different points. 
-    // Example, consolidaterewards at different points can cause this
-    // to change on pre static reward addresses. 
+    // Other instances that can cause this to differ are:
+    // consolidaterewards at different points, etc  
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmhash_no_undo", hashHexNoUndo);
 

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3712,7 +3712,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
 
     const auto evmHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
     if (evmHashHex) {
-        result.pushKV("evmhash", std::string(*evmHashHex));
+        result.pushKV("evm_db_node_hash", std::string(*evmHashHex));
     }
 
     if (gArgs.GetBoolArg("-oceanarchive", DEFAULT_OCEAN_INDEXER_ENABLED) ||

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3708,18 +3708,25 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     UniValue result(UniValue::VOBJ);
     result.pushKV("height", height);
     result.pushKV("blockhash", blockHash);
+    // Note that this only guaranteed to be equal with other nodes
+    // if they didn't hit undo changes at different points. 
+    // Example, consolidaterewards at different points can cause this
+    // to change on pre static reward addresses. 
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmhash_no_undo", hashHexNoUndo);
 
     auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
     if (res) {
         // Only available after EVM activation
+        // EVM block hash already is inclusive of it's all it's 
+        // state, so we don't need to do the DVM shenangins.
         auto evmBlockHash = uint256::FromByteArray(*res).GetHex();
         result.pushKV("evmhash", evmBlockHash);
     }
 
     const auto evmDbNodeHashHex = XResultValueLogged(evm_try_get_hash_db_state(result));
     if (evmDbNodeHashHex) {
+        // Note: This can vary from node to node unlike the rest. 
         result.pushKV("evm_db_node_hash", std::string(*evmDbNodeHashHex));
     }
 


### PR DESCRIPTION
## Summary

- Add block hash to logdbhashes so when comparing results we can be sure that we are comparing the same chain.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
