### PR TITLE
Add account hashes to logdbhashes

### DIFF
--- a/src/dfi/masternodes.h
+++ b/src/dfi/masternodes.h
@@ -51,7 +51,7 @@ CAmount GetProposalCreationFee(int height, const CCustomCSView &view, const CCre
 // Missing call fixed in: https://github.com/DeFiCh/ain/pull/1766
 void CalcMissingRewardTempFix(CCustomCSView &mnview, const uint32_t targetHeight, const CWallet &wallet);
 
-std::pair<std::string, std::string> GetDVMDBHashes(CCustomCSView &view);
+std::tuple<std::string, std::string, std::string> GetDVMDBHashes(CCustomCSView &view);
 
 enum class UpdateMasternodeType : uint8_t {
     None = 0x00,

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3713,7 +3713,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     // - consolidaterewards at different points if pre-static addresses are involved.
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmwithoutundohash", hashHexNoUndo);
-    result.pushKV("dvmaccounthashes", hashHexAccount);
+    result.pushKV("dvmaccounthash", hashHexAccount);
 
     auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
     if (res) {

--- a/src/dfi/rpc_accounts.cpp
+++ b/src/dfi/rpc_accounts.cpp
@@ -3697,7 +3697,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     pcustomcsview->Flush();
     pcustomcsDB->Flush();
 
-    auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);
+    auto [hashHex, hashHexNoUndo, hashHexAccount] = GetDVMDBHashes(*pcustomcsview);
 
     // Get the current block height
     const auto height = ::ChainActive().Height();
@@ -3713,6 +3713,7 @@ UniValue logdbhashes(const JSONRPCRequest &request) {
     // - consolidaterewards at different points if pre-static addresses are involved.
     result.pushKV("dvmhash", hashHex);
     result.pushKV("dvmwithoutundohash", hashHexNoUndo);
+    result.pushKV("dvmaccounthashes", hashHexAccount);
 
     auto res = XResultValueLogged(evm_try_get_latest_block_hash(result));
     if (res) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2251,8 +2251,8 @@ bool AppInitMain(InitInterfaces& interfaces)
         }
 
         {
-            auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);
-            LogPrintf("Pre-consolidate rewards for DVM hash: %s hash-no-undo: %s\n", hashHex, hashHexNoUndo);
+            auto [hashHex, hashHexNoUndo, hashHexAccount] = GetDVMDBHashes(*pcustomcsview);
+            LogPrintf("Pre-consolidate rewards for DVM hash: %s hash-no-undo: %s hash-account: %s\n", hashHex, hashHexNoUndo, hashHexAccount);
         }
 
         if (fullRewardConsolidation) {
@@ -2291,8 +2291,8 @@ bool AppInitMain(InitInterfaces& interfaces)
         pcustomcsDB->Flush();
 
         {
-            auto [hashHex, hashHexNoUndo] = GetDVMDBHashes(*pcustomcsview);
-            LogPrintf("Post-consolidate rewards for DVM hash: %s hash-no-undo: %s\n", hashHex, hashHexNoUndo);
+            auto [hashHex, hashHexNoUndo, hashHexAccount] = GetDVMDBHashes(*pcustomcsview);
+            LogPrintf("Post-consolidate rewards for DVM hash: %s hash-no-undo: %s hash-account: %s\n", hashHex, hashHexNoUndo, hashHexAccount);
         }
     }
 

--- a/test/functional/feature_consolidate_rewards.py
+++ b/test/functional/feature_consolidate_rewards.py
@@ -155,8 +155,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
     def pre_fork24_consolidate(self):
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmwithoutundohash"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmwithoutundohash"]
         assert_equal(hash_0, hash_1)
 
         # Generate rewards
@@ -186,8 +186,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.idGOOGL = list(self.nodes[0].gettoken(self.symbolGOOGL).keys())[0]
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmwithoutundohash"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmwithoutundohash"]
         assert_equal(hash_0, hash_1)
 
     def post_fork24_consolidate(self):
@@ -200,8 +200,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.sync_blocks()
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmwithoutundohash"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmwithoutundohash"]
         assert_equal(hash_0, hash_1)
 
         # Stop node
@@ -224,8 +224,8 @@ class ConsolidateRewardsTest(DefiTestFramework):
         self.sync_blocks()
 
         # Compare hash before consolidation
-        hash_0 = self.nodes[0].logdbhashes()["dvmhash_no_undo"]
-        hash_1 = self.nodes[1].logdbhashes()["dvmhash_no_undo"]
+        hash_0 = self.nodes[0].logdbhashes()["dvmwithoutundohash"]
+        hash_1 = self.nodes[1].logdbhashes()["dvmwithoutundohash"]
         assert_equal(hash_0, hash_1)
 
 


### PR DESCRIPTION
## Summary

- Add account hashes to logdbhashes.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
