### PR TITLE
depends: Update Boost URL

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,16 +1,9 @@
 package=boost
 
-# Official version hashes
-# 77: fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
-# 78: 8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
-# 83: 6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
-
-$(package)_version=1_83_0
-$(package)_sha256_hash=6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e
-
-$(package)_version_dot=$(subst _,.,$($(package)_version))
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version_dot)/source/
-$(package)_file_name=$(package)_$($(package)_version).tar.bz2
+$(package)_version=1.83.0
+$(package)_sha256_hash=c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
+$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
+$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.gz
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release


### PR DESCRIPTION
## Summary

- Boost URL no longer valid, updated to use archives.boost.io.

## Implications

- Storage
  - [ ] Database reindex required
  - [ ] Database reindex optional
  - [ ] Database reindex not required
  - [x] None

- Consensus
  - [ ] Network upgrade required
  - [ ] Includes backward compatible changes
  - [ ] Includes consensus workarounds
  - [ ] Includes consensus refactors
  - [x] None
